### PR TITLE
Refactor KernelDict

### DIFF
--- a/eradiate/_util.py
+++ b/eradiate/_util.py
@@ -29,7 +29,6 @@ def is_vector3(value):
     if isinstance(value, pint.Quantity):
         return is_vector3(value.magnitude)
 
-    # @formatter:off
     return (
         (
             isinstance(value, numpy.ndarray)
@@ -38,7 +37,6 @@ def is_vector3(value):
         and len(value) == 3
         and all(map(lambda x: isinstance(x, Number), value))
     )
-    # @formatter:on
 
 
 class Singleton(type):

--- a/eradiate/scenes/atmosphere/tests/test_heterogeneous.py
+++ b/eradiate/scenes/atmosphere/tests/test_heterogeneous.py
@@ -61,7 +61,7 @@ def test_heterogeneous_nowrite(mode_mono):
 
     # Load all elements at once (and use references)
     with unit_context_kernel.override({"length": "km"}):
-        kernel_dict = KernelDict.empty()
+        kernel_dict = KernelDict.new()
         kernel_dict.add(a)
         scene = kernel_dict.load()
         assert scene is not None
@@ -87,7 +87,7 @@ def test_heterogeneous_write(mode_mono, tmpdir):
     assert a.albedo_fname.is_file()
     assert a.sigma_t_fname.is_file()
     # Check if written files can be loaded
-    assert KernelDict.empty().add(a).load() is not None
+    assert KernelDict.new(a).load() is not None
 
     # Check that inconsistent init will raise
     with pytest.raises(ValueError):
@@ -114,7 +114,7 @@ def test_heterogeneous_us76(mode_mono, tmpdir):
     assert a.albedo_fname.is_file()
     assert a.sigma_t_fname.is_file()
     # Check if written files can be loaded
-    assert KernelDict.empty().add(a).load() is not None
+    assert KernelDict.new(a).load() is not None
 
 
 def test_heterogeneous_units(mode_mono):

--- a/eradiate/scenes/atmosphere/tests/test_homogeneous.py
+++ b/eradiate/scenes/atmosphere/tests/test_homogeneous.py
@@ -33,8 +33,7 @@ def test_homogeneous(mode_mono, ref):
     assert load_dict(dict_shape) is not None
 
     # Check if produced scene can be instantiated
-    kernel_dict = KernelDict.empty()
-    kernel_dict.add(r)
+    kernel_dict = KernelDict.new(r)
     assert kernel_dict.load() is not None
 
     # Construct with parameters
@@ -53,7 +52,7 @@ def test_homogeneous(mode_mono, ref):
     assert np.isclose(r.kernel_width, 10. / compute_sigma_s_air(wavelength=wavelength))
 
     # Check if produced scene can be instantiated
-    assert KernelDict.empty().add(r).load() is not None
+    assert KernelDict.new(r).load() is not None
 
     # Check that sigma_s wavelength specification is correctly taken from eradiate mode
     eradiate.set_mode("mono", wavelength=650.)

--- a/eradiate/scenes/measure/_core.py
+++ b/eradiate/scenes/measure/_core.py
@@ -101,7 +101,7 @@ class Measure(SceneElement, ABC):
         """Return a tuple of sensor information data structures.
 
         Returns → list[:class:`.SensorInfo`]:
-            List of sensor
+            List of sensor information data structures.
         """
         spps = self._split_spp()
 
@@ -125,7 +125,7 @@ class Measure(SceneElement, ABC):
         Sensor records will have to be combined using
         :meth:`.postprocess_results`.
 
-        Returns → list[float]:
+        Returns → list[int]:
             List of split SPPs if relevant.
         """
         mode = eradiate.mode()

--- a/eradiate/scenes/measure/_distant.py
+++ b/eradiate/scenes/measure/_distant.py
@@ -286,7 +286,7 @@ class DistantMeasure(Measure):
         "scene. The target can be specified using an array-like with 3 "
         "elements (which will be converted to a :class:`TargetPoint`) or a "
         "dictionary interpreted by :meth:`Target.convert`.",
-        type=":class:`Target` or None",
+        type=":class:`TargetOrigin` or None",
         default="None",
     )
 

--- a/eradiate/scenes/measure/tests/test_measure_distant.py
+++ b/eradiate/scenes/measure/tests/test_measure_distant.py
@@ -113,20 +113,20 @@ def test_target_origin(mode_mono):
 def test_distant(mode_mono):
     # Test default constructor
     d = DistantMeasure()
-    assert KernelDict.empty().add(d).load() is not None
+    assert KernelDict.new(d).load() is not None
 
     # Test target support
     # -- Target a point
     d = DistantMeasure(target=[0, 0, 0])
-    assert KernelDict.empty().add(d).load() is not None
+    assert KernelDict.new(d).load() is not None
 
     # -- Target an axis-aligned rectangular patch
     d = DistantMeasure(
         target={"type": "rectangle", "xmin": 0, "xmax": 1, "ymin": 0, "ymax": 1}
     )
-    assert KernelDict.empty().add(d).load() is not None
+    assert KernelDict.new(d).load() is not None
 
     # Test origin support
     # -- Project origins to a sphere
     d = DistantMeasure(origin={"type": "sphere", "center": [0, 0, 0], "radius": 1})
-    assert KernelDict.empty().add(d).load() is not None
+    assert KernelDict.new(d).load() is not None

--- a/eradiate/scenes/measure/tests/test_measure_perspective.py
+++ b/eradiate/scenes/measure/tests/test_measure_perspective.py
@@ -7,7 +7,7 @@ from eradiate.scenes.measure import PerspectiveCameraMeasure
 def test_perspective(mode_mono):
     # Constructor
     d = PerspectiveCameraMeasure()
-    assert KernelDict.empty().add(d).load() is not None
+    assert KernelDict.new(d).load() is not None
 
     # Origin and target cannot be the same
     for point in [[0, 0, 0], [1, 1, 1], [-1, 0.5, 1.3333]]:

--- a/eradiate/scenes/measure/tests/test_measure_radiancemeter.py
+++ b/eradiate/scenes/measure/tests/test_measure_radiancemeter.py
@@ -7,6 +7,7 @@ def test_radiancemeter(mode_mono):
     s = RadiancemeterMeasure()
 
     # Film is appropropriately set
+    # fmt: off
     assert s._film_dicts() == [{
         "film": {
             "type": "hdrfilm",
@@ -17,6 +18,7 @@ def test_radiancemeter(mode_mono):
             "rfilter": {"type": "box"},
         }
     }]
+    # fmt: on
 
     # The kernel dict can be instantiated
-    assert KernelDict.empty().add(s).load() is not None
+    assert KernelDict.new(s).load() is not None

--- a/eradiate/scenes/tests/test_core.py
+++ b/eradiate/scenes/tests/test_core.py
@@ -14,42 +14,39 @@ from eradiate.exceptions import KernelVariantError
 
 
 def test_kernel_dict():
-    # Check that object creation is possible only if a variant is set
+    # Object creation is possible only if a variant is set
     importlib.reload(
-        eradiate.kernel)  # Required to ensure that any variant set by another test is unset
+        eradiate.kernel
+    )  # Required to ensure that any variant set by another test is unset
     with pytest.raises(KernelVariantError):
         KernelDict()
     eradiate.kernel.set_variant("scalar_mono")
 
-    # Check that empty factory behaves as intended
-    kernel_dict = KernelDict.empty()
+    # Constructor class method initialises an empty kernel scene dict
+    kernel_dict = KernelDict.new()
     assert kernel_dict == {"type": "scene"}
 
-    # Check that variant attribute is set properly
+    # variant attribute is set properly
     kernel_dict = KernelDict({})
     assert kernel_dict.variant == "scalar_mono"
 
-    # Check that check method raises upon missing scene type
+    # Check method raises upon missing scene type
     kernel_dict = KernelDict({})
     with pytest.raises(ValueError):
         kernel_dict.check()
 
-    # Check that normalize method works as intended
-    kernel_dict.normalize()
-    kernel_dict.check()
-
-    # Check that check method raises if dict and set variants are incompatible
+    # Check method raises if dict and set variants are incompatible
     eradiate.kernel.set_variant("scalar_mono_double")
     with pytest.raises(KernelVariantError):
         kernel_dict.check()
 
-    # Check that load method works
+    # Load method returns a kernel object
     eradiate.kernel.set_variant("scalar_mono_double")
     kernel_dict = KernelDict({"type": "scene", "shape": {"type": "sphere"}})
     assert kernel_dict.load() is not None
 
-    # Check that add method works as intended with dicts
-    kernel_dict = KernelDict.empty()
+    # Add method merges dicts
+    kernel_dict = KernelDict.new()
     kernel_dict.add({"shape": {"type": "sphere"}})
     assert kernel_dict == {"type": "scene", "shape": {"type": "sphere"}}
 
@@ -81,32 +78,24 @@ def test_scene_element(mode_mono):
                 self.id: {
                     "type": "directional",
                     "irradiance": self.irradiance,
-                    "direction": self.direction.to("m").magnitude
+                    "direction": self.direction.to("m").magnitude,
                 }
             }
 
     # Dict initialiser tests
     # -- Check if scalar + units yields proper field value
-    d = TinyDirectional.from_dict({
-        "direction": [0, 0, -1],
-        "direction_units": "km"
-    })
+    d = TinyDirectional.from_dict({"direction": [0, 0, -1], "direction_units": "km"})
     assert np.allclose(d.direction, ureg.Quantity([0, 0, -1], ureg.km))
     # -- Check if scalar is attached default units as expected
-    d = TinyDirectional.from_dict({
-        "direction": [0, 0, -1]
-    })
+    d = TinyDirectional.from_dict({"direction": [0, 0, -1]})
     assert np.allclose(d.direction, ureg.Quantity([0, 0, -1], ureg.m))
     # -- Check if quantity is attached default units as expected
-    d = TinyDirectional.from_dict({
-        "direction": ureg.Quantity([0, 0, -1], "km")
-    })
+    d = TinyDirectional.from_dict({"direction": ureg.Quantity([0, 0, -1], "km")})
     assert np.allclose(d.direction, ureg.Quantity([0, 0, -1], ureg.km))
     # -- Check if the unit field can be used to force conversion of quantity
-    d = TinyDirectional.from_dict({
-        "direction": ureg.Quantity([0, 0, -1], "km"),
-        "direction_units": "m"
-    })
+    d = TinyDirectional.from_dict(
+        {"direction": ureg.Quantity([0, 0, -1], "km"), "direction_units": "m"}
+    )
     print(d)
     assert np.allclose(d.direction, ureg.Quantity([0, 0, -1], ureg.km))
     assert d.direction.units == ureg.m
@@ -126,14 +115,12 @@ def test_scene_element(mode_mono):
         d.direction = [0, 0, -1] * ureg.s
 
     # Check that created scene can be instantiated by the kernel
-    kernel_dict = KernelDict.empty()
+    kernel_dict = KernelDict.new()
     kernel_dict.add(d)
     assert kernel_dict.load() is not None
 
     # Check that undesired parameters raise
     with pytest.raises(TypeError):
-        TinyDirectional.from_dict({
-            "direction": [0, 0, -1],
-            "irradiance": 1.0,
-            "unexpected_param": 0
-        })
+        TinyDirectional.from_dict(
+            {"direction": [0, 0, -1], "irradiance": 1.0, "unexpected_param": 0}
+        )

--- a/eradiate/scenes/tests/test_illumination.py
+++ b/eradiate/scenes/tests/test_illumination.py
@@ -11,42 +11,42 @@ def test_constant(mode_mono):
     c = ConstantIllumination()
     assert c.kernel_dict()[c.id] == {
         "type": "constant",
-        "radiance": {"type": "uniform", "value": 1.0}
+        "radiance": {"type": "uniform", "value": 1.0},
     }
-    assert KernelDict.empty().add(c).load() is not None
+    assert KernelDict.new(c).load() is not None
 
     # Check if a more detailed spec is valid
     c = ConstantIllumination(radiance={"type": "uniform", "value": 1.0})
-    assert KernelDict.empty().add(c).load() is not None
+    assert KernelDict.new(c).load() is not None
 
     # Check if 'uniform' shortcut works
     c = ConstantIllumination(radiance={"type": "uniform", "value": 1.0})
-    assert KernelDict.empty().add(c).load() is not None
+    assert KernelDict.new(c).load() is not None
 
     # Check if super lazy way works too
     c = ConstantIllumination(radiance=1.0)
-    assert KernelDict.empty().add(c).load() is not None
+    assert KernelDict.new(c).load() is not None
 
 
 def test_directional(mode_mono):
     # Constructor
     d = DirectionalIllumination()
-    assert KernelDict.empty().add(d).load() is not None
+    assert KernelDict.new(d).load() is not None
 
     # Check if a more detailed spec is valid
     d = DirectionalIllumination(irradiance={"type": "uniform", "value": 1.0})
-    assert KernelDict.empty().add(d).load() is not None
+    assert KernelDict.new(d).load() is not None
 
     # Check if solar irradiance spectrum can be used
     d = DirectionalIllumination(irradiance={"type": "solar_irradiance"})
-    assert KernelDict.empty().add(d).load() is not None
+    assert KernelDict.new(d).load() is not None
 
     # Check if specification from a float works
-    d = DirectionalIllumination(irradiance=1.)
-    assert KernelDict.empty().add(d).load() is not None
+    d = DirectionalIllumination(irradiance=1.0)
+    assert KernelDict.new(d).load() is not None
 
     # Check if specification from a constant works
-    d = DirectionalIllumination(irradiance=ureg.Quantity(1., "W/m^2/nm"))
-    assert KernelDict.empty().add(d).load() is not None
+    d = DirectionalIllumination(irradiance=ureg.Quantity(1.0, "W/m^2/nm"))
+    assert KernelDict.new(d).load() is not None
     with pytest.raises(pinttr.exceptions.UnitsError):  # Wrong units
-        DirectionalIllumination(irradiance=ureg.Quantity(1., "W/m^2/sr/nm"))
+        DirectionalIllumination(irradiance=ureg.Quantity(1.0, "W/m^2/sr/nm"))

--- a/eradiate/scenes/tests/test_integrators.py
+++ b/eradiate/scenes/tests/test_integrators.py
@@ -2,7 +2,7 @@ from eradiate.scenes.core import KernelDict
 from eradiate.scenes.integrators import (
     PathIntegrator,
     VolPathIntegrator,
-    VolPathMISIntegrator
+    VolPathMISIntegrator,
 )
 
 
@@ -10,7 +10,7 @@ def test_path(mode_mono):
     # Basic specification
     integrator = PathIntegrator()
     assert integrator.kernel_dict()["integrator"] == {"type": "path"}
-    assert KernelDict.empty().add(integrator).load() is not None
+    assert KernelDict.new(integrator).load() is not None
 
     # More detailed specification
     integrator = PathIntegrator(max_depth=5, rr_depth=3, hide_emitters=False)
@@ -18,16 +18,16 @@ def test_path(mode_mono):
         "type": "path",
         "max_depth": 5,
         "rr_depth": 3,
-        "hide_emitters": False
+        "hide_emitters": False,
     }
-    assert KernelDict.empty().add(integrator).load() is not None
+    assert KernelDict.new(integrator).load() is not None
 
 
 def test_volpath(mode_mono):
     # Basic specification
     integrator = VolPathIntegrator()
     assert integrator.kernel_dict()["integrator"] == {"type": "volpath"}
-    assert KernelDict.empty().add(integrator).load() is not None
+    assert KernelDict.new(integrator).load() is not None
 
     # More detailed specification
     integrator = VolPathIntegrator(max_depth=5, rr_depth=3, hide_emitters=False)
@@ -35,24 +35,26 @@ def test_volpath(mode_mono):
         "type": "volpath",
         "max_depth": 5,
         "rr_depth": 3,
-        "hide_emitters": False
+        "hide_emitters": False,
     }
-    assert KernelDict.empty().add(integrator).load() is not None
+    assert KernelDict.new(integrator).load() is not None
 
 
 def test_volpathmis(mode_mono):
     # Basic specification
     integrator = VolPathMISIntegrator()
     assert integrator.kernel_dict()["integrator"] == {"type": "volpathmis"}
-    assert KernelDict.empty().add(integrator).load() is not None
+    assert KernelDict.new(integrator).load() is not None
 
     # More detailed specification
-    integrator = VolPathMISIntegrator(max_depth=5, rr_depth=3, hide_emitters=False, use_spectral_mis=True)
+    integrator = VolPathMISIntegrator(
+        max_depth=5, rr_depth=3, hide_emitters=False, use_spectral_mis=True
+    )
     assert integrator.kernel_dict()["integrator"] == {
         "type": "volpathmis",
         "max_depth": 5,
         "rr_depth": 3,
         "hide_emitters": False,
-        "use_spectral_mis": True
+        "use_spectral_mis": True,
     }
-    assert KernelDict.empty().add(integrator).load() is not None
+    assert KernelDict.new(integrator).load() is not None

--- a/eradiate/scenes/tests/test_surface.py
+++ b/eradiate/scenes/tests/test_surface.py
@@ -1,13 +1,8 @@
 import numpy as np
 
-
-from eradiate.scenes.core import KernelDict
-from eradiate.scenes.surface import (
-    LambertianSurface,
-    RPVSurface,
-    BlackSurface,
-)
 from eradiate import unit_registry as ureg
+from eradiate.scenes.core import KernelDict
+from eradiate.scenes.surface import BlackSurface, LambertianSurface, RPVSurface
 
 
 def test_lambertian(mode_mono):
@@ -15,15 +10,14 @@ def test_lambertian(mode_mono):
     ls = LambertianSurface()
 
     # Check if produced scene can be instantiated
-    kernel_dict = KernelDict.empty()
-    kernel_dict.add(ls)
+    kernel_dict = KernelDict.new(ls)
     assert kernel_dict.load() is not None
 
     # Constructor with arguments
-    ls = LambertianSurface(width=1000., reflectance={"type": "uniform", "value": .3})
+    ls = LambertianSurface(width=1000.0, reflectance={"type": "uniform", "value": 0.3})
 
     # Check if produced scene can be instantiated
-    assert KernelDict.empty().add(ls).load() is not None
+    assert KernelDict.new(ls).load() is not None
 
 
 def test_rpv(mode_mono):
@@ -31,21 +25,15 @@ def test_rpv(mode_mono):
     ls = RPVSurface()
 
     # Check if produced scene can be instantiated
-    kernel_dict = KernelDict.empty()
-    kernel_dict.add(ls)
+    kernel_dict = KernelDict.new(ls)
     assert kernel_dict.load() is not None
 
     # Constructor with arguments
-    ls = RPVSurface(
-        width=ureg.Quantity(1000., "km"),
-        rho_0=0.3,
-        k=1.4,
-        ttheta=-0.23
-    )
+    ls = RPVSurface(width=ureg.Quantity(1000.0, "km"), rho_0=0.3, k=1.4, ttheta=-0.23)
     assert np.allclose(ls.width, ureg.Quantity(1e6, ureg.m))
 
     # Check if produced scene can be instantiated
-    assert KernelDict.empty().add(ls).load() is not None
+    assert KernelDict.new(ls).load() is not None
 
 
 def test_black(mode_mono):
@@ -53,11 +41,10 @@ def test_black(mode_mono):
     bs = BlackSurface()
 
     # Check if produced scene can be instantiated
-    kernel_dict = KernelDict.empty()
-    kernel_dict.add(bs)
+    kernel_dict = KernelDict.new(bs)
     assert kernel_dict.load() is not None
 
     # Check if the correct kernel dict is created
     ls = LambertianSurface(reflectance={"type": "uniform", "value": 0})
 
-    assert KernelDict.empty().add(ls) == KernelDict.empty().add(bs)
+    assert KernelDict.new(ls) == KernelDict.new(bs)

--- a/eradiate/solvers/core/_runner.py
+++ b/eradiate/solvers/core/_runner.py
@@ -21,12 +21,12 @@ def runner(kernel_dict):
        Prior to usage, a kernel variant must be selected using
        :func:`~mitsuba.set_variant`.
 
-    Parameter ``kernel_dict`` (dict):
-            Dictionary describing the kernel scene.
+    Parameter ``kernel_dict`` (:class:.KernelDict`):
+        Dictionary describing the kernel scene.
 
-        Returns → dict:
-            Dictionary mapping sensor IDs to the corresponding recorded data.
-            Sensors without an ID are assigned a default key.
+    Returns → dict:
+        Dictionary mapping sensor IDs to the corresponding recorded data.
+        Sensors without an ID are assigned a default key.
     """
     _check_variant()
 
@@ -40,7 +40,7 @@ def runner(kernel_dict):
     # Run computation
     from eradiate.kernel.core.xml import load_dict
 
-    kernel_scene = load_dict(kernel_dict)
+    kernel_scene = load_dict(kernel_dict.data)
 
     for i_sensor, sensor in enumerate(kernel_scene.sensors()):
         kernel_scene.integrator().render(kernel_scene, sensor)

--- a/eradiate/solvers/onedim/_scene.py
+++ b/eradiate/solvers/onedim/_scene.py
@@ -6,7 +6,11 @@ from ..._attrs import documented, get_doc, parse_docs
 from ...scenes.atmosphere import Atmosphere, AtmosphereFactory, HomogeneousAtmosphere
 from ...scenes.core import KernelDict
 from ...scenes.integrators import Integrator, IntegratorFactory, VolPathIntegrator
-from ...scenes.measure._distant import DistantMeasure, TargetOriginPoint, TargetOriginSphere
+from ...scenes.measure._distant import (
+    DistantMeasure,
+    TargetOriginPoint,
+    TargetOriginSphere,
+)
 from ...scenes.surface import LambertianSurface, Surface, SurfaceFactory
 
 
@@ -99,17 +103,17 @@ class OneDimScene(Scene):
                     )
 
     def kernel_dict(self, ref=True):
-        result = KernelDict.empty()
+        result = KernelDict.new()
 
         if self.atmosphere is not None:
-            result.add([self.atmosphere])
+            result.add(self.atmosphere)
 
         # fmt: off
-        result.add([
+        result.add(
             self.surface,
             self.illumination,
             *self.measures,
             self.integrator
-        ])
+        )
         # fmt: on
         return result

--- a/eradiate/solvers/rami/_scene.py
+++ b/eradiate/solvers/rami/_scene.py
@@ -49,11 +49,7 @@ class RamiScene(Scene):
     )
 
     padding = documented(
-        attr.ib(
-            default=0,
-            converter=int,
-            validator=validators.is_positive
-        ),
+        attr.ib(default=0, converter=int, validator=validators.is_positive),
         doc="Padding level. The scene will be padded with copies to account for "
         "adjacency effects. This, in practice, has effects similar to "
         "making the scene periodic."
@@ -114,7 +110,7 @@ class RamiScene(Scene):
     def kernel_dict(self, ref=True):
         from eradiate.kernel.core import ScalarTransform4f
 
-        result = KernelDict.empty()
+        result = KernelDict.new()
 
         if self.canopy is not None:
             canopy_dict = self.canopy.kernel_dict(ref=True)
@@ -130,24 +126,22 @@ class RamiScene(Scene):
                     for y_offset in np.arange(-self.padding, self.padding + 1):
                         instance_dict = {
                             "type": "instance",
-                            "group": {
-                                "type": "ref",
-                                "id": f"{shapegroup_id}"
-                            },
-                            "to_world": ScalarTransform4f.translate([
-                                patch_size.m_as(kdu_length) * x_offset,
-                                patch_size.m_as(kdu_length) * y_offset,
-                                0.0
-                            ])
-
+                            "group": {"type": "ref", "id": f"{shapegroup_id}"},
+                            "to_world": ScalarTransform4f.translate(
+                                [
+                                    patch_size.m_as(kdu_length) * x_offset,
+                                    patch_size.m_as(kdu_length) * y_offset,
+                                    0.0,
+                                ]
+                            ),
                         }
                         result[f"instance{x_offset}_{y_offset}"] = instance_dict
 
-        result.add([
+        result.add(
             self.surface,
             self.illumination,
             *self.measures,
             self.integrator,
-        ])
+        )
 
         return result

--- a/eradiate/tests/system/test_basic.py
+++ b/eradiate/tests/system/test_basic.py
@@ -3,6 +3,7 @@
 import numpy as np
 import pytest
 
+from eradiate.scenes.core import KernelDict
 from eradiate.solvers.core import runner
 
 
@@ -48,31 +49,33 @@ def test_radiometric_accuracy(mode_mono, illumination, spp, li):
     vza = np.linspace(0, 80, 10)
     rho = 0.5
 
-    kernel_dict = {
-        "type": "scene",
-        "surface": {
-            "type": "rectangle",
-            "bsdf": {
-                "type": "diffuse",
-                "reflectance": rho,
+    kernel_dict = KernelDict.new(
+        {
+            "type": "scene",
+            "surface": {
+                "type": "rectangle",
+                "bsdf": {
+                    "type": "diffuse",
+                    "reflectance": rho,
+                },
             },
-        },
-        "measure": {
-            "type": "distant",
-            "id": "measure",
-            "ray_target": [0, 0, 0],
-            "sampler": {"type": "independent", "sample_count": spp},
-            "film": {
-                "type": "hdrfilm",
-                "width": len(vza),
-                "height": 1,
-                "pixel_format": "luminance",
-                "component_format": "float32",
-                "rfilter": {"type": "box"},
+            "measure": {
+                "type": "distant",
+                "id": "measure",
+                "ray_target": [0, 0, 0],
+                "sampler": {"type": "independent", "sample_count": spp},
+                "film": {
+                    "type": "hdrfilm",
+                    "width": len(vza),
+                    "height": 1,
+                    "pixel_format": "luminance",
+                    "component_format": "float32",
+                    "rfilter": {"type": "box"},
+                },
             },
-        },
-        "integrator": {"type": "path"},
-    }
+            "integrator": {"type": "path"},
+        }
+    )
 
     if illumination == "directional":
         kernel_dict["illumination"] = {


### PR DESCRIPTION
# Description

This PR refactors the `KernelDict` class. The code has been cleaned up and the interface has been slightly updated for improved consistency. Changes are as follows:

- `KernelDict` now inherits from `UserDict` (see [this post](https://treyhunner.com/2019/04/why-you-shouldnt-inherit-from-list-and-dict-in-python/#So_should_I_use_abstract_base_classes_or_UserDict_and_UserList?) for the motivation)
- The `empty()` class method has been replaced with a `new()` class method which also accepts initialisation content
- The `add()` method is now variadic and no longer accepts lists

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
