### PR TITLE
Added thermoprops utilities for clouds

### DIFF
--- a/eradiate/thermoprops/tests/test_thermoprops_util.py
+++ b/eradiate/thermoprops/tests/test_thermoprops_util.py
@@ -6,12 +6,45 @@ from eradiate.thermoprops.us76 import make_profile
 from eradiate.thermoprops.util import (
     _find_regular_params_gcd,
     _to_regular,
+    equilibrium_water_vapor_fraction,
     make_profile_regular,
-    profile_dataset_spec
+    profile_dataset_spec,
+    water_vapor_saturation_pressure
 )
 
 
 Q_ = ureg.Quantity
+
+
+def test_water_vapor_saturation_pressure():
+    # values are correct, reference value from:
+    # https://www.engineeringtoolbox.com/water-vapor-saturation-pressure-d_599.html
+    t = ureg.Quantity(18, "celsius")
+    p = water_vapor_saturation_pressure(t=t)
+    assert np.isclose(p, ureg.Quantity(2.065, "kPa"), rtol=0.1)
+
+    # accepts temperature below freezing point
+    t = ureg.Quantity(-10, "celsius")
+    p = water_vapor_saturation_pressure(t=t)
+
+
+def test_equilibrium_water_vapor_fraction():
+    # raises when equilibrium does not exist
+    with pytest.raises(ValueError):
+        equilibrium_water_vapor_fraction(p=ureg.Quantity(3, "kPa"),
+                                         t=ureg.Quantity(50, "celsius"))
+        equilibrium_water_vapor_fraction(p=ureg.Quantity(3, "kPa"),
+                                         t=ureg.Quantity(-10, "celsius"))
+        equilibrium_water_vapor_fraction(p=ureg.Quantity(100, "Pa"),
+                                         t=ureg.Quantity(10, "celsius"))
+        equilibrium_water_vapor_fraction(p=ureg.Quantity(100, "Pa"),
+                                         t=ureg.Quantity(-10, "celsius"))
+        equilibrium_water_vapor_fraction(p=ureg.Quantity(1, "bar"),
+                                         t=ureg.Quantity(120, "celsius"))
+    # values are in [0, 1]
+    value = equilibrium_water_vapor_fraction(p=ureg.Quantity(90, "kPa"),
+                                             t=ureg.Quantity(20, "celsius"))
+    assert 0. <= value <= 1.
 
 
 def test_find_regular_params_gcd():

--- a/requirements/environment-linux-64.lock
+++ b/requirements/environment-linux-64.lock
@@ -195,6 +195,7 @@ https://conda.anaconda.org/conda-forge/linux-64/terminado-0.9.2-py37h89c1867_0.t
 https://conda.anaconda.org/conda-forge/noarch/backports.functools_lru_cache-1.6.1-py_0.tar.bz2#d36df15eaef96549ce6231e3088fba54
 https://conda.anaconda.org/conda-forge/noarch/bleach-3.3.0-pyh44b312d_0.tar.bz2#abf6b76c39358ca36ca706c46f054f2a
 https://conda.anaconda.org/conda-forge/linux-64/distributed-2021.2.0-py37h89c1867_0.tar.bz2#3ac5c849147b24b8482e4baaa239761f
+https://conda.anaconda.org/conda-forge/noarch/iapws-1.5.2-pyh9f0ad1d_0.tar.bz2#3aa31b761bc6aa3acc0d6d01e0bf2e01
 https://conda.anaconda.org/conda-forge/linux-64/importlib_resources-5.1.0-py37h89c1867_0.tar.bz2#73e16856addd8f46afef612fa77f76b9
 https://conda.anaconda.org/conda-forge/noarch/isort-5.7.0-pyhd8ed1ab_0.tar.bz2#073e46728e0d9a8722457cbf1c335c14
 https://conda.anaconda.org/conda-forge/noarch/jinja2-2.11.3-pyh44b312d_0.tar.bz2#1d4c3605d85a3655b1595e0694138eb6

--- a/requirements/environment-osx-64.lock
+++ b/requirements/environment-osx-64.lock
@@ -177,6 +177,7 @@ https://conda.anaconda.org/conda-forge/noarch/pyopenssl-20.0.1-pyhd8ed1ab_0.tar.
 https://conda.anaconda.org/conda-forge/osx-64/ruamel.yaml-0.16.12-py37hf967b71_2.tar.bz2#c4cb71a668bce6384de9b5f7a282d29b
 https://conda.anaconda.org/conda-forge/osx-64/scipy-1.6.0-py37hc22aa43_0.tar.bz2#72c393f99c5752543abb1395121675c2
 https://conda.anaconda.org/conda-forge/osx-64/bokeh-2.2.3-py37hf985489_0.tar.bz2#6e96c1c721f06414a3151a8701f537ad
+https://conda.anaconda.org/conda-forge/noarch/iapws-1.5.2-pyh9f0ad1d_0.tar.bz2#3aa31b761bc6aa3acc0d6d01e0bf2e01
 https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.1.2-pyh9f0ad1d_0.tar.bz2#2cbd910890bb328e8959246a1e16fac7
 https://conda.anaconda.org/conda-forge/osx-64/matplotlib-3.3.4-py37hf985489_0.tar.bz2#e2a971a1ec1ef929cf446bc6c8b9b5e8
 https://conda.anaconda.org/conda-forge/noarch/nbformat-5.1.2-pyhd8ed1ab_1.tar.bz2#9633dbb668ac1f9266427672816899dc

--- a/requirements/environment.yml
+++ b/requirements/environment.yml
@@ -10,6 +10,7 @@ dependencies:
   - click
   - cerberus
   - dask
+  - iapws
   - matplotlib
   - netcdf4
   - numpy

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ install_requires =
     click
     cerberus
     dask
+    iapws
     matplotlib
     netcdf4
     numpy


### PR DESCRIPTION
# Description

I've added a function that computes the water vapor volume fraction at equilibrium, given pressure and temperature values. This function will be useful to adjust the gaseous atmospheric's thermophysical properties when clouds are added to the gaseous atmosphere.

⚠️ I've updated the dependencies to include `iapws`.

# Checklist

- [x] The code follows the relevant coding guidelines
- ~[ ]  The code generates no new warnings~
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
