### PR TITLE
Added support to new us76_u86_4 datasets and throw away usa_mls

### DIFF
--- a/eradiate/data/absorption_spectra.py
+++ b/eradiate/data/absorption_spectra.py
@@ -2,42 +2,227 @@
 
 **Category ID**: ``absorption_cross_section_spectrum``
 
+.. admonition:: Note
+
+   In the table below, wavenumber ranges are exact whereas wavelength ranges are approximative (numbers are rounded):w
+
+
 .. list-table:: Available data sets and corresponding identifiers
    :widths: 1 1 1 1
    :header-rows: 1
 
    * - Data set ID
      - Reference
-     - Spectral range [cm^-1]
-     - Spectral range [nm]
-   * - ``usa_mls-fullrange``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/usa_mls.py``
-     - [18000, 19000]
-     - [~527, ~555]
-   * - ``usa_mls-fullrange``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/usa_mls.py``
-     - [4000, 25711]
-     - [~389, 2500]
-   * - ``us76_u86_4-fullrange``
+     - Wavenumber range [cm^-1]
+     - Wavelength range [nm]
+   * - ``spectra-us76_u86_4-4000_25711``
      - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
-     - [4000, 25711]
-     - [~389, 2500]
+     - [4000.00413, 25710.993092]
+     - [389, 2500]
+   * - ``spectra-us76_u86_4-4000_4500``
+     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+     - [4000, 4500]
+     - [2222, 2500]
+   * - ``spectra-us76_u86_4-4500_5000``
+     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+     - [4500, 5000]
+     - [2000, 2222]
+   * - ``spectra-us76_u86_4-5000_5500``
+     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+     - [5000, 5500]
+     - [1818, 2000]
+   * - ``spectra-us76_u86_4-5500_6000``
+     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+     - [5500, 6000]
+     - [1666, 1818]
+   * - ``spectra-us76_u86_4-6000_6500``
+     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+     - [6000, 6500]
+     - [1538, 1666]
+   * - ``spectra-us76_u86_4-6500_7000``
+     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+     - [6500, 7000]
+     - [1428, 1538]
+   * - ``spectra-us76_u86_4-7000_7500``
+     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+     - [7000, 7500]
+     - [1333, 1428]
+   * - ``spectra-us76_u86_4-7500_8000``
+     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+     - [7500, 8000]
+     - [1250, 1333]
+   * - ``spectra-us76_u86_4-8000_8500``
+     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+     - [8000, 8500]
+     - [1176, 1250]
+   * - ``spectra-us76_u86_4-8500_9000``
+     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+     - [8500, 9000]
+     - [1111, 1176]
+   * - ``spectra-us76_u86_4-9000_9500``
+     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+     - [9000, 9500]
+     - [1052, 1111]
+   * - ``spectra-us76_u86_4-9500_10000``
+     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+     - [9500, 10000]
+     - [1000, 1052]
+   * - ``spectra-us76_u86_4-10000_10500``
+     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+     - [10000, 10500]
+     - [952, 1000]
+   * - ``spectra-us76_u86_4-10500_11000``
+     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+     - [10500, 11000]
+     - [909, 952]
+   * - ``spectra-us76_u86_4-11000_11500``
+     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+     - [11000, 11500]
+     - [869, 909]
+   * - ``spectra-us76_u86_4-11500_12000``
+     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+     - [11500, 12000]
+     - [833, 869]
+   * - ``spectra-us76_u86_4-12000_12500``
+     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+     - [12000, 12500]
+     - [800, 833]
+   * - ``spectra-us76_u86_4-12500_13000``
+     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+     - [12500, 13000]
+     - [769, 800]
+   * - ``spectra-us76_u86_4-13000_13500``
+     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+     - [13000, 13500]
+     - [740, 769]
+   * - ``spectra-us76_u86_4-13500_14000``
+     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+     - [13500, 14000]
+     - [714, 740]
+   * - ``spectra-us76_u86_4-14000_14500``
+     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+     - [14000, 14500]
+     - [689, 714]
+   * - ``spectra-us76_u86_4-14500_15000``
+     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+     - [14500, 15000]
+     - [666, 689]
+   * - ``spectra-us76_u86_4-15000_15500``
+     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+     - [15000, 15500]
+     - [645, 666]
+   * - ``spectra-us76_u86_4-15500_16000``
+     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+     - [15500, 16000]
+     - [625, 645]
+   * - ``spectra-us76_u86_4-16000_16500``
+     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+     - [16000, 16500]
+     - [606, 625]
+   * - ``spectra-us76_u86_4-16500_17000``
+     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+     - [16500, 17000]
+     - [588, 606]
+   * - ``spectra-us76_u86_4-17000_17500``
+     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+     - [17000, 17500]
+     - [571, 588]
+   * - ``spectra-us76_u86_4-17500_18000``
+     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+     - [17500, 18000]
+     - [555, 571]
+   * - ``spectra-us76_u86_4-18000_18500``
+     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+     - [18000, 18500]
+     - [540, 555]
+   * - ``spectra-us76_u86_4-18500_19000``
+     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+     - [18500, 19000]
+     - [526, 540]
+   * - ``spectra-us76_u86_4-19000_19500``
+     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+     - [19000, 19500]
+     - [512, 526]
+   * - ``spectra-us76_u86_4-19500_20000``
+     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+     - [19500, 20000]
+     - [500, 512]
+   * - ``spectra-us76_u86_4-20000_20500``
+     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+     - [20000, 20500]
+     - [487, 500]
+   * - ``spectra-us76_u86_4-20500_21000``
+     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+     - [20500, 21000]
+     - [476, 487]
+   * - ``spectra-us76_u86_4-21000_21500``
+     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+     - [21000, 21500]
+     - [465, 476]
+   * - ``spectra-us76_u86_4-21500_22000``
+     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+     - [21500, 22000]
+     - [454, 465]
+   * - ``spectra-us76_u86_4-22000_22500``
+     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+     - [22000, 22500]
+     - [444, 454]
+   * - ``spectra-us76_u86_4-22500_23000``
+     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+     - [22500, 23000]
+     - [434, 444]
+   * - ``spectra-us76_u86_4-23000_23500``
+     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+     - [23000, 23500]
+     - [425, 434]
+   * - ``spectra-us76_u86_4-23500_24000``
+     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+     - [23500, 24000]
+     - [416, 425]
+   * - ``spectra-us76_u86_4-24000_24500``
+     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+     - [24000, 24500]
+     - [408, 416]
+   * - ``spectra-us76_u86_4-24500_25000``
+     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+     - [24500, 25000]
+     - [400, 408]
+   * - ``spectra-us76_u86_4-25000_25500``
+     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+     - [25000, 25500]
+     - [392, 400]
+   * - ``spectra-us76_u86_4-25500_25711``
+     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+     - [25500, 25711]
+     - [389, 392]
 """
 
+import numpy as np
+import pathlib
 import xarray as xr
 
 from .core import DataGetter
 from ..util.presolver import PathResolver
+from ..util.units import ureg
 
 _presolver = PathResolver()
+
+_US76_U86_4_PATH = "spectra/absorption/us76_u86_4"
+_US76_U86_4_PREF = "spectra-us76_u86_4"
 
 
 class _AbsorptionGetter(DataGetter):
     PATHS = {
-        "usa_mls-narrowrange": "spectra/absorption/usa_mls/narrowrange/*.nc",
-        "usa_mls-fullrange": "spectra/absorption/usa_mls/fullrange/*.nc",
-        "us76_u86_4-fullrange": "spectra/absorption/us76_u86_4/fullrange/*.nc",
-        "test": "tests/absorption/us76_u86_4/*.nc"
+        "spectra-us76_u86_4-4000_25711": "spectra/absorption/us76_u86_4/"
+                                         "spectra-us76_u86_4-4000_25711/*.nc",
+        **{f"{_US76_U86_4_PREF}-{x}_{x + 500}": f"{_US76_U86_4_PATH}/"
+                                                f"{_US76_U86_4_PREF}-{x}_"
+                                                f"{x + 500}/*.nc"
+           for x in np.arange(4000, 25500, 500)},
+        f"{_US76_U86_4_PREF}-25500_25711": f"{_US76_U86_4_PATH}/"
+                                           f"{_US76_U86_4_PREF}-"
+                                           f"25500_25711/*.nc",
+        "test": "tests/absorption/us76_u86_4/*.nc",
     }
 
     @classmethod
@@ -59,3 +244,37 @@ class _AbsorptionGetter(DataGetter):
             result[id] = bool(len(list(paths)))
 
         return result
+
+
+@ureg.wraps(ret=None, args=("cm^-1", None, None), strict=False)
+def available_datasets(wavenumber, absorber="us76_u86_4", engine="spectra"):
+    """Returns the available datasets corresponding to a given wavenumber,
+    absorber and absorption cross section engine.
+
+    Parameter ``wavenumber`` (:class:`~pint.Quantity`):
+        Wavenumber value [cm^-1].
+
+    Parameter ``absorber`` (str):
+        Absorber name.
+
+    Parameter ``engine`` (str):
+        Engine used to compute the absorption cross sections.
+
+    Returns → list or ``None``:
+        Available dataset ids.
+    """
+    if absorber == "us76_u86_4":
+        if engine != "spectra":
+            raise ValueError(f"engine {engine} is not supported.")
+        absorber_dir = pathlib.Path(f"resources/data/spectra/absorption/{absorber}")
+        subdirs = [f for f in absorber_dir.glob("*") if f.is_dir() and not f.name.startswith(".")]
+        available = []
+        for subdir in subdirs:
+            _engine, _absorber, w_range = tuple(subdir.name.split("-"))
+            if _absorber == absorber and _engine == engine:
+                w_min, w_max = w_range.split("_")
+                if float(w_min) <= wavenumber < float(w_max):
+                    available.append(subdir.name)
+        return available if len(available) > 0 else None
+    else:
+        raise ValueError(f"absorber {absorber} is not supported.")

--- a/eradiate/radprops/rad_profile.py
+++ b/eradiate/radprops/rad_profile.py
@@ -371,8 +371,7 @@ class US76ApproxRadProfile(RadProfile):
 
        Instantiating this class requires to download the absorption datasets
        for the ``us76_u86_4`` gas mixture and place them in
-       ``$ERADIATE_DIR/resources/data/spectra/absorption/us76_u86_4/fullrange/``
-       (create the directory if necessary).
+       ``$ERADIATE_DIR/resources/data/``.
 
     The radiative properties are computed based upon the so-called US76
     atmospheric vertical profile.
@@ -401,8 +400,8 @@ class US76ApproxRadProfile(RadProfile):
 
         Unit-enabled field (default: cdu[length]).
 
-    ``dataset`` ("us76_u86_4-fullrange" or "test"):
-        Dataset identifier. Default: ``"us76_u86_4-fullrange"``.
+    ``dataset`` (str):
+        Dataset identifier. Default: ``"spectra-us76_u86_4-4000_25711"``.
 
         .. warning::
 
@@ -444,8 +443,8 @@ class US76ApproxRadProfile(RadProfile):
     )
 
     dataset = attr.ib(
-        default="us76_u86_4-fullrange",
-        validator=attr.validators.in_({"us76_u86_4-fullrange", "test"}),
+        default="spectra-us76_u86_4-4000_25711",
+        validator=attr.validators.in_({"spectra-us76_u86_4-4000_25711", "test"}),
     )
 
     def __attrs_post_init__(self):


### PR DESCRIPTION
# Description

I've updated the parts of the code that deal with the absorption datasets to support the new `us76_u86_4` datasets. The main new thing is the chunked datasets. These datasets have a smaller wavenumber range, 500 cm^-1, which makes them smaller in size and faster to load. The datasets are also named according to this convention:
```python
f"{engine}-{absorber}-{w_min}_{w_max}"
```
where
- `engine` is the engine used to compute the absorption cross section. Only the value `spectra` is supported at the moment, but future values could be: `hapi`, `radis`, `kspectrum`, etc
- `absorber` is the name of the absorbing gas species or mixture. Only the value `us76_u86_4` is supported at the moment, but future values could be: `n2`, `o2`, `co2`, `ch4`, `h2o`, `us62`, etc
- `w_min` and `w_max` are the minimum and maximum wavenumber values corresponding to this dataset

Example: `spectra-us76_u86_4-4000_25711` is the absorption dataset for the absorber `us76_u86_4` computed using the `SPECTRA` engine (unfortunately this name is a bit confusing) and its wavenumber range goes from 4000 to 25711 cm^-1.

This convention covers all cases I can think of so far

Changes are:
- `data.absorption_spectra`:
  - updated list of available datasets: got rid of mentions to obsolete `usa_mls` datasets.
  - added a function `available_datasets()` that scans the folder `resources/data/spectra/absorption` and returns the available (based on what the user has downloaded) datasets corresponding to a given absorber and wavenumber value.
- `radprops.absorption.compute_sigma_a()`: the function scans the available datasets before it loads the appropriate dataset, corresponding to the current wavelength value.
- radprops.rad_profile: updated `us76_u86_4-fullrange` to `spectra-us76_u86_4-4000_25711`

Note: if this pull request is approved, I'll remove `eradiate-data_us76_u86_4_fullrange.zip` from the ftp server --- it's replaced by `spectra-us76_u86_4-4000_25711.zip`.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is apropriately documented.
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license