### PR TITLE
Added boa_altitude attribute and bottom and top properties to atmosphere base class

### DIFF
--- a/eradiate/scenes/atmosphere/base.py
+++ b/eradiate/scenes/atmosphere/base.py
@@ -44,8 +44,15 @@ class Atmosphere(SceneElement, ABC):
     )
 
     boa_altitude = attrib_quantity(
-        default=ureg.Quantity(0., "km"),
+        default="auto",
+        converter=converter_or_auto(converter_to_units(cdu.generator("length"))),
+        validator=validator_or_auto(
+            validator_units_compatible(ureg.m),
+            validator_is_positive
+        ),
         units_compatible=cdu.generator("length"),
+        units_add_converter=False,
+        units_add_validator=False
     )
 
     toa_altitude = attrib_quantity(
@@ -73,19 +80,18 @@ class Atmosphere(SceneElement, ABC):
     )
 
     @property
+    @abstractmethod
     def top(self):
         """Top of the atmosphere altitude.
         """
-        if self.toa_altitude == "auto":
-            return ureg.Quantity(100, ureg.km)
-        else:
-            return self.toa_altitude
+        pass
 
     @property
+    @abstractmethod
     def bottom(self):
         """Bottom of the atmosphere altitude (alias to ``boa_altitude``).
         """
-        return self.boa_altitude
+        pass
 
     @property
     def height(self):

--- a/eradiate/scenes/atmosphere/base.py
+++ b/eradiate/scenes/atmosphere/base.py
@@ -43,6 +43,11 @@ class Atmosphere(SceneElement, ABC):
         validator=attr.validators.optional(attr.validators.instance_of(str)),
     )
 
+    boa_altitude = attrib_quantity(
+        default=ureg.Quantity(0., "km"),
+        units_compatible=cdu.generator("length"),
+    )
+
     toa_altitude = attrib_quantity(
         default="auto",
         converter=converter_or_auto(converter_to_units(cdu.generator("length"))),
@@ -68,15 +73,25 @@ class Atmosphere(SceneElement, ABC):
     )
 
     @property
-    def height(self):
-        """Actual value of the atmosphere's height as a :class:`pint.Quantity`.
-        If ``toa_altitude`` is set to ``"auto"``, a value of 100 km is returned;
-        otherwise, ``toa_altitude`` is returned.
+    def top(self):
+        """Top of the atmosphere altitude.
         """
         if self.toa_altitude == "auto":
-            return ureg.Quantity(100., ureg.km)
+            return ureg.Quantity(100, ureg.km)
         else:
             return self.toa_altitude
+
+    @property
+    def bottom(self):
+        """Bottom of the atmosphere altitude (alias to ``boa_altitude``).
+        """
+        return self.boa_altitude
+
+    @property
+    def height(self):
+        """Atmosphere's height.
+        """
+        return self.top - self.bottom
 
     @property
     def kernel_height(self):

--- a/eradiate/scenes/atmosphere/homogeneous.py
+++ b/eradiate/scenes/atmosphere/homogeneous.py
@@ -8,7 +8,7 @@ from ..spectra import Spectrum, SpectrumFactory, UniformSpectrum
 from ...radprops.rayleigh import compute_sigma_s_air
 from ...util.attrs import converter_or_auto, validator_has_quantity, validator_or_auto
 from ...util.collections import onedict_value
-from ...util.units import kernel_default_units
+from ...util.units import kernel_default_units, ureg
 
 
 @AtmosphereFactory.register("homogeneous")
@@ -59,6 +59,25 @@ class HomogeneousAtmosphere(Atmosphere):
         validator=[attr.validators.instance_of(Spectrum),
                    validator_has_quantity("collision_coefficient")]
     )
+
+    def __attrs_post_init__(self):
+        if self.bottom > self.top:
+            raise ValueError(f"boa_altitude ({self.bottom}) must be "
+                             f"smaller than toa_altitude ({self.top})")
+
+    @property
+    def top(self):
+        if self.toa_altitude == "auto":
+            return ureg.Quantity(100, ureg.km)
+        else:
+            return self.toa_altitude
+
+    @property
+    def bottom(self):
+        if self.boa_altitude == "auto":
+            return ureg.Quantity(0, ureg.km)
+        else:
+            return self.boa_altitude
 
     @property
     def kernel_width(self):

--- a/eradiate/scenes/atmosphere/homogeneous.py
+++ b/eradiate/scenes/atmosphere/homogeneous.py
@@ -8,7 +8,7 @@ from ..spectra import Spectrum, SpectrumFactory, UniformSpectrum
 from ...radprops.rayleigh import compute_sigma_s_air
 from ...util.attrs import converter_or_auto, validator_has_quantity, validator_or_auto
 from ...util.collections import onedict_value
-from ...util.units import ureg, kernel_default_units
+from ...util.units import kernel_default_units
 
 
 @AtmosphereFactory.register("homogeneous")

--- a/eradiate/scenes/atmosphere/tests/test_heterogeneous.py
+++ b/eradiate/scenes/atmosphere/tests/test_heterogeneous.py
@@ -40,6 +40,20 @@ def test_heterogeneous_nowrite(mode_mono):
         )
     )
 
+    # Atmosphere top must be above atmosphere bottom
+    with pytest.raises(ValueError):
+        r = HeterogeneousAtmosphere(
+            width=ureg.Quantity(100., ureg.km),
+            boa_altitude=ureg.Quantity(2., ureg.km),
+            toa_altitude=ureg.Quantity(1., ureg.km),
+            sigma_t_fname=_presolver.resolve(
+                "tests/textures/heterogeneous_atmosphere_mono/sigma_t.vol"
+            ),
+            albedo_fname=_presolver.resolve(
+                "tests/textures/heterogeneous_atmosphere_mono/albedo.vol"
+            )
+        )
+
     # Check if default output can be loaded
     p = a.phase()
     assert load_dict(onedict_value(p)) is not None

--- a/eradiate/scenes/atmosphere/tests/test_heterogeneous.py
+++ b/eradiate/scenes/atmosphere/tests/test_heterogeneous.py
@@ -32,6 +32,7 @@ def test_heterogeneous_nowrite(mode_mono):
     a = HeterogeneousAtmosphere(
         width=ureg.Quantity(100., ureg.km),
         toa_altitude=ureg.Quantity(100., ureg.km),
+        boa_altitude=ureg.Quantity(0., ureg.km),
         sigma_t_fname=_presolver.resolve(
             "tests/textures/heterogeneous_atmosphere_mono/sigma_t.vol"
         ),

--- a/eradiate/scenes/atmosphere/tests/test_homogeneous.py
+++ b/eradiate/scenes/atmosphere/tests/test_homogeneous.py
@@ -22,6 +22,13 @@ def test_homogeneous(mode_mono, ref):
     assert r.kernel_offset == ureg.Quantity(0.1, "km")
     assert r.kernel_height == ureg.Quantity(100.1, "km")
 
+    # Atmosphere top must be above atmosphere bottom
+    with pytest.raises(ValueError):
+        r = HomogeneousAtmosphere(
+            boa_altitude=2.,
+            toa_altitude=1.,
+        )
+
     # Check if default constructs can be loaded by the kernel
     dict_phase = onedict_value(r.phase())
     assert load_dict(dict_phase) is not None


### PR DESCRIPTION
# Description
This is a suggestion.

## Changes
I've added a `boa_altitude` attribute and a `bottom` property and `top` property to the atmosphere base class. The atmosphere height is defined as `height = top - bottom`. The `boa_altitude` attribute behaves like the `toa_altitude` attribute.

## Motivation
These properties would help a lot in the handling of atmospheres that start at a non-zero altitudes, and also in the positioning of particles layers in the atmosphere.

For example, take an atmosphere that is defined by `boa_altitude = 2.0` and `toa_altitude = 120.0` (`height = 118.0`). Say that inside that atmosphere, you must place a particles layer with bottom and top altitudes of e.g. `3.0` and `5.0`. Given the `height` information only, you would place it at `3.0` vertical units above the bottom of the atmosphere -- assuming that the atmosphere starts at the altitude `0.0` -- where, in fact, it's only `1.0` unit above.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is apropriately documented.
- [x] The code is tested to prove its function
- [ ] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license