### PR TITLE
Reset default dataset value to actual dataset id

### DIFF
--- a/eradiate/radprops/rad_profile.py
+++ b/eradiate/radprops/rad_profile.py
@@ -446,7 +446,7 @@ class US76ApproxRadProfile(RadProfile):
     )
 
     dataset = attr.ib(
-        default=None,
+        default="spectra-us76_u86_4-18000_18500",
         validator=attr.validators.optional(
             attr.validators.in_(
                 list(data.getter("absorption_spectrum").PATHS.keys())))


### PR DESCRIPTION
# Description

Changed default `dataset` from `None` to `"spectra-us76_u86_4-18000_18500"` in `US76ApproxRadProfile`.

This fixes the test `eradiate/solvers/onedim/tests/test_app.py` that was raising an exception.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is apropriately documented.
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license