### PR TITLE
Rami3 hom dis testcase

### DIFF
--- a/eradiate/scenes/tests/test_biosphere.py
+++ b/eradiate/scenes/tests/test_biosphere.py
@@ -16,7 +16,7 @@ def test_homogeneous_discrete_canopy_instantiate(mode_mono):
     # default parameters are used correctly
     cloud2 = HomogeneousDiscreteCanopy.from_parameters(size=[0, 0, 0], leaf_radius=0.25)
     assert cloud2._n_leaves == 4000
-    assert np.allclose(cloud2._size,
+    assert np.allclose(cloud2.size,
                        [16.17, 16.15, 15.28] * ureg.m, rtol=1.e-2)
 
     # size takes precedence over number of leaves


### PR DESCRIPTION
# Description

Closes eradiate/eradiate-issues#38.

This PR reconciles `RamiSolverApp` and `HomogeneousDiscreteCanopy`, to enable running them together in the RAMI benchmarks.

I have changed the canopy to return a shapegroup with all leaves and the bsdf specification as a separate object.
This way it is only a reasonable amount of dict manipulation to add the surface to the shape group in the application.
The canopy class also has a `form_dict` method now.

Additionally, the application was extended to accommodate the canopy in the `kernel_dict` method.

I added a new validator to `utils/attrs` which lets you compare two attributes of the same instance and ensures they have the same array shape.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is apropriately documented.
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license