### PR TITLE
Added solid_2017_mean to list of available solar irradiance datasets

### DIFF
--- a/docs/rst/user_guide/solar_irradiance_spectra.rst
+++ b/docs/rst/user_guide/solar_irradiance_spectra.rst
@@ -57,7 +57,8 @@ spectrum datasets:
   (695.7e6 km) and the distance of the blackbody to the Earth (:math:`D`) is set
   to 1 astronomical unit (149.5978707e6 km) which is the Sun-Earth average
   distance. The wavelength range extends from 280 nm to 2400 nm to cover
-  Eradiate's wavelength range.
+  Eradiate's wavelength range. Reference:
+  :cite:`Liou2002IntroductionAtmosphericRadiation`.
 
 - ``meftah_2017``: reference solar irradiance spectrum based on observations
   from the SOLSPEC instrument of the SOLAR payload onboard the internationial
@@ -68,12 +69,14 @@ spectrum datasets:
   of the solar cycle 24. Wavelength range: [165.0, 3000.1] nm. Resolution:
   better than 1 nm below 1000 nm, and 1 nm in the [1000, 3000] nm wavelength
   range. Absolute uncertainty: 1.26 % (1 standard deviation). Total solar
-  irradiance: 1372.3 +/- 16.9 W/m^2 (1 standard deviation).
+  irradiance: 1372.3 +/- 16.9 W/m^2 (1 standard deviation). Reference:
+  :cite:`Meftah2017SOLARISSReference`.
 
 - ``solid_2017```: observational solar irradiance spectrum composite based on
   data from 20 different instruments. The dataset provides daily solar
   irradiance spectra from 1978-11-7 to 2014-12-31. Wavelength range: [0.5,
-  1991.5] nm. Resolution: variable, between 1 and 16 nm.
+  1991.5] nm. Resolution: variable, between 1 and 16 nm. Reference:
+  :cite:`Haberreiter2017ObservationalSolarIrradiance`.
 
 - ``solid_2017_mean``: time-average of the ``solid_2017`` dataset over all days
   from 1978-11-7 to 2014-12-31.
@@ -85,6 +88,7 @@ spectrum datasets:
   spectrum. Wavelength range: [200, 2397] nm. Resolution: 1 nm. The mean
   absolute uncertainty is of 2 to 3 %. The spectrum is representative of
   moderately high solar activity. Total solar irradiance: 1367.7 W/m^2.
+  Reference: :cite:`Thuillier2003SolarSpectralIrradiance`.
 
 - ``whi_2008_*``: combination of simultaneous satellite observations from the
   SEE and SORCE instruments (from 2008-03-25 to 2008-04-16) onboard the TIMED
@@ -104,6 +108,7 @@ spectrum datasets:
       Total solar irradiance: 1360.84 W/m^2.
 
   ``whi_2008`` is an alias to the quiet sun spectrum ``whi_2008_3``.
+  Reference: :cite:`Woods2008SolarIrradianceReference`.
 
 Visualise a solar irradiance spectrum
 -------------------------------------

--- a/eradiate/data/solar_irradiance_spectra.py
+++ b/eradiate/data/solar_irradiance_spectra.py
@@ -15,6 +15,9 @@
    * - ``meftah_2017``
      - :cite:`Meftah2017SOLARISSReference`
      - [165, 3000.1]
+   * - ``solid_2017_mean``
+     - :cite:`Haberreiter2017ObservationalSolarIrradiance`
+     - [0.5, 1991.5]
    * - ``thuillier_2003``
      - :cite:`Thuillier2003SolarSpectralIrradiance`
      - [200, 2397]
@@ -45,6 +48,7 @@ class _SolarIrradianceGetter(DataGetter):
         "blackbody_sun": "spectra/solar_irradiance/blackbody_sun.nc",
         "meftah_2017": "spectra/solar_irradiance/meftah_2017.nc",
         "thuillier_2003": "spectra/solar_irradiance/thuillier_2003.nc",
+        "solid_2017_mean": "spectra/solar_irradiance/solid_2017_mean.nc",
         "whi_2008": "spectra/solar_irradiance/whi_2008_time_period_1.nc",  # alias
         "whi_2008_1": "spectra/solar_irradiance/whi_2008_time_period_1.nc",
         "whi_2008_2": "spectra/solar_irradiance/whi_2008_time_period_2.nc",

--- a/eradiate/scenes/tests/test_spectra.py
+++ b/eradiate/scenes/tests/test_spectra.py
@@ -13,13 +13,13 @@ from eradiate.util.units import kernel_default_units as kdu
 
 
 def test_converter(mode_mono):
-    # Check if dicts are correctly processed
+    # Dicts are correctly processed
     s = SpectrumFactory.converter("radiance")({"type": "uniform"})
     assert s == UniformSpectrum(quantity="radiance", value=1.0)
     s = SpectrumFactory.converter("irradiance")({"type": "uniform"})
     assert s == UniformSpectrum(quantity="irradiance", value=1.0)
 
-    # Check if floats and quantities are correctly processed
+    # Floats and quantities are correctly processed
     s = SpectrumFactory.converter("radiance")(1.0)
     assert s == UniformSpectrum(quantity="radiance", value=1.0)
     s = SpectrumFactory.converter("radiance")(ureg.Quantity(1e6, "W/km^2/sr/nm"))
@@ -61,10 +61,10 @@ def test_uniform(mode_mono):
         "quantity": "radiance", "value": 1., "value_units": "W/km^2/sr/nm"
     })
 
-    # Check that produced kernel dict is valid
+    # Produced kernel dict is valid
     assert load_dict(onedict_value(s.kernel_dict())) is not None
 
-    # Check if unit scaling is properly applied
+    # Unit scaling is properly applied
     with cdu.override({"radiance": "W/m^2/sr/nm"}):
         s = UniformSpectrum(quantity="radiance", value=1.)
     with kdu.override({"radiance": "kW/m^2/sr/nm"}):
@@ -75,23 +75,28 @@ def test_uniform(mode_mono):
 def test_solar(mode_mono):
     from eradiate.kernel.core.xml import load_dict
 
-    # Check if we can instantiate the element
+    # We can instantiate the element
     s = SolarIrradianceSpectrum()
 
-    # Check that unsupported solar spectrum keywords raise
+    # Unsupported solar spectrum keywords raise
     with pytest.raises(ValueError):
         SolarIrradianceSpectrum(dataset="doesnt_exist")
 
-    # Check that produced kernel dict is valid
+    # Produced kernel dict is valid
     assert load_dict(onedict_value(s.kernel_dict())) is not None
 
-    # Check that a more detailed specification still produces a valid object
+    # A more detailed specification still produces a valid object
     s = SolarIrradianceSpectrum(scale=2.0)
     assert load_dict(onedict_value(s.kernel_dict())) is not None
 
-    # Check that the element doesn't work out of the supported spectral range
+    # Element doesn't work out of the supported spectral range
     s = SolarIrradianceSpectrum(dataset="thuillier_2003")
 
     with pytest.raises(ValueError):
         eradiate.set_mode("mono", wavelength=2400.)
         s.kernel_dict()
+
+    # solid_2017_mean dataset can be used
+    eradiate.set_mode("mono", wavelength=550.)
+    s = SolarIrradianceSpectrum(dataset="solid_2017_mean")
+    assert load_dict(onedict_value(s.kernel_dict()))


### PR DESCRIPTION
# Description

I updated `_SolarIrradianceGetter(DataGetter).PATHS` and corresponding API documentation to add the missing `solid_2017_mean` solar irradiance dataset (an omission on my part that Ferran made me realise during the workshop). I took the opportunity to update the user guide and added also all references to each solar irradiance dataset there so that you cannot miss them! I've added a test to check that `SolarIrradiance(dataset=solid_2017_mean)` works, and refactored the tests descriptions texts as we discussed previously.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is apropriately documented.
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license