### PR TITLE
Docker: Fix wrong path for additional datasets in the images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ RUN mkdir -p /sources \
     && cd /sources/eradiate \
     && wget -q https://eradiate.eu/data/solid_2017.zip # Silent and may take a while \
     && wget -q https://eradiate.eu/data/spectra-us76_u86_4.zip # Silent and may take a while \
-    && cd eradiate/data && (unzip ../../solid_2017.zip || true) \
+    && cd resources/data && (unzip ../../solid_2017.zip || true) \
     && (unzip ../../spectra-us76_u86_4.zip || true) \
     && cd /sources/eradiate && python3 setup.py install --single-version-externally-managed --root=/ \
     && cp -r /sources/eradiate/resources /usr/local/lib/python3.8/dist-packages/eradiate/resources \

--- a/eradiate/tests/Dockerfile
+++ b/eradiate/tests/Dockerfile
@@ -35,6 +35,7 @@ RUN pip3 install                \
     isort                       \
     jupyterlab                  \
     setuptools                  \
+    toolz                       \
     twine                       \
     mock                        \
     pydata-sphinx-theme         \

--- a/eradiate/tests/Dockerfile
+++ b/eradiate/tests/Dockerfile
@@ -56,8 +56,9 @@ WORKDIR /sources/eradiate
 RUN ln -sf /usr/bin/python3 /usr/bin/python
 RUN ln -sf /usr/bin/pip3 /usr/bin/pip
 
-CMD wget https://eradiate.eu/data/solid_2017.zip  \
-    && wget https://eradiate.eu/data/spectra-us76_u86_4.zip  \
-    && cd eradiate/data && (unzip ../../solid_2017.zip || true) \
+CMD echo "Downloading datasets..." && wget https://eradiate.eu/data/solid_2017.zip -q  \
+    && wget https://eradiate.eu/data/spectra-us76_u86_4.zip -q \
+    && echo "Done downloading." \
+    && cd resources/data && (unzip ../../solid_2017.zip || true) \
     && (unzip ../../spectra-us76_u86_4.zip || true) && cd ../.. \
     && pytest eradiate


### PR DESCRIPTION
# Description

Both Dockerfile and eradiate/tests/Dockerfile had the additional dataset saved in the wrong folder.
The eradiate/tests/Dockerfile was missing one dependency.
This patch fixes this. 

The tests now run smoothly in Docker, following the intervention of Yvan in the issue: close #54 

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
