### PR TITLE
Updated docs wrt molecular absorption datasets

### DIFF
--- a/docs/rst/user_guide/data_guide.rst
+++ b/docs/rst/user_guide/data_guide.rst
@@ -25,12 +25,9 @@ Adding manually downloaded data
 
 Due to the impracticality of storing large data sets with the code base
 Eradiate does not ship all data required to run simulations.
-Certain large data sets are hosted on an FTP server and need to be
-downloaded manually.
-
-:ref:`This section <sec-user_guide-molecular_absorption_datasets>` contains a list of
-molecular absorption datasets, including a description of their extent and limitations as well as
-a download link.
+Certain large data sets, e.g.
+:ref:`molecular absorption datasets <sec-user_guide-molecular_absorption_datasets>`
+are hosted on an FTP server and need to be downloaded manually.
 
 The data are served in compressed archives, including their containing
 folders. To install the downloaded data, first decompress the archive into a temporary

--- a/docs/rst/user_guide/molecular_absorption_datasets.rst
+++ b/docs/rst/user_guide/molecular_absorption_datasets.rst
@@ -3,49 +3,26 @@
 Molecular absorption datasets
 =============================
 
-Eradiate ships with several molecular absorption datasets. This guide will provide a list
-of available data and include a detailed description of the dataset, its properties and limitations.
-Please refer to :ref:`this <sec-user_guide-manual_download>` section for instructions on installing
-these datasets.
+Eradiate ships with several molecular absorption datasets. This guide will
+provide a list of available data and include a detailed description of the
+datasets, their properties and limitations.
 
 List of available molecular absorption datasets
 -----------------------------------------------
 
-The following list contains all available datasets. The next sections contain a detailed description
-for each of these data sets.
+The list of all available datasets can be found in the documentation for the
+:mod:`absorption_spectra <eradiate.data.absorption_spectra>` module.
+Click any item in that list to download the corresponding dataset.
+Refer to :ref:`this section <sec-user_guide-manual_download>` for instructions
+on installing these datasets.
 
-.. list-table::
-   :widths: 15 30 10
-   :header-rows: 1
-
-   * - Dataset name
-     - Description
-     - Download link
-   * - :ref:`spectra_us76_u86_4 <sec-user_guide-molecular_absorption_datasets-spectra_us76_u86_4>`
-     - US76 standard atmosphere absorption cross sections below 86km with four molecules (N2, O2, CO2 and CH4)
-     - `Link <https://eradiate.eu/data/spectra-us76_u86_4-4000_25711.zip>`_
-
-.. _sec-user_guide-molecular_absorption_datasets-spectra_us76_u86_4:
-
-spectra_us76_u86_4
+spectra-us76_u86_4
 ------------------
 
-Absorption cross section dataset for the ``us76_u86_4`` mixture. The dataset follows the US76 atmospheric profile
-:cite:`NASA1976USStandardAtmosphere` up to an altitude of 86 kilometers and contains four molecular species.
-The absorption cross section values were computed using `SPECTRA <https://spectra.iao.ru/>`_.
-
-This dataset can be interpolated both in wavenumber and in pressure.
-Since the dataset is specific to the US76 atmosphere thermophysical profile, when interpolating along one of the axes,
-the other axis' value will match the corresponding value pair in said profile.
-In other words, the dataset must be interpolated only once to find the absorption cross section corresponding
-to a set of pressure and temperature values.
-
-The dataset is limited to altitudes below 86 kilometers, because for these altitudes, the gasses can be
-assumed to be well mixed. Above 86 kilometers the air number density is smaller than a factor of 1e-5 compared
-to sea level and the assumption of well mixing breaks down.
-
-The ``us76_u86_4`` mixture is defined as the gas mixture in the US76 atmosphere model for altitudes below
-86 kilometers and restricted to four gas species: N2, O2, CO2, CH4.
+Absorption cross section dataset for the ``us76_u86_4`` mixture.
+The ``us76_u86_4`` mixture is defined as the gas mixture in the US76 atmosphere
+model for altitudes below 86 kilometers and restricted to four gas species:
+N2, O2, CO2, CH4.
 The volume fractions are the following:
 
 - N2: 0.78084
@@ -55,6 +32,25 @@ The volume fractions are the following:
 
 .. admonition:: Note
 
-   The dataset is restricted to these four species, because the others (Ar, Ne, He, Kr, Xe) are not
-   available in the `HITRAN <https://hitran.org/>`_ database used by SPECTRA.
+   The dataset is restricted to these four species, because the others
+   (Ar, Ne, He, Kr, Xe) are not available in the
+   `HITRAN <https://hitran.org/>`_ database used by SPECTRA.
    Notably H2O is absent from this list of gas species as well!
+
+The dataset follows the US76 atmospheric profile
+:cite:`NASA1976USStandardAtmosphere` up to an altitude of 86 kilometers and
+contains four molecular species. The absorption cross section values were
+computed using `SPECTRA <https://spectra.iao.ru/>`_.
+
+This dataset can be interpolated both in wavenumber and in pressure.
+Since the dataset is specific to the US76 atmosphere thermophysical profile,
+when interpolating along one of the axes, the other axis' value will match the
+corresponding value pair in said profile.
+In other words, the dataset must be interpolated only once to find the
+absorption cross section corresponding to a set of pressure and temperature
+values.
+
+The dataset is limited to altitudes below 86 kilometers, because for these
+altitudes, the gasses can be assumed to be well mixed. Above 86 kilometers the
+air number density is smaller than a factor of 1e-5 compared to sea level and
+the assumption of well mixing breaks down.

--- a/eradiate/data/absorption_spectra.py
+++ b/eradiate/data/absorption_spectra.py
@@ -4,195 +4,150 @@
 
 .. admonition:: Note
 
-   In the table below, wavenumber ranges are exact whereas wavelength ranges are approximative (numbers are rounded):w
+   In the table below, wavenumber ranges are exact whereas wavelength ranges
+   are approximative (numbers are rounded).
 
 
-.. list-table:: Available data sets and corresponding identifiers
-   :widths: 1 1 1 1
+.. list-table:: Available data sets and corresponding spectral ranges
+   :widths: 15 10 10
    :header-rows: 1
 
    * - Data set ID
-     - Reference
      - Wavenumber range [cm^-1]
      - Wavelength range [nm]
-   * - ``spectra-us76_u86_4-4000_25711``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+   * - `spectra-us76_u86_4-4000_25711 <https://eradiate.eu/data/spectra-us76_u86_4-4000_25711.zip>`_
      - [4000.00413, 25710.993092]
      - [389, 2500]
-   * - ``spectra-us76_u86_4-4000_4500``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+   * - `spectra-us76_u86_4-4000_4500 <https://eradiate.eu/data/spectra-us76_u86_4-4000_4500.zip>`_
      - [4000, 4500]
      - [2222, 2500]
-   * - ``spectra-us76_u86_4-4500_5000``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+   * - `spectra-us76_u86_4-4500_5000 <https://eradiate.eu/data/spectra-us76_u86_4-4500_5000.zip>`_
      - [4500, 5000]
      - [2000, 2222]
-   * - ``spectra-us76_u86_4-5000_5500``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+   * - `spectra-us76_u86_4-5000_5500 <https://eradiate.eu/data/spectra-us76_u86_4-5000_5500.zip>`_
      - [5000, 5500]
      - [1818, 2000]
-   * - ``spectra-us76_u86_4-5500_6000``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+   * - `spectra-us76_u86_4-5500_6000 <https://eradiate.eu/data/spectra-us76_u86_4-5500_6000.zip>`_
      - [5500, 6000]
      - [1666, 1818]
-   * - ``spectra-us76_u86_4-6000_6500``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+   * - `spectra-us76_u86_4-6000_6500 <https://eradiate.eu/data/spectra-us76_u86_4-6000_6500.zip>`_
      - [6000, 6500]
      - [1538, 1666]
-   * - ``spectra-us76_u86_4-6500_7000``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+   * - `spectra-us76_u86_4-6500_7000 <https://eradiate.eu/data/spectra-us76_u86_4-6500_7000.zip>`_
      - [6500, 7000]
      - [1428, 1538]
-   * - ``spectra-us76_u86_4-7000_7500``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+   * - `spectra-us76_u86_4-7000_7500 <https://eradiate.eu/data/spectra-us76_u86_4-7000_7500.zip>`_
      - [7000, 7500]
      - [1333, 1428]
-   * - ``spectra-us76_u86_4-7500_8000``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+   * - `spectra-us76_u86_4-7500_8000 <https://eradiate.eu/data/spectra-us76_u86_4-7500_8000.zip>`_
      - [7500, 8000]
      - [1250, 1333]
-   * - ``spectra-us76_u86_4-8000_8500``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+   * - `spectra-us76_u86_4-8000_8500 <https://eradiate.eu/data/spectra-us76_u86_4-8000_8500.zip>`_
      - [8000, 8500]
      - [1176, 1250]
-   * - ``spectra-us76_u86_4-8500_9000``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+   * - `spectra-us76_u86_4-8500_9000 <https://eradiate.eu/data/spectra-us76_u86_4-8500_9000.zip>`_
      - [8500, 9000]
      - [1111, 1176]
-   * - ``spectra-us76_u86_4-9000_9500``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+   * - `spectra-us76_u86_4-9000_9500 <https://eradiate.eu/data/spectra-us76_u86_4-9000_9500.zip>`_
      - [9000, 9500]
      - [1052, 1111]
-   * - ``spectra-us76_u86_4-9500_10000``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+   * - `spectra-us76_u86_4-9500_10000 <https://eradiate.eu/data/spectra-us76_u86_4-9500_10000.zip>`_
      - [9500, 10000]
      - [1000, 1052]
-   * - ``spectra-us76_u86_4-10000_10500``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+   * - `spectra-us76_u86_4-10000_10500 <https://eradiate.eu/data/spectra-us76_u86_4-10000_10500.zip>`_
      - [10000, 10500]
      - [952, 1000]
-   * - ``spectra-us76_u86_4-10500_11000``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+   * - `spectra-us76_u86_4-10500_11000 <https://eradiate.eu/data/spectra-us76_u86_4-10500_11000.zip>`_
      - [10500, 11000]
      - [909, 952]
-   * - ``spectra-us76_u86_4-11000_11500``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+   * - `spectra-us76_u86_4-11000_11500 <https://eradiate.eu/data/spectra-us76_u86_4-11000_11500.zip>`_
      - [11000, 11500]
      - [869, 909]
-   * - ``spectra-us76_u86_4-11500_12000``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+   * - `spectra-us76_u86_4-11500_12000 <https://eradiate.eu/data/spectra-us76_u86_4-11500_12000.zip>`_
      - [11500, 12000]
      - [833, 869]
-   * - ``spectra-us76_u86_4-12000_12500``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+   * - `spectra-us76_u86_4-12000_12500 <https://eradiate.eu/data/spectra-us76_u86_4-12000_12500.zip>`_
      - [12000, 12500]
      - [800, 833]
-   * - ``spectra-us76_u86_4-12500_13000``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+   * - `spectra-us76_u86_4-12500_13000 <https://eradiate.eu/data/spectra-us76_u86_4-12500_13000.zip>`_
      - [12500, 13000]
      - [769, 800]
-   * - ``spectra-us76_u86_4-13000_13500``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+   * - `spectra-us76_u86_4-13000_13500 <https://eradiate.eu/data/spectra-us76_u86_4-13000_13500.zip>`_
      - [13000, 13500]
      - [740, 769]
-   * - ``spectra-us76_u86_4-13500_14000``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+   * - `spectra-us76_u86_4-13500_14000 <https://eradiate.eu/data/spectra-us76_u86_4-13500_14000.zip>`_
      - [13500, 14000]
      - [714, 740]
-   * - ``spectra-us76_u86_4-14000_14500``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+   * - `spectra-us76_u86_4-14000_14500 <https://eradiate.eu/data/spectra-us76_u86_4-14000_14500.zip>`_
      - [14000, 14500]
      - [689, 714]
-   * - ``spectra-us76_u86_4-14500_15000``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+   * - `spectra-us76_u86_4-14500_15000 <https://eradiate.eu/data/spectra-us76_u86_4-14500_15000.zip>`_
      - [14500, 15000]
      - [666, 689]
-   * - ``spectra-us76_u86_4-15000_15500``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+   * - `spectra-us76_u86_4-15000_15500 <https://eradiate.eu/data/spectra-us76_u86_4-15000_15500.zip>`_
      - [15000, 15500]
      - [645, 666]
-   * - ``spectra-us76_u86_4-15500_16000``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+   * - `spectra-us76_u86_4-15500_16000 <https://eradiate.eu/data/spectra-us76_u86_4-15500_16000.zip>`_
      - [15500, 16000]
      - [625, 645]
-   * - ``spectra-us76_u86_4-16000_16500``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+   * - `spectra-us76_u86_4-16000_16500 <https://eradiate.eu/data/spectra-us76_u86_4-16000_16500.zip>`_
      - [16000, 16500]
      - [606, 625]
-   * - ``spectra-us76_u86_4-16500_17000``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+   * - `spectra-us76_u86_4-16500_17000 <https://eradiate.eu/data/spectra-us76_u86_4-16500_17000.zip>`_
      - [16500, 17000]
      - [588, 606]
-   * - ``spectra-us76_u86_4-17000_17500``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+   * - `spectra-us76_u86_4-17000_17500 <https://eradiate.eu/data/spectra-us76_u86_4-17000_17500.zip>`_
      - [17000, 17500]
      - [571, 588]
-   * - ``spectra-us76_u86_4-17500_18000``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+   * - `spectra-us76_u86_4-17500_18000 <https://eradiate.eu/data/spectra-us76_u86_4-17500_18000.zip>`_
      - [17500, 18000]
      - [555, 571]
-   * - ``spectra-us76_u86_4-18000_18500``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+   * - `spectra-us76_u86_4-18000_18500 <https://eradiate.eu/data/spectra-us76_u86_4-18000_18500.zip>`_
      - [18000, 18500]
      - [540, 555]
-   * - ``spectra-us76_u86_4-18500_19000``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+   * - `spectra-us76_u86_4-18500_19000 <https://eradiate.eu/data/spectra-us76_u86_4-18500_19000.zip>`_
      - [18500, 19000]
      - [526, 540]
-   * - ``spectra-us76_u86_4-19000_19500``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+   * - `spectra-us76_u86_4-19000_19500 <https://eradiate.eu/data/spectra-us76_u86_4-19000_19500.zip>`_
      - [19000, 19500]
      - [512, 526]
-   * - ``spectra-us76_u86_4-19500_20000``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+   * - `spectra-us76_u86_4-19500_20000 <https://eradiate.eu/data/spectra-us76_u86_4-19500_20000.zip>`_
      - [19500, 20000]
      - [500, 512]
-   * - ``spectra-us76_u86_4-20000_20500``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+   * - `spectra-us76_u86_4-20000_20500 <https://eradiate.eu/data/spectra-us76_u86_4-20000_20500.zip>`_
      - [20000, 20500]
      - [487, 500]
-   * - ``spectra-us76_u86_4-20500_21000``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+   * - `spectra-us76_u86_4-20500_21000 <https://eradiate.eu/data/spectra-us76_u86_4-20500_21000.zip>`_
      - [20500, 21000]
      - [476, 487]
-   * - ``spectra-us76_u86_4-21000_21500``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+   * - `spectra-us76_u86_4-21000_21500 <https://eradiate.eu/data/spectra-us76_u86_4-21000_21500.zip>`_
      - [21000, 21500]
      - [465, 476]
-   * - ``spectra-us76_u86_4-21500_22000``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+   * - `spectra-us76_u86_4-21500_22000 <https://eradiate.eu/data/spectra-us76_u86_4-21500_22000.zip>`_
      - [21500, 22000]
      - [454, 465]
-   * - ``spectra-us76_u86_4-22000_22500``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+   * - `spectra-us76_u86_4-22000_22500 <https://eradiate.eu/data/spectra-us76_u86_4-22000_22500.zip>`_
      - [22000, 22500]
      - [444, 454]
-   * - ``spectra-us76_u86_4-22500_23000``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+   * - `spectra-us76_u86_4-22500_23000 <https://eradiate.eu/data/spectra-us76_u86_4-22500_23000.zip>`_
      - [22500, 23000]
      - [434, 444]
-   * - ``spectra-us76_u86_4-23000_23500``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+   * - `spectra-us76_u86_4-23000_23500 <https://eradiate.eu/data/spectra-us76_u86_4-23000_23500.zip>`_
      - [23000, 23500]
      - [425, 434]
-   * - ``spectra-us76_u86_4-23500_24000``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+   * - `spectra-us76_u86_4-23500_24000 <https://eradiate.eu/data/spectra-us76_u86_4-23500_24000.zip>`_
      - [23500, 24000]
      - [416, 425]
-   * - ``spectra-us76_u86_4-24000_24500``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+   * - `spectra-us76_u86_4-24000_24500 <https://eradiate.eu/data/spectra-us76_u86_4-24000_24500.zip>`_
      - [24000, 24500]
      - [408, 416]
-   * - ``spectra-us76_u86_4-24500_25000``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+   * - `spectra-us76_u86_4-24500_25000 <https://eradiate.eu/data/spectra-us76_u86_4-24500_25000.zip>`_
      - [24500, 25000]
      - [400, 408]
-   * - ``spectra-us76_u86_4-25000_25500``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+   * - `spectra-us76_u86_4-25000_25500 <https://eradiate.eu/data/spectra-us76_u86_4-25000_25500.zip>`_
      - [25000, 25500]
      - [392, 400]
-   * - ``spectra-us76_u86_4-25500_25711``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
+   * - `spectra-us76_u86_4-25500_25711 <https://eradiate.eu/data/spectra-us76_u86_4-25500_25711.zip>`_
      - [25500, 25711]
      - [389, 392]
 """


### PR DESCRIPTION
# Description

I've updated the documentation --- `User guide > Molecular absorption datasets` and `API reference > eradiate.data.absorption_spectra` --- to include download links to all molecular absorption datasets (not only the largest one).

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is apropriately documented.
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license