### PR TITLE
User guide - solar irradiance spectra section update

### DIFF
--- a/docs/rst/user_guide/solar_irradiance_spectra.rst
+++ b/docs/rst/user_guide/solar_irradiance_spectra.rst
@@ -72,11 +72,20 @@ spectrum datasets:
   irradiance: 1372.3 +/- 16.9 W/m^2 (1 standard deviation). Reference:
   :cite:`Meftah2017SOLARISSReference`.
 
-- ``solid_2017```: observational solar irradiance spectrum composite based on
+- ``solid_2017``: observational solar irradiance spectrum composite based on
   data from 20 different instruments. The dataset provides daily solar
   irradiance spectra from 1978-11-7 to 2014-12-31. Wavelength range: [0.5,
   1991.5] nm. Resolution: variable, between 1 and 16 nm. Reference:
-  :cite:`Haberreiter2017ObservationalSolarIrradiance`.
+  :cite:`Haberreiter2017ObservationalSolarIrradiance`. See also
+  `the Cal/Val Portal of the Committee on Earth Observation Satellites
+  <http://calvalportal.ceos.org/solar-irradiance-spectrum>`_
+
+.. note::
+    Due to its larger size, the ``solid_2017`` dataset is not shipped with the
+    code base. You can download it from the eradiate FTP server
+    (`download link <https://eradiate.eu/data/solid_2017.zip>`_).
+    Extract the archive into a temporary location then copy-merge the folder
+    in ``resources/data``.
 
 - ``solid_2017_mean``: time-average of the ``solid_2017`` dataset over all days
   from 1978-11-7 to 2014-12-31.


### PR DESCRIPTION
# Description

I fixed two issues in the solar irradiance spectra section of the user guide :
* the user guide mentions the `solid_2017` solar irradiance dataset but does not provide a download link to the data
* a typo in the tutorial notebook

These issues were pointed out by Sylvain during the workshop.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is apropriately documented.
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license