### PR TITLE
Added tutorial notebook about simulations with 1D heterogeneous atmospheres

### DIFF
--- a/docs/notebooks/tutorials/onedim_solver_app/heterogeneous_atmospheres.ipynb
+++ b/docs/notebooks/tutorials/onedim_solver_app/heterogeneous_atmospheres.ipynb
@@ -1,0 +1,1 @@
+../../../../resources/data/notebooks/tutorials/onedim_solver_app/heterogeneous_atmospheres.ipynb

--- a/docs/rst/user_guide/onedim_solver_app.rst
+++ b/docs/rst/user_guide/onedim_solver_app.rst
@@ -22,10 +22,16 @@ features, configuration format and usage of this application.
    :hidden:
 
    Tutorial <../../notebooks/tutorials/onedim_solver_app/onedim_solver_app.ipynb>
+   Heterogeneous atmospheres <../../notebooks/tutorials/onedim_solver_app/heterogeneous_atmospheres.ipynb>
 
 .. link-button:: tut-onedim_solver_app
    :type: ref
    :text: Tutorial
+   :classes: btn-outline-primary btn-block
+
+.. link-button:: tut-heterogeneous_atmospheres
+   :type: ref
+   :text: Tutorial - Simulations with 1D heterogeneous atmospheres
    :classes: btn-outline-primary btn-block
 
 Available features


### PR DESCRIPTION
Resolves eradiate/eradiate-issues#35.

# Description

I've added a tutorial notebook about using `OneDimSolverApp` with heterogeneous atmospheres (based on `US76ApproxRadProfile`) and updated the documentation accordingly. The tutorial notebook is in draft state. In particular, I did not include all the links to the API reference. I'm waiting for your feedback on the big picture before I polish the details. 😃 

While writing this tutorial, I encountered some issues/bugs (see eradiate/eradiate-issues#34 and eradiate/eradiate-issues#36). In the tutorial notebook, I chose configurations that produce no errors and "normal results" but if you play a bit with the notebook and change some parameters values, you might run into the same issues as I've had.

# Checklist

- [ ] The code follows the relevant coding guidelines
- [ ] The code generates no new warnings
- [ ] The code is apropriately documented.
- [ ] The code is tested to prove its function
- [ ] The feature branch is rebased on the current state of the `main` branch
- [ ] I give permission that the Eradiate project may redistribute my contributions under the terms of its license