### PR TITLE
presolver: Raise a user friendly ValueError when the ERADIATE_DIR env var is not set correctly

### DIFF
--- a/eradiate/_presolver.py
+++ b/eradiate/_presolver.py
@@ -38,10 +38,30 @@ class PathResolver(metaclass=Singleton):
         ``[$PWD, $ERADIATE_DIR/resources/data]``
         """
 
+        eradiate_dir = os.getenv("ERADIATE_DIR")
+        if eradiate_dir is None:
+            raise ValueError(
+                "Environment variable ERADIATE_DIR is not set.\n"
+                "Please set this variable to the absolute path of the Eradiate installation folder.\n"
+                "If you are running Eradiate directly from the sources, " 
+                "then you can alternatively source the provided setpath.sh script."
+            )
+        
+        eradiate_path = Path(eradiate_dir).absolute()
+        eradiate_init = eradiate_path / "eradiate" / "__init__.py"
+        if not eradiate_init.exists():
+            raise ValueError(
+                f"Could not find {eradiate_init} file.\n"
+                "Please make sure the ERADIATE_DIR environment variable is correctly set to the Eradiate "
+                "installation folder.\n"
+                "If you are running Eradiate directly from the sources, " 
+                "then you can alternatively source the provided setpath.sh script."
+            )
+
         self.clear()
         for path in [
             Path.cwd(),  # Current working directory
-            Path(os.getenv("ERADIATE_DIR")).absolute() / "resources/data"  # Eradiate data directory
+            eradiate_path / "resources" / "data"  # Eradiate data directory
         ]:
             self.append(path)
 


### PR DESCRIPTION
# Description

The eradiate/_presolver.py used to fail with a cryptic error message when the ERADIATE_DIR variable was not set. This was an issue because a new user installing Eradiate is likely to forget to set this variable.

This simple patch add a user friendly error message with a correct ValueError in the case ERADIATE_DIR is not set.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
