### PR TITLE
Updated dependency files and added the biosphere module to the scene …

### DIFF
--- a/docs/rst/api_reference/scenes.rst
+++ b/docs/rst/api_reference/scenes.rst
@@ -17,6 +17,7 @@ Scene generation [eradiate.scenes]
 
    core
    atmosphere
+   biosphere
    illumination
    lithosphere
    measure

--- a/eradiate/scenes/biosphere.py
+++ b/eradiate/scenes/biosphere.py
@@ -4,7 +4,8 @@
     :class: hint
 
     .. factorytable::
-        :modules: biosphere
+       :factory: SceneElementFactory
+       :modules: eradiate.scenes.biosphere
 """
 
 import aabbtree

--- a/eradiate/scenes/core.py
+++ b/eradiate/scenes/core.py
@@ -165,6 +165,7 @@ class SceneElementFactory(BaseFactory):
     #: List of submodules where to look for registered classes
     _modules = [
         "eradiate.scenes.atmosphere",
+        "eradiate.scenes.biosphere",
         "eradiate.scenes.illumination",
         "eradiate.scenes.lithosphere",
         "eradiate.scenes.measure",

--- a/resources/deps/requirements_conda.yml
+++ b/resources/deps/requirements_conda.yml
@@ -3,6 +3,7 @@ channels:
   - default
 dependencies:
   - python=3.7
+  - aabbtree=2.6
   - attrs=20.2
   - click=7
   - dask=2.30

--- a/resources/deps/requirements_pip.txt
+++ b/resources/deps/requirements_pip.txt
@@ -1,4 +1,5 @@
 attrs==20.2
+aabbtree==2.6
 cerberus~=1.3
 click==7
 dask~=2.30


### PR DESCRIPTION
…element factory

# Description
closes [#28](https://github.com/eradiate/eradiate-issues/issues/28)

This bugfix adds the biosphere module to the scene element factory and adds the aabbtree module to the dependency files.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is apropriately documented.
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license