### PR TITLE
Spectral context

### DIFF
--- a/docs/examples/tutorials/01_quick_overview.py
+++ b/docs/examples/tutorials/01_quick_overview.py
@@ -22,12 +22,12 @@ Quick overview
 # %%
 # Using the command-line
 # ----------------------
-# 
-# A first entry point to Eradiate is the command-line interface to its solvers. 
-# They are directly accessible from a terminal, provided that environment 
-# variables are set correctly. 
-# 
-# For convenience, we will define a command to execute shell commands and 
+#
+# A first entry point to Eradiate is the command-line interface to its solvers.
+# They are directly accessible from a terminal, provided that environment
+# variables are set correctly.
+#
+# For convenience, we will define a command to execute shell commands and
 # display their output.
 
 import subprocess
@@ -35,48 +35,48 @@ def shell_command(args):
     print(subprocess.run(args.split(), capture_output=True).stdout.decode("utf-8"))
 
 # %%
-# For this example, we will use the ``ertonedim``` 
-# application, which works on a one-dimensional scene consisting of a flat 
-# surface and an atmosphere. We can first call it with its ``--help`` flag to 
+# For this example, we will use the ``ertonedim```
+# application, which works on a one-dimensional scene consisting of a flat
+# surface and an atmosphere. We can first call it with its ``--help`` flag to
 # display the help text:
 
 shell_command("ertonedim --help")
 
 # %%
-# This application is configured with a file which uses the 
-# `YAML format <https://yaml.org/>`_. A sample configuration file is given 
+# This application is configured with a file which uses the
+# `YAML format <https://yaml.org/>`_. A sample configuration file is given
 # with this tutorial. We can visualise it:
 
 shell_command("cat 01_quick_overview_config.yml")
 
 # %%
-# The file format is described in the :ref:`sec-user_guide-onedim_solver_app` 
+# The file format is described in the :ref:`sec-user_guide-onedim_solver_app`
 # guide.
 #
-# In addition, ``ertonedim`` requires the user to specify output and plot 
+# In addition, ``ertonedim`` requires the user to specify output and plot
 # filename prefixes. These can be absolute or relative paths.
 
 shell_command("ertonedim 01_quick_overview_config.yml ertonedim ertonedim")
 
 # %%
-# The application saves plots and results to the instructed location. 
+# The application saves plots and results to the instructed location.
 #
-# * Results are saved in the netCDF format and can be further processed using 
-#   your tools of choice. One netCDF file is created for each measure specified 
+# * Results are saved in the netCDF format and can be further processed using
+#   your tools of choice. One netCDF file is created for each measure specified
 #   in the configuration file.
-# * One plot is generated for each measure specified in the configuration file. 
-#   Note that Eradiate's applications do not allow for plot customisation; 
+# * One plot is generated for each measure specified in the configuration file.
+#   Note that Eradiate's applications do not allow for plot customisation;
 #   should that be done, the Python API should be preferred.
 
 # %%
 # Using the Python API
 # --------------------
-# 
-# Eradiate also provides total access to its features through a complete and 
+#
+# Eradiate also provides total access to its features through a complete and
 # documented API (see :ref:`sec-reference`). The ``ertonedim``
 # command-line tool is a thin wrapper around the :class:`.OneDimSolverApp`
 # class. We can easily reproduce the previous computation using it.
-# 
+#
 # We start by loading our YAML configuration file into a dictionary:
 
 import ruamel.yaml as yaml
@@ -85,10 +85,12 @@ with open("01_quick_overview_config.yml") as f:
 config
 
 # %%
-# We can see here that the contents of the configuration file are directly 
-# translated into a configuration dictionary. This dictionary can be used as 
+# We can see here that the contents of the configuration file are directly
+# translated into a configuration dictionary. This dictionary can be used as
 # the argument of the :class:`.OneDimSolverApp` constructor:
 
+import eradiate
+eradiate.set_mode("mono")
 from eradiate.solvers.onedim import OneDimSolverApp
 
 solver = OneDimSolverApp.from_dict(config)
@@ -99,24 +101,24 @@ solver = OneDimSolverApp.from_dict(config)
 solver.run()
 
 # %%
-# Unlike the command-line interface, a call to :meth:`~.OneDimSolverApp.run` 
-# without argument will not create any result or plot files. Instead, results 
-# are saved in the solver object's ``results`` dictionary. In this case, we 
-# have a single measure, so ``solver.results`` contains a single element under 
-# the key ``"toa_hsphere"`` which corresponds to the only measure defined in 
+# Unlike the command-line interface, a call to :meth:`~.OneDimSolverApp.run`
+# without argument will not create any result or plot files. Instead, results
+# are saved in the solver object's ``results`` dictionary. In this case, we
+# have a single measure, so ``solver.results`` contains a single element under
+# the key ``"toa_hsphere"`` which corresponds to the only measure defined in
 # the configuration file. This element is a :class:`xarray.Dataset`:
 
 ds = solver.results["toa_hsphere"]
 ds
 
 # %%
-# The usual xarray writing facilities can be used to save the results to a 
+# The usual xarray writing facilities can be used to save the results to a
 # netCDF file:
 
 ds.to_netcdf("ertonedim.nc")
 
 # %%
-# Results can then easily be plotted using Eradiate's matplotlib/xarray-based 
+# Results can then easily be plotted using Eradiate's matplotlib/xarray-based
 # plotting facilities:
 
 import matplotlib.pyplot as plt
@@ -127,13 +129,13 @@ ds.brf.squeeze().ert.plot_pcolormesh_polar()
 ertplt.remove_xylabels()
 plt.show()
 
-# %% 
+# %%
 # The figure can be saved using the usual matplotlib pattern:
 
 fig.savefig("ertonedim_toa_brf.png")
 plt.close()
 
-# %% 
+# %%
 # From there, any post-processing or customised plotting can be applied.
 #
 # We finish this sequence with a quick cleanup:
@@ -141,3 +143,5 @@ plt.close()
 import glob, os
 for fname in  glob.glob("ertonedim*.png") + glob.glob("ertonedim*.nc"):
     os.remove(fname)
+
+# %%

--- a/docs/examples/tutorials/01_quick_overview_config.yml
+++ b/docs/examples/tutorials/01_quick_overview_config.yml
@@ -1,6 +1,4 @@
-mode:
-  type: mono
-  wavelength: 550.  # nm
+mode: mono
 surface:
   type: lambertian
   reflectance:
@@ -17,7 +15,8 @@ illumination:
     type: uniform
     value: 1.8e+6  # W/km^2/nm
 measures:
-  - type: toa_hsphere
+  - type: distant
+    id: toa_hsphere
+    spectral_cfg:
+      wavelength: 550.  # nm
     spp: 32000  # dimensionless
-    zenith_res: 10.  # deg
-    azimuth_res: 10.  # deg

--- a/docs/examples/tutorials/atmosphere/01_homogeneous.py
+++ b/docs/examples/tutorials/atmosphere/01_homogeneous.py
@@ -9,7 +9,7 @@ Homogeneous atmospheres
 # and set the wavelength to 550 nm:
 
 import eradiate
-eradiate.set_mode("mono", wavelength=550.)
+eradiate.set_mode("mono")
 
 # %%
 # Get started

--- a/docs/examples/tutorials/atmosphere/02_heterogeneous.py
+++ b/docs/examples/tutorials/atmosphere/02_heterogeneous.py
@@ -9,7 +9,7 @@ Heterogeneous atmospheres
 # and set the wavelength to 550 nm:
 
 import eradiate
-eradiate.set_mode("mono", wavelength=550.)
+eradiate.set_mode("mono")
 
 # %%
 # This is required because heterogeneous atmospheres are objects whose internal
@@ -98,7 +98,7 @@ atmosphere = eradiate.scenes.atmosphere.HeterogeneousAtmosphere(
 # -----------------------------------
 # Check the atmosphere's dimensions using:
 
-print(atmosphere.height.to("km"))
+print(atmosphere.height().to("km"))
 
 # %%
 
@@ -128,7 +128,8 @@ atmosphere = eradiate.scenes.atmosphere.HeterogeneousAtmosphere(
 # ---------------------------------------------
 # You can fetch the atmospheric radiative properties into a data set:
 
-ds = atmosphere.profile.to_dataset()
+spectral_ctx = eradiate.contexts.SpectralContext.new()
+ds = atmosphere.profile.to_dataset(spectral_ctx)
 ds
 
 # %%

--- a/docs/examples/tutorials/biosphere/01_discrete_canopy.py
+++ b/docs/examples/tutorials/biosphere/01_discrete_canopy.py
@@ -26,6 +26,9 @@ def display_canopy(canopy, distance=85):
     # Compute camera location
     origin = np.full((3,), distance / np.sqrt(3))
 
+    # Prepare kernel evaluation context
+    ctx = eradiate.contexts.KernelDictContext()
+
     # Build kernel scene dictionary suitable for visualisation
     # (we'll render only direct illumination for optimal speed)
     kernel_dict = eradiate.scenes.core.KernelDict.new(
@@ -36,10 +39,12 @@ def display_canopy(canopy, distance=85):
             origin=origin,
             target=(0, 0, 0),
             up=(0, 0, 1),
+            spectral_cfg=ctx.spectral_ctx,
         ),
         eradiate.scenes.illumination.DirectionalIllumination(),
         eradiate.scenes.integrators.PathIntegrator(max_depth=2),
         canopy,
+        ctx=ctx,
     )
 
     # Render image

--- a/docs/examples/tutorials/solver_onedim/01_solver_onedim.py
+++ b/docs/examples/tutorials/solver_onedim/01_solver_onedim.py
@@ -6,7 +6,7 @@ One-dimensional solver application
 # %%
 #
 # This tutorial introduces a classical workflow with one-dimensional scenes
-# using the :class:`.OneDimSolverApp` class. It simulates radiative transfer in 
+# using the :class:`.OneDimSolverApp` class. It simulates radiative transfer in
 # a one-dimensional scene with an atmosphere and a plane surface.
 #
 # Configuring the application
@@ -16,17 +16,17 @@ One-dimensional solver application
 # operational mode. We will run a monochromatic simulation at 577 nm.
 
 import eradiate
-eradiate.set_mode("mono_double", wavelength=577.0)
+eradiate.set_mode("mono_double")
 
 # %%
-# The first thing we have to do is configure the solver application 
-# which will run our simulations. 
+# The first thing we have to do is configure the solver application
+# which will run our simulations.
 # :class:`.OneDimSolverApp` can be instantiated in a variety of ways. While we
 # will go with the more classical way of working with it, we will see at the
 # end of this tutorial that there are alternatives which you might feel more
 # comfortable with.
 #
-# Let's first start by configuring our scene. :class:`.OneDimSolverApp` 
+# Let's first start by configuring our scene. :class:`.OneDimSolverApp`
 # encapsulates an instance of :class:`.OneDimScene`, which itself holds a
 # number of attributes.
 #
@@ -121,13 +121,14 @@ illumination
 # a quick simulation with more samples and less noise.
 #
 # In order to identify our results more easily afterwards, we will assign a
-# ``toa_hsphere`` identifier (for "top-of-atmosphere, hemisphere") to our 
+# ``toa_hsphere`` identifier (for "top-of-atmosphere, hemisphere") to our
 # measure.
 
 measure = eradiate.scenes.measure.DistantMeasure(
     id="toa_hsphere",
     film_resolution=(32, 32),
     spp=10000,
+    spectral_cfg={"wavelength": 577.0},
 )
 measure
 
@@ -191,7 +192,7 @@ from pprint import pprint
 pprint(app.results)
 
 # %%
-# In that case, we have a single measure ``toa_hsphere`` for which we can easily 
+# In that case, we have a single measure ``toa_hsphere`` for which we can easily
 # display the data set:
 
 ds = app.results["toa_hsphere"]
@@ -217,9 +218,9 @@ brf.squeeze().plot()
 plt.show()
 
 # %%
-# We can see that we have a "hot spot" in the back scattering direction (a 
+# We can see that we have a "hot spot" in the back scattering direction (a
 # distinctive feature of the RPV BRDF). If we reduce the amount of scattering in
-# our atmosphere, the hot spot becomes sharper (see the bounds of the colour 
+# our atmosphere, the hot spot becomes sharper (see the bounds of the colour
 # map):
 
 scene = eradiate.solvers.onedim.OneDimScene(
@@ -246,9 +247,9 @@ plt.show()
 #
 # While the hemispherical views we have created so far are convenient for
 # basic checks, they are fairly noisy and we usually prefer visualising results
-# in the principal plane. For that purpose, we can configure our 
-# :class:`.DistantMeasure` by assigning 1 to the film height. Since we are 
-# significantly reducing the number of pixels, we can increase the number of 
+# in the principal plane. For that purpose, we can configure our
+# :class:`.DistantMeasure` by assigning 1 to the film height. Since we are
+# significantly reducing the number of pixels, we can increase the number of
 # samples we will take while (more or less) preserving our computational time.
 
 scene = eradiate.solvers.onedim.OneDimScene(
@@ -262,6 +263,7 @@ scene = eradiate.solvers.onedim.OneDimScene(
         id="toa_pplane",
         film_resolution=(32, 1),
         spp=1000000,
+        spectral_cfg={"wavelength": 577.0},
     ),
 )
 app = eradiate.solvers.onedim.OneDimSolverApp(scene)
@@ -280,12 +282,12 @@ plt.show()
 # %%
 # Alternative object configuration methods
 # ----------------------------------------
-# 
+#
 # So far, we have been using Eradiate's Python API exclusively. However, all
-# scene elements and solver applications can also be configured using 
+# scene elements and solver applications can also be configured using
 # dictionaries. While it requires a little more knowledge of the API (your IDE
-# will not assist you in writing configuration dictionaries), it also saves some 
-# importing. For instance, the scene used for the previous simulation can also 
+# will not assist you in writing configuration dictionaries), it also saves some
+# importing. For instance, the scene used for the previous simulation can also
 # be configured as follows:
 
 scene = eradiate.solvers.onedim.OneDimScene(
@@ -308,6 +310,7 @@ scene = eradiate.solvers.onedim.OneDimScene(
         "id": "toa_hsphere",
         "film_resolution": (32, 1),
         "spp": 1000000,
+        "spectral_cfg": {"wavelength": 577.0},
     },
 )
 
@@ -335,20 +338,18 @@ scene = eradiate.solvers.onedim.OneDimScene.from_dict({
         "id": "toa_hsphere",
         "film_resolution": (32, 1),
         "spp": 1000000,
+        "spectral_cfg": {"wavelength": 577.0},
     },
 })
 
 # %%
-# Finally, we can configure the entire application with a dictionary. This app 
+# Finally, we can configure the entire application with a dictionary. This app
 # configuration dictionary is basically the previous scene configuration, to
-# which we add a mode configuration section used to force mode setup upon 
+# which we add a mode configuration section used to force mode setup upon
 # instantiation of the application object:
 
 config = {
-    "mode": {
-        "type": "mono_double",
-        "wavelength": 577.0,
-    },
+    "mode": "mono_double",
     "surface": {
         "type": "rpv",
     },
@@ -368,6 +369,7 @@ config = {
         "id": "toa_hsphere",
         "film_resolution": (32, 1),
         "spp": 1000000,
+        "spectral_cfg": {"wavelength": 577.0},
     },
 }
 app = eradiate.solvers.onedim.OneDimSolverApp.from_dict(config)
@@ -379,12 +381,12 @@ config
 # case and will automatically attach to a scalar field the units defined a
 # corresponding field with the ``_units``.
 #
-# .. note:: While we use YAML in this example, nothing prevents the use of 
+# .. note:: While we use YAML in this example, nothing prevents the use of
 #    another language to generate your dictionaries.
 #
 # Let's load the following file
 # [:download:`01_solver_onedim_config.yml </examples/tutorials/solver_onedim/01_solver_onedim_config.yml>`]:
-# 
+#
 # .. include:: /examples/tutorials/solver_onedim/01_solver_onedim_config.yml
 #    :literal:
 

--- a/docs/examples/tutorials/solver_onedim/01_solver_onedim_config.yml
+++ b/docs/examples/tutorials/solver_onedim/01_solver_onedim_config.yml
@@ -1,6 +1,4 @@
-mode:
-  type: mono_double # Double-precision monochromatic mode
-  wavelength: 577.0 # Evaluate optical properties at 577 nm
+mode: mono_double # Double-precision monochromatic mode
 surface:
   type: rpv # Use a RPV surface with default parameters
 atmosphere:
@@ -24,3 +22,5 @@ measures:
     orientation_units: deg
     film_resolution: [32, 1]  # ... and because we're setting the film height to 1, thus restricting sampling to a plane
     spp: 1000000     # We take a lot of samples to reduce the variance in our results as much as possible
+    spectral_cfg:
+      wavelength: 577.0 # This measure will compute radiance values at 577 nm

--- a/docs/examples/tutorials/solver_onedim/02_onedim_sim_hetero_atm.py
+++ b/docs/examples/tutorials/solver_onedim/02_onedim_sim_hetero_atm.py
@@ -35,10 +35,7 @@ import xarray as xr
 from eradiate.solvers.onedim import OneDimSolverApp
 
 config = {
-    "mode": {
-        "type": "mono_double",
-        "wavelength": 579.
-    },
+    "mode": "mono_double",
     "atmosphere": {
         "type": "heterogeneous",
         "profile": {
@@ -49,7 +46,8 @@ config = {
         "type": "distant",
         "id": "toa_plane",
         "film_resolution": [90,1],
-        "spp": 65536
+        "spp": 65536,
+        "spectral_cfg": {"wavelength": 579.0},
     }]
 }
 app = OneDimSolverApp.from_dict(config)
@@ -82,7 +80,8 @@ visualise(results_579)
 # reflectance.
 # Indeed, the atmosphere we have created is almost purely scattering:
 
-print(app.scene.atmosphere.profile.albedo)
+spectral_ctx = app.scene.measures[0].spectral_ctx
+print(app.scene.atmosphere.profile.albedo(spectral_ctx))
 
 # %%
 # At higher zenith angles, we observe that the scene is less reflective, which
@@ -100,10 +99,7 @@ print(app.scene.atmosphere.profile.albedo)
 # wavelength.
 
 config = {
-    "mode": {
-        "type": "mono_double",
-        "wavelength": 1281.
-    },
+    "mode": "mono_double",
     "atmosphere": {
         "type": "heterogeneous",
         "profile": {
@@ -114,7 +110,8 @@ config = {
         "type": "distant",
         "id": "toa_plane",
         "film_resolution": [90, 1],
-        "spp": 65536
+        "spp": 65536,
+        "spectral_cfg": {"wavelength": 1281.0},
     }]
 }
 app = OneDimSolverApp.from_dict(config)
@@ -122,7 +119,8 @@ app = OneDimSolverApp.from_dict(config)
 # %%
 # Let us confirm our intuition:
 
-print(app.scene.atmosphere.profile.albedo)
+spectral_ctx = app.scene.measures[0].spectral_ctx
+print(app.scene.atmosphere.profile.albedo(spectral_ctx))
 
 # %%
 # Let us run the infrared simulation and compare our results with the

--- a/docs/examples/tutorials/solver_rami/01_solver_rami.py
+++ b/docs/examples/tutorials/solver_rami/01_solver_rami.py
@@ -19,7 +19,7 @@ typically used in the RAMI benchmarking exercise.
 
 import eradiate
 
-eradiate.set_mode("mono", wavelength=550.0)
+eradiate.set_mode("mono")
 
 # %%
 # We also assign an alias to the unit registry:
@@ -94,6 +94,7 @@ measure = eradiate.scenes.measure.DistantMeasure(
     id="toa_brf",
     film_resolution=(32, 32),
     spp=1000,
+    spectral_cfg={"wavelength": 550.0}
 )
 measure
 

--- a/docs/rst/reference/contexts.rst
+++ b/docs/rst/reference/contexts.rst
@@ -1,0 +1,13 @@
+.. _sec-reference-contexts:
+
+Context data structures [eradiate.contexts]
+===========================================
+
+.. currentmodule:: eradiate.contexts
+
+.. autosummary::
+   :toctree: generated/
+
+   KernelDictContext
+   SpectralContext
+   MonoSpectralContext

--- a/docs/rst/reference/core.rst
+++ b/docs/rst/reference/core.rst
@@ -21,11 +21,7 @@ Mode control
 
       _mode.ModeSpectrum
       _mode.ModePrecision
-      _mode.register_mode
       _mode.Mode
-      _mode.ModeNone
-      _mode.ModeMono
-      _mode.ModeMonoDouble
 
 Units and quantities
 --------------------

--- a/docs/rst/reference/index.rst
+++ b/docs/rst/reference/index.rst
@@ -17,6 +17,7 @@ Eradiate's API reference documentation is generated automatically using Sphinx's
    :maxdepth: 2
 
    core
+   contexts
    scenes
    solvers
    kernel

--- a/docs/rst/reference/scenes.rst
+++ b/docs/rst/reference/scenes.rst
@@ -199,3 +199,4 @@ Spectra [eradiate.scenes.spectra]
 
    UniformSpectrum
    SolarIrradianceSpectrum
+   AirScatteringCoefficientSpectrum

--- a/eradiate/__init__.py
+++ b/eradiate/__init__.py
@@ -28,20 +28,21 @@ del PathResolver
 
 # ------------------------------------------------------------------------------
 
-from . import converters, kernel, scenes, solvers, validators, xarray
+from . import converters, contexts, kernel, scenes, solvers, validators, xarray
 
 __all__ = [
     "__version__",
+    "converters",
+    "contexts",
     "mode",
     "modes",
-    "set_mode",
     "path_resolver",
-    "unit_registry",
+    "scenes",
+    "set_mode",
+    "solvers",
     "unit_context_config",
     "unit_context_kernel",
-    "scenes",
-    "solvers",
-    "converters",
+    "unit_registry",
     "validators",
     "xarray",
 ]

--- a/eradiate/_mode.py
+++ b/eradiate/_mode.py
@@ -1,14 +1,13 @@
 import enum
 
 import attr
-import pinttr
-
-from ._units import unit_context_config as ucc
-from ._units import unit_registry as ureg
+import mitsuba
 
 
 class ModeSpectrum(enum.Enum):
-    """An enumeration defining known kernel spectrum representations."""
+    """
+    An enumeration defining known spectrum representations.
+    """
 
     MONO = "mono"
     # POLY = "poly"
@@ -17,7 +16,9 @@ class ModeSpectrum(enum.Enum):
 
 
 class ModePrecision(enum.Enum):
-    """An enumeration defining known kernel precision."""
+    """
+    An enumeration defining known kernel precision.
+    """
 
     SINGLE = "single"
     DOUBLE = "double"
@@ -25,34 +26,34 @@ class ModePrecision(enum.Enum):
 
 # Map associating a mode ID string to the corresponding class
 # (aliased in public API section)
-_mode_registry = {}
-
-
-def register_mode(mode_id, spectrum="mono", precision="single"):
-    # This decorator is meant to be added to added to an Mode child class.
-    # It adds it to mode_registry.
-
-    spectrum = ModeSpectrum(spectrum)
-    precision = ModePrecision(precision)
-
-    def decorator(cls):
-        _mode_registry[mode_id] = cls
-        cls.id = mode_id
-        cls.precision = precision
-        cls.spectrum = spectrum
-        return cls
-
-    return decorator
+_mode_registry = {
+    "mono": {
+        "spectrum": "mono",
+        "precision": "single",
+        "kernel_variant": "scalar_mono",
+    },
+    "mono_double": {
+        "spectrum": "mono",
+        "precision": "double",
+        "kernel_variant": "scalar_mono_double",
+    },
+}
 
 
 @attr.s(frozen=True)
 class Mode:
-    # Parent class for all operational modes
-    # All derived classes will be frozen
-    # Side-effect: they will also implement from_dict()
-    id = None
-    precision = None
-    spectrum = None
+    id = attr.ib()
+    precision = attr.ib(converter=attr.converters.optional(ModePrecision))
+    spectrum = attr.ib(converter=attr.converters.optional(ModeSpectrum))
+    kernel_variant = attr.ib()
+
+    @staticmethod
+    def new(mode_id):
+        try:
+            mode_kwargs = _mode_registry[mode_id]
+        except KeyError:
+            raise ValueError(f"unknown mode '{mode_id}'")
+        return Mode(id=mode_id, **mode_kwargs)
 
     def is_monochromatic(self):
         return self.spectrum is ModeSpectrum.MONO
@@ -63,56 +64,9 @@ class Mode:
     def is_double_precision(self):
         return self.precision is ModePrecision.DOUBLE
 
-    @staticmethod
-    def new(mode_id, **kwargs):
-        try:
-            mode_cls = _mode_registry[mode_id]
-        except KeyError:
-            raise ValueError(f"unknown mode '{mode_id}'")
-        return mode_cls(**kwargs)
-
-
-@register_mode("none")
-@attr.s
-class ModeNone(Mode):
-    # Default mode, defined to improve error messages
-    pass
-
-
-@register_mode("mono", spectrum="mono", precision="single")
-@attr.s
-class ModeMono(Mode):
-    # Monochromatic mode, single precision
-    wavelength = pinttr.ib(
-        default=ureg.Quantity(550.0, ureg.nm),
-        units=ucc.deferred("wavelength"),
-        on_setattr=None,
-    )
-
-    def __attrs_post_init__(self):
-        import mitsuba
-
-        mitsuba.set_variant("scalar_mono")
-
-
-@register_mode("mono_double", spectrum="mono", precision="double")
-@attr.s
-class ModeMonoDouble(Mode):
-    # Monochromatic mode, double precision
-    wavelength = pinttr.ib(
-        default=ureg.Quantity(550.0, ureg.nm),
-        units=ucc.deferred("wavelength"),
-        on_setattr=None,
-    )
-
-    def __attrs_post_init__(self):
-        import mitsuba
-
-        mitsuba.set_variant("scalar_mono_double")
-
 
 # Eradiate's operational mode configuration
-_current_mode = ModeNone()
+_current_mode = None
 
 
 # -- Public API ----------------------------------------------------------------
@@ -138,36 +92,28 @@ def modes():
     return _mode_registry
 
 
-def set_mode(mode_id, **kwargs):
+def set_mode(mode_id):
     """
     Set Eradiate's operational mode.
 
-    This function sets and configures Eradiate's operational mode. In addition,
-    it invokes the :func:`~mitsuba.set_variant` kernel function to select the
-    kernel variant corresponding to the selected mode.
-
-    The main argument ``mode_id`` defines which mode is selected. Then,
-    keyword arguments are used to pass additional configuration details for the
-    selected mode. The mode configuration is critical since many code components
-    (*e.g.* spectrum-related components) adapt their behaviour based on the
-    selected mode.
+    This function sets and configures Eradiate's operational mode. Eradiate's
+    modes map to Mitsuba's variants and are used to make contextual decisions
+    when relevant during the translation of a scene to its kernel format.
 
     Parameter ``mode_id`` (str):
         Mode to be selected (see list below).
 
-    .. rubric:: Available modes and corresponding keyword arguments
+    .. rubric:: Available modes
 
-    ``mono`` (monochromatic mode, single precision)
-        ``wavelength`` (float):
-            Wavelength selected for monochromatic operation. Default: 550 nm.
-
-            Unit-enabled field (default: cdu[wavelength]).
-
-    ``mono_double`` (monochromatic mode, double-precision)
-        ``wavelength`` (float):
-            Wavelength selected for monochromatic operation. Default: 550 nm.
-
-            Unit-enabled field (default: cdu[wavelength]).
+    * ``mono`` (monochromatic mode, single precision)
+    * ``mono_double`` (monochromatic mode, double-precision)
     """
     global _current_mode
-    _current_mode = Mode.new(mode_id, **kwargs)
+
+    if mode_id in _mode_registry.keys():
+        mode = Mode.new(mode_id)
+        mitsuba.set_variant(mode.kernel_variant)
+    else:
+        mode = None
+
+    _current_mode = mode

--- a/eradiate/contexts.py
+++ b/eradiate/contexts.py
@@ -1,0 +1,132 @@
+import attr
+import pinttr
+
+import eradiate
+from ._attrs import documented, parse_docs
+from ._units import unit_context_config as ucc
+from ._units import unit_registry as ureg
+from .exceptions import ModeError
+
+
+@attr.s
+class SpectralContext:
+    """
+    Context data structure holding state relevant to the evaluation of spectrally
+    dependent objects.
+
+    This object is usually used as part of a :class:`.KernelDictContext` to pass
+    around spectral information to kernel dictionary emission methods which
+    require spectral configuration information.
+
+    :class:`Measures <.Measure>` also store a user-configured
+    :class:`.SpectralContext` instance which drives contextual spectral
+    configuration in solver applications.
+
+    While this class is abstract, it should however be the main entry point
+    to create :class:`.SpectralContext` child class objects through the
+    :meth:`.SpectralContext.new` class method constructor.
+    """
+
+    @staticmethod
+    def new(**kwargs):
+        """
+        Create a new instance of one of the :class:`SpectralContext` child
+        classes. *The instantiated class is defined based on the currently active
+        mode.* Keyword arguments are passed to the instantiated class's
+        constructor:
+
+        .. rubric:: Monochromatic modes [:class:`MonoSpectralContext`]
+
+        Parameter ``wavelength`` (float):
+            Wavelength. Default: 550 nm.
+
+            Unit-enabled field (default: ucc[wavelength]).
+
+        .. seealso::
+
+           * :func:`eradiate.mode`
+           * :func:`eradiate.set_mode`
+        """
+        mode = eradiate.mode()
+
+        if mode.is_monochromatic():
+            return MonoSpectralContext(**kwargs)
+
+        raise ModeError(f"unsupported mode '{mode.id}'")
+
+    @staticmethod
+    def from_dict(d):
+        """
+        Create from a dictionary. This class method will additionally pre-process
+        the passed dictionary to merge any field with an associated ``"_units"``
+        field into a :class:`pint.Quantity` container.
+
+        Parameter ``d`` (dict):
+            Configuration dictionary used for initialisation.
+
+        Returns → instance of cls:
+            Created object.
+        """
+
+        # Pre-process dict: apply units to unit-enabled fields
+        d_copy = pinttr.interpret_units(d, ureg=ureg)
+
+        # Perform object creation
+        return SpectralContext.new(**d_copy)
+
+    @staticmethod
+    def convert(value):
+        """
+        Object converter method.
+
+        If ``value`` is a dictionary, this method uses :meth:`from_dict` to
+        create a :class:`.SpectralContext`.
+
+        Otherwise, it returns ``value``.
+        """
+        if isinstance(value, dict):
+            return SpectralContext.from_dict(value)
+
+        return value
+
+
+@attr.s
+class MonoSpectralContext(SpectralContext):
+    wavelength = pinttr.ib(
+        default=ureg.Quantity(550.0, ureg.nm),
+        units=ucc.deferred("wavelength"),
+    )
+
+
+@parse_docs
+@attr.s
+class KernelDictContext:
+    """
+    Kernel dictionary evaluation context data structure. This class is used
+    *e.g.* to store information about the spectral configuration to apply
+    when generating kernel dictionaries associated with a :class:`.SceneElement`
+    instance.
+    """
+    spectral_ctx = documented(
+        attr.ib(factory=SpectralContext.new, converter=SpectralContext.convert),
+        doc="Spectral context (used to evaluate quantities with any degree "
+        "or kind of dependency vs spectrally varying quantities).",
+        type=":class:`.SpectralContext`",
+        default=":meth:`SpectralContext.new() <.SpectralContext.new>`",
+    )
+
+    ref = documented(
+        attr.ib(default=True, converter=bool),
+        doc="If ``True``, use references when relevant during kernel dictionary "
+        "generation.",
+        type="bool",
+        default="True",
+    )
+
+    atmosphere_kernel_width = documented(
+        pinttr.ib(default=None, units=ucc.deferred("length")),
+        doc="If relevant, stores the width of the kernel object associated with "
+        "the atmosphere.",
+        type="float or None",
+        default="None",
+    )

--- a/eradiate/radprops/rad_profile.py
+++ b/eradiate/radprops/rad_profile.py
@@ -578,10 +578,12 @@ class US76ApproxRadProfile(RadProfile):
         Returns → :class:`xarray.Dataset`:
             Radiative properties dataset.
         """
+        profile = self.eval_thermoprops_profile()
+
         return make_dataset(
             wavelength=self._wavelength,
-            z_level=self.eval_thermoprops_profile().z_level.values,
-            z_layer=self.eval_thermoprops_profile().z_layer.values,
+            z_level=profile.z_level.values,
+            z_layer=profile.z_layer.values,
             sigma_a=self.sigma_a(spectral_ctx).flatten(),
             sigma_s=self.sigma_s(spectral_ctx).flatten(),
         )
@@ -838,7 +840,7 @@ class AFGL1986RadProfile(RadProfile):
 
     def eval_sigma_a(self, spectral_ctx):
         """
-        Evaluate absorption coefficient given spectral context.
+        Evaluate absorption coefficient given a spectral context.
 
         .. note:: Extrapolate to zero when wavelength, pressure and/or
            temperature are out of bounds.
@@ -892,7 +894,7 @@ class AFGL1986RadProfile(RadProfile):
 
     def eval_sigma_s(self, spectral_ctx):
         """
-        Evaluate scattering coefficient given spectral context.
+        Evaluate scattering coefficient given a spectral context.
         """
         wavelength = spectral_ctx.wavelength
         profile = self.eval_thermoprops_profile()

--- a/eradiate/scenes/atmosphere/__init__.py
+++ b/eradiate/scenes/atmosphere/__init__.py
@@ -1,19 +1,6 @@
-"""Atmosphere-related scene generation facilities.
-
-.. admonition:: Registered factory members [:class:`.AtmosphereFactory`]
-    :class: hint
-
-    .. factorytable::
-       :factory: AtmosphereFactory
-"""
-
-from ._base import (
-    Atmosphere,
-    AtmosphereFactory
-)
+from ._base import Atmosphere, AtmosphereFactory
 from ._heterogeneous import HeterogeneousAtmosphere
 from ._homogeneous import HomogeneousAtmosphere
-
 
 __all__ = [
     "Atmosphere",

--- a/eradiate/scenes/atmosphere/tests/test_homogeneous.py
+++ b/eradiate/scenes/atmosphere/tests/test_homogeneous.py
@@ -6,6 +6,7 @@ import eradiate
 from eradiate.radprops.rayleigh import compute_sigma_s_air
 from eradiate.scenes.atmosphere._homogeneous import HomogeneousAtmosphere
 from eradiate.scenes.core import KernelDict
+from eradiate.contexts import KernelDictContext
 from eradiate._util import onedict_value
 from eradiate import unit_registry as ureg
 
@@ -19,45 +20,49 @@ def test_homogeneous(mode_mono, ref):
     # Check if default constructor works
     r = HomogeneousAtmosphere()
     assert r.toa_altitude == "auto"
-    assert r.kernel_offset == ureg.Quantity(0.1, "km")
-    assert r.kernel_height == ureg.Quantity(100.1, "km")
+    assert r.kernel_offset() == ureg.Quantity(0.1, "km")
+    assert r.kernel_height() == ureg.Quantity(100.1, "km")
 
     # Check if default constructs can be loaded by the kernel
-    dict_phase = onedict_value(r.phase())
+    ctx = KernelDictContext(ref=False)
+
+    dict_phase = onedict_value(r.phase(ctx))
     assert load_dict(dict_phase) is not None
 
-    dict_medium = onedict_value(r.media())
+    dict_medium = onedict_value(r.media(ctx))
     assert load_dict(dict_medium) is not None
 
-    dict_shape = onedict_value(r.shapes())
+    dict_shape = onedict_value(r.shapes(ctx))
     assert load_dict(dict_shape) is not None
 
     # Check if produced scene can be instantiated
-    kernel_dict = KernelDict.new(r)
+    ctx = KernelDictContext(ref=True)
+
+    kernel_dict = KernelDict.new(r, ctx=ctx)
     assert kernel_dict.load() is not None
 
     # Construct with parameters
     r = HomogeneousAtmosphere(sigma_s=1e-5)
-    assert r.sigma_s.value == ureg.Quantity(1e-5, ureg.m ** -1)
+    assert r.eval_sigma_s() == ureg.Quantity(1e-5, ureg.m ** -1)
 
-    eradiate.set_mode("mono", wavelength=650.)
     r = HomogeneousAtmosphere(toa_altitude=ureg.Quantity(10, ureg.km))
-    assert r.toa_altitude == ureg.Quantity(10, ureg.km)
-
-    # Check if sigma_s was correctly computed using the mode wavelength value
-    wavelength = eradiate.mode().wavelength
-    assert np.isclose(r._sigma_s.value, compute_sigma_s_air(wavelength=wavelength))
+    assert r.toa_altitude == ureg.Quantity(10.0, ureg.km)
 
     # Check if automatic scene width works as intended
-    assert np.isclose(r.kernel_width, 10. / compute_sigma_s_air(wavelength=wavelength))
+    wavelength = ctx.spectral_ctx.wavelength
+    assert np.isclose(
+        r.kernel_width(ctx), 10.0 / compute_sigma_s_air(wavelength=wavelength)
+    )
 
     # Check if produced scene can be instantiated
-    assert KernelDict.new(r).load() is not None
+    assert KernelDict.new(r, ctx=ctx).load() is not None
 
     # Check that sigma_s wavelength specification is correctly taken from eradiate mode
-    eradiate.set_mode("mono", wavelength=650.)
-    r = HomogeneousAtmosphere(sigma_s="auto")
-    assert np.allclose(r._sigma_s.value, compute_sigma_s_air(wavelength=650.))
+    ctx.spectral_ctx.wavelength = 650.0
+    r = HomogeneousAtmosphere()
+    assert np.allclose(
+        r.eval_sigma_s(ctx.spectral_ctx), compute_sigma_s_air(wavelength=650.0)
+    )
 
     # Check that attributes wrong units or invalid values raise an error
     with pytest.raises(pinttr.exceptions.UnitsError):
@@ -70,7 +75,7 @@ def test_homogeneous(mode_mono, ref):
         HomogeneousAtmosphere(sigma_s=ureg.Quantity(1e-7, "m"))
 
     with pytest.raises(ValueError):
-        HomogeneousAtmosphere(toa_altitude=-100.)
+        HomogeneousAtmosphere(toa_altitude=-100.0)
 
     with pytest.raises(ValueError):
-        HomogeneousAtmosphere(width=-50.)
+        HomogeneousAtmosphere(width=-50.0)

--- a/eradiate/scenes/biosphere/_core.py
+++ b/eradiate/scenes/biosphere/_core.py
@@ -43,7 +43,7 @@ class Canopy(SceneElement, ABC):
     )
 
     @abstractmethod
-    def bsdfs(self):
+    def bsdfs(self, ctx=None):
         """
         Return BSDF plugin specifications only.
 
@@ -55,7 +55,7 @@ class Canopy(SceneElement, ABC):
         pass
 
     @abstractmethod
-    def shapes(self, ref=False):
+    def shapes(self, ctx=None):
         """
         Return shape plugin specifications only.
 
@@ -67,11 +67,13 @@ class Canopy(SceneElement, ABC):
         pass
 
     @abstractmethod
-    def kernel_dict(self, ref=True):
-        """Return a dictionary suitable for kernel scene configuration.
+    def kernel_dict(self, ctx=None):
+        """
+        Return a dictionary suitable for kernel scene configuration.
 
-        Parameter ``ref`` (bool):
-            If ``True``, use referencing for all relevant nested kernel plugins.
+        Parameter ``ctx`` (:class:`.KernelDictContext` or None):
+            A context data structure containing parameters relevant for kernel
+            dictionary generation.
 
         Returns → dict:
             Dictionary suitable for merge with a kernel scene dictionary

--- a/eradiate/scenes/illumination/_constant.py
+++ b/eradiate/scenes/illumination/_constant.py
@@ -10,7 +10,9 @@ from ...validators import has_quantity
 @parse_docs
 @attr.s
 class ConstantIllumination(Illumination):
-    """Constant illumination scene element [:factorykey:`constant`]."""
+    """
+    Constant illumination scene element [:factorykey:`constant`].
+    """
 
     radiance = documented(
         attr.ib(
@@ -21,13 +23,13 @@ class ConstantIllumination(Illumination):
         doc="Emitted radiance spectrum. Must be a radiance spectrum "
         "(in W/m^2/sr/nm or compatible units).",
         type="float or :class:`~eradiate.scenes.spectra.Spectrum`",
-        default="1.0 cdu[radiance]",
+        default="1.0 ucc[radiance]",
     )
 
-    def kernel_dict(self, ref=True):
+    def kernel_dict(self, ctx=None):
         return {
             self.id: {
                 "type": "constant",
-                "radiance": self.radiance.kernel_dict()["spectrum"],
+                "radiance": self.radiance.kernel_dict(ctx=ctx)["spectrum"],
             }
         }

--- a/eradiate/scenes/illumination/_core.py
+++ b/eradiate/scenes/illumination/_core.py
@@ -3,24 +3,31 @@ from abc import ABC
 import attr
 
 from ..core import SceneElement
+from ..._attrs import documented, get_doc, parse_docs
 from ..._factory import BaseFactory
 
 
+@parse_docs
 @attr.s
 class Illumination(SceneElement, ABC):
-    """Abstract base class for all illumination scene elements.
-
-    See :class:`~eradiate.scenes.core.SceneElement` for undocumented members.
+    """
+    Abstract base class for all illumination scene elements.
     """
 
-    id = attr.ib(
-        default="illumination",
-        validator=attr.validators.optional(attr.validators.instance_of(str)),
+    id = documented(
+        attr.ib(
+            default="illumination",
+            validator=attr.validators.optional(attr.validators.instance_of(str)),
+        ),
+        doc=get_doc(SceneElement, "id", "doc"),
+        type=get_doc(SceneElement, "id", "type"),
+        default='"illumination"',
     )
 
 
 class IlluminationFactory(BaseFactory):
-    """This factory constructs objects whose classes are derived from
+    """
+    This factory constructs objects whose classes are derived from
     :class:`Illumination`.
 
     .. admonition:: Registered factory members

--- a/eradiate/scenes/illumination/_directional.py
+++ b/eradiate/scenes/illumination/_directional.py
@@ -27,7 +27,7 @@ class DirectionalIllumination(Illumination):
             validator=is_positive,
             units=ucc.deferred("angle"),
         ),
-        doc="Zenith angle. \n" "\n" "Unit-enabled field (default units: cdu[angle]).",
+        doc="Zenith angle.\n\nUnit-enabled field (default units: ucc[angle]).",
         type="float",
         default="0.0 deg",
     )
@@ -40,7 +40,7 @@ class DirectionalIllumination(Illumination):
         ),
         doc="Azimuth angle value.\n"
         "\n"
-        "Unit-enabled field (default units: cdu[angle]).",
+        "Unit-enabled field (default units: ucc[angle]).",
         type="float",
         default="0.0 deg",
     )
@@ -62,16 +62,16 @@ class DirectionalIllumination(Illumination):
         default=":class:`SolarIrradianceSpectrum() <.SolarIrradianceSpectrum>`",
     )
 
-    def kernel_dict(self, ref=True):
+    def kernel_dict(self, ctx=None):
         return {
             self.id: {
                 "type": "directional",
                 "direction": list(
                     -angles_to_direction(
-                        theta=self.zenith.to(ureg.rad).magnitude,
-                        phi=self.azimuth.to(ureg.rad).magnitude,
+                        theta=self.zenith.m_as(ureg.rad),
+                        phi=self.azimuth.m_as(ureg.rad),
                     )
                 ),
-                "irradiance": self.irradiance.kernel_dict()["spectrum"],
+                "irradiance": self.irradiance.kernel_dict(ctx=ctx)["spectrum"],
             }
         }

--- a/eradiate/scenes/illumination/tests/test_illumination_directional.py
+++ b/eradiate/scenes/illumination/tests/test_illumination_directional.py
@@ -2,29 +2,36 @@ import pinttr
 import pytest
 
 from eradiate import unit_registry as ureg
+from eradiate._util import onedict_value
 from eradiate.scenes.core import KernelDict
+from eradiate.contexts import KernelDictContext, SpectralContext
 from eradiate.scenes.illumination import DirectionalIllumination
 
 
 def test_directional(mode_mono):
+    from mitsuba.core.xml import load_dict
+
+    # We need a default spectral config
+    ctx = KernelDictContext()
+
     # Constructor
     d = DirectionalIllumination()
-    assert KernelDict.new(d).load() is not None
+    assert load_dict(onedict_value(d.kernel_dict(ctx))) is not None
 
     # Check if a more detailed spec is valid
     d = DirectionalIllumination(irradiance={"type": "uniform", "value": 1.0})
-    assert KernelDict.new(d).load() is not None
+    assert load_dict(onedict_value(d.kernel_dict(ctx))) is not None
 
     # Check if solar irradiance spectrum can be used
     d = DirectionalIllumination(irradiance={"type": "solar_irradiance"})
-    assert KernelDict.new(d).load() is not None
+    assert load_dict(onedict_value(d.kernel_dict(ctx))) is not None
 
     # Check if specification from a float works
     d = DirectionalIllumination(irradiance=1.0)
-    assert KernelDict.new(d).load() is not None
+    assert load_dict(onedict_value(d.kernel_dict(ctx))) is not None
 
     # Check if specification from a constant works
     d = DirectionalIllumination(irradiance=ureg.Quantity(1.0, "W/m^2/nm"))
-    assert KernelDict.new(d).load() is not None
+    assert load_dict(onedict_value(d.kernel_dict(ctx))) is not None
     with pytest.raises(pinttr.exceptions.UnitsError):  # Wrong units
         DirectionalIllumination(irradiance=ureg.Quantity(1.0, "W/m^2/sr/nm"))

--- a/eradiate/scenes/integrators/_core.py
+++ b/eradiate/scenes/integrators/_core.py
@@ -24,7 +24,8 @@ class Integrator(SceneElement):
 
 
 class IntegratorFactory(BaseFactory):
-    """This factory constructs objects whose classes are derived from
+    """
+    This factory constructs objects whose classes are derived from
     :class:`Integrator`.
 
     .. admonition:: Registered factory members

--- a/eradiate/scenes/integrators/_path_tracers.py
+++ b/eradiate/scenes/integrators/_path_tracers.py
@@ -50,7 +50,7 @@ class MonteCarloIntegrator(Integrator):
         default="None",
     )
 
-    def kernel_dict(self, ref=True):
+    def kernel_dict(self, ctx=None):
         result = {self.id: {}}
 
         if self.max_depth is not None:
@@ -67,15 +67,16 @@ class MonteCarloIntegrator(Integrator):
 @parse_docs
 @attr.s
 class PathIntegrator(MonteCarloIntegrator):
-    """A thin interface to the `path tracer kernel plugin <https://eradiate-kernel.readthedocs.io/en/latest/generated/plugins.html#path-tracer-path>`_.
+    """
+    A thin interface to the `path tracer kernel plugin <https://eradiate-kernel.readthedocs.io/en/latest/generated/plugins.html#path-tracer-path>`_.
 
     This integrator samples paths using random walks starting from the sensor.
     It supports multiple scattering and does not account for volume
     interactions.
     """
 
-    def kernel_dict(self, ref=True):
-        result = super(PathIntegrator, self).kernel_dict(ref)
+    def kernel_dict(self, ctx=None):
+        result = super(PathIntegrator, self).kernel_dict()
         result[self.id]["type"] = "path"
         return result
 
@@ -84,14 +85,15 @@ class PathIntegrator(MonteCarloIntegrator):
 @parse_docs
 @attr.s
 class VolPathIntegrator(MonteCarloIntegrator):
-    """A thin interface to the volumetric path tracer kernel plugin.
+    """
+    A thin interface to the volumetric path tracer kernel plugin.
 
     This integrator samples paths using random walks starting from the sensor.
     It supports multiple scattering and accounts for volume interactions.
     """
 
-    def kernel_dict(self, ref=True):
-        result = super(VolPathIntegrator, self).kernel_dict(ref)
+    def kernel_dict(self, ctx=None):
+        result = super(VolPathIntegrator, self).kernel_dict()
         result[self.id]["type"] = "volpath"
         return result
 
@@ -111,8 +113,8 @@ class VolPathMISIntegrator(MonteCarloIntegrator):
         converter=attr.converters.optional(bool)
     )
 
-    def kernel_dict(self, ref=True):
-        result = super(VolPathMISIntegrator, self).kernel_dict(ref)
+    def kernel_dict(self, ctx=None):
+        result = super(VolPathMISIntegrator, self).kernel_dict()
 
         result[self.id]["type"] = "volpathmis"
         if self.use_spectral_mis is not None:

--- a/eradiate/scenes/measure/_perspective.py
+++ b/eradiate/scenes/measure/_perspective.py
@@ -14,7 +14,8 @@ from ..._units import unit_registry as ureg
 @parse_docs
 @attr.s
 class PerspectiveCameraMeasure(Measure):
-    """Perspective camera scene element [:factorykey:`perspective`].
+    """
+    Perspective camera scene element [:factorykey:`perspective`].
 
     This scene element is a thin wrapper around the ``perspective`` sensor
     kernel plugin. It positions a perspective camera based on a set of vectors,

--- a/eradiate/scenes/measure/_radiancemeter.py
+++ b/eradiate/scenes/measure/_radiancemeter.py
@@ -14,11 +14,13 @@ from ..._units import unit_registry as ureg
 @parse_docs
 @attr.s
 class RadiancemeterMeasure(Measure):
-    """Radiance meter measure scene element [:factorykey:`radiancemeter`].
+    """
+    Radiance meter measure scene element [:factorykey:`radiancemeter`].
 
     This measure scene element is a thin wrapper around the ``radiancemeter``
     sensor kernel plugin. It records the incident power per unit area per unit
-    solid angle along a certain ray."""
+    solid angle along a certain ray.
+    """
 
     origin = documented(
         pinttr.ib(

--- a/eradiate/scenes/measure/_radiancemeterarray.py
+++ b/eradiate/scenes/measure/_radiancemeterarray.py
@@ -3,7 +3,6 @@ import numpy as np
 import pinttr
 
 from ._core import Measure, MeasureFactory
-from ... import validators
 from ..._attrs import documented, parse_docs
 from ..._units import unit_context_config as ucc
 from ..._units import unit_context_kernel as uck

--- a/eradiate/scenes/measure/tests/test_measure_core.py
+++ b/eradiate/scenes/measure/tests/test_measure_core.py
@@ -1,10 +1,11 @@
 from eradiate.scenes.measure._core import Measure, SensorInfo
 
 
-def test_measure():
+def test_measure(mode_mono):
     """
     Unit tests for :class:`.Measure`.
     """
+
     # Concrete class to test
     class MyMeasure(Measure):
         @property
@@ -46,7 +47,7 @@ def test_measure():
     }
 
 
-def test_measure_spp_splitting():
+def test_measure_spp_splitting(mode_mono):
     """
     Unit tests for SPP splitting.
     """

--- a/eradiate/scenes/spectra/__init__.py
+++ b/eradiate/scenes/spectra/__init__.py
@@ -1,10 +1,12 @@
 from ._core import Spectrum, SpectrumFactory
 from ._solar_irradiance import SolarIrradianceSpectrum
 from ._uniform import UniformSpectrum
+from ._air_scattering_coefficient import AirScatteringCoefficientSpectrum
 
 __all__ = [
     "Spectrum",
     "SpectrumFactory",
+    "AirScatteringCoefficientSpectrum",
     "SolarIrradianceSpectrum",
     "UniformSpectrum",
 ]

--- a/eradiate/scenes/spectra/_air_scattering_coefficient.py
+++ b/eradiate/scenes/spectra/_air_scattering_coefficient.py
@@ -1,0 +1,44 @@
+import attr
+
+import eradiate
+
+from ._core import Spectrum, SpectrumFactory
+from ..._attrs import parse_docs
+from ..._units import PhysicalQuantity
+from ..._units import unit_context_kernel as uck
+from ...exceptions import ModeError
+from ...radprops.rayleigh import compute_sigma_s_air
+
+
+@SpectrumFactory.register("air_scattering_coefficient")
+@parse_docs
+@attr.s(frozen=True)
+class AirScatteringCoefficientSpectrum(Spectrum):
+    """
+    Air scattering coefficient spectrum.
+
+    .. seealso:: :func:`~eradiate.radprops.rayleigh.compute_sigma_s_air`
+    """
+
+    quantity = attr.ib(
+        default=PhysicalQuantity.COLLISION_COEFFICIENT, init=False, repr=False
+    )
+
+    def eval(self, spectral_ctx=None):
+        if eradiate.mode().is_monochromatic():
+            return compute_sigma_s_air(wavelength=spectral_ctx.wavelength)
+        else:
+            raise ModeError(f"unsupported mode {eradiate.mode().id}")
+
+    def kernel_dict(self, ctx=None):
+        if eradiate.mode().is_monochromatic():
+            return {
+                "spectrum": {
+                    "type": "uniform",
+                    "value": self.eval(ctx.spectral_ctx).m_as(
+                        uck.get("collision_coefficient")
+                    ),
+                }
+            }
+
+        raise ModeError(f"unsupported mode '{eradiate.mode().id}'")

--- a/eradiate/scenes/spectra/_core.py
+++ b/eradiate/scenes/spectra/_core.py
@@ -1,4 +1,4 @@
-from abc import ABC
+from abc import ABC, abstractmethod
 
 import attr
 import pint
@@ -12,7 +12,9 @@ from ...scenes.core import SceneElement
 @parse_docs
 @attr.s
 class Spectrum(SceneElement, ABC):
-    """Spectrum abstract base class."""
+    """
+    Spectrum abstract base class.
+    """
 
     quantity = documented(
         attr.ib(
@@ -40,19 +42,24 @@ class Spectrum(SceneElement, ABC):
                 f"got value '{value}', expected one of {str()}"
             )
 
-    @property
-    def _values(self):
-        """Return spectrum internal values."""
-        raise NotImplementedError
+    @abstractmethod
+    def eval(self, spectral_ctx=None):
+        """
+        Evaluate spectrum.
 
-    @property
-    def values(self):
-        """Evaluate (as a Pint quantity) spectrum values based on currently active mode."""
-        raise NotImplementedError
+        Parameter ``spectral_ctx`` (:class:`.SpectralContext` or None):
+            A spectral context data structure containing relevant spectral
+            parameters (*e.g.* wavelength in monochromatic mode).
+
+        Returns → :class:`pint.Quantity`:
+            Evaluated spectrum.
+        """
+        pass
 
 
 class SpectrumFactory(BaseFactory):
-    """This factory constructs objects whose classes are derived from
+    """
+    This factory constructs objects whose classes are derived from
     :class:`Spectrum`.
 
     .. admonition:: Registered factory members
@@ -67,7 +74,8 @@ class SpectrumFactory(BaseFactory):
 
     @staticmethod
     def converter(quantity):
-        """Generate a converter wrapping :meth:`SpectrumFactory.convert` to
+        """
+        Generate a converter wrapping :meth:`SpectrumFactory.convert` to
         handle defaults for shortened spectrum definitions. The produced
         converter processes a parameter ``value`` as follows:
 
@@ -76,9 +84,10 @@ class SpectrumFactory(BaseFactory):
           ``{"type": "uniform", "quantity": quantity, "value": value}``;
         * if ``value`` is a dictionary, it adds a ``"quantity": quantity`` entry
           for the following values of the ``"type"`` entry:
+
           * ``"uniform"``;
-        * otherwise, it forwards ``value`` to
-          :meth:`.SpectrumFactory.convert`.
+
+        * otherwise, it forwards ``value`` to :meth:`.SpectrumFactory.convert`.
 
         Parameter ``quantity`` (str or :class:`PhysicalQuantity`):
             Quantity specifier (converted by :meth:`SpectrumQuantity.from_any`).

--- a/eradiate/scenes/spectra/_uniform.py
+++ b/eradiate/scenes/spectra/_uniform.py
@@ -51,20 +51,16 @@ class UniformSpectrum(Spectrum):
                 self.value, ucc.get(self.quantity)
             )
 
-    @property
-    def _values(self):
+    def eval(self, spectral_ctx=None):
         return self.value
 
-    @property
-    def values(self):
-        return self.value
-
-    def kernel_dict(self, ref=True):
+    def kernel_dict(self, ctx=None):
         kernel_units = uck.get(self.quantity)
+        spectral_ctx = ctx.spectral_ctx if ctx is not None else None
 
         return {
             "spectrum": {
                 "type": "uniform",
-                "value": self.value.m_as(kernel_units),
+                "value": self.eval(spectral_ctx).m_as(kernel_units),
             }
         }

--- a/eradiate/scenes/spectra/tests/test_spectra_air_scattering_coefficient.py
+++ b/eradiate/scenes/spectra/tests/test_spectra_air_scattering_coefficient.py
@@ -1,0 +1,24 @@
+import numpy as np
+
+from eradiate import unit_registry as ureg
+from eradiate._util import onedict_value
+from eradiate.contexts import KernelDictContext
+from eradiate.scenes.spectra import AirScatteringCoefficientSpectrum
+
+
+def test_air_scattering_coefficient(mode_mono):
+    ctx = KernelDictContext()
+
+    # We can instantiate the class
+    s = AirScatteringCoefficientSpectrum()
+
+    # The spectrum evaluates correctly
+    assert np.allclose(
+        s.eval(ctx.spectral_ctx),
+        ureg.Quantity(0.0114934, "km^-1"),
+    )
+
+    # The associated kernel dict is correctly formed and can be loaded
+    from mitsuba.core.xml import load_dict
+
+    assert load_dict(onedict_value(s.kernel_dict(ctx=ctx))) is not None

--- a/eradiate/scenes/spectra/tests/test_spectra_solar_irradiance.py
+++ b/eradiate/scenes/spectra/tests/test_spectra_solar_irradiance.py
@@ -1,14 +1,17 @@
 import numpy as np
 import pytest
 
-import eradiate
 from eradiate import unit_registry as ureg
 from eradiate._util import onedict_value
+from eradiate.contexts import KernelDictContext, SpectralContext
 from eradiate.scenes.spectra import SolarIrradianceSpectrum
 
 
-def test_solar(mode_mono):
+def test_solar_irradiance(mode_mono):
     from mitsuba.core.xml import load_dict
+
+    # Default context
+    ctx = KernelDictContext()
 
     # We can instantiate the element
     s = SolarIrradianceSpectrum()
@@ -18,25 +21,27 @@ def test_solar(mode_mono):
         SolarIrradianceSpectrum(dataset="doesnt_exist")
 
     # Produced kernel dict is valid
-    assert load_dict(onedict_value(s.kernel_dict())) is not None
+    assert load_dict(onedict_value(s.kernel_dict(ctx))) is not None
 
     # A more detailed specification still produces a valid object
     s = SolarIrradianceSpectrum(scale=2.0)
-    assert load_dict(onedict_value(s.kernel_dict())) is not None
+    assert load_dict(onedict_value(s.kernel_dict(ctx))) is not None
 
     # Element doesn't work out of the supported spectral range
     s = SolarIrradianceSpectrum(dataset="thuillier_2003")
 
     with pytest.raises(ValueError):
-        eradiate.set_mode("mono", wavelength=2400.0)
-        s.kernel_dict()
+        ctx = KernelDictContext(spectral_ctx={"wavelength": 2400.0})
+        s.kernel_dict(ctx)
 
     # solid_2017_mean dataset can be used
-    eradiate.set_mode("mono", wavelength=550.0)
+    ctx = KernelDictContext()
     s = SolarIrradianceSpectrum(dataset="solid_2017_mean")
-    assert load_dict(onedict_value(s.kernel_dict()))
+    assert load_dict(onedict_value(s.kernel_dict(ctx)))
 
-    # values properties interpolates the irradiance as expected
-    eradiate.set_mode("mono", wavelength=550.0)
+
+def test_solar_irradiance_eval(mode_mono):
+    # Irradiance is correctly interpolated in mono mode
     s = SolarIrradianceSpectrum(dataset="thuillier_2003")
-    assert np.allclose(s.values, ureg.Quantity(1.87938, "W/m^2/nm"))
+    spectral_ctx = SpectralContext.new(wavelength=550.0)
+    assert np.allclose(s.eval(spectral_ctx), ureg.Quantity(1.87938, "W/m^2/nm"))

--- a/eradiate/scenes/surface/_black.py
+++ b/eradiate/scenes/surface/_black.py
@@ -8,12 +8,13 @@ from ..._attrs import parse_docs
 @parse_docs
 @attr.s
 class BlackSurface(Surface):
-    """Black surface scene element [:factorykey:`black`].
+    """
+    Black surface scene element [:factorykey:`black`].
 
     This class creates a square surface with a black BRDF attached.
     """
 
-    def bsdfs(self):
+    def bsdfs(self, ctx=None):
         return {
             f"bsdf_{self.id}": {
                 "type": "diffuse",

--- a/eradiate/scenes/surface/_lambertian.py
+++ b/eradiate/scenes/surface/_lambertian.py
@@ -10,7 +10,8 @@ from ..._attrs import documented, parse_docs
 @parse_docs
 @attr.s
 class LambertianSurface(Surface):
-    """Lambertian surface scene element [:factorykey:`lambertian`].
+    """
+    Lambertian surface scene element [:factorykey:`lambertian`].
 
     This class creates a square surface to which a Lambertian BRDF is attached.
     """
@@ -30,7 +31,7 @@ class LambertianSurface(Surface):
         default="0.5",
     )
 
-    def bsdfs(self):
+    def bsdfs(self, ctx=None):
         return {
             f"bsdf_{self.id}": {
                 "type": "diffuse",

--- a/eradiate/scenes/surface/_rpv.py
+++ b/eradiate/scenes/surface/_rpv.py
@@ -8,7 +8,8 @@ from ..._attrs import documented, parse_docs
 @parse_docs
 @attr.s
 class RPVSurface(Surface):
-    """RPV surface scene element [:factorykey:`rpv`].
+    """
+    RPV surface scene element [:factorykey:`rpv`].
 
     This class creates a square surface to which a RPV BRDF
     :cite:`Rahman1993CoupledSurfaceatmosphereReflectance`
@@ -42,7 +43,7 @@ class RPVSurface(Surface):
         default="-0.1",
     )
 
-    def bsdfs(self):
+    def bsdfs(self, ctx=None):
         return {
             f"bsdf_{self.id}": {
                 "type": "rpv",

--- a/eradiate/scenes/surface/tests/test_surface_black.py
+++ b/eradiate/scenes/surface/tests/test_surface_black.py
@@ -1,16 +1,19 @@
 from eradiate.scenes.core import KernelDict
+from eradiate.contexts import KernelDictContext
 from eradiate.scenes.surface import BlackSurface, LambertianSurface
 
 
 def test_black(mode_mono):
+    ctx = KernelDictContext()
+
     # Default constructor
     bs = BlackSurface()
 
     # Check if produced scene can be instantiated
-    kernel_dict = KernelDict.new(bs)
+    kernel_dict = KernelDict.new(bs, ctx=ctx)
     assert kernel_dict.load() is not None
 
     # Check if the correct kernel dict is created
     ls = LambertianSurface(reflectance={"type": "uniform", "value": 0})
 
-    assert KernelDict.new(ls) == KernelDict.new(bs)
+    assert KernelDict.new(ls, ctx=ctx) == KernelDict.new(bs, ctx=ctx)

--- a/eradiate/scenes/surface/tests/test_surface_lambertian.py
+++ b/eradiate/scenes/surface/tests/test_surface_lambertian.py
@@ -1,17 +1,20 @@
 from eradiate.scenes.core import KernelDict
+from eradiate.contexts import KernelDictContext
 from eradiate.scenes.surface import LambertianSurface
 
 
 def test_lambertian(mode_mono):
+    ctx = KernelDictContext()
+
     # Default constructor
     ls = LambertianSurface()
 
     # Check if produced scene can be instantiated
-    kernel_dict = KernelDict.new(ls)
+    kernel_dict = KernelDict.new(ls, ctx=ctx)
     assert kernel_dict.load() is not None
 
     # Constructor with arguments
     ls = LambertianSurface(width=1000.0, reflectance={"type": "uniform", "value": 0.3})
 
     # Check if produced scene can be instantiated
-    assert KernelDict.new(ls).load() is not None
+    assert KernelDict.new(ls, ctx=ctx).load() is not None

--- a/eradiate/scenes/surface/tests/test_surface_rpv.py
+++ b/eradiate/scenes/surface/tests/test_surface_rpv.py
@@ -2,15 +2,18 @@ import numpy as np
 
 from eradiate import unit_registry as ureg
 from eradiate.scenes.core import KernelDict
+from eradiate.contexts import KernelDictContext
 from eradiate.scenes.surface import RPVSurface
 
 
 def test_rpv(mode_mono):
+    ctx = KernelDictContext()
+
     # Default constructor
     ls = RPVSurface()
 
     # Check if produced scene can be instantiated
-    kernel_dict = KernelDict.new(ls)
+    kernel_dict = KernelDict.new(ls, ctx=ctx)
     assert kernel_dict.load() is not None
 
     # Constructor with arguments
@@ -18,4 +21,4 @@ def test_rpv(mode_mono):
     assert np.allclose(ls.width, ureg.Quantity(1e6, ureg.m))
 
     # Check if produced scene can be instantiated
-    assert KernelDict.new(ls).load() is not None
+    assert KernelDict.new(ls, ctx=ctx).load() is not None

--- a/eradiate/scenes/tests/test_core.py
+++ b/eradiate/scenes/tests/test_core.py
@@ -73,7 +73,7 @@ def test_scene_element(mode_mono):
             validator=[is_number, is_positive],
         )
 
-        def kernel_dict(self, ref=True):
+        def kernel_dict(self, ctx=None):
             return {
                 self.id: {
                     "type": "directional",

--- a/eradiate/solvers/core/_scene.py
+++ b/eradiate/solvers/core/_scene.py
@@ -13,7 +13,9 @@ from ...scenes.measure import DistantMeasure, MeasureFactory
 @parse_docs
 @attr.s
 class Scene(SceneElement, ABC):
-    """Abstract class common to all scenes."""
+    """
+    Abstract class common to all scenes.
+    """
 
     illumination = documented(
         attr.ib(

--- a/eradiate/solvers/onedim/_solver_app.py
+++ b/eradiate/solvers/onedim/_solver_app.py
@@ -1,26 +1,20 @@
 import datetime
 
 import attr
-import numpy as np
-import xarray as xr
 
 import eradiate
-
 from ._scene import OneDimScene
-from ..core._postprocess import distant_measure_compute_viewing_angles
 from ..core._solver_app import SolverApp
 from ... import unit_context_kernel as uck
-from ... import unit_registry as ureg
 from ..._attrs import documented, parse_docs
-from ..._util import ensure_array
-from ...scenes.measure._distant import DistantMeasure
 from ...xarray.metadata import DatasetSpec, VarSpec
 
 
 @parse_docs
 @attr.s
 class OneDimSolverApp(SolverApp):
-    """Solver application dedicated to the simulation of radiative transfer on
+    """
+    Solver application dedicated to the simulation of radiative transfer on
     one-dimensional scenes.
     """
 
@@ -40,112 +34,46 @@ class OneDimSolverApp(SolverApp):
         default=":class:`OneDimScene() <.OneDimScene>`",
     )
 
-    def postprocess(self):
-        """Post-process raw results stored in hidden attribute
-        ``self._raw_results`` after successful execution of :meth:`process`.
-        Post-processed results are stored in ``self.results``.
+    def postprocess(self, measure=None):
+        # Select measure
+        if measure is None:
+            measure = self.scene.measures[0]
 
-        Raises → ValueError:
-            If ``self._raw_results`` is ``None``, *i.e.* if :meth:`process`
-            has not been successfully run.
+        # Apply post-processing
+        super(OneDimSolverApp, self).postprocess(measure)
 
-        .. seealso:: :meth:`process`, :meth:`run`
-        """
-        if self._raw_results is None:
-            raise ValueError(
-                f"raw results are unset: simulation must first be completed "
-                f"using {self.__class__.__name__}.process()"
-            )
+        # Add missing metadata
+        ds = self.results[measure.id]
 
-        scene = self.scene
-
-        # Ensure that scalar values used as xarray coordinates are arrays
-        illumination = scene.illumination
-
-        # Collect illumination parameters
-        sza = ensure_array(illumination.zenith.to(ureg.deg).magnitude, dtype=float)
-        cos_sza = np.cos(illumination.zenith.to(ureg.rad).magnitude)
-        saa = ensure_array(illumination.azimuth.to(ureg.deg).magnitude, dtype=float)
-        wavelength = ensure_array(eradiate.mode().wavelength.magnitude, dtype=float)
-
-        # Format results
-        for measure in scene.measures:
-            # Collect results from sensors associated to processed measure
-            data = measure.postprocess_results(self._raw_results)
-
-            if len(data.shape) != 2:
-                raise ValueError(
-                    f"raw result array has incorrect shape " f"{data.shape}"
-                )
-
-            # Add missing dimensions to raw result array
-            data = np.expand_dims(data, [0, 1, -1])
-
-            # Create an empty dataset to store results
-            ds = xr.Dataset()
-
-            if isinstance(measure, DistantMeasure):
-                # Assign leaving radiance variable and corresponding coords
-                ds["lo"] = xr.DataArray(
-                    data,
-                    coords=(
-                        ("sza", sza),
-                        ("saa", saa),
-                        ("y", range(data.shape[2])),
-                        ("x", range(data.shape[3])),
-                        ("wavelength", wavelength),
-                    ),
-                )
-
-                # Add viewing angles
-                ds = distant_measure_compute_viewing_angles(ds, measure)
-
-            else:
-                raise ValueError(f"Unsupported measure type {measure.__class__}")
-
-            # Add other variables
-            irradiance = self.scene.illumination.irradiance.values
-            ds["irradiance"] = (
-                ("sza", "saa", "wavelength"),
-                np.array(irradiance.m_as(uck.get("irradiance")) * cos_sza).reshape(
-                    (1, 1, 1)
+        dataset_spec = DatasetSpec(
+            convention="CF-1.8",
+            title="Top-of-atmosphere simulation results",
+            history=f"{datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')} - "
+            f"data creation - {__name__}.{self.__class__.__name__}.postprocess",
+            source=f"eradiate, version {eradiate.__version__}",
+            references="",
+            var_specs={
+                "irradiance": VarSpec(
+                    standard_name="toa_horizontal_solar_irradiance_per_unit_wavelength",
+                    units=str(uck.get("irradiance")),
+                    long_name="top-of-atmosphere horizontal spectral irradiance",
                 ),
-            )
-            ds["brdf"] = ds["lo"] / ds["irradiance"]
-            ds["brf"] = ds["brdf"] * np.pi
-
-            # Add missing metadata
-            dataset_spec = DatasetSpec(
-                convention="CF-1.8",
-                title="Top-of-atmosphere simulation results",
-                history=f"{datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')} - "
-                f"data creation - {__name__}.{self.__class__.__name__}.postprocess",
-                source=f"eradiate, version {eradiate.__version__}",
-                references="",
-                var_specs={
-                    "irradiance": VarSpec(
-                        standard_name="toa_horizontal_solar_irradiance_per_unit_wavelength",
-                        units=str(uck.get("irradiance")),
-                        long_name="top-of-atmosphere horizontal spectral irradiance",
-                    ),
-                    "lo": VarSpec(
-                        standard_name="toa_outgoing_radiance_per_unit_wavelength",
-                        units=str(uck.get("radiance")),
-                        long_name="top-of-atmosphere outgoing spectral radiance",
-                    ),
-                    "brf": VarSpec(
-                        standard_name="toa_brf",
-                        units="dimensionless",
-                        long_name="top-of-atmosphere bi-directional reflectance factor",
-                    ),
-                    "brdf": VarSpec(
-                        standard_name="toa_brdf",
-                        units="1/sr",
-                        long_name="top-of-atmosphere bi-directional reflection distribution function",
-                    ),
-                },
-                coord_specs="angular_observation",
-            )
-            ds.ert.normalize_metadata(dataset_spec)
-
-            self.results[measure.id] = ds
+                "lo": VarSpec(
+                    standard_name="toa_outgoing_radiance_per_unit_wavelength",
+                    units=str(uck.get("radiance")),
+                    long_name="top-of-atmosphere outgoing spectral radiance",
+                ),
+                "brf": VarSpec(
+                    standard_name="toa_brf",
+                    units="dimensionless",
+                    long_name="top-of-atmosphere bi-directional reflectance factor",
+                ),
+                "brdf": VarSpec(
+                    standard_name="toa_brdf",
+                    units="1/sr",
+                    long_name="top-of-atmosphere bi-directional reflection distribution function",
+                ),
+            },
+            coord_specs="angular_observation",
+        )
+        ds.ert.normalize_metadata(dataset_spec)

--- a/eradiate/solvers/rami/_scene.py
+++ b/eradiate/solvers/rami/_scene.py
@@ -103,7 +103,7 @@ class RamiScene(Scene):
                             ymax=0.5 * self.surface.width,
                         )
 
-    def kernel_dict(self, ref=True):
+    def kernel_dict(self, ctx=None):
         result = KernelDict.new()
 
         if self.canopy is not None:
@@ -114,7 +114,7 @@ class RamiScene(Scene):
                 canopy = self.canopy
                 surface = self.surface
 
-            result.add(canopy.kernel_dict(ref=True))
+            result.add(canopy.kernel_dict(ctx=ctx))
         else:
             surface = self.surface
 
@@ -123,6 +123,7 @@ class RamiScene(Scene):
             self.illumination,
             *self.measures,
             self.integrator,
+            ctx=ctx,
         )
 
         return result

--- a/eradiate/solvers/rami/_solver_app.py
+++ b/eradiate/solvers/rami/_solver_app.py
@@ -1,26 +1,20 @@
 import datetime
 
 import attr
-import numpy as np
-import xarray as xr
 
 import eradiate
-
 from ._scene import RamiScene
-from ..core._postprocess import distant_measure_compute_viewing_angles
 from ..core._solver_app import SolverApp
 from ... import unit_context_kernel as uck
-from ... import unit_registry as ureg
 from ..._attrs import documented, parse_docs
-from ..._util import ensure_array
-from ...scenes.measure._distant import DistantMeasure
 from ...xarray.metadata import DatasetSpec, VarSpec
 
 
 @parse_docs
 @attr.s
 class RamiSolverApp(SolverApp):
-    """Solver application dedicated to the simulation of radiative transfer on
+    """
+    Solver application dedicated to the simulation of radiative transfer on
     RAMI benchmark scenes.
     """
 
@@ -39,112 +33,46 @@ class RamiSolverApp(SolverApp):
         default=":class:`RamiScene() <RamiScene>`",
     )
 
-    def postprocess(self):
-        """Post-process raw results stored in hidden attribute
-        ``self._raw_results`` after successful execution of :meth:`process`.
-        Post-processed results are stored in ``self.results``.
+    def postprocess(self, measure=None):
+        # Select measure
+        if measure is None:
+            measure = self.scene.measures[0]
 
-        Raises → ValueError:
-            If ``self._raw_results`` is ``None``, *i.e.* if :meth:`process`
-            has not been successfully run.
+        # Apply post-processing
+        super(RamiSolverApp, self).postprocess(measure)
 
-        .. seealso:: :meth:`process`, :meth:`run`
-        """
-        if self._raw_results is None:
-            raise ValueError(
-                f"raw results are unset: simulation must first be completed "
-                f"using {self.__class__.__name__}.process()"
-            )
+        # Add missing metadata
+        ds = self.results[measure.id]
 
-        scene = self.scene
-
-        # Ensure that scalar values used as xarray coordinates are arrays
-        illumination = scene.illumination
-
-        # Collect illumination parameters
-        sza = ensure_array(illumination.zenith.m_as(ureg.deg), dtype=float)
-        cos_sza = np.cos(illumination.zenith.m_as(ureg.rad))
-        saa = ensure_array(illumination.azimuth.m_as(ureg.deg), dtype=float)
-        wavelength = ensure_array(eradiate.mode().wavelength.magnitude, dtype=float)
-
-        # Format results
-        for measure in scene.measures:
-            # Collect results from sensors associated to processed measure
-            data = measure.postprocess_results(self._raw_results)
-
-            if len(data.shape) != 2:
-                raise ValueError(
-                    f"raw result array has incorrect shape " f"{data.shape}"
-                )
-
-            # Add missing dimensions to raw result array
-            data = np.expand_dims(data, [0, 1, -1])
-
-            # Create an empty dataset to store results
-            ds = xr.Dataset()
-
-            if isinstance(measure, DistantMeasure):
-                # Assign leaving radiance variable and corresponding coords
-                ds["lo"] = xr.DataArray(
-                    data,
-                    coords=(
-                        ("sza", sza),
-                        ("saa", saa),
-                        ("y", range(data.shape[2])),
-                        ("x", range(data.shape[3])),
-                        ("wavelength", wavelength),
-                    ),
-                )
-
-                # Add viewing angles
-                ds = distant_measure_compute_viewing_angles(ds, measure)
-
-            else:
-                raise ValueError(f"Unsupported measure type {measure.__class__}")
-
-            # Add other variables
-            irradiance = self.scene.illumination.irradiance.values
-            ds["irradiance"] = (
-                ("sza", "saa", "wavelength"),
-                np.array(irradiance.m_as(uck.get("irradiance")) * cos_sza).reshape(
-                    (1, 1, 1)
+        dataset_spec = DatasetSpec(
+            convention="CF-1.8",
+            title="Top-of-canopy simulation results",
+            history=f"{datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')} - "
+            f"data creation - {__name__}.{self.__class__.__name__}.postprocess",
+            source=f"eradiate, version {eradiate.__version__}",
+            references="",
+            var_specs={
+                "irradiance": VarSpec(
+                    standard_name="toc_horizontal_solar_irradiance_per_unit_wavelength",
+                    units=str(uck.get("irradiance")),
+                    long_name="top-of-canopy horizontal spectral irradiance",
                 ),
-            )
-            ds["brdf"] = ds["lo"] / ds["irradiance"]
-            ds["brf"] = ds["brdf"] * np.pi
-
-            # Add missing metadata
-            dataset_spec = DatasetSpec(
-                convention="CF-1.8",
-                title="Top-of-canopy simulation results",
-                history=f"{datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')} - "
-                f"data creation - {__name__}.{self.__class__.__name__}.postprocess",
-                source=f"eradiate, version {eradiate.__version__}",
-                references="",
-                var_specs={
-                    "irradiance": VarSpec(
-                        standard_name="toc_horizontal_solar_irradiance_per_unit_wavelength",
-                        units=str(uck.get("irradiance")),
-                        long_name="top-of-canopy horizontal spectral irradiance",
-                    ),
-                    "lo": VarSpec(
-                        standard_name="toc_outgoing_radiance_per_unit_wavelength",
-                        units=str(uck.get("radiance")),
-                        long_name="top-of-canopy outgoing spectral radiance",
-                    ),
-                    "brf": VarSpec(
-                        standard_name="toc_brf",
-                        units="dimensionless",
-                        long_name="top-of-canopy bi-directional reflectance factor",
-                    ),
-                    "brdf": VarSpec(
-                        standard_name="toc_brdf",
-                        units="1/sr",
-                        long_name="top-of-canopy bi-directional reflection distribution function",
-                    ),
-                },
-                coord_specs="angular_observation",
-            )
-            ds.ert.normalize_metadata(dataset_spec)
-
-            self._results[measure.id] = ds
+                "lo": VarSpec(
+                    standard_name="toc_outgoing_radiance_per_unit_wavelength",
+                    units=str(uck.get("radiance")),
+                    long_name="top-of-canopy outgoing spectral radiance",
+                ),
+                "brf": VarSpec(
+                    standard_name="toc_brf",
+                    units="dimensionless",
+                    long_name="top-of-canopy bi-directional reflectance factor",
+                ),
+                "brdf": VarSpec(
+                    standard_name="toc_brdf",
+                    units="1/sr",
+                    long_name="top-of-canopy bi-directional reflection distribution function",
+                ),
+            },
+            coord_specs="angular_observation",
+        )
+        ds.ert.normalize_metadata(dataset_spec)

--- a/eradiate/solvers/tests/test_rami.py
+++ b/eradiate/solvers/tests/test_rami.py
@@ -7,27 +7,30 @@ import eradiate
 from eradiate import unit_registry as ureg
 from eradiate.exceptions import ModeError
 from eradiate.scenes.biosphere import DiscreteCanopy
+from eradiate.contexts import KernelDictContext
 from eradiate.scenes.measure import DistantMeasure
 from eradiate.solvers.rami import RamiScene, RamiSolverApp
 
 
 def test_rami_scene(mode_mono):
+    ctx = KernelDictContext()
+
     # Construct with default parameters
     s = RamiScene()
-    assert s.kernel_dict().load() is not None
+    assert s.kernel_dict(ctx=ctx).load() is not None
 
     # Test non-trivial init sequence steps
 
     # -- Init with a single measure (not wrapped in a sequence)
     s = RamiScene(measures=DistantMeasure())
-    assert s.kernel_dict().load() is not None
+    assert s.kernel_dict(ctx=ctx).load() is not None
     # -- Init from a dict-based measure spec
     # ---- Correctly wrapped in a sequence
     s = RamiScene(measures=[{"type": "distant"}])
-    assert s.kernel_dict().load() is not None
+    assert s.kernel_dict(ctx=ctx).load() is not None
     # ---- Not wrapped in a sequence
     s = RamiScene(measures={"type": "distant"})
-    assert s.kernel_dict().load() is not None
+    assert s.kernel_dict(ctx=ctx).load() is not None
 
     # -- Surface size is appropriately inherited from canopy
     s = RamiScene(
@@ -73,6 +76,8 @@ def test_rami_solver_app_new():
 
 
 def test_rami_scene_real_life(mode_mono):
+    ctx = KernelDictContext()
+
     # Construct with typical parameters
     s = RamiScene(
         surface={"type": "lambertian"},
@@ -87,7 +92,7 @@ def test_rami_scene_real_life(mode_mono):
         illumination={"type": "directional", "zenith": 45.0},
         measures={"type": "distant"},
     )
-    assert s.kernel_dict().load() is not None
+    assert s.kernel_dict(ctx=ctx).load() is not None
 
 
 @pytest.mark.slow

--- a/eradiate/tests/unit/test_mode.py
+++ b/eradiate/tests/unit/test_mode.py
@@ -13,18 +13,12 @@ def test_modes():
     eradiate.set_mode("mono_double")
     # We expect that the kernel variant is appropriately selected
     assert mitsuba.variant() == "scalar_mono_double"
+    assert eradiate.mode().is_monochromatic()
+    assert eradiate.mode().is_double_precision()
 
     # Check that switching to mono mode works
     eradiate.set_mode("mono")
     # We expect that the kernel variant is appropriately selected
     assert mitsuba.variant() == "scalar_mono"
-    # We check for defaults
-    assert eradiate.mode().wavelength == ureg.Quantity(550., ureg.nm)
-
-    # Check for unit conversion
-    eradiate.set_mode("mono", wavelength=300.)
-    assert eradiate.mode().wavelength == ureg.Quantity(300., ureg.nm)
-
-    # Check that mode instances are frozen
-    with pytest.raises(FrozenInstanceError):
-        eradiate.mode().wavelength = 100
+    assert eradiate.mode().is_monochromatic()
+    assert eradiate.mode().is_single_precision()


### PR DESCRIPTION
# Description

This PR closes eradiate/eradiate-issues#73. It removes spectrum-related global state and transfer relevant information it to context data structures. Changes are as follows:

- Mode components have been refactored: Global spectral state has been removed.
- A new `eradiate.contexts` module has been added. In defines context data structures. `KernelDictContext` is used to pass around kernel dictionary-related data; `SpectralContext` is used to pass around data driving the behaviour of spectrally dependent components.
- The `SceneElement.kernel_dict()` method now takes a `KernelDictContext` instance as its argument (which extends and supersedes the `ref` argument).
- Spectrally dependent components of the `rad_props` modules were refactored to implement a `SpectralContext`-based design.
- A consequence of this transition is that spectral state is now inferred from measures in solver applications.
- Consequently, `Measure`s now have an attribute defining their spectral configuration.
- Post-processing facilities are transferred to `Measure`s when possible and relevant.
- Documentation updates: API docs and tutorial code was updated.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
