### PR TITLE
Split SceneElementFactory into specialised factories

### DIFF
--- a/docs/_ext/ertdocs.py
+++ b/docs/_ext/ertdocs.py
@@ -18,11 +18,21 @@ from sphinx.util import nested_parse_with_titles
 from tinydb import TinyDB, Query
 from tinydb.storages import MemoryStorage
 
-from eradiate.scenes.core import SceneElementFactory
+from eradiate.scenes.atmosphere import AtmosphereFactory
+from eradiate.scenes.biosphere import BiosphereFactory
+from eradiate.scenes.illumination import IlluminationFactory
+from eradiate.scenes.measure import MeasureFactory
+from eradiate.scenes.spectra import SpectrumFactory
+from eradiate.scenes.lithosphere import SurfaceFactory
 from eradiate.scenes.atmosphere.radiative_properties.rad_profile import RadProfileFactory
 
 factory_classes = {
-    "SceneElementFactory": SceneElementFactory,
+    "AtmosphereFactory": AtmosphereFactory,
+    "BiosphereFactory": BiosphereFactory,
+    "IlluminationFactory": IlluminationFactory,
+    "MeasureFactory": MeasureFactory,
+    "SpectrumFactory": SpectrumFactory,
+    "SurfaceFactory": SurfaceFactory,
     "RadProfileFactory": RadProfileFactory
 }
 

--- a/docs/rst/developer_guide/factory_guide.rst
+++ b/docs/rst/developer_guide/factory_guide.rst
@@ -31,8 +31,9 @@ interface.
    Factories deriving from :class:`~eradiate.util.factory.BaseFactory` are not
    meant to be instantiated and only implement class methods.
 
-Class registration to factory objects is done using the :meth:`~eradiate.util.factory.register`
-class decorator (see _`Registering a class to a factory`).
+Class registration to factory objects is done using the
+:meth:`~eradiate.util.factory.register` class decorator (see
+_`Registering a class to a factory`).
 
 Using a factory created from this base class simply requires to import it and
 call its :meth:`~eradiate.util.factory.BaseFactory.create` class method with a
@@ -58,13 +59,13 @@ YAML or JSON fragments.
 
    The following code snippet instantiates a
    :class:`~eradiate.scenes.illumination.DirectionalIllumination` element
-   using its :factorykey:`SceneElementFactory::directional` factory name:
+   using its :factorykey:`IlluminationFactory::directional` factory name:
 
    .. code:: python
 
-       from eradiate.scenes.core import SceneElementFactory
+       from eradiate.scenes.illumination import IlluminationFactory
 
-       illumination = SceneElementFactory.create({
+       illumination = IlluminationFactory.create({
            "type": "directional",
            "irradiance": {"type": "uniform", "value": 1.0},
            "zenith": 30.0,
@@ -85,12 +86,12 @@ YAML or JSON fragments.
 
    Under the hood, this call creates a both
    :class:`~eradiate.scenes.illumination.DirectionalIllumination` and
-   :class:`~eradiate.scenes.spectral.UniformIrradianceSpectrum`: the former
+   :class:`~eradiate.scenes.spectra.UniformSpectrum`: the former
    is instantiated directly (either implicitly using
-   :meth:`~eradiate.util.factory.BaseFactory.create`, explicitly using the
-   :class:`~eradiate.scenes.illumination.DirectionalIllumination` constructor;
+   :meth:`~eradiate.util.factory.BaseFactory.create`, or explicitly using the
+   :class:`~eradiate.scenes.illumination.DirectionalIllumination` constructor);
    the latter is instantiated when the dictionary passed as the ``irradiance``
-   parameter is passed to :meth:`~eradiate.util.factory.BaseFactory.convert`.
+   parameter is forwarded to :meth:`~eradiate.util.factory.BaseFactory.convert`.
 
 Enabling a class for factory usage
 ----------------------------------
@@ -112,13 +113,16 @@ is automatic (mind, however, that the declaration order is critical, so the
 factory declaration must be placed before any call to its
 :meth:`~eradiate.util.factory.BaseFactory.register` decorator).
 
-If a factory and classes to be registered to it are placed in different modules,
-importing the factory won't necessary result in its register to be properly
-populated. For this reason, some factories can benefit from some additional
-registration code, which will make sure that modules containing classes to
-register will be discovered automatically when the factory will be imported.
-The :class:`~eradiate.scenes.core.SceneElementFactory` factory implements this
-kind of discovery system.
+.. note::
+
+   If a factory and classes to be registered to it are placed in different
+   modules, importing the factory won't necessary result in its register to be
+   properly populated. For this reason, some factories can benefit from some
+   additional registration code, which will make sure that modules containing
+   classes to register will be discovered automatically when the factory will be
+   imported. However, this can result in unreliable import sequence, since
+   discovery will inevitably introduce an import loop. For this reason,
+   automatic module discovery is not performed by Eradiate's factories.
 
 Documenting factories
 ---------------------
@@ -129,33 +133,20 @@ Printing a table of registered types
 A ``.. factorytable::`` directive prints a table mapping a factory's keys to
 the corresponding registered types:
 
-::
+.. tabbed:: ReST
 
-  .. factorytable::
-     :factory: eradiate.scenes.core.SceneElementFactory
+   .. code-block:: restructuredtext
+
+      .. factorytable::
+         :factory: IlluminationFactory
+
+.. tabbed:: Output
+
+   .. factorytable::
+        :factory: IlluminationFactory
 
 This will create a factory key mapping table for the
-:class:`eradiate.scenes.core.SceneElementFactory` class.
-
-A ``sections`` option groups registered classes with respect to the module where
-they are defined:
-
-::
-
-  .. factorytable::
-     :factory: eradiate.scenes.core.SceneElementFactory
-     :sections:
-
-A ``modules`` option restricts the table to registered classes lying in a
-specified set of modules and their submodules:
-
-::
-
-  .. factorytable::
-       :factory: eradiate.scenes.core.SceneElementFactory
-       :modules: eradiate.scenes.atmosphere
-
-Multiple modules can be passed as a comma-separated list.
+:class:`eradiate.scenes.illumination.IlluminationFactory` class.
 
 Referencing registered classes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -163,14 +154,28 @@ Referencing registered classes
 A registered class can be referenced by its factory key using the ``:factorykey:``
 role.
 
-::
+.. tabbed:: ReST
 
-  The directional illumination scene element [:factorykey:`directional`] ...
+   .. code-block:: restructuredtext
+
+      The directional illumination scene element [:factorykey:`directional`] ...
+
+.. tabbed:: Output
+
+   The directional illumination scene element [:factorykey:`directional`] ...
 
 This role takes a single argument, interpreted as the requested factory key.
 If multiple factories use the same key to reference different types, the
 referenced factory can be specified as a prefix, and using a ``::`` separator:
 
-::
+.. tabbed:: ReST
 
-  :factorykey:`SceneElementFactory::directional`
+   .. code-block:: restructuredtext
+
+      The directional illumination scene element
+      [:factorykey:`IlluminationFactory::directional`] ...
+
+.. tabbed:: Output
+
+   The directional illumination scene element
+   [:factorykey:`IlluminationFactory::directional`] ...

--- a/eradiate/scenes/atmosphere/__init__.py
+++ b/eradiate/scenes/atmosphere/__init__.py
@@ -1,12 +1,12 @@
 """Atmosphere-related scene generation facilities.
 
-.. admonition:: Registered factory members
+.. admonition:: Registered factory members [:class:`.AtmosphereFactory`]
     :class: hint
 
     .. factorytable::
-       :factory: SceneElementFactory
-       :modules: eradiate.scenes.atmosphere
+       :factory: AtmosphereFactory
 """
 
+from .base import AtmosphereFactory
 from .heterogeneous import HeterogeneousAtmosphere
 from .homogeneous import HomogeneousAtmosphere

--- a/eradiate/scenes/atmosphere/base.py
+++ b/eradiate/scenes/atmosphere/base.py
@@ -13,6 +13,7 @@ from ...util.attrs import (
     validator_is_positive,
     validator_units_compatible
 )
+from ...util.factory import BaseFactory
 from ...util.units import config_default_units as cdu
 from ...util.units import ureg
 
@@ -138,3 +139,17 @@ class Atmosphere(SceneElement, ABC):
             kernel_dict[f"{self.id}"] = self.shapes(ref=True)[f"shape_{self.id}"]
 
         return kernel_dict
+
+
+class AtmosphereFactory(BaseFactory):
+    """This factory constructs objects whose classes are derived from
+    :class:`Atmosphere`.
+
+    .. admonition:: Registered factory members
+       :class: hint
+
+       .. factorytable::
+          :factory: AtmosphereFactory
+    """
+    _constructed_type = Atmosphere
+    registry = {}

--- a/eradiate/scenes/atmosphere/heterogeneous.py
+++ b/eradiate/scenes/atmosphere/heterogeneous.py
@@ -7,9 +7,8 @@ import attr
 import numpy as np
 import xarray as xr
 
-from .base import Atmosphere
+from .base import Atmosphere, AtmosphereFactory
 from .radiative_properties.rad_profile import RadProfile, RadProfileFactory
-from ..core import SceneElementFactory
 from ...util.attrs import validator_is_file
 from ...util.units import kernel_default_units as kdu, ureg
 
@@ -93,7 +92,7 @@ def _dataarray_to_ndarray(value):
         return value
 
 
-@SceneElementFactory.register("heterogeneous")
+@AtmosphereFactory.register("heterogeneous")
 @attr.s
 class HeterogeneousAtmosphere(Atmosphere):
     r"""Heterogeneous atmosphere scene element

--- a/eradiate/scenes/atmosphere/homogeneous.py
+++ b/eradiate/scenes/atmosphere/homogeneous.py
@@ -3,16 +3,15 @@
 import attr
 
 import eradiate
-from .base import Atmosphere
+from .base import Atmosphere, AtmosphereFactory
 from .radiative_properties.rayleigh import compute_sigma_s_air
-from ..core import SceneElementFactory
-from ..spectra import Spectrum, UniformSpectrum
+from ..spectra import Spectrum, SpectrumFactory, UniformSpectrum
 from ...util.attrs import converter_or_auto, validator_has_quantity, validator_or_auto
 from ...util.collections import onedict_value
 from ...util.units import ureg
 
 
-@SceneElementFactory.register("homogeneous")
+@AtmosphereFactory.register("homogeneous")
 @attr.s()
 class HomogeneousAtmosphere(Atmosphere):
     """Homogeneous atmosphere scene element [:factorykey:`homogeneous`].
@@ -32,21 +31,21 @@ class HomogeneousAtmosphere(Atmosphere):
         function. Default: ``"auto"``.
 
         Can be initialised with a dictionary processed by
-        :class:`.SceneElementFactory`.
+        :class:`.SpectrumFactory`.
 
     ``sigma_a`` (:class:`~eradiate.scenes.spectra.Spectrum`):
         Atmosphere absorption coefficient value.
         Default: 0 cdu[collision_coefficient] (no absorption).
 
         Can be initialised with a dictionary processed by
-        :class:`.SceneElementFactory`.
+        :class:`.SpectrumFactory`.
 
     """
 
     sigma_s = attr.ib(
         default="auto",
         converter=converter_or_auto(
-            Spectrum.converter("collision_coefficient")
+            SpectrumFactory.converter("collision_coefficient")
         ),
         validator=validator_or_auto(
             attr.validators.instance_of(Spectrum),
@@ -56,7 +55,7 @@ class HomogeneousAtmosphere(Atmosphere):
 
     sigma_a = attr.ib(
         default=0.,
-        converter=Spectrum.converter("collision_coefficient"),
+        converter=SpectrumFactory.converter("collision_coefficient"),
         validator=[attr.validators.instance_of(Spectrum),
                    validator_has_quantity("collision_coefficient")]
     )

--- a/eradiate/scenes/atmosphere/radiative_properties/__init__.py
+++ b/eradiate/scenes/atmosphere/radiative_properties/__init__.py
@@ -1,13 +1,11 @@
 """Atmospheric radiative properties calculation package.
 
+.. admonition:: Registered factory members [:class:`.RadProfileFactory`]
+   :class: hint
 
+   .. factorytable::
+      :factory: RadProfileFactory
 """
 
-
-
-
-
-
-
-
-
+from .rad_profile import RadProfileFactory
+from .rad_profile import ArrayRadProfile, US76ApproxRadProfile

--- a/eradiate/scenes/biosphere.py
+++ b/eradiate/scenes/biosphere.py
@@ -1,30 +1,46 @@
 """Biosphere-related scene generation facilities.
 
-.. admonition:: Factory-enabled scene elements
+.. admonition:: Registered factory members [:class:`BiosphereFactory`]
     :class: hint
 
     .. factorytable::
-       :factory: SceneElementFactory
-       :modules: eradiate.scenes.biosphere
+       :factory: BiosphereFactory
 """
 
 import aabbtree
 import attr
 import numpy as np
 
-from .core import SceneElement, SceneElementFactory
-from .spectra import Spectrum
+from .core import SceneElement
+from .spectra import Spectrum, SpectrumFactory
 from ..util.attrs import (
     attrib_quantity,
     validator_has_len,
     validator_has_quantity,
     validator_is_positive
 )
-from ..util.units import config_default_units as cdu, ureg
+from ..util.factory import BaseFactory
+from ..util.units import config_default_units as cdu
 from ..util.units import kernel_default_units as kdu
+from ..util.units import ureg
 
 
-@SceneElementFactory.register(name="homogeneous_discrete_canopy")
+class BiosphereFactory(BaseFactory):
+    """This factory constructs objects whose classes are derived from
+    :class:`.SceneElement`.
+
+    .. admonition:: Registered factory members
+       :class: hint
+
+       .. factorytable::
+          :factory: BiosphereFactory
+    """
+
+    _constructed_type = SceneElement
+    registry = {}
+
+
+@BiosphereFactory.register(name="homogeneous_discrete_canopy")
 @attr.s
 class HomogeneousDiscreteCanopy(SceneElement):
     """A generator for the `homogenous discrete canopy used in the RAMI benchmark
@@ -181,7 +197,7 @@ class HomogeneousDiscreteCanopy(SceneElement):
 
     leaf_reflectance = attr.ib(
         default=0.5,
-        converter=Spectrum.converter("reflectance"),
+        converter=SpectrumFactory.converter("reflectance"),
         validator=[
             attr.validators.instance_of(Spectrum),
             validator_has_quantity("reflectance")
@@ -190,7 +206,7 @@ class HomogeneousDiscreteCanopy(SceneElement):
 
     leaf_transmittance = attr.ib(
         default=0.5,
-        converter=Spectrum.converter("transmittance"),
+        converter=SpectrumFactory.converter("transmittance"),
         validator=[
             attr.validators.instance_of(Spectrum),
             validator_has_quantity("transmittance")

--- a/eradiate/scenes/core.py
+++ b/eradiate/scenes/core.py
@@ -116,9 +116,8 @@ class SceneElement(ABC):
 
     .. note::
 
-        This class is designed to integrate with the :class:`SceneElementFactory`
-        class. See the corresponding documentation for a list of factory-enabled
-        scene element classes.
+        This class is designed to integrate with factory classes derived from
+        :class:`.Factory`.
 
     .. rubric:: Constructor arguments / instance attributes
 
@@ -144,41 +143,3 @@ class SceneElement(ABC):
         """
         # TODO: return a KernelDict
         pass
-
-
-class SceneElementFactory(BaseFactory):
-    """This factory constructs objects whose classes are derived from
-    :class:`SceneElement`. For optimal use, it needs to discover registered
-    classes in modules listed in its :attr:`_modules` class attribute.
-
-    .. admonition:: Registered factory members
-        :class: hint
-
-        .. factorytable::
-           :factory: SceneElementFactory
-           :sections:
-    """
-
-    _constructed_type = SceneElement
-    registry = {}
-
-    #: List of submodules where to look for registered classes
-    _modules = [
-        "eradiate.scenes.atmosphere",
-        "eradiate.scenes.biosphere",
-        "eradiate.scenes.illumination",
-        "eradiate.scenes.lithosphere",
-        "eradiate.scenes.measure",
-        "eradiate.scenes.spectra"
-    ]
-
-    @classmethod
-    def _discover(cls):
-        """Import submodules containing classes to be automatically added to
-        :class:`SceneElementFactory`'s registry."""
-        for module_name in cls._modules:
-            importlib.import_module(module_name)
-
-
-# Trigger factory module discovery
-SceneElementFactory._discover()

--- a/eradiate/scenes/illumination.py
+++ b/eradiate/scenes/illumination.py
@@ -1,24 +1,24 @@
 """Illumination-related scene generation facilities.
 
-.. admonition:: Registered factory members
-    :class: hint
+.. admonition:: Registered factory members [:class:`IlluminationFactory`]
+   :class: hint
 
-    .. factorytable::
-       :factory: SceneElementFactory
-       :modules: eradiate.scenes.illumination
+   .. factorytable::
+      :factory: IlluminationFactory
 """
 
 from abc import ABC
 
 import attr
 
-from .core import SceneElement, SceneElementFactory
-from .spectra import SolarIrradianceSpectrum, Spectrum
+from .core import SceneElement
+from .spectra import SolarIrradianceSpectrum, Spectrum, SpectrumFactory
 from ..util.attrs import (
     attrib_quantity,
     validator_has_quantity,
     validator_is_positive
 )
+from ..util.factory import BaseFactory
 from ..util.frame import angles_to_direction
 from ..util.units import config_default_units as cdu
 from ..util.units import ureg
@@ -37,7 +37,21 @@ class Illumination(SceneElement, ABC):
     )
 
 
-@SceneElementFactory.register(name="constant")
+class IlluminationFactory(BaseFactory):
+    """This factory constructs objects whose classes are derived from
+    :class:`Illumination`.
+
+    .. admonition:: Registered factory members
+       :class: hint
+
+       .. factorytable::
+          :factory: IlluminationFactory
+    """
+    _constructed_type = Illumination
+    registry = {}
+
+
+@IlluminationFactory.register(name="constant")
 @attr.s
 class ConstantIllumination(Illumination):
     """Constant illumination scene element [:factorykey:`constant`].
@@ -54,7 +68,7 @@ class ConstantIllumination(Illumination):
 
     radiance = attr.ib(
         default=1.,
-        converter=Spectrum.converter("radiance"),
+        converter=SpectrumFactory.converter("radiance"),
         validator=[attr.validators.instance_of(Spectrum),
                    validator_has_quantity("radiance")]
     )
@@ -68,7 +82,7 @@ class ConstantIllumination(Illumination):
         }
 
 
-@SceneElementFactory.register(name="directional")
+@IlluminationFactory.register(name="directional")
 @attr.s
 class DirectionalIllumination(Illumination):
     """Directional illumination scene element [:factorykey:`directional`].
@@ -96,7 +110,7 @@ class DirectionalIllumination(Illumination):
         Default: :class:`~eradiate.scenes.spectra.SolarIrradianceSpectrum`.
 
         Can be initialised with a dictionary processed by
-        :class:`.SceneElementFactory`.
+        :meth:`.SpectrumFactory.convert`.
     """
 
     zenith = attrib_quantity(
@@ -113,7 +127,7 @@ class DirectionalIllumination(Illumination):
 
     irradiance = attr.ib(
         factory=SolarIrradianceSpectrum,
-        converter=Spectrum.converter("irradiance"),
+        converter=SpectrumFactory.converter("irradiance"),
         validator=[attr.validators.instance_of(Spectrum),
                    validator_has_quantity("irradiance")]
     )

--- a/eradiate/scenes/lithosphere.py
+++ b/eradiate/scenes/lithosphere.py
@@ -1,22 +1,22 @@
 """Lithosphere-related scene generation facilities.
 
-.. admonition:: Registered factory members
-    :class: hint
+.. admonition:: Registered factory members [:class:`SurfaceFactory`]
+   :class: hint
 
-    .. factorytable::
-       :factory: SceneElementFactory
-       :modules: eradiate.scenes.lithosphere
+   .. factorytable::
+      :factory: SurfaceFactory
 """
 
 from abc import ABC, abstractmethod
 
 import attr
 
-from .core import SceneElement, SceneElementFactory
-from .spectra import Spectrum
+from .core import SceneElement
+from .spectra import Spectrum, SpectrumFactory
 from ..util.attrs import (
     attrib_quantity, validator_has_quantity, validator_is_positive
 )
+from ..util.factory import BaseFactory
 from ..util.units import config_default_units as cdu
 from ..util.units import kernel_default_units as kdu
 from ..util.units import ureg
@@ -99,7 +99,21 @@ class Surface(SceneElement, ABC):
         return kernel_dict
 
 
-@SceneElementFactory.register(name="lambertian")
+class SurfaceFactory(BaseFactory):
+    """This factory constructs objects whose classes are derived from
+    :class:`Surface`.
+
+    .. admonition:: Registered factory members
+       :class: hint
+
+       .. factorytable::
+          :factory: SurfaceFactory
+    """
+    _constructed_type = Surface
+    registry = {}
+
+
+@SurfaceFactory.register(name="lambertian")
 @attr.s
 class LambertianSurface(Surface):
     """Lambertian surface scene element [:factorykey:`lambertian`].
@@ -114,12 +128,12 @@ class LambertianSurface(Surface):
         Reflectance spectrum. Default: 0.5.
 
         Can be initialised with a dictionary processed by
-        :class:`.SceneElementFactory`.
+        :class:`.SpectrumFactory`.
     """
 
     reflectance = attr.ib(
         default=0.5,
-        converter=Spectrum.converter("reflectance"),
+        converter=SpectrumFactory.converter("reflectance"),
         validator=[attr.validators.instance_of(Spectrum),
                    validator_has_quantity("reflectance")]
     )
@@ -133,7 +147,7 @@ class LambertianSurface(Surface):
         }
 
 
-@SceneElementFactory.register(name="black")
+@SurfaceFactory.register(name="black")
 @attr.s
 class BlackSurface(Surface):
     """Black surface scene element [:factorykey:`black`].
@@ -152,7 +166,7 @@ class BlackSurface(Surface):
         }
 
 
-@SceneElementFactory.register(name="rpv")
+@SurfaceFactory.register(name="rpv")
 @attr.s
 class RPVSurface(Surface):
     """RPV surface scene element [:factorykey:`rpv`].

--- a/eradiate/scenes/measure.py
+++ b/eradiate/scenes/measure.py
@@ -1,25 +1,25 @@
 """Measurement-related scene generation facilities.
 
-.. admonition:: Registered factory members
+.. admonition:: Registered factory members [:class:`MeasureFactory`]
     :class: hint
 
     .. factorytable::
-       :factory: SceneElementFactory
-       :modules: eradiate.scenes.measure
+       :factory: MeasureFactory
 """
 from abc import ABC
 from abc import abstractmethod
+from copy import deepcopy
 
 import attr
-from copy import deepcopy
 import numpy as np
 
 import eradiate.kernel
-from .core import SceneElement, SceneElementFactory
+from .core import SceneElement
 from ..util import always_iterable
 from ..util.attrs import (
     attrib_quantity, validator_has_len, validator_is_positive
 )
+from ..util.factory import BaseFactory
 from ..util.frame import angles_to_direction, spherical_to_cartesian
 from ..util.units import config_default_units as cdu
 from ..util.units import kernel_default_units as kdu
@@ -66,7 +66,21 @@ class Measure(SceneElement, ABC):
         pass
 
 
-@SceneElementFactory.register(name="distant")
+class MeasureFactory(BaseFactory):
+    """This factory constructs objects whose classes are derived from
+    :class:`Measure`.
+
+    .. admonition:: Registered factory members
+       :class: hint
+
+       .. factorytable::
+          :factory: MeasureFactory
+    """
+    _constructed_type = Measure
+    registry = {}
+
+
+@MeasureFactory.register(name="distant")
 @attr.s
 class DistantMeasure(Measure):
     """Distant measure scene element [:factorykey:`distant`].
@@ -159,7 +173,7 @@ class DistantMeasure(Measure):
         }
 
 
-@SceneElementFactory.register(name="perspective")
+@MeasureFactory.register(name="perspective")
 @attr.s
 class PerspectiveCameraMeasure(Measure):
     """Perspective camera scene element [:factorykey:`perspective`].
@@ -300,7 +314,7 @@ class PerspectiveCameraMeasure(Measure):
         }
 
 
-@SceneElementFactory.register(name="radiancemeter_hsphere")
+@MeasureFactory.register(name="radiancemeter_hsphere")
 @attr.s
 class RadianceMeterHsphereMeasure(Measure):
     """Hemispherical radiancemeter measure scene element
@@ -445,7 +459,7 @@ class RadianceMeterHsphereMeasure(Measure):
         spp_sum = np.sum(sensor_spp)
 
         # multiply each sensor's result by its relative SPP and sum all results
-        results = np.dot(sensors.transpose(), sensor_spp/spp_sum).transpose()
+        results = np.dot(sensors.transpose(), sensor_spp / spp_sum).transpose()
 
         return np.reshape(results, (len(self._zenith_angles), len(self._azimuth_angles)))
 
@@ -525,7 +539,7 @@ class RadianceMeterHsphereMeasure(Measure):
 
 
 @attr.s
-@SceneElementFactory.register(name="radiancemeter_pplane")
+@MeasureFactory.register(name="radiancemeter_pplane")
 class RadianceMeterPPlaneMeasure(Measure):
     """Distant principal plane measure scene generation helper [:factorykey:`radiancemeter_pplane`].
 
@@ -664,7 +678,7 @@ class RadianceMeterPPlaneMeasure(Measure):
         spp_sum = np.sum(sensor_spp)
 
         # multiply each sensor's result by its relative SPP and sum all results
-        results = np.dot(sensors.transpose(), sensor_spp/spp_sum).transpose()
+        results = np.dot(sensors.transpose(), sensor_spp / spp_sum).transpose()
         print(results)
 
         return np.reshape(results, (len(self._zenith_angles), 2))

--- a/eradiate/scenes/tests/test_core.py
+++ b/eradiate/scenes/tests/test_core.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 
 import eradiate.kernel
-from eradiate.scenes.core import KernelDict, SceneElement, SceneElementFactory
+from eradiate.scenes.core import KernelDict, SceneElement
 from eradiate.scenes.illumination import DirectionalIllumination
 from eradiate.util.attrs import (
     attrib_quantity, validator_has_len, validator_is_number,
@@ -136,31 +136,3 @@ def test_scene_element(mode_mono):
             "irradiance": 1.0,
             "unexpected_param": 0
         })
-
-
-def test_factory():
-    # We expect that correct object specification will yield an object
-    assert SceneElementFactory.create({"type": "directional", "zenith": 45.}) is not None
-
-    # We expect that incorrect object specification will raise
-    # (here, the 'direction' field is not part of the expected parameters)
-    with pytest.raises(TypeError):
-        SceneElementFactory.create({"type": "directional", "direction": [0, -1, -1]})
-
-    # We expect that an empty dict will raise
-    with pytest.raises(KeyError):
-        SceneElementFactory.create({})
-
-    # We expect that an unregistered 'type' will raise
-    with pytest.raises(ValueError):
-        SceneElementFactory.create({"type": "dzeiaticional"})
-
-    # Test converter
-    assert isinstance(
-        SceneElementFactory.convert({"type": "directional", "zenith": 45.}),
-        DirectionalIllumination
-    )
-    assert isinstance(
-        SceneElementFactory.convert(DirectionalIllumination()),
-        DirectionalIllumination
-    )

--- a/eradiate/scenes/tests/test_measure.py
+++ b/eradiate/scenes/tests/test_measure.py
@@ -82,8 +82,6 @@ def test_pplane_orientation(mode_mono):
     Once with a hemispherical view and once with a pplane view. Select the values corresponding to
     the pplane from the hemispherical dataset and compare with the pplane data."""
 
-    from eradiate.scenes.core import SceneElementFactory, KernelDict
-
     measure_config = {
         "zenith_res": 9,
         "origin": [0, 0, 1],

--- a/eradiate/scenes/tests/test_spectra.py
+++ b/eradiate/scenes/tests/test_spectra.py
@@ -3,7 +3,7 @@ import pytest
 
 import eradiate
 from eradiate.scenes.spectra import (
-    SolarIrradianceSpectrum, Spectrum, UniformSpectrum
+    SolarIrradianceSpectrum, SpectrumFactory, UniformSpectrum
 )
 from eradiate.util.collections import onedict_value
 from eradiate.util.exceptions import UnitsError
@@ -14,18 +14,18 @@ from eradiate.util.units import kernel_default_units as kdu
 
 def test_converter(mode_mono):
     # Check if dicts are correctly processed
-    s = Spectrum.converter("radiance")({"type": "uniform"})
+    s = SpectrumFactory.converter("radiance")({"type": "uniform"})
     assert s == UniformSpectrum(quantity="radiance", value=1.0)
-    s = Spectrum.converter("irradiance")({"type": "uniform"})
+    s = SpectrumFactory.converter("irradiance")({"type": "uniform"})
     assert s == UniformSpectrum(quantity="irradiance", value=1.0)
 
     # Check if floats and quantities are correctly processed
-    s = Spectrum.converter("radiance")(1.0)
+    s = SpectrumFactory.converter("radiance")(1.0)
     assert s == UniformSpectrum(quantity="radiance", value=1.0)
-    s = Spectrum.converter("radiance")(ureg.Quantity(1e6, "W/km^2/sr/nm"))
+    s = SpectrumFactory.converter("radiance")(ureg.Quantity(1e6, "W/km^2/sr/nm"))
     assert s == UniformSpectrum(quantity="radiance", value=1.0)
     with pytest.raises(UnitsError):
-        Spectrum.converter("irradiance")(ureg.Quantity(1, "W/m^2/sr/nm"))
+        SpectrumFactory.converter("irradiance")(ureg.Quantity(1, "W/m^2/sr/nm"))
 
 
 def test_uniform(mode_mono):

--- a/eradiate/solvers/onedim/app.py
+++ b/eradiate/solvers/onedim/app.py
@@ -14,8 +14,12 @@ import xarray as xr
 
 import eradiate.kernel
 from .runner import OneDimRunner
-from ...scenes.core import KernelDict, SceneElementFactory
-from ...scenes.measure import RadianceMeterHsphereMeasure, RadianceMeterPPlaneMeasure
+from ...scenes.atmosphere import AtmosphereFactory
+from ...scenes.core import KernelDict
+from ...scenes.illumination import IlluminationFactory
+from ...scenes.lithosphere import SurfaceFactory
+from ...scenes.measure import MeasureFactory, RadianceMeterHsphereMeasure, \
+    RadianceMeterPPlaneMeasure
 from ...util import ensure_array
 from ...util import plot as ertplt
 from ...util import xarray as ertxr
@@ -298,14 +302,15 @@ class OneDimSolverApp(ConfigObject):
 
         with cdu.override({"length": "km"}), kdu.override({"length": "km"}):
                 # Set illumination
-                self._elements["illumination"] = SceneElementFactory.create(
-                    self.config["illumination"])
+                self._elements["illumination"] = \
+                    IlluminationFactory.create(self.config["illumination"])
 
                 # Set atmosphere
                 config_atmosphere = config.get("atmosphere", None)
 
                 if config_atmosphere is not None:
-                    self._elements["atmosphere"] = SceneElementFactory.create(config_atmosphere)
+                    self._elements["atmosphere"] = \
+                        AtmosphereFactory.create(config_atmosphere)
 
                 # Set surface
                 atmosphere = self._elements.get("atmosphere", None)
@@ -317,7 +322,7 @@ class OneDimSolverApp(ConfigObject):
                         )
                     config["surface"]["width"] = atmosphere.kernel_width
 
-                self._elements["surface"] = SceneElementFactory.create(config["surface"])
+                self._elements["surface"] = SurfaceFactory.create(config["surface"])
 
                 # Set measure
                 for config_measure in self.config["measure"]:
@@ -351,8 +356,8 @@ class OneDimSolverApp(ConfigObject):
                     config_measure["hemisphere"] = "back"
                     # TODO: warn when overriding parameters set by user
 
-                    self._elements[config_measure["id"]] = SceneElementFactory.create(
-                        config_measure)
+                    self._elements[config_measure["id"]] = \
+                        MeasureFactory.create(config_measure)
                     sensor_info = self._elements[config_measure["id"]].sensor_info()
                     for sensor_id, sensor_spp in sensor_info:
                         self._measure_registry.insert(

--- a/eradiate/util/factory.py
+++ b/eradiate/util/factory.py
@@ -64,7 +64,7 @@ class BaseFactory:
             .. code:: python
 
                 # Note that the register() decorator is applied *after* attr.s()
-                @SceneElementFactory.register(name="constant")
+                @IlluminationFactory.register(name="constant")
                 @attr.s
                 class ConstantIllumination(SceneElement):
                     radiance = attr.ib(


### PR DESCRIPTION
# Description

This PR closes eradiate/eradiate-issues#25. Changes are as follows:

- Split `SceneElementFactory` into specialised factories
- Transferred Spectrum.converter() to `SpectrumFactory`
- Updated docstrings and factory guide

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is apropriately documented.
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license