### PR TITLE
Added missing import eradiate.data

### DIFF
--- a/eradiate/radprops/rad_profile.py
+++ b/eradiate/radprops/rad_profile.py
@@ -39,6 +39,7 @@ import xarray as xr
 import eradiate
 from .absorption import compute_sigma_a
 from .rayleigh import compute_sigma_s_air
+from .. import data
 from ..data.absorption_spectra import find_dataset
 from ..thermoprops import us76
 from ..util.attrs import (


### PR DESCRIPTION
# Description

It seems to me that there is a missing import in `radprops/rad_profile.py`. 🤔 

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
