### PR TITLE
us76_u86_4 fix

### DIFF
--- a/eradiate/radprops/absorption.py
+++ b/eradiate/radprops/absorption.py
@@ -50,9 +50,6 @@
     The meaning of the first 5 attributes is explained in the C.F. 1.8
     convention (http://cfconventions.org/).
 """
-
-import numpy as np
-
 import eradiate.data as data
 from eradiate.data.absorption_spectra import available_datasets
 from ..util.units import ureg

--- a/eradiate/radprops/rad_profile.py
+++ b/eradiate/radprops/rad_profile.py
@@ -37,6 +37,7 @@ import numpy as np
 import xarray as xr
 
 from eradiate import __version__
+from eradiate import data
 from .absorption import compute_sigma_a
 from .rayleigh import compute_sigma_s_air
 from ..thermoprops import us76
@@ -401,13 +402,15 @@ class US76ApproxRadProfile(RadProfile):
         Unit-enabled field (default: cdu[length]).
 
     ``dataset`` (str):
-        Dataset identifier. Default: ``"spectra-us76_u86_4-4000_25711"``.
+        Dataset identifier. Default: ``None``.
 
         .. warning::
 
-           This attribute exists for debugging purposes. Unless during testing,
-           it should be used with its default value.
-
+           This attribute exists for testing purposes. Unless during testing,
+           it should be used with its default value. The
+           :func:`eradiate.radprops.absorption.compute_sigma_a`
+           function will figure out automatically what absorption dataset
+           to use, based on the thermophysical profile and the wavelength value.
     """
     n_layers = attr.ib(
         default=50,
@@ -443,8 +446,10 @@ class US76ApproxRadProfile(RadProfile):
     )
 
     dataset = attr.ib(
-        default="spectra-us76_u86_4-4000_25711",
-        validator=attr.validators.in_({"spectra-us76_u86_4-4000_25711", "test"}),
+        default=None,
+        validator=attr.validators.optional(
+            attr.validators.in_(
+                list(data.getter("absorption_spectrum").PATHS.keys())))
     )
 
     def __attrs_post_init__(self):


### PR DESCRIPTION
# Description

This is a fix for the recent [8f6ff68](https://github.com/eradiate/eradiate/commit/8f6ff6815c3e03b572a846e1f41b3e2a3726da12) about supporting the new absorption datasets for the `us76_u86_4` gas mixture.

1. A function `available_datasets` was added to `data.absorption_spectra` module, that would scan the `resources/data/spectra/absorption/` directory. This function would work properly only if the python kernel is executed from the Eradiate root directory, which is not desirable. This was changed in the present pull request: the function finds the absorption datasets from whatever directory the python kernel was started in.

2. `US76RadProfile` default dataset was `spectra-us76_u86_4-4000_25711` (the large absorption data set) and was changed to `None`. The absorption coefficient values are computed with `compute_sigma_a` which will scan the `spectra/absorption` folder and automatically chooses the appropriate dataset to use.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is apropriately documented.
- ~~[ ] The code is tested to prove its function~~
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license