### PR TITLE
Spectrum refactoring

### DIFF
--- a/eradiate/scenes/biosphere.py
+++ b/eradiate/scenes/biosphere.py
@@ -12,25 +12,16 @@ import aabbtree
 import attr
 import numpy as np
 
-from .core import SceneElementFactory, SceneElement
-from .spectra import Spectrum, UniformReflectanceSpectrum, UniformTransmittanceSpectrum
+from .core import SceneElement, SceneElementFactory
+from .spectra import Spectrum
 from ..util.attrs import (
-    attrib_quantity, validator_has_len, validator_is_positive
+    attrib_quantity,
+    validator_has_len,
+    validator_has_quantity,
+    validator_is_positive
 )
 from ..util.units import config_default_units as cdu, ureg
 from ..util.units import kernel_default_units as kdu
-
-
-def _validator_has_quantity(quantity):
-    def f(_, attribute, value):
-        if value._quantity != quantity:
-            raise ValueError(
-                f"incompatible quantity '{value._quantity}' "
-                f"used to set field '{attribute.name}' "
-                f"(allowed: '{quantity}')"
-            )
-
-    return f
 
 
 @SceneElementFactory.register(name="homogeneous_discrete_canopy")
@@ -56,76 +47,58 @@ class HomogeneousDiscreteCanopy(SceneElement):
     .. rubric:: Constructor arguments / instance attributes
 
     ``id`` (str):
-        Identifier
-
-        Default value: "RAMI-I_leaf_cloud"
+        Identifier. Default value: "homogeneous_discrete_canopy"
 
     ``lai`` (float):
-        Leaf area index
-
-        Default value: 3.
+        Leaf area index. Default value: 3.
 
     ``radius`` (float):
-        Leaf radius. Default 0.25
+        Leaf radius. Default 0.25.
 
         Unit-enabled field (default unit: cdu[length])
 
     ``mu`` (float):
-        First parameter for the beta distribution
-
-        Default value: 1.066
+        First parameter for the beta distribution. Default: 1.066.
 
     ``nu`` (float):
-        Second parameter for the beta distribution
-
-        Default value: 1.853
+        Second parameter for the beta distribution. Default value: 1.853.
 
     ``n_leaves`` (int):
-        Total number of leaves to generate.
-        If the ``size`` parameter is set, it will override
-        this parameter.
-
-        Default value: 4000
+        Total number of leaves to generate. If ``size`` is set, it will override
+        this parameter. Default: 4000
 
     ``hdo`` (float):
-        Mean horizontal distance between leaves.
-        If the ``size`` parameter is set, it will override
-        this parameter. Default: 1.
+        Mean horizontal distance between leaves. If ``size`` is set, it will
+        override this parameter. Default: 1.
 
         Unit-enabled field (default unit: cdu[length])
 
     ``hvr`` (float):
         Ratio of mean horizontal leaf distance and vertical canopy extent.
-        If the ``size`` parameter is set, it will override
-        this parameter.
-
-        Default value: 1.
+        If ``size`` is set, it will override this parameter. Default: 1.
 
     ``size`` (list[float]):
-        Three dimensional length of the canopy.
-        A canopy with size [x, y, z] will extend over
-        [-x/2.,x/2], [-y/2,y/2] and [0,z] centered on the value of
-        the ``position`` parameter. Default: [0, 0, 0]
+        Length of the canopy in the three dimensions. A canopy with size
+        [x, y, z] will extend over [-x/2, x/2], [-y/2, y/2] and [0, z], centered
+        at ``position`` parameter. Default: [0, 0, 0].
 
-        If size is not set, ``hdo``, ``hvr`` and ``n_leaves``
-        will be used to compute it.
+        If ``size`` is not set, it will be automaticaly computed from ``hdo``,
+        ``hvr`` and ``n_leaves``.
 
-        Unit-enabled field (default unit: cdu[length])
+        Unit-enabled field (default units: cdu[length]).
 
     ``position`` (list[float]):
-        Three dimensional position of the canopy. Default: [0, 0, 0]
+        Three dimensional position of the canopy. Default: [0, 0, 0].
 
-        Unit-enabled field (default unit: cdu[length])
+        Unit-enabled field (default units: cdu[length])
 
     ``seed`` (int):
-        Seed for the random number generator
-
-        Default value: 1
+        Seed for the random number generator. Default: 1.
 
     ``avoid_overlap`` (bool):
-        If true, the scene element will attempt to place the leaves such
+        If ``True``, the scene element will attempt to place the leaves such
         that they do not overlap. If a leaf cannot be placed without overlap
-        after 1^6 tries, it will raise a RuntimeError.
+        after 1e6 tries, it will raise a ``RuntimeError``. Default: True.
 
         .. admonition:: Note
 
@@ -134,17 +107,13 @@ class HomogeneousDiscreteCanopy(SceneElement):
             different ``seed`` values and after a certain amount of
             failures, run it without overlap avoidance.
 
-        Default value: True
+    ``leaf_reflectance`` (float or :class:`~eradiate.scenes.spectra.Spectrum`):
+        Reflectance spectrum of the leaves in the cloud. Must be a reflectance
+        spectrum (dimensionless). Default: 0.5.
 
-    ``leaf_reflectance`` (:class:`~eradiate.scenes.spectra.Spectrum`):
-        Reflectance spectrum of the leaves in the cloud. Must be a reflectance spectrum (dimensionless).
-
-        Default: :class:`~eradiate.scenes.spectra.UniformReflectanceSpectrum`.
-
-    ``leaf_transmittance`` (:class:`~eradiate.scenes.spectra.Spectrum`):
-        Transmittance spectrum of the leaves in the cloud. Must be a transmittance spectrum (dimensionless).
-
-        Default: :class:`~eradiate.scenes.spectra.UniformTransmittanceSpectrum`.
+    ``leaf_transmittance`` (float or :class:`~eradiate.scenes.spectra.Spectrum`):
+        Transmittance spectrum of the leaves in the cloud. Must be a
+        transmittance spectrum (dimensionless). Default: 0.5.
     """
 
     id = attr.ib(
@@ -211,20 +180,20 @@ class HomogeneousDiscreteCanopy(SceneElement):
     )
 
     leaf_reflectance = attr.ib(
-        default=attr.Factory(lambda: UniformReflectanceSpectrum(value=0.5)),
+        default=0.5,
         converter=Spectrum.converter("reflectance"),
         validator=[
             attr.validators.instance_of(Spectrum),
-            _validator_has_quantity("reflectance")
+            validator_has_quantity("reflectance")
         ]
     )
 
     leaf_transmittance = attr.ib(
-        default=attr.Factory(lambda: UniformTransmittanceSpectrum(value=0.5)),
+        default=0.5,
         converter=Spectrum.converter("transmittance"),
         validator=[
             attr.validators.instance_of(Spectrum),
-            _validator_has_quantity("transmittance")
+            validator_has_quantity("transmittance")
         ]
     )
 
@@ -237,21 +206,24 @@ class HomogeneousDiscreteCanopy(SceneElement):
         np.random.seed(self.seed)
 
         # n_leaves or horizontal extent
-        if self.size[0].magnitude == 0 or self.size[
-            1].magnitude == 0:
+        if self.size[0].magnitude == 0 or self.size[1].magnitude == 0:
             self.size[0] = self.size[1] = \
                 np.sqrt(
                     self.n_leaves * np.pi *
                     self.leaf_radius ** 2 / self.leaf_area_index
                 )
         else:
-            self.n_leaves = int(np.floor(self.size[0] * self.size[1] * \
-                                         self.leaf_area_index / (np.pi * self.leaf_radius**2)))
+            self.n_leaves = int(np.floor(
+                self.size[0] * self.size[1] * self.leaf_area_index /
+                (np.pi * self.leaf_radius ** 2)
+            ))
 
         # hdo/hvr or vertical extent
         if self.size[2].magnitude == 0:
-            self.size[2] = self.leaf_area_index * self.hdo ** 3 / \
-                           (np.pi * self.leaf_radius**2 * self.hvr)
+            self.size[2] = (
+                    self.leaf_area_index * self.hdo ** 3 /
+                    (np.pi * self.leaf_radius ** 2 * self.hvr)
+            )
         else:
             self.hdo = np.power(
                 np.pi * self.leaf_radius ** 2 * self.size[2] * self.hvr /
@@ -276,13 +248,11 @@ class HomogeneousDiscreteCanopy(SceneElement):
         for i in range(self.n_leaves):
             if not self.avoid_overlap:
                 rand = np.random.rand(3)
-                positions_temp.append(
-                    [
-                        rand[0] * size_magnitude[0] - size_magnitude[0] / 2.,
-                        rand[1] * size_magnitude[1] - size_magnitude[1] / 2.,
-                        rand[2] * size_magnitude[2]
-                    ]
-                )
+                positions_temp.append([
+                    rand[0] * size_magnitude[0] - size_magnitude[0] / 2.,
+                    rand[1] * size_magnitude[1] - size_magnitude[1] / 2.,
+                    rand[2] * size_magnitude[2]
+                ])
             else:
                 for j in range(self._tries):
                     rand = np.random.rand(3)
@@ -291,22 +261,20 @@ class HomogeneousDiscreteCanopy(SceneElement):
                         rand[1] * size_magnitude[1] - size_magnitude[1] / 2.,
                         rand[2] * size_magnitude[2]
                     ]
-                    aabb = aabbtree.AABB(
-                        [
-                            (
-                                pos_candidate[0] - radius_mag,
-                                pos_candidate[0] + radius_mag
-                            ),
-                            (
-                                pos_candidate[1] - radius_mag,
-                                pos_candidate[1] + radius_mag
-                            ),
-                            (
-                                pos_candidate[2] - radius_mag,
-                                pos_candidate[2] + radius_mag
-                            )
-                        ]
-                    )
+                    aabb = aabbtree.AABB([
+                        (
+                            pos_candidate[0] - radius_mag,
+                            pos_candidate[0] + radius_mag
+                        ),
+                        (
+                            pos_candidate[1] - radius_mag,
+                            pos_candidate[1] + radius_mag
+                        ),
+                        (
+                            pos_candidate[2] - radius_mag,
+                            pos_candidate[2] + radius_mag
+                        )
+                    ])
                     if i == 0:
                         positions_temp.append(pos_candidate)
                         tree.add(aabb)
@@ -318,33 +286,27 @@ class HomogeneousDiscreteCanopy(SceneElement):
                             break
                 else:
                     raise RuntimeError(
-                        "Unable to place all leaves."
-                        "The specified canopy might be too dense."
+                        "unable to place all leaves: "
+                        "the specified canopy might be too dense"
                     )
         self._positions = positions_temp * ureg.m
 
     def kernel_dict(self, ref=True):
         from eradiate.kernel.core import ScalarTransform4f, ScalarVector3f
         return_dict = {
-            "leaf":
-                {
-                    "type": "shapegroup",
-                    "shape_01":
-                        {
-                            "type": "disk",
-                            "bsdf":
-                                {
-                                    "type":
-                                        "bilambertian",
-                                    "reflectance":
-                                        self.leaf_reflectance.kernel_dict()
-                                        ["spectrum"],
-                                    "transmittance":
-                                        self.leaf_transmittance.kernel_dict()
-                                        ["spectrum"],
-                                }
-                        }
+            "leaf": {
+                "type": "shapegroup",
+                "shape_01": {
+                    "type": "disk",
+                    "bsdf": {
+                        "type": "bilambertian",
+                        "reflectance":
+                            self.leaf_reflectance.kernel_dict()["spectrum"],
+                        "transmittance":
+                            self.leaf_transmittance.kernel_dict()["spectrum"],
+                    }
                 }
+            }
         }
 
         self._compute_positions()
@@ -355,13 +317,15 @@ class HomogeneousDiscreteCanopy(SceneElement):
             theta = np.rad2deg(self._inversebeta())
             phi = np.random.rand() * 360.
 
-            to_world = \
-            ScalarTransform4f.translate(ScalarVector3f(
-                self.position.to(kdu_length).magnitude +
-                self._positions[i].to(kdu_length).magnitude)) * \
-            ScalarTransform4f.rotate(ScalarVector3f(0, 0, 1), phi) * \
-            ScalarTransform4f.rotate(ScalarVector3f(0, -1, 0), theta) * \
-            ScalarTransform4f.scale(ScalarVector3f(radius, radius, 1))
+            to_world = (
+                    ScalarTransform4f.translate(ScalarVector3f(
+                        self.position.to(kdu_length).magnitude +
+                        self._positions[i].to(kdu_length).magnitude)
+                    ) *
+                    ScalarTransform4f.rotate(ScalarVector3f(0, 0, 1), phi) *
+                    ScalarTransform4f.rotate(ScalarVector3f(0, -1, 0), theta) *
+                    ScalarTransform4f.scale(ScalarVector3f(radius, radius, 1))
+            )
 
             return_dict[f"shape_{i}"] = {
                 "type": "instance",

--- a/eradiate/scenes/illumination.py
+++ b/eradiate/scenes/illumination.py
@@ -13,13 +13,12 @@ from abc import ABC
 import attr
 
 from .core import SceneElement, SceneElementFactory
-from .spectra import (
-    Spectrum,
-    UniformIrradianceSpectrum,
-    UniformRadianceSpectrum,
-    validator_has_quantity
+from .spectra import SolarIrradianceSpectrum, Spectrum
+from ..util.attrs import (
+    attrib_quantity,
+    validator_has_quantity,
+    validator_is_positive
 )
-from ..util.attrs import attrib_quantity, validator_is_positive
 from ..util.frame import angles_to_direction
 from ..util.units import config_default_units as cdu
 from ..util.units import ureg
@@ -47,17 +46,14 @@ class ConstantIllumination(Illumination):
 
     .. rubric:: Constructor arguments / instance attributes
 
-    ``radiance`` (:class:`~eradiate.scenes.spectra.Spectrum`):
+    ``radiance`` (float or :class:`~eradiate.scenes.spectra.Spectrum`):
         Emitted radiance spectrum. Must be a radiance spectrum (in W/m^2/sr/nm
-        or compatible unit).
-        Default: :class:`~eradiate.scenes.spectra.UniformRadianceSpectrum`.
-
-        Can be initialised with a dictionary processed by
-        :class:`.SceneElementFactory`.
+        or compatible units).
+        Default: 1 cdu[radiance].
     """
 
     radiance = attr.ib(
-        default=attr.Factory(UniformRadianceSpectrum),
+        default=1.,
         converter=Spectrum.converter("radiance"),
         validator=[attr.validators.instance_of(Spectrum),
                    validator_has_quantity("radiance")]
@@ -87,12 +83,12 @@ class DirectionalIllumination(Illumination):
     ``zenith`` (float):
          Zenith angle. Default: 0 deg.
 
-        Unit-enabled field (default unit: cdu[angle]).
+        Unit-enabled field (default units: cdu[angle]).
 
     ``azimuth`` (float):
         Azimuth angle value. Default: 0 deg.
 
-        Unit-enabled field (default unit: cdu[angle]).
+        Unit-enabled field (default units: cdu[angle]).
 
     ``irradiance`` (:class:`~eradiate.scenes.spectra.Spectrum`):
         Emitted power flux in the plane orthogonal to the illumination direction.
@@ -116,7 +112,7 @@ class DirectionalIllumination(Illumination):
     )
 
     irradiance = attr.ib(
-        default=attr.Factory(UniformIrradianceSpectrum),
+        factory=SolarIrradianceSpectrum,
         converter=Spectrum.converter("irradiance"),
         validator=[attr.validators.instance_of(Spectrum),
                    validator_has_quantity("irradiance")]

--- a/eradiate/scenes/lithosphere.py
+++ b/eradiate/scenes/lithosphere.py
@@ -13,8 +13,10 @@ from abc import ABC, abstractmethod
 import attr
 
 from .core import SceneElement, SceneElementFactory
-from .spectra import Spectrum, UniformReflectanceSpectrum, validator_has_quantity
-from ..util.attrs import attrib_quantity, validator_is_positive
+from .spectra import Spectrum
+from ..util.attrs import (
+    attrib_quantity, validator_has_quantity, validator_is_positive
+)
 from ..util.units import config_default_units as cdu
 from ..util.units import kernel_default_units as kdu
 from ..util.units import ureg
@@ -109,15 +111,14 @@ class LambertianSurface(Surface):
     .. rubric:: Constructor arguments / instance attributes
 
     ``reflectance`` (:class:`.UniformSpectrum`):
-        Reflectance spectrum.
-        Default: ``UniformReflectanceSpectrum(value=0.5)``.
+        Reflectance spectrum. Default: 0.5.
 
         Can be initialised with a dictionary processed by
         :class:`.SceneElementFactory`.
     """
 
     reflectance = attr.ib(
-        default=attr.Factory(lambda: UniformReflectanceSpectrum(value=0.5)),
+        default=0.5,
         converter=Spectrum.converter("reflectance"),
         validator=[attr.validators.instance_of(Spectrum),
                    validator_has_quantity("reflectance")]
@@ -137,7 +138,7 @@ class LambertianSurface(Surface):
 class BlackSurface(Surface):
     """Black surface scene element [:factorykey:`black`].
 
-    This class creates a square surface with a non reflecting BRDF attached.
+    This class creates a square surface with a non-reflecting BRDF attached.
 
     See :class:`.Surface` for undocumented members.
     """
@@ -146,7 +147,7 @@ class BlackSurface(Surface):
         return {
             f"bsdf_{self.id}": {
                 "type": "diffuse",
-                "reflectance": {"type": "uniform", "value": 0}
+                "reflectance": {"type": "uniform", "value": 0.}
             }
         }
 

--- a/eradiate/scenes/tests/test_illumination.py
+++ b/eradiate/scenes/tests/test_illumination.py
@@ -16,7 +16,7 @@ def test_constant(mode_mono):
     assert KernelDict.empty().add(c).load() is not None
 
     # Check if a more detailed spec is valid
-    c = ConstantIllumination(radiance={"type": "uniform_radiance", "value": 1.0})
+    c = ConstantIllumination(radiance={"type": "uniform", "value": 1.0})
     assert KernelDict.empty().add(c).load() is not None
 
     # Check if 'uniform' shortcut works

--- a/eradiate/scenes/tests/test_spectra.py
+++ b/eradiate/scenes/tests/test_spectra.py
@@ -2,60 +2,74 @@ import numpy as np
 import pytest
 
 import eradiate
-from eradiate.scenes.spectra import \
-    SolarIrradianceSpectrum, Spectrum, \
-    UniformIrradianceSpectrum, UniformRadianceSpectrum
+from eradiate.scenes.spectra import (
+    SolarIrradianceSpectrum, Spectrum, UniformSpectrum
+)
 from eradiate.util.collections import onedict_value
 from eradiate.util.exceptions import UnitsError
+from eradiate.util.units import PhysicalQuantity, ureg
 from eradiate.util.units import config_default_units as cdu
 from eradiate.util.units import kernel_default_units as kdu
-from eradiate.util.units import ureg
 
 
 def test_converter(mode_mono):
     # Check if dicts are correctly processed
     s = Spectrum.converter("radiance")({"type": "uniform"})
-    assert s == UniformRadianceSpectrum(value=1.0)
+    assert s == UniformSpectrum(quantity="radiance", value=1.0)
     s = Spectrum.converter("irradiance")({"type": "uniform"})
-    assert s == UniformIrradianceSpectrum(value=1.0)
+    assert s == UniformSpectrum(quantity="irradiance", value=1.0)
 
     # Check if floats and quantities are correctly processed
     s = Spectrum.converter("radiance")(1.0)
-    assert s == UniformRadianceSpectrum(value=1.0)
+    assert s == UniformSpectrum(quantity="radiance", value=1.0)
     s = Spectrum.converter("radiance")(ureg.Quantity(1e6, "W/km^2/sr/nm"))
-    assert s == UniformRadianceSpectrum(value=1.0)
+    assert s == UniformSpectrum(quantity="radiance", value=1.0)
     with pytest.raises(UnitsError):
-        s = Spectrum.converter("irradiance")(ureg.Quantity(1, "W/m^2/sr/nm"))
+        Spectrum.converter("irradiance")(ureg.Quantity(1, "W/m^2/sr/nm"))
 
 
 def test_uniform(mode_mono):
     from eradiate.kernel.core.xml import load_dict
 
-    # Check if we can instantiate the element
-    s = UniformRadianceSpectrum()
-    assert s.value == ureg.Quantity(1., "W/m^2/sr/nm")
+    # Instantiate without argument
+    UniformSpectrum()
+
+    # Instantiate with only quantity
+    UniformSpectrum(quantity=PhysicalQuantity.COLLISION_COEFFICIENT)
+    UniformSpectrum(quantity="COLLISION_COEFFICIENT")
+    UniformSpectrum(quantity="collision_coefficient")
+
+    # Instantiate with unsupported quantity
+    with pytest.raises(ValueError):
+        UniformSpectrum(quantity="speed")
+
+    # Instantiate with all arguments
+    s = UniformSpectrum(quantity="collision_coefficient", value=1.)
+    assert s.value == ureg.Quantity(1., "m^-1")
+    with pytest.raises(ValueError):
+        UniformSpectrum(quantity="collision_coefficient", value=-1.)
+
+    # Raise if units and quantity are inconsistent
+    with pytest.raises(UnitsError):
+        UniformSpectrum(
+            quantity="collision_coefficient",
+            value=ureg.Quantity(1., "")
+        )
+
+    # Instantiate from dictionary
+    s = UniformSpectrum.from_dict({
+        "quantity": "radiance", "value": 1., "value_units": "W/km^2/sr/nm"
+    })
 
     # Check that produced kernel dict is valid
     assert load_dict(onedict_value(s.kernel_dict())) is not None
 
-    # Check if inconsistent units are detected
-    with pytest.raises(UnitsError):
-        s.value = ureg.Quantity(1., ureg.m)
-
-    # Check if default units are correctly applied
-    with cdu.override({"radiance": "W/km^2/sr/nm"}):
-        s = UniformRadianceSpectrum(value=1.)
-    assert s.value == ureg.Quantity(1., "W/km^2/sr/nm")
-
-    # Check if unit scaling is prorperly applied
+    # Check if unit scaling is properly applied
     with cdu.override({"radiance": "W/m^2/sr/nm"}):
-        s = UniformRadianceSpectrum(value=1.)
+        s = UniformSpectrum(quantity="radiance", value=1.)
     with kdu.override({"radiance": "kW/m^2/sr/nm"}):
         d = s.kernel_dict()
         assert np.allclose(d["spectrum"]["value"], 1e-3)
-
-    # Check if unit-enabled fields are correctly listed
-    assert UniformRadianceSpectrum._fields_with_units() == {"value": ureg.Unit("W/m^2/sr/nm")}
 
 
 def test_solar(mode_mono):

--- a/eradiate/util/tests/test_attrs.py
+++ b/eradiate/util/tests/test_attrs.py
@@ -30,8 +30,14 @@ def test_unit_support():
             default=ureg.Quantity(0, "m"),
         )
 
-    # -- This also tests if _fields_with_units() returns the expected value
-    assert MyClass._fields_with_units() == {
+    # -- This also tests if bound class methods return the expected value
+    assert MyClass._fields_supporting_units() == (
+        "field_distance",
+        "field_angle",
+        "field_no_quantity"
+    )
+
+    assert MyClass._fields_compatible_units() == {
         "field_distance": ureg.m,
         "field_angle": ureg.deg
     }
@@ -173,7 +179,7 @@ def test_unit_enabled():
         c = attrib_quantity()
 
     # Check that field metadata is correct
-    assert MyClass._fields_with_units() == {
+    assert MyClass._fields_compatible_units() == {
         "a": ureg.km,
         "b": ureg.s
     }

--- a/eradiate/util/units.py
+++ b/eradiate/util/units.py
@@ -10,9 +10,10 @@ __all__ = [
     "kernel_default_units"
 ]
 
+import enum
 from contextlib import contextmanager
 from copy import deepcopy
-import enum
+from functools import lru_cache
 
 import pint
 
@@ -85,6 +86,23 @@ class PhysicalQuantity(enum.Enum):
     TIME = enum.auto()
     TRANSMITTANCE = enum.auto()
     WAVELENGTH = enum.auto()
+
+    @classmethod
+    @lru_cache(maxsize=32)
+    def spectrum(cls):
+        """Return a tuple containing a subset of :class:`PhysicalQuantity`
+        members suitable for :class:`.Spectrum` initialisation. This function
+        caches its results for improved efficiency.
+        """
+        return (
+            cls.ALBEDO,
+            cls.COLLISION_COEFFICIENT,
+            cls.DIMENSIONLESS,
+            cls.IRRADIANCE,
+            cls.RADIANCE,
+            cls.REFLECTANCE,
+            cls.TRANSMITTANCE
+        )
 
     @classmethod
     def from_str(cls, s):


### PR DESCRIPTION
# Description

This PR refactors `Spectrum`. Changes are as follows:

- The convoluted type-based ` Spectrum` subclassing system has been replaced with a simpler attribute-based tracking system for attached quantities. The new system uses the updated enum-based physical quantity specification introduced by cbde014b53c169c49fc31d33f7e51a23761586b9. Extending this system (_i.e._ adding a new `Spectrum` subclass or a new physical quantity) is much simpler than before.
- The `Spectrum` class still has a `convert()` method which allows for simplified dict-based initialisation for fields where the expected physical quantity is known (_e.g._ `ConstantIllumination.radiance` can be initialised with `{"type": "uniform", "value": 1.0}` and the appropriate quantity and units will be automatically added).
- The updated `UniformSpectrum` type supports basic arithmetics, currently as a proof of concept.
- The `util.attrs` module has been updated: we now distinguish between fields supporting units (which can be applied units when initialised with a dictionary) and fields which also have specified compatible units (which will be automatically checked for unit correctness and applied defaults). This information is stored as field metadata. Note that only the first is required to implement unit support; the second is used upon attribute definition to automate converter and validator definition, but similar behaviour can be implemented manually.
- Classes expecting spectra have been updated to use this new infrastructure.
- Moved `validator_has_quantity` to `util.attrs`.
- Various docstrings were updated or refreshed.
- Updated tutorial notebooks accordingly.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is apropriately documented.
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license