### PR TITLE
4 variance based render tests

### DIFF
--- a/eradiate/tests/renders/test_renders_het04.py
+++ b/eradiate/tests/renders/test_renders_het04.py
@@ -1,0 +1,145 @@
+import numpy as np
+import os
+
+import eradiate
+eradiate.set_mode("mono_double")
+
+from eradiate.solvers.rami import RamiSolverApp
+from eradiate._units import unit_registry as ureg
+
+from eradiate.kernel.core.xml import load_dict
+
+from util import bitmap_extract, z_test
+
+eradiate_dir = os.environ["ERADIATE_DIR"]
+
+def test_render_het04():
+    """
+    Test the computational results by rendering a pre defined scene and comparing
+    the results with a reference.
+
+    Here we employ a statistical test method, the z-test. By computing for
+    each pixel the probability of agreeing with the reference values we get a
+    measure of the overall agreement. If at least 95% of pixels agree with
+    the reference, we accept the result and pass the test.
+    """
+
+    spp = 512000
+
+    scene_dict = {
+            "canopy": {
+                "type": "discrete_canopy",
+                "instanced_leaf_clouds": [
+                    {
+                        "construct": "from_file",
+                        "filename": "/home/mopsi/src/rayference/eradiate/resources/tests/HET04/HET04_sph_positions.def",
+                        "leaf_cloud": {
+                            "construct": "from_file",
+                            "filename": "/home/mopsi/src/rayference/eradiate/resources/tests/HET04/HET04_sph.def",
+                            "leaf_reflectance": 0.49,
+                            "leaf_transmittance": 0.41,
+                            "id": "spherical_leaf_cloud"
+                        },
+                    },
+                    {
+                        "construct": "from_file",
+                        "filename": "/home/mopsi/src/rayference/eradiate/resources/tests/HET04/HET04_cyl_positions.def",
+                        "leaf_cloud": {
+                            "construct": "from_file",
+                            "filename": "/home/mopsi/src/rayference/eradiate/resources/tests/HET04/HET04_cyl.def",
+                            "leaf_reflectance": 0.45,
+                            "leaf_transmittance": 0.3,
+                            "id": "cylindrical_leaf_cloud"
+                        }
+                    }
+                ],
+                "size": [270, 270, 30] * ureg.m
+            },
+            "surface": {
+                "type": "lambertian",
+                "reflectance": 0.15
+            },
+            "padding": 20,
+            "measures": [{
+                "type": "distant",
+                "spp": spp,
+                "target": {
+                    "type": "rectangle",
+                    "xmin": -135.0*ureg.m,
+                    "xmax":135.0*ureg.m,
+                    "ymin": -135.0*ureg.m,
+                    "ymax": 135.0*ureg.m
+                },
+                "film_resolution": (45, 1),
+                "orientation": (0 + 180)*ureg.deg
+            }],
+            "illumination": {
+                "type": "directional",
+                "zenith": 20*ureg.deg,
+                "irradiance": 20.
+            },
+            "integrator": {
+                "type": "path",
+                "max_depth": -1
+            }
+        }
+
+    app_inf_pplane = RamiSolverApp(scene_dict)
+    scene_dict = app_inf_pplane.scene.kernel_dict()
+    inner_integrator = scene_dict.pop("integrator")
+    scene_dict["integrator"] = {
+        "type": "moment",
+        "subintegrator": inner_integrator
+    }
+    scene = load_dict(dict(scene_dict))
+    sensor = scene.sensors()[0]
+    scene.integrator().render(scene, sensor)
+
+    bmp = scene.sensors()[0].film().bitmap(raw=False)
+    img, var_img = bitmap_extract(bmp)
+
+
+    ref_data = np.load(f"{eradiate_dir}/resources/data/tests/test_renders/HET04/HET04.npz")
+    ref_img = ref_data["img"]
+    ref_var_img = ref_data["var_img"]
+
+
+    significance_level = 0.01
+    p_value = z_test(img, spp, ref_img, ref_var_img)
+
+    # this correction accounts for the fact that the probability for a test to fail by chance
+    # increases with the number of pixels
+    alpha = 1.0 - (1.0 - significance_level) ** (1.0 / 45.)
+    success = (p_value > alpha)
+
+    # 2 out of 45 is roughly 5% of tests
+    # we fail the test is more than 5% of pixels deviate from the reference
+    if sum(int(i) for i in success) < 43:
+        print(f"{45-sum(int(i) for i in success)} pixels deviated. Test failed.")
+        import matplotlib.pyplot as plt
+        output_dir = f"{eradiate_dir}/eradiate/tests/renders/output"
+        if not os.path.exists(f"{eradiate_dir}/eradiate/tests/renders/output"):
+            os.mkdir(output_dir)
+        if os.path.isfile(os.path.join(output_dir, "HET04.png")):
+            os.remove(os.path.join(output_dir, "HET04.png"))
+        fig, ax = plt.subplots(2, 2, figsize=(5,5), dpi=120)
+        # plt.tight_layout()
+        x = np.arange(-89, 90, 4)
+
+        ax[0][0].plot(x, img)
+        ax[0][0].set_title("Image")
+        ax[0][0].set_ylabel("Leaving radiance")
+        ax[0][0].set_xlabel("VZA")
+        ax[0][1].plot(x, ref_img)
+        ax[0][1].set_title("Reference image")
+        ax[0][1].set_xlabel("VZA")
+        ax[1][0].plot(x, var_img)
+        ax[1][0].set_title("Variance")
+        ax[1][0].set_xlabel("VZA")
+        ax[1][0].set_ylabel("Sample variance")
+        ax[1][1].plot(x, ref_var_img)
+        ax[1][1].set_title("Reference variance")
+        ax[1][1].set_xlabel("VZA")
+
+        plt.savefig(f"{eradiate_dir}/eradiate/tests/renders/output/HET04.png")
+        assert False

--- a/eradiate/tests/renders/util.py
+++ b/eradiate/tests/renders/util.py
@@ -1,0 +1,28 @@
+import numpy as np
+import enoki as ek
+
+from eradiate.kernel.core import Bitmap, Struct
+
+def z_test(mean, sample_count, reference, reference_var):
+    # Sanitize the variance images
+    # reference_var = np.maximum(reference_var, 1e-4)
+
+    # Compute Z statistic
+    z_stat = np.abs(mean - reference) * np.sqrt(sample_count / reference_var)
+
+    # Cumulative distribution function of the standard normal distribution
+    def stdnormal_cdf(x):
+        shape = x.shape
+        cdf = (1.0 - ek.erf(-x.flatten() / ek.sqrt(2.0))) * 0.5
+        return np.array(cdf).reshape(shape)
+
+    # Compute p-value
+    p_value = 2.0 * (1.0 - stdnormal_cdf(z_stat))
+
+    return p_value
+
+def bitmap_extract(bmp):
+    split = bmp.split()
+    img = np.squeeze(np.array(split[2][1].convert(Bitmap.PixelFormat.Y, Struct.Type.Float32, srgb_gamma=False), copy=False))
+    img_m2 = np.squeeze(np.array(split[1][1].convert(Bitmap.PixelFormat.Y, Struct.Type.Float32, srgb_gamma=False), copy=False))
+    return img, img_m2 - (img * img)

--- a/eradiate/tests/system/test_renders_onedim.py
+++ b/eradiate/tests/system/test_renders_onedim.py
@@ -1,0 +1,108 @@
+"""Rendering based tests for OneDimSolverApp"""
+
+import pytest
+from .util import aov_to_variance, z_test
+from eradiate.solvers.onedim.app import OneDimSolverApp
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+def app_config(surface="lambertian", atmosphere=None, illumination="directional", spp=1000):
+    """Return a valid config file for the OneDimSolverApp.
+    To set constant illumination, set the illumination_direction to [0, 0, 0].
+    """
+    config = {}
+
+    # create surface config section
+    if surface == "lambertian":
+        config["surface"] = {
+            "type": "lambertian",
+            "reflectance": {
+                "type": "uniform",
+                "value": 0.5
+            }
+        }
+    elif surface == "rpv":
+        config["surface"] = {
+            "type": "rpv",
+            "rho_0": {
+                "type": "uniform",
+                "value": 0.183
+            },
+            "k": {
+                "type": "uniform",
+                "value": 0.780
+            },
+            "ttheta": {
+                "type": "uniform",
+                "value": -0.1
+            }
+        }
+
+    # create atmosphere config section
+    if atmosphere is None:
+        pass
+    elif atmosphere == "rayleigh":
+        config["atmosphere"] = {
+        "type": "rayleigh_homogeneous",
+        "height": 120.,
+        "height_units": "km",
+        "sigma_s": 1.e-4
+    }
+
+    # illumination config section
+    if illumination=="constant":
+        config["illumination"] = {
+            "type": "constant",
+            "radiance": {
+                "type": "uniform",
+                "value": 1e3
+            }
+        }
+    elif illumination == "directional":
+        config["illumination"] = {
+        "type": "directional",
+        "zenith": 30.,
+        "azimuth": 0.,
+        "irradiance": {
+            "type": "uniform",
+            "value": 1.8e+6,
+            "value_units": "W/km**2/nm"
+        },
+    }
+
+    # measure section
+    config["measure"] = [{
+        "type": "toa_hsphere",
+        "spp": spp,
+        "zenith_res": 5.,
+        "azimuth_res": 5.
+    }]
+    return config
+
+
+@pytest.mark.parametrize("surface", ["lambertian", "rpv"])
+@pytest.mark.parametrize("atmosphere", [None, "rayleigh"])
+@pytest.mark.parametrize("illumination", ["constant", "directional"])
+@pytest.mark.slow
+def test_render_onedim(surface, atmosphere, illumination):
+
+    bmp = []
+    for spp in [10**i for i in range(5)]:
+        config = app_config(surface, atmosphere, illumination, spp)
+
+        app = OneDimSolverApp(config)
+
+        integrator_dict = {
+            "integrator": {
+                "type": "moment",
+                "integrator": {
+                    "type": "path"
+                }
+            }
+        }
+        app._kernel_dict["integrator"] = integrator_dict
+        app.run()
+
+        bmp.append(app.results["toa_hsphere"]["lo"])
+    return bmp

--- a/eradiate/tests/system/util.py
+++ b/eradiate/tests/system/util.py
@@ -1,0 +1,42 @@
+"""Utilities for system tests"""
+
+import enoki as ek
+import numpy as np
+from eradiate.kernel.core import Bitmap
+
+def aov_to_variance(bmp):
+    # AVOs from the moment integrator are in XYZ (float32)
+    if isinstance(bmp, Bitmap):
+        split = bmp.split()
+        img = np.array(split[1][1], copy=False)
+        img_m2 = np.array(split[2][1], copy=False)
+    else:
+        ...
+    return img, img_m2 - img * img
+
+
+def z_test(mean, sample_count, reference, reference_var, significance_level=0.01):
+    # Sanitize the variance images
+    reference_var = np.maximum(reference_var, 1e-4)
+
+    # Compute Z statistic
+    z_stat = np.abs(mean - reference) * np.sqrt(sample_count / reference_var)
+
+    # Cumulative distribution function of the standard normal distribution
+    def stdnormal_cdf(x):
+        shape = x.shape
+        cdf = (1.0 - ek.erf(-x.flatten() / ek.sqrt(2.0))) * 0.5
+        return np.array(cdf).reshape(shape)
+
+    # Compute p-value
+    p_value = 2.0 * (1.0 - stdnormal_cdf(z_stat))
+
+    # Apply the Sidak correction term, since we'll be conducting multiple independent
+    # hypothesis tests. This accounts for the fact that the probability of a failure
+    # increases quickly when several hypothesis tests are run in sequence.
+    pixel_count = len(np.flatten(reference))
+    alpha = 1.0 - (1.0 - significance_level) ** (1.0 / pixel_count)
+
+    success = (p_value > alpha)
+
+    return success


### PR DESCRIPTION
# Description

This PR introduces the first statistical render tests, similar to Mitsuba. The first available test runs the HET04 or "real zoom in" canopy scene.

Closes [4](https://github.com/eradiate/eradiate-issues/issues/4)

# Checklist

- [ ] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [ ] The feature branch is rebased on the current state of the `main` branch
- [ ] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
