### PR TITLE
Refactored compute_sigma_a

### DIFF
--- a/docs/rst/getting_started/install.rst
+++ b/docs/rst/getting_started/install.rst
@@ -263,7 +263,7 @@ Downloading required data files
 
 Eradiate does not automatically ship all available data sets due to their size.
 In order to successfully run all tests and tutorials, the
-`us76_u86_4-4000_25711 data set <https://eradiate.eu/data/spectra-us76_u86_4-4000_25711.zip>`_
+`spectra-us76_u86_4 data set <https://eradiate.eu/data/spectra-us76_u86_4.zip>`_
 must be downloaded manually and placed in the ``resources/data`` directory.
 :ref:`This section <sec-user_guide-manual_download>` explains in detail where
 the data set can be found and where it must be placed exactly.

--- a/docs/rst/user_guide/molecular_absorption_datasets.rst
+++ b/docs/rst/user_guide/molecular_absorption_datasets.rst
@@ -23,38 +23,64 @@ for each of these data sets.
      - Download link
    * - :ref:`spectra_us76_u86_4 <sec-user_guide-molecular_absorption_datasets-spectra_us76_u86_4>`
      - US76 standard atmosphere absorption cross sections below 86km with four molecules (N2, O2, CO2 and CH4)
-     - `Link <https://eradiate.eu/data/spectra-us76_u86_4-4000_25711.zip>`_
+     - `Link <https://eradiate.eu/data/spectra-us76_u86_4.zip>`_
 
 .. _sec-user_guide-molecular_absorption_datasets-spectra_us76_u86_4:
 
-spectra_us76_u86_4
+spectra-us76_u86_4
 ------------------
 
-Absorption cross section dataset for the ``us76_u86_4`` mixture. The dataset follows the US76 atmospheric profile
-:cite:`NASA1976USStandardAtmosphere` up to an altitude of 86 kilometers and contains four molecular species.
-The absorption cross section values were computed using `SPECTRA <https://spectra.iao.ru/>`_.
+This absorption spectrum is that of the gas mixture ``us76_u86_4`` defined by
+the following volume mixing ratio:
 
-This dataset can be interpolated both in wavenumber and in pressure.
-Since the dataset is specific to the US76 atmosphere thermophysical profile, when interpolating along one of the axes,
-the other axis' value will match the corresponding value pair in said profile.
-In other words, the dataset must be interpolated only once to find the absorption cross section corresponding
-to a set of pressure and temperature values.
+- ``N2``: 0.78084
+- ``O2``: 0.209476
+- ``CO2``: 0.000314
+- ``CH4``: 0.000002
 
-The dataset is limited to altitudes below 86 kilometers, because for these altitudes, the gasses can be
-assumed to be well mixed. Above 86 kilometers the air number density is smaller than a factor of 1e-5 compared
-to sea level and the assumption of well mixing breaks down.
+This gas mixture corresponds to the gas mixture that is present in the lower
+86 km part of the atmosphere in the US76 model
+:cite:`NASA1976USStandardAtmosphere`, when the composition is
+restricted to 4 gas species, namely **N2**, **O2**, **CO2** and **CH4**.
+The dataset is limited to altitudes below 86 kilometers, because for these
+altitudes, the gases are assumed to be well mixed in the US76 atmosphere
+thermophysical model.
 
-The ``us76_u86_4`` mixture is defined as the gas mixture in the US76 atmosphere model for altitudes below
-86 kilometers and restricted to four gas species: N2, O2, CO2, CH4.
-The volume fractions are the following:
+The absorption cross section values were computed using
+`SPECTRA <https://spectra.iao.ru/>`_.
 
-- N2: 0.78084
-- O2: 0.209476
-- CO2: 0.000314
-- CH4: 0.000002
+The ``spectra-us76_u86_4`` dataset has a wavenumber coordinate and a pressure
+coordinate. The table below indicates the characteristics of the spectral and
+pressure meshes.
 
-.. admonition:: Note
+.. list-table::
+   :widths: 1 1 1 1
+   :header-rows: 1
 
-   The dataset is restricted to these four species, because the others (Ar, Ne, He, Kr, Xe) are not
-   available in the `HITRAN <https://hitran.org/>`_ database used by SPECTRA.
-   Notably H2O is absent from this list of gas species as well!
+   * - Coordinate
+     - Minimum value
+     - Maximum value
+     - Step
+   * - Wavenumber (cm^-1)
+     - 4000
+     - 25711
+     - 0.00314
+   * - Wavelength (nm)
+     - ~389
+     - 2500
+     - (variable)
+   * - Pressure (Pa)
+     - 0.101325
+     - 101325
+     - (variable)
+
+The pressure mesh is 64 values geometrically spaced between the minimum and
+maximum values.
+This dataset can be interpolated both in wavenumber and pressure, but has no
+temperature coordinate.
+Since the dataset is specific to the US76 atmosphere thermophysical profile,
+when interpolating along the pressure axis, the temperature axis' value will
+match the corresponding value pair in said profile.
+In other words, the dataset must be interpolated only once to find the
+absorption cross section corresponding to a set of pressure and temperature
+values.

--- a/eradiate/data/absorption_spectra.py
+++ b/eradiate/data/absorption_spectra.py
@@ -1,200 +1,17 @@
 """Absorption cross section spectrum data sets shipped with Eradiate.
 
-**Category ID**: ``absorption_cross_section_spectrum``
-
-.. admonition:: Note
-
-   In the table below, wavenumber ranges are exact whereas wavelength ranges are approximative (numbers are rounded):w
-
+**Category ID**: ``absorption_spectrum``
 
 .. list-table:: Available data sets and corresponding identifiers
-   :widths: 1 1 1 1
+   :widths: 1 1 1
    :header-rows: 1
 
-   * - Data set ID
+   * - Dataset ID
      - Reference
-     - Wavenumber range [cm^-1]
-     - Wavelength range [nm]
-   * - ``spectra-us76_u86_4-4000_25711``
+     - Spetral range [nm]
+   * - ``spectra-us76_u86_4``
      - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
-     - [4000.00413, 25710.993092]
-     - [389, 2500]
-   * - ``spectra-us76_u86_4-4000_4500``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
-     - [4000, 4500]
-     - [2222, 2500]
-   * - ``spectra-us76_u86_4-4500_5000``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
-     - [4500, 5000]
-     - [2000, 2222]
-   * - ``spectra-us76_u86_4-5000_5500``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
-     - [5000, 5500]
-     - [1818, 2000]
-   * - ``spectra-us76_u86_4-5500_6000``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
-     - [5500, 6000]
-     - [1666, 1818]
-   * - ``spectra-us76_u86_4-6000_6500``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
-     - [6000, 6500]
-     - [1538, 1666]
-   * - ``spectra-us76_u86_4-6500_7000``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
-     - [6500, 7000]
-     - [1428, 1538]
-   * - ``spectra-us76_u86_4-7000_7500``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
-     - [7000, 7500]
-     - [1333, 1428]
-   * - ``spectra-us76_u86_4-7500_8000``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
-     - [7500, 8000]
-     - [1250, 1333]
-   * - ``spectra-us76_u86_4-8000_8500``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
-     - [8000, 8500]
-     - [1176, 1250]
-   * - ``spectra-us76_u86_4-8500_9000``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
-     - [8500, 9000]
-     - [1111, 1176]
-   * - ``spectra-us76_u86_4-9000_9500``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
-     - [9000, 9500]
-     - [1052, 1111]
-   * - ``spectra-us76_u86_4-9500_10000``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
-     - [9500, 10000]
-     - [1000, 1052]
-   * - ``spectra-us76_u86_4-10000_10500``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
-     - [10000, 10500]
-     - [952, 1000]
-   * - ``spectra-us76_u86_4-10500_11000``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
-     - [10500, 11000]
-     - [909, 952]
-   * - ``spectra-us76_u86_4-11000_11500``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
-     - [11000, 11500]
-     - [869, 909]
-   * - ``spectra-us76_u86_4-11500_12000``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
-     - [11500, 12000]
-     - [833, 869]
-   * - ``spectra-us76_u86_4-12000_12500``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
-     - [12000, 12500]
-     - [800, 833]
-   * - ``spectra-us76_u86_4-12500_13000``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
-     - [12500, 13000]
-     - [769, 800]
-   * - ``spectra-us76_u86_4-13000_13500``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
-     - [13000, 13500]
-     - [740, 769]
-   * - ``spectra-us76_u86_4-13500_14000``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
-     - [13500, 14000]
-     - [714, 740]
-   * - ``spectra-us76_u86_4-14000_14500``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
-     - [14000, 14500]
-     - [689, 714]
-   * - ``spectra-us76_u86_4-14500_15000``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
-     - [14500, 15000]
-     - [666, 689]
-   * - ``spectra-us76_u86_4-15000_15500``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
-     - [15000, 15500]
-     - [645, 666]
-   * - ``spectra-us76_u86_4-15500_16000``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
-     - [15500, 16000]
-     - [625, 645]
-   * - ``spectra-us76_u86_4-16000_16500``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
-     - [16000, 16500]
-     - [606, 625]
-   * - ``spectra-us76_u86_4-16500_17000``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
-     - [16500, 17000]
-     - [588, 606]
-   * - ``spectra-us76_u86_4-17000_17500``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
-     - [17000, 17500]
-     - [571, 588]
-   * - ``spectra-us76_u86_4-17500_18000``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
-     - [17500, 18000]
-     - [555, 571]
-   * - ``spectra-us76_u86_4-18000_18500``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
-     - [18000, 18500]
-     - [540, 555]
-   * - ``spectra-us76_u86_4-18500_19000``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
-     - [18500, 19000]
-     - [526, 540]
-   * - ``spectra-us76_u86_4-19000_19500``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
-     - [19000, 19500]
-     - [512, 526]
-   * - ``spectra-us76_u86_4-19500_20000``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
-     - [19500, 20000]
-     - [500, 512]
-   * - ``spectra-us76_u86_4-20000_20500``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
-     - [20000, 20500]
-     - [487, 500]
-   * - ``spectra-us76_u86_4-20500_21000``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
-     - [20500, 21000]
-     - [476, 487]
-   * - ``spectra-us76_u86_4-21000_21500``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
-     - [21000, 21500]
-     - [465, 476]
-   * - ``spectra-us76_u86_4-21500_22000``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
-     - [21500, 22000]
-     - [454, 465]
-   * - ``spectra-us76_u86_4-22000_22500``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
-     - [22000, 22500]
-     - [444, 454]
-   * - ``spectra-us76_u86_4-22500_23000``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
-     - [22500, 23000]
-     - [434, 444]
-   * - ``spectra-us76_u86_4-23000_23500``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
-     - [23000, 23500]
-     - [425, 434]
-   * - ``spectra-us76_u86_4-23500_24000``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
-     - [23500, 24000]
-     - [416, 425]
-   * - ``spectra-us76_u86_4-24000_24500``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
-     - [24000, 24500]
-     - [408, 416]
-   * - ``spectra-us76_u86_4-24500_25000``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
-     - [24500, 25000]
-     - [400, 408]
-   * - ``spectra-us76_u86_4-25000_25500``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
-     - [25000, 25500]
-     - [392, 400]
-   * - ``spectra-us76_u86_4-25500_25711``
-     - ``eradiate-datasets_maker/scripts/spectra/acs/spectra/us76_u86_4.py``
-     - [25500, 25711]
-     - [389, 392]
+     - [~389, 2500]
 """
 
 import numpy as np
@@ -212,8 +29,6 @@ _US76_U86_4_PREF = "spectra-us76_u86_4"
 
 class _AbsorptionGetter(DataGetter):
     PATHS = {
-        "spectra-us76_u86_4-4000_25711": "spectra/absorption/us76_u86_4/"
-                                         "spectra-us76_u86_4-4000_25711/*.nc",
         **{f"{_US76_U86_4_PREF}-{x}_{x + 500}": f"{_US76_U86_4_PATH}/"
                                                 f"{_US76_U86_4_PREF}-{x}_"
                                                 f"{x + 500}/*.nc"
@@ -246,8 +61,8 @@ class _AbsorptionGetter(DataGetter):
 
 
 @ureg.wraps(ret=None, args=("cm^-1", None, None), strict=False)
-def available_datasets(wavenumber, absorber="us76_u86_4", engine="spectra"):
-    """Returns the available dataset(s) corresponding to a given wavenumber,
+def find_dataset(wavenumber, absorber="us76_u86_4", engine="spectra"):
+    """Finds the dataset corresponding to a given wavenumber,
     absorber and absorption cross section engine.
 
     Parameter ``wavenumber`` (:class:`~pint.Quantity`):
@@ -259,13 +74,12 @@ def available_datasets(wavenumber, absorber="us76_u86_4", engine="spectra"):
     Parameter ``engine`` (str):
         Engine used to compute the absorption cross sections.
 
-    Returns → list or ``None``:
-        Available dataset id(s).
+    Returns → str:
+        Available dataset id.
     """
     if absorber == "us76_u86_4":
         if engine != "spectra":
             raise ValueError(f"engine {engine} is not supported.")
-        available = []
         for d in [_AbsorptionGetter.PATHS[k] for k in _AbsorptionGetter.PATHS
                   if k != "test"]:
             path = _presolver.resolve(d.strip("/*.nc"))
@@ -274,7 +88,10 @@ def available_datasets(wavenumber, absorber="us76_u86_4", engine="spectra"):
                 if _absorber == absorber and _engine == engine:
                     w_min, w_max = w_range.split("_")
                     if float(w_min) <= wavenumber < float(w_max):
-                        available.append(path.name)
-        return available if len(available) > 0 else None
+                        return path.name
+        raise ValueError(f"could not find the dataset corresponding to "
+                         f"wavenumber = {wavenumber}, "
+                         f"absorber = {absorber} and "
+                         f"engine = {engine}")
     else:
         raise ValueError(f"absorber {absorber} is not supported.")

--- a/eradiate/radprops/tests/test_absorption.py
+++ b/eradiate/radprops/tests/test_absorption.py
@@ -1,16 +1,39 @@
 import numpy as np
+import pytest
 
+import eradiate.data as data
 from eradiate.radprops.absorption import compute_sigma_a
 from eradiate.util.units import ureg
 
 
-def test_sigma_a():
-    # Test function with default value
-    x = compute_sigma_a(dataset_id="test")
-
-    # test that the function returns a quantity that holds an array of values
+def test_compute_sigma_a():
+    # returns a single-valued quantity with default p and t parameters
+    ds = data.open(category="absorption_spectrum", id="test")
+    x = compute_sigma_a(ds, wl=630.8)
     assert isinstance(x, ureg.Quantity)
-    assert isinstance(x.magnitude, np.ndarray)
-
-    # test that units are m^-1
+    assert isinstance(x.magnitude, float)
     assert x.units == ureg.Unit("m^-1")
+
+    # returns an array quantity when an array is passed to p
+    x = compute_sigma_a(ds, wl=630.8, p=np.array([1., 2.]))
+    assert isinstance(x.magnitude, np.ndarray)
+    assert x.magnitude.size == 2
+
+    # absorption coefficient scales with number density
+    x = compute_sigma_a(ds, wl=630.8, n=np.array([1., 2.]))
+    assert x[1] == 2 * x[0]
+
+    # dataset with no temperature coordinate is not interpolated on temperature
+    x = compute_sigma_a(ds, wl=630.8, t=200., n=1.)
+    y = compute_sigma_a(ds, wl=630.8, t=300., n=1.)
+    assert x == y
+
+    # raises when outside of range
+    with pytest.raises(ValueError):
+        compute_sigma_a(ds, wl=600.)
+
+    with pytest.raises(ValueError):
+        compute_sigma_a(ds, wl=630.8, p=1e-7)
+
+    # does not raise if p_fill_value is not None
+    x = compute_sigma_a(ds, wl=630.8, p=1e-7, p_fill_value=0.)


### PR DESCRIPTION
# Description

We have refactored `compute_sigma_a` so that it takes a dataset in input, and not a dataset id. `US76ApproxRadProfile` objects are now in charge of finding out what dataset to open and opening it.

The multiple datasets archive files on the ftp server are now put together into one single archive file [link](https://eradiate.eu/data/spectra-us76_u86_4.zip) (approx. 2.3 GB). This single archive file contains all 44 (wavenumber) * 64 (pressure) individual `us76_u86_4` datasets.

⚠️ Once/if this pull request is accepted, I'll remove the obsolete absorption datasets archive files.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is apropriately documented.
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license