### PR TITLE
Update dataset attribute according to actual wavelength

### DIFF
--- a/eradiate/radprops/absorption.py
+++ b/eradiate/radprops/absorption.py
@@ -93,7 +93,7 @@ def compute_sigma_a(wavelength=550., profile=None, dataset_id=None):
     Returns → float or array:
         Absorption coefficient [m^-1].
     """
-    wavenumber = (1 / ureg.Quantity(wavelength, "nm")).to("cm^-1")
+    wavenumber = (1.0 / ureg.Quantity(wavelength, "nm")).to("cm^-1")
 
     # make default profile
     if profile is None:

--- a/eradiate/radprops/rad_profile.py
+++ b/eradiate/radprops/rad_profile.py
@@ -446,13 +446,6 @@ class US76ApproxRadProfile(RadProfile):
         repr=False,
     )
 
-    dataset = attr.ib(
-        default="spectra-us76_u86_4-18000_18500",  # this is a dummy default
-        validator=attr.validators.optional(
-            attr.validators.in_(
-                list(data.getter("absorption_spectrum").PATHS.keys())))
-    )
-
     def __attrs_post_init__(self):
         self.update()
 
@@ -487,15 +480,13 @@ class US76ApproxRadProfile(RadProfile):
         )
 
         # find the absorption dataset
-        wavenumber = (1 / wavelength).to("cm^-1")
+        wavenumber = (1.0 / wavelength).to("cm^-1")
         available = available_datasets(
             wavenumber=wavenumber.magnitude,
             absorber="us76_u86_4",
             engine="spectra",
         )
-        if available is not None:
-            self.dataset = available[0]  # take first available dataset
-        else:
+        if not available:
             raise ValueError(f"Could not find available datasets "
                              f"corresponding to the current wavelength value "
                              f"({wavelength})")
@@ -504,7 +495,7 @@ class US76ApproxRadProfile(RadProfile):
         self._sigma_a_values = compute_sigma_a(
             wavelength=wavelength,
             profile=profile,
-            dataset_id=self.dataset,
+            dataset_id=available[0],
         )
 
     @property

--- a/eradiate/radprops/tests/test_rad_profile.py
+++ b/eradiate/radprops/tests/test_rad_profile.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 
+import eradiate
 from eradiate.radprops import (
     ArrayRadProfile, RadProfileFactory, US76ApproxRadProfile
 )
@@ -32,28 +33,27 @@ def test_array_rad_props_profile(mode_mono):
                             sigma_t_values=np.linspace(0., 1e-5, 10))
 
 
+@pytest.mark.slow
 def test_us76_approx_rad_profile(mode_mono):
-    import eradiate
-
     # We set the wavelength ourselves because the test absorption dataset has
     # a very narrow wavelength range
     eradiate.set_mode("mono", wavelength=ureg.Quantity(630.827266, "nm"))
 
     # Default constructor
-    p = US76ApproxRadProfile(dataset="test")
+    p = US76ApproxRadProfile()
 
     for x in [p.sigma_a, p.sigma_s, p.sigma_t, p.albedo]:
         assert isinstance(x, ureg.Quantity)
         assert x.shape == (1, 1, 50)
 
     # Custom atmosphere height
-    p = US76ApproxRadProfile(height=120., dataset="test")
+    p = US76ApproxRadProfile(height=120.)
     for x in [p.sigma_a, p.sigma_s, p.sigma_t, p.albedo]:
         assert isinstance(x, ureg.Quantity)
         assert x.shape == (1, 1, 50)
 
     # Custom number of layers
-    p = US76ApproxRadProfile(n_layers=36, dataset="test")
+    p = US76ApproxRadProfile(n_layers=36)
     for x in [p.sigma_a, p.sigma_s, p.sigma_t, p.albedo]:
         assert isinstance(x, ureg.Quantity)
         assert x.shape == (1, 1, 36)

--- a/eradiate/scenes/atmosphere/tests/test_heterogeneous.py
+++ b/eradiate/scenes/atmosphere/tests/test_heterogeneous.py
@@ -96,10 +96,7 @@ def test_heterogeneous_us76(mode_mono, tmpdir):
     # Check if volume data file creation works as expected
     a = HeterogeneousAtmosphere(
         width=ureg.Quantity(1000., "km"),
-        profile={
-            "type": "us76_approx",
-            "dataset": "test",
-        },
+        profile={"type": "us76_approx"},
         cache_dir=tmpdir
     )
 

--- a/eradiate/solvers/onedim/tests/test_app.py
+++ b/eradiate/solvers/onedim/tests/test_app.py
@@ -75,12 +75,7 @@ def test_onedim_solver_app_new():
         OneDimSolverApp.new()
 
 
-_d = {attr.name: attr.default for attr in RadProfileFactory.registry["us76_approx"].__attrs_attrs__}
-_default_absorption_spectrum = _d["dataset"]
-
-
 @pytest.mark.slow
-@pytest.mark.skipif_data_not_found("absorption_spectrum", _default_absorption_spectrum)
 def test_onedim_scene_real_life(mode_mono):
     # Construct with typical parameters
     s = OneDimScene(


### PR DESCRIPTION
# Description

This is a quick fix for the issue with the `US76RadProfile.dataset` attribute being set a default value that is not appropriate outside a narrow wavelength range (~ 540 - 555 nm), and thus must be updated according to actual wavelength value.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is apropriately documented.
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license