### PR TITLE
Update spectral response function data set format

### DIFF
--- a/docs/examples/tutorials/data/03_visualise_srf_data_set.py
+++ b/docs/examples/tutorials/data/03_visualise_srf_data_set.py
@@ -1,0 +1,46 @@
+"""
+Visualise spectral response function data sets
+==============================================
+"""
+
+# %%
+# This tutorial illustrates how to visualise the data from a
+# :ref:`spectral response function data set <sec-user_guide-data-srf>`.
+
+import matplotlib.pyplot as plt
+import eradiate
+
+# %%
+# We will plot the spectral response function from the band 5 of the OLCI
+# instrument onboard the Sentinel-3A platform.
+# Open the data set using the
+# :meth:`eradiate.data.open` method.
+# Spectral response function data sets belong to the
+# ``spectral_response_function`` category.
+# Spectral response function data set identifiers are defined according to the
+# :ref:`following convention <sec-user_guide-data-srf-naming_convention>`.
+# In this example, the data set that we want to open has the
+# ``sentinel_3a-olci-5`` identifier:
+
+ds = eradiate.data.open(category="spectral_response_function",
+                        id="sentinel_3a-olci-5")
+
+# %%
+# Plot the spectral response function data by calling the ``plot`` method
+# of the ``srf`` data variable:
+
+ds.srf.plot()
+plt.show()
+
+# %%
+# Plot the spectral response function uncertainties by calling the ``plot``
+# method of the ``srf_u`` data variable:
+
+ds.srf_u.plot()
+plt.show()
+
+# %%
+# .. note::
+#    Not all calibration teams provide the uncertainties on the spectral
+#    response function data.
+#    In those cases, the above code will produce an empty plot.

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -39,6 +39,17 @@
     pages = {1116--1130},
 }
 
+@techreport{ESA2017Sentinel2SpectralResponse,
+    author = {European Space Agency},
+    title = {Sentinel-2 Spectral Response Functions},
+    issue = {3},
+    number = {COPE-GSEG-EOPG-TN-15-0007},
+    institution = {European Space Agency},
+    year = {2017},
+    url = {https://sentinel.esa.int/documents/247904/685211/S2-SRF_COPE-GSEG-EOPG-TN-15-0007_3.0.xlsx},
+    urldate = {2021-04-07}
+}
+
 @article{Gordon2016HITRAN2016MolecularSpectroscopic,
     author = {I.E. Gordon and L.S. Rothman and C. Hill and R.V. Kochanov and Y. Tan and P.F. Bernath and M. Birk and V. Boudon and A. Campargue and K.V. Chance and B.J. Drouin and J.-M. Flaud and R.R. Gamache and J.T. Hodges and D. Jacquemart and V.I. Perevalov and A. Perrin and K.P. Shine and M.-A.H. Smith and J. Tennyson and G.C. Toon and H. Tran and V.G. Tyuterev and A. Barbe and A.G. Császár and V.M. Devi and T. Furtenbacher and J.J. Harrison and J.-M. Hartmann and A. Jolly and T.J. Johnson and T. Karman and I. Kleiner and A.A. Kyuberis and J. Loos and O.M. Lyulin and S.T. Massie and S.N. Mikhailenko and N. Moazzen-Ahmadi and H.S.P. Müller and O.V. Naumenko and A.V. Nikitin and O.L. Polyansky and M. Rey and M. Rotger and S.W. Sharpe and K. Sung and E. Starikova and S.A. Tashkun and J. Vander Auwera and G. Wagner and J. Wilzewski and P. Wcisło and S. Yu and E.J. Zak},
     title = {The {HITRAN2016} Molecular Spectroscopic Database},
@@ -112,6 +123,15 @@
     shorttitle = {US76}
 }
 
+@misc{MODIS2004,
+    author = {MODIS Characterization Support Team},
+    year = {2004},
+    institution = {National Aeronautics and Space Administration},
+    howpublished = {https://mcst.gsfc.nasa.gov/calibration/parameters},
+    url = {https://mcst.gsfc.nasa.gov/sites/default/files/file_attachments/MODIS_PFM_IB_OOB_RSR_merged.xls},
+    urldate = {2021-04-08},
+}
+
 @article{Nimier-David2019MitsubaRetargetableForward,
     title = {Mitsuba 2: {{A Retargetable Forward}} and {{Inverse Renderer}}},
     shorttitle = {Mitsuba 2},
@@ -146,6 +166,28 @@
     pages = {20791--20801},
     issn = {0148-0227},
     doi = {10.1029/93JD02072}
+}
+
+@techreport{Sentinel3CalValTeam2016OLCIASpectralResponse,
+    author = {Sentinel 3 CalVal Team},
+    title = {OLCI-A spectral response functions},
+    issue = {2},
+    number = {S3-TN-ESA-OL-660},
+    institution = {European Space Research and Technology Centre, European Space Agency},
+    year = {2016},
+    url = {https://sentinel.esa.int/documents/247904/2700436/Sentinel-3-OLCI-A-spectral-response-functions},
+    urldate = {2021-04-08},
+}
+
+@techreport{Sentinel3CalValTeam2016OLCIBSpectralResponse,
+    author = {Sentinel 3 CalVal Team},
+    title = {Sentinel-3 OLCI-B spectral response functions from pre-flight characterisation},
+    issue = {1},
+    number = {S3-TN-ESA-OL-660},
+    institution = {European Space Research and Technology Centre, European Space Agency},
+    year = {2016},
+    url = {https://sentinel.esa.int/documents/247904/2700436/Sentinel-3-OLCI-B-spectral-response-functions},
+    urldate = {2021-04-08},
 }
 
 @book{Taine2014TransfertsThermiquesIntroduction,

--- a/docs/rst/user_guide/data/index.rst
+++ b/docs/rst/user_guide/data/index.rst
@@ -6,4 +6,5 @@ Data guide
 .. toctree::
 
    intro
+   srf
    spectra-us76_u86_4

--- a/docs/rst/user_guide/data/srf.rst
+++ b/docs/rst/user_guide/data/srf.rst
@@ -1,0 +1,46 @@
+.. _sec-user_guide-data-srf:
+
+Spectral response function data sets
+====================================
+
+A spectral response function data set provide the spectral response of a
+given instrument on a specific platform and in a specific spectral band.
+
+Structure
+---------
+
+Spectral response function data sets include two data variables:
+
+* the instrument's spectral response function (``srf``)
+* the uncertainties on the ``srf`` data (``srf_u``)
+
+and one
+`dimension coordinate <http://xarray.pydata.org/en/stable/data-structures.html#coordinates>`_:
+
+* the wavelength (``w``)
+
+Both data variables (``srf`` and ``srf_u``) are tabulated with respect to
+wavelength.
+
+The following additional data set attributes are provided:
+
+* ``platform``: platform identifier (e.g. ``sentinel_3b``)
+* ``instrument``: instrument identifier (e.g. ``slstr``)
+* ``band``: spectral band number (e.g. ``5``)
+
+.. _sec-user_guide-data-srf-naming_convention:
+
+Naming convention
+-----------------
+
+Data sets files are named according the following convention:
+``platform-instrument-band.nc``.
+For example the spectral response function data set of the SLSTR instrument
+onboard Sentinel-3B and in the spectral band number 5 is named
+``sentinel_3b-slstr-5.nc``.
+
+Visualise the data
+------------------
+
+Refer to the
+:ref:`dedicated tutorial <sphx_glr_examples_generated_tutorials_data_03_visualise_srf_data_set.py>`.

--- a/eradiate/data/spectral_response_function.py
+++ b/eradiate/data/spectral_response_function.py
@@ -1,97 +1,59 @@
-"""Spectral response function data sets shipped with Eradiate.
-
-**Category ID**: ``spectral_response_function``
-
-.. list-table:: Available data sets and corresponding identifiers
-   :widths: 1 1 1
-   :header-rows: 1
-
-   * - Data set ID
-     - Reference
-     - Spectral range [nm]
-   * - ``sentinel-3a-slstr-s1``
-     - :cite:`RAL2015Sentinel3ASLSTR`
-     - [515, 595]
-   * - ``sentinel-3a-slstr-s2``
-     - :cite:`RAL2015Sentinel3ASLSTR`
-     - [619, 699]
-   * - ``sentinel-3a-slstr-s3``
-     - :cite:`RAL2015Sentinel3ASLSTR`
-     - [825, 905]
-   * - ``sentinel-3a-slstr-s4``
-     - :cite:`RAL2015Sentinel3ASLSTR`
-     - [1345, 1405]
-   * - ``sentinel-3a-slstr-s5``
-     - :cite:`RAL2015Sentinel3ASLSTR`
-     - [1490, 1730]
-   * - ``sentinel-3a-slstr-s6``
-     - :cite:`RAL2015Sentinel3ASLSTR`
-     - [2150, 2350]
-   * - ``sentinel-3a-slstr-s7``
-     - :cite:`RAL2015Sentinel3ASLSTR`
-     - [2980, 4500]
-   * - ``sentinel-3a-slstr-s8``
-     - :cite:`RAL2015Sentinel3ASLSTR`
-     - [9050, 12650]
-   * - ``sentinel-3a-slstr-s9``
-     - :cite:`RAL2015Sentinel3ASLSTR`
-     - [10000, 14000]
-   * - ``sentinel-3b-slstr-s1``
-     - :cite:`RAL2017Sentinel3BSLSTR`
-     - [515, 595]
-   * - ``sentinel-3b-slstr-s2``
-     - :cite:`RAL2017Sentinel3BSLSTR`
-     - [619, 699]
-   * - ``sentinel-3b-slstr-s3``
-     - :cite:`RAL2017Sentinel3BSLSTR`
-     - [825, 905]
-   * - ``sentinel-3b-slstr-s4``
-     - :cite:`RAL2017Sentinel3BSLSTR`
-     - [1345, 1405]
-   * - ``sentinel-3b-slstr-s5``
-     - :cite:`RAL2017Sentinel3BSLSTR`
-     - [1490, 1730]
-   * - ``sentinel-3b-slstr-s6``
-     - :cite:`RAL2017Sentinel3BSLSTR`
-     - [2150, 2350]
-   * - ``sentinel-3b-slstr-s7``
-     - :cite:`RAL2017Sentinel3BSLSTR`
-     - [2980, 4500]
-   * - ``sentinel-3b-slstr-s8``
-     - :cite:`RAL2017Sentinel3BSLSTR`
-     - [9050, 12650]
-   * - ``sentinel-3b-slstr-s9``
-     - :cite:`RAL2017Sentinel3BSLSTR`
-     - [10000, 14000]
-
-
-.. admonition:: Spectral response functions dataset specification
-
-   The data structure is a :class:`~xarray.Dataset` with specific data variables, dimensions and data coordinates.
-
-   Data variables must be:
-
-   - ``srf``: spectral response values [dimensionless],
-
-    The `array dimension <http://xarray.pydata.org/en/stable/terminology.html>`_ of ``srf`` is ``w``.
-
-   The data coordinate is:
-
-   - ``w``: wavelength values [nm].
+"""Spectral response function data getter.
 """
-
+import enum
 import xarray as xr
 
 from .core import DataGetter
 from .. import path_resolver as _presolver
 
 
+class Platform(enum.Enum):
+    Sentinel_2A = "sentinel_2a"
+    Sentinel_2B = "sentinel_2b"
+    Sentinel_3A = "sentinel_3a"
+    Sentinel_3B = "sentinel_3b"
+    Terra = "terra"
+
+
+class Instrument(enum.Enum):
+    MODIS = "modis"
+    MSI = "msi"
+    OLCI = "olci"
+    SLSTR = "slstr"
+
+
+_MODIS_BANDS = [x for x in range(1, 37)]
+_MSI_BANDS = [1, 2, 3, 4, 5, 6, 7, 8, "8a", 9, 10, 11, 12]
+_OLCI_BANDS = [x for x in range(1, 22)]
+_SLSTR_BANDS = [x for x in range(1, 10)]
+
+_BANDS = {
+    (Platform.Sentinel_2A, Instrument.MSI): _MSI_BANDS,
+    (Platform.Sentinel_2B, Instrument.MSI): _MSI_BANDS,
+    (Platform.Sentinel_3A, Instrument.OLCI): _OLCI_BANDS,
+    (Platform.Sentinel_3A, Instrument.SLSTR): _SLSTR_BANDS,
+    (Platform.Sentinel_3B, Instrument.OLCI): _OLCI_BANDS,
+    (Platform.Sentinel_3B, Instrument.SLSTR): _SLSTR_BANDS,
+    (Platform.Terra, Instrument.MODIS): _MODIS_BANDS,
+}
+
+
+def _srf_ds_id(platform, instrument, band):
+    platform_id = platform.value.lower()
+    instrument_id = instrument.value.lower()
+    band_id = str(band).lower()
+    return f"{platform_id}-{instrument_id}-{band_id}"
+
+
+_PATHS = {}
+for platform, instrument in _BANDS:
+    for band in _BANDS[(platform, instrument)]:
+        ds_id = _srf_ds_id(platform, instrument, band)
+        _PATHS[ds_id] = f"spectra/srf/{ds_id}.nc"
+
+
 class _SpectralResponseFunctionGetter(DataGetter):
-    PATHS = {
-        f"sentinel-3{satellite}-slstr-s{channel}":
-        f"spectra/srf/sentinel-3{satellite}-slstr-s{channel}.nc"
-        for satellite in ["a", "b"] for channel in range(1, 10)
-    }
+    PATHS = _PATHS
 
     @classmethod
     def open(cls, id):

--- a/eradiate/data/tests/test_data.py
+++ b/eradiate/data/tests/test_data.py
@@ -13,6 +13,13 @@ def test_open():
         if dataset_id != "solid_2017":  # this dataset is not available in eradiate-data
             data.open(category=cat, id=dataset_id)
 
+    # All spectral response function data sets can be opened
+    paths = data.spectral_response_function._SpectralResponseFunctionGetter.PATHS
+
+    for data_set_id in paths:
+        data.open(category="spectral_response_function",
+                  id=data_set_id)
+
     # Check that unknown category raises
     with pytest.raises(ValueError):
         ds = data.open("doesnt_exist", "blackbody_sun")

--- a/eradiate/solvers/core/_postprocess.py
+++ b/eradiate/solvers/core/_postprocess.py
@@ -93,7 +93,7 @@ def apply_srf(da, srf):
 
         .. code:: python
 
-            apply_srf(results, "sentinel-3a-slstr-s01")
+            apply_srf(results, "sentinel_3a-slstr-1")
 
 
     Parameter ``da`` (:class:`~xarray.DataArray`):

--- a/eradiate/solvers/tests/test_postprocess.py
+++ b/eradiate/solvers/tests/test_postprocess.py
@@ -9,11 +9,11 @@ def test_apply_srf():
         np.random.random((4, 5)),
         dims=["w", "another"],
         coords={"w": 515 + 80 * np.random.random(4)})
-    output_da = apply_srf(da, "sentinel-3a-slstr-s1")
+    output_da = apply_srf(da, "sentinel_3a-slstr-1")
 
     dataset = data.open(
         category="spectral_response_function",
-        id="sentinel-3a-slstr-s1")
+        id="sentinel_3a-slstr-1")
     weights = dataset.srf.interp(w=da.w.values)
     weighted = da.weighted(weights)
     weighted_sum = weighted.sum(dim="w")


### PR DESCRIPTION
# Description

Resolves eradiate/eradiate-issues#71

Additional changes:

* updated eradiate-data submodule with new spectral response function data sets (Sentinel-2A/B, Sentinel-3A/B and Terra)
* uploaded the new data sets to [https://eradiate.eu/data/](https://eradiate.eu/data/).
* added a test to check that all spectral response function data sets can be opened

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
