### PR TITLE
Spectral loop

### DIFF
--- a/docs/examples/tutorials/01_quick_overview_config.yml
+++ b/docs/examples/tutorials/01_quick_overview_config.yml
@@ -6,11 +6,11 @@ surface:
     value: 0.5  # dimensionless
 atmosphere:
   type: homogeneous
-  toa_altitude: 40.  # km
+  toa_altitude: 40.0  # km
 illumination:
   type: directional
-  zenith: 30.  # deg
-  azimuth: 0.  # deg
+  zenith: 30.0  # deg
+  azimuth: 0.0  # deg
   irradiance:
     type: uniform
     value: 1.8e+6  # W/km^2/nm
@@ -18,5 +18,5 @@ measures:
   - type: distant
     id: toa_hsphere
     spectral_cfg:
-      wavelength: 550.  # nm
+      wavelengths: [550.0]  # nm
     spp: 32000  # dimensionless

--- a/docs/examples/tutorials/solver_onedim/01_solver_onedim.py
+++ b/docs/examples/tutorials/solver_onedim/01_solver_onedim.py
@@ -128,7 +128,7 @@ measure = eradiate.scenes.measure.DistantMeasure(
     id="toa_hsphere",
     film_resolution=(32, 32),
     spp=10000,
-    spectral_cfg={"wavelength": 577.0},
+    spectral_cfg={"wavelengths": [577.0]},
 )
 measure
 
@@ -263,7 +263,7 @@ scene = eradiate.solvers.onedim.OneDimScene(
         id="toa_pplane",
         film_resolution=(32, 1),
         spp=1000000,
-        spectral_cfg={"wavelength": 577.0},
+        spectral_cfg={"wavelengths": [577.0]},
     ),
 )
 app = eradiate.solvers.onedim.OneDimSolverApp(scene)
@@ -310,7 +310,7 @@ scene = eradiate.solvers.onedim.OneDimScene(
         "id": "toa_hsphere",
         "film_resolution": (32, 1),
         "spp": 1000000,
-        "spectral_cfg": {"wavelength": 577.0},
+        "spectral_cfg": {"wavelengths": [577.0]},
     },
 )
 
@@ -338,7 +338,7 @@ scene = eradiate.solvers.onedim.OneDimScene.from_dict({
         "id": "toa_hsphere",
         "film_resolution": (32, 1),
         "spp": 1000000,
-        "spectral_cfg": {"wavelength": 577.0},
+        "spectral_cfg": {"wavelengths": [577.0]},
     },
 })
 
@@ -369,7 +369,7 @@ config = {
         "id": "toa_hsphere",
         "film_resolution": (32, 1),
         "spp": 1000000,
-        "spectral_cfg": {"wavelength": 577.0},
+        "spectral_cfg": {"wavelengths": [577.0]},
     },
 }
 app = eradiate.solvers.onedim.OneDimSolverApp.from_dict(config)

--- a/docs/examples/tutorials/solver_onedim/01_solver_onedim_config.yml
+++ b/docs/examples/tutorials/solver_onedim/01_solver_onedim_config.yml
@@ -23,4 +23,4 @@ measures:
     film_resolution: [32, 1]  # ... and because we're setting the film height to 1, thus restricting sampling to a plane
     spp: 1000000     # We take a lot of samples to reduce the variance in our results as much as possible
     spectral_cfg:
-      wavelength: 577.0 # This measure will compute radiance values at 577 nm
+      wavelengths: [577.0] # This measure will compute radiance values at 577 nm

--- a/docs/examples/tutorials/solver_onedim/02_onedim_sim_hetero_atm.py
+++ b/docs/examples/tutorials/solver_onedim/02_onedim_sim_hetero_atm.py
@@ -132,7 +132,7 @@ app.run()
 
 results_1281 = app.results["toa_plane"]
 ds = xr.merge([results_579, results_1281])
-ds.brf.plot(x="vza", hue="wavelengths", marker="o", markersize=2, linewidth=0.5)
+ds.brf.plot(x="vza", hue="w", marker="o", markersize=2, linewidth=0.5)
 plt.show()
 
 # %%

--- a/docs/examples/tutorials/solver_onedim/02_onedim_sim_hetero_atm.py
+++ b/docs/examples/tutorials/solver_onedim/02_onedim_sim_hetero_atm.py
@@ -47,7 +47,7 @@ config = {
         "id": "toa_plane",
         "film_resolution": [90,1],
         "spp": 65536,
-        "spectral_cfg": {"wavelength": 579.0},
+        "spectral_cfg": {"wavelengths": [579.0]},
     }]
 }
 app = OneDimSolverApp.from_dict(config)
@@ -80,7 +80,7 @@ visualise(results_579)
 # reflectance.
 # Indeed, the atmosphere we have created is almost purely scattering:
 
-spectral_ctx = app.scene.measures[0].spectral_ctx
+spectral_ctx = app.scene.measures[0].spectral_cfg.spectral_ctxs()[0]
 print(app.scene.atmosphere.profile.albedo(spectral_ctx))
 
 # %%
@@ -111,7 +111,7 @@ config = {
         "id": "toa_plane",
         "film_resolution": [90, 1],
         "spp": 65536,
-        "spectral_cfg": {"wavelength": 1281.0},
+        "spectral_cfg": {"wavelengths": [1281.0]},
     }]
 }
 app = OneDimSolverApp.from_dict(config)
@@ -119,7 +119,7 @@ app = OneDimSolverApp.from_dict(config)
 # %%
 # Let us confirm our intuition:
 
-spectral_ctx = app.scene.measures[0].spectral_ctx
+spectral_ctx = app.scene.measures[0].spectral_cfg.spectral_ctxs()[0]
 print(app.scene.atmosphere.profile.albedo(spectral_ctx))
 
 # %%
@@ -132,7 +132,7 @@ app.run()
 
 results_1281 = app.results["toa_plane"]
 ds = xr.merge([results_579, results_1281])
-ds.brf.plot(x="vza", hue="wavelength", marker="o", markersize=2, linewidth=0.5)
+ds.brf.plot(x="vza", hue="wavelengths", marker="o", markersize=2, linewidth=0.5)
 plt.show()
 
 # %%

--- a/docs/examples/tutorials/solver_rami/01_solver_rami.py
+++ b/docs/examples/tutorials/solver_rami/01_solver_rami.py
@@ -94,7 +94,7 @@ measure = eradiate.scenes.measure.DistantMeasure(
     id="toa_brf",
     film_resolution=(32, 32),
     spp=1000,
-    spectral_cfg={"wavelength": 550.0}
+    spectral_cfg={"wavelengths": [550.0]}
 )
 measure
 

--- a/docs/rst/reference/scenes.rst
+++ b/docs/rst/reference/scenes.rst
@@ -145,6 +145,13 @@ Measures [eradiate.scenes.measure]
    RadiancemeterMeasure
    RadiancemeterArrayMeasure
 
+**Result storage and processing**
+
+.. autosummary::
+   :toctree: generated/
+
+   MeasureResults
+
 .. dropdown:: **Private: Target and origin specification for DistantMeasure**
 
    .. autosummary::

--- a/eradiate/__init__.py
+++ b/eradiate/__init__.py
@@ -12,11 +12,11 @@ from ._mode import mode, set_mode, modes  # isort: skip
 
 # -- Unit management facilities ------------------------------------------------
 
-from ._units import (
-    unit_registry,
+from ._units import (  # isort: skip
     unit_context_config,
     unit_context_kernel,
-)  # isort: skip
+    unit_registry,
+)
 
 # -- Path resolver -------------------------------------------------------------
 
@@ -28,7 +28,7 @@ del PathResolver
 
 # ------------------------------------------------------------------------------
 
-from . import converters, contexts, kernel, scenes, solvers, validators, xarray
+from . import contexts, converters, kernel, scenes, solvers, validators, xarray
 
 __all__ = [
     "__version__",

--- a/eradiate/_mode.py
+++ b/eradiate/_mode.py
@@ -46,7 +46,9 @@ _mode_registry = {
 @attr.s(frozen=True)
 class Mode:
     id: str = attr.ib()
-    precision: ModePrecision = attr.ib(converter=attr.converters.optional(ModePrecision))
+    precision: ModePrecision = attr.ib(
+        converter=attr.converters.optional(ModePrecision)
+    )
     spectrum: ModeSpectrum = attr.ib(converter=attr.converters.optional(ModeSpectrum))
     kernel_variant: str = attr.ib()
     spectral_coord_label: str = attr.ib()

--- a/eradiate/_mode.py
+++ b/eradiate/_mode.py
@@ -32,21 +32,24 @@ _mode_registry = {
         "spectrum": "mono",
         "precision": "single",
         "kernel_variant": "scalar_mono",
+        "spectral_coord_label": "w",
     },
     "mono_double": {
         "spectrum": "mono",
         "precision": "double",
         "kernel_variant": "scalar_mono_double",
+        "spectral_coord_label": "w",
     },
 }
 
 
 @attr.s(frozen=True)
 class Mode:
-    id = attr.ib()
-    precision = attr.ib(converter=attr.converters.optional(ModePrecision))
-    spectrum = attr.ib(converter=attr.converters.optional(ModeSpectrum))
-    kernel_variant = attr.ib()
+    id: str = attr.ib()
+    precision: ModePrecision = attr.ib(converter=attr.converters.optional(ModePrecision))
+    spectrum: ModeSpectrum = attr.ib(converter=attr.converters.optional(ModeSpectrum))
+    kernel_variant: str = attr.ib()
+    spectral_coord_label: str = attr.ib()
 
     @staticmethod
     def new(mode_id):

--- a/eradiate/_mode.py
+++ b/eradiate/_mode.py
@@ -4,6 +4,8 @@ from typing import Optional
 import attr
 import mitsuba
 
+from eradiate._attrs import documented, parse_docs
+
 
 class ModeSpectrum(enum.Enum):
     """
@@ -43,18 +45,54 @@ _mode_registry = {
 }
 
 
+@parse_docs
 @attr.s(frozen=True)
 class Mode:
-    id: str = attr.ib()
-    precision: ModePrecision = attr.ib(
-        converter=attr.converters.optional(ModePrecision)
+    """
+    Data structure describing Eradiate's operational mode and associated ancillary
+    data.
+
+    .. important:: Instances are immutable.
+    """
+
+    id: str = documented(
+        attr.ib(converter=attr.converters.optional(str)),
+        doc="Mode identifier.",
+        type="str",
     )
-    spectrum: ModeSpectrum = attr.ib(converter=attr.converters.optional(ModeSpectrum))
-    kernel_variant: str = attr.ib()
-    spectral_coord_label: str = attr.ib()
+
+    precision: ModePrecision = documented(
+        attr.ib(converter=attr.converters.optional(ModePrecision)),
+        doc="Mode precision flag.",
+        type=":class:`.ModePrecision`",
+    )
+
+    spectrum: ModeSpectrum = documented(
+        attr.ib(converter=attr.converters.optional(ModeSpectrum)),
+        doc="Mode spectrum flag.",
+        type=":class:`.ModeSpectrum`",
+    )
+
+    kernel_variant: str = documented(
+        attr.ib(converter=attr.converters.optional(str)),
+        doc="Mode kernel variant.",
+        type="str",
+    )
+
+    spectral_coord_label: str = documented(
+        attr.ib(converter=attr.converters.optional(str)),
+        doc="Mode spectral coordinate label.",
+        type="str",
+    )
 
     @staticmethod
     def new(mode_id):
+        """
+        Create a :class:`Mode` instance given its identifier. Available modes are:
+
+        * ``mono``: Monochromatic, single-precision
+        * ``mono_double``: Monochromatic, double-precision
+        """
         try:
             mode_kwargs = _mode_registry[mode_id]
         except KeyError:
@@ -62,12 +100,21 @@ class Mode:
         return Mode(id=mode_id, **mode_kwargs)
 
     def is_monochromatic(self):
+        """
+        Return ``True`` if active mode is monochromatic.
+        """
         return self.spectrum is ModeSpectrum.MONO
 
     def is_single_precision(self):
+        """
+        Return ``True`` if active mode is single-precision.
+        """
         return self.precision is ModePrecision.SINGLE
 
     def is_double_precision(self):
+        """
+        Return ``True`` if active mode is double-precision.
+        """
         return self.precision is ModePrecision.DOUBLE
 
 

--- a/eradiate/contexts.py
+++ b/eradiate/contexts.py
@@ -22,10 +22,6 @@ class SpectralContext:
     around spectral information to kernel dictionary emission methods which
     require spectral configuration information.
 
-    :class:`Measures <.Measure>` also store a user-configured
-    :class:`.SpectralContext` instance which drives contextual spectral
-    configuration in solver applications.
-
     While this class is abstract, it should however be the main entry point
     to create :class:`.SpectralContext` child class objects through the
     :meth:`.SpectralContext.new` class method constructor.

--- a/eradiate/contexts.py
+++ b/eradiate/contexts.py
@@ -1,3 +1,4 @@
+from abc import ABC, abstractmethod
 from typing import Dict, Optional
 
 import attr
@@ -13,7 +14,7 @@ from .exceptions import ModeError
 
 
 @attr.s
-class SpectralContext:
+class SpectralContext(ABC):
     """
     Context data structure holding state relevant to the evaluation of spectrally
     dependent objects.
@@ -26,6 +27,11 @@ class SpectralContext:
     to create :class:`.SpectralContext` child class objects through the
     :meth:`.SpectralContext.new` class method constructor.
     """
+
+    @property
+    @abstractmethod
+    def wavelength(self):
+        pass
 
     @staticmethod
     def new(**kwargs) -> "SpectralContext":
@@ -90,12 +96,31 @@ class SpectralContext:
         return value
 
 
+@parse_docs
 @attr.s
 class MonoSpectralContext(SpectralContext):
-    wavelength: pint.Quantity = pinttr.ib(
-        default=ureg.Quantity(550.0, ureg.nm),
-        units=ucc.deferred("wavelength"),
+    """
+    Monochromatic spectral context data structure.
+    """
+
+    _wavelength: pint.Quantity = documented(
+        pinttr.ib(
+            default=ureg.Quantity(550.0, ureg.nm),
+            units=ucc.deferred("wavelength"),
+        ),
+        doc="A single wavelength value.\n\nUnit-enabled field "
+        "(default: ucc[wavelength]).",
+        type="float",
+        default="550.0 nm",
     )
+
+    @property
+    def wavelength(self):
+        return self._wavelength
+
+    @wavelength.setter
+    def wavelength(self, value):
+        self._wavelength = value
 
 
 @parse_docs

--- a/eradiate/contexts.py
+++ b/eradiate/contexts.py
@@ -12,6 +12,8 @@ from ._units import unit_context_config as ucc
 from ._units import unit_registry as ureg
 from .exceptions import ModeError
 
+# -- Spectral contexts ---------------------------------------------------------
+
 
 @attr.s
 class SpectralContext(ABC):
@@ -31,6 +33,8 @@ class SpectralContext(ABC):
     @property
     @abstractmethod
     def wavelength(self):
+        # Wavelength associated with spectral context
+        # (may raise NotImplementedError if irrelevant)
         pass
 
     @staticmethod
@@ -70,7 +74,7 @@ class SpectralContext(ABC):
         Parameter ``d`` (dict):
             Configuration dictionary used for initialisation.
 
-        Returns → instance of cls:
+        Returns → :class:`.SpectralContext`:
             Created object.
         """
 
@@ -121,6 +125,9 @@ class MonoSpectralContext(SpectralContext):
     @wavelength.setter
     def wavelength(self, value):
         self._wavelength = value
+
+
+# -- Kernel dictionary contexts ------------------------------------------------
 
 
 @parse_docs

--- a/eradiate/scenes/atmosphere/tests/test_heterogeneous.py
+++ b/eradiate/scenes/atmosphere/tests/test_heterogeneous.py
@@ -8,6 +8,7 @@ import pytest
 from eradiate import path_resolver, unit_context_config, unit_context_kernel
 from eradiate import unit_registry as ureg
 from eradiate._util import onedict_value
+from eradiate.contexts import KernelDictContext
 from eradiate.data import _presolver
 from eradiate.radprops import AFGL1986RadProfile, US76ApproxRadProfile
 from eradiate.scenes.atmosphere._heterogeneous import (
@@ -16,7 +17,6 @@ from eradiate.scenes.atmosphere._heterogeneous import (
     write_binary_grid3d,
 )
 from eradiate.scenes.core import KernelDict
-from eradiate.contexts import KernelDictContext
 
 
 def test_read_binary_grid3d():

--- a/eradiate/scenes/atmosphere/tests/test_homogeneous.py
+++ b/eradiate/scenes/atmosphere/tests/test_homogeneous.py
@@ -2,12 +2,12 @@ import numpy as np
 import pinttr
 import pytest
 
+from eradiate import unit_registry as ureg
+from eradiate._util import onedict_value
+from eradiate.contexts import KernelDictContext
 from eradiate.radprops.rayleigh import compute_sigma_s_air
 from eradiate.scenes.atmosphere._homogeneous import HomogeneousAtmosphere
 from eradiate.scenes.core import KernelDict
-from eradiate.contexts import KernelDictContext
-from eradiate._util import onedict_value
-from eradiate import unit_registry as ureg
 
 
 @pytest.mark.parametrize("ref", (False, True))

--- a/eradiate/scenes/atmosphere/tests/test_homogeneous.py
+++ b/eradiate/scenes/atmosphere/tests/test_homogeneous.py
@@ -2,7 +2,6 @@ import numpy as np
 import pinttr
 import pytest
 
-import eradiate
 from eradiate.radprops.rayleigh import compute_sigma_s_air
 from eradiate.scenes.atmosphere._homogeneous import HomogeneousAtmosphere
 from eradiate.scenes.core import KernelDict

--- a/eradiate/scenes/biosphere/_discrete.py
+++ b/eradiate/scenes/biosphere/_discrete.py
@@ -1124,7 +1124,11 @@ class InstancedLeafCloud(SceneElement):
         }
 
     def kernel_dict(self, ctx=None):
-        return {**self.bsdfs(ctx=ctx), **self.shapes(ctx=ctx), **self.instances(ctx=ctx)}
+        return {
+            **self.bsdfs(ctx=ctx),
+            **self.shapes(ctx=ctx),
+            **self.instances(ctx=ctx),
+        }
 
 
 @BiosphereFactory.register("discrete_canopy")

--- a/eradiate/scenes/biosphere/tests/test_biosphere_discrete.py
+++ b/eradiate/scenes/biosphere/tests/test_biosphere_discrete.py
@@ -5,6 +5,7 @@ import numpy as np
 import pytest
 
 from eradiate import unit_registry as ureg
+from eradiate.contexts import KernelDictContext
 from eradiate.scenes.biosphere._discrete import (
     DiscreteCanopy,
     InstancedLeafCloud,
@@ -18,10 +19,9 @@ from eradiate.scenes.biosphere._discrete import (
     _leaf_cloud_radii,
 )
 from eradiate.scenes.core import KernelDict
-from eradiate.contexts import KernelDictContext
-
 
 # -- Fixture definitions -------------------------------------------------------
+
 
 @pytest.fixture(scope="function")
 def rng():

--- a/eradiate/scenes/illumination/tests/test_illumination_directional.py
+++ b/eradiate/scenes/illumination/tests/test_illumination_directional.py
@@ -3,8 +3,8 @@ import pytest
 
 from eradiate import unit_registry as ureg
 from eradiate._util import onedict_value
-from eradiate.scenes.core import KernelDict
 from eradiate.contexts import KernelDictContext, SpectralContext
+from eradiate.scenes.core import KernelDict
 from eradiate.scenes.illumination import DirectionalIllumination
 
 

--- a/eradiate/scenes/integrators/_path_tracers.py
+++ b/eradiate/scenes/integrators/_path_tracers.py
@@ -14,38 +14,30 @@ class MonteCarloIntegrator(Integrator):
 
     .. warning:: This class should not be instantiated.
     """
+
     max_depth = documented(
-        attr.ib(
-            default=None,
-            converter=attr.converters.optional(int)
-        ),
+        attr.ib(default=None, converter=attr.converters.optional(int)),
         doc="Longest path depth in the generated measure data (where -1 corresponds "
-            "to ∞). A value of 1 will display only visible emitters. 2 will lead to "
-            "direct illumination (no multiple scattering), etc. If set to ``None``, "
-            "the kernel default value (-1) will be used.",
+        "to ∞). A value of 1 will display only visible emitters. 2 will lead to "
+        "direct illumination (no multiple scattering), etc. If set to ``None``, "
+        "the kernel default value (-1) will be used.",
         type="int",
         default="None",
     )
 
     rr_depth = documented(
-        attr.ib(
-            default=None,
-            converter=attr.converters.optional(int)
-        ),
+        attr.ib(default=None, converter=attr.converters.optional(int)),
         doc="Minimum path depth after which the implementation will start to use the "
-            "Russian roulette path termination criterion. If set to ``None``, "
-            "the kernel default value (5) will be used.",
+        "Russian roulette path termination criterion. If set to ``None``, "
+        "the kernel default value (5) will be used.",
         type="int",
         default="None",
     )
 
     hide_emitters = documented(
-        attr.ib(
-            default=None,
-            converter=attr.converters.optional(bool)
-        ),
+        attr.ib(default=None, converter=attr.converters.optional(bool)),
         doc="Hide directly visible emitters. If set to ``None``, "
-            "the kernel default value (``false``) will be used.",
+        "the kernel default value (``false``) will be used.",
         type="bool",
         default="None",
     )
@@ -108,10 +100,7 @@ class VolPathMISIntegrator(MonteCarloIntegrator):
     :cite:`Miller2019NullscatteringPathIntegral`.
     """
 
-    use_spectral_mis = attr.ib(
-        default=None,
-        converter=attr.converters.optional(bool)
-    )
+    use_spectral_mis = attr.ib(default=None, converter=attr.converters.optional(bool))
 
     def kernel_dict(self, ctx=None):
         result = super(VolPathMISIntegrator, self).kernel_dict()

--- a/eradiate/scenes/measure/__init__.py
+++ b/eradiate/scenes/measure/__init__.py
@@ -1,4 +1,4 @@
-from ._core import Measure, MeasureFactory
+from ._core import Measure, MeasureFactory, MeasureSpectralConfig
 from ._distant import DistantMeasure
 from ._perspective import PerspectiveCameraMeasure
 from ._radiancemeter import RadiancemeterMeasure
@@ -6,6 +6,7 @@ from ._radiancemeterarray import RadiancemeterArrayMeasure
 
 __all__ = [
     "Measure",
+    "MeasureSpectralConfig",
     "MeasureFactory",
     "DistantMeasure",
     "PerspectiveCameraMeasure",

--- a/eradiate/scenes/measure/__init__.py
+++ b/eradiate/scenes/measure/__init__.py
@@ -1,4 +1,4 @@
-from ._core import Measure, MeasureFactory, MeasureSpectralConfig
+from ._core import Measure, MeasureFactory, MeasureResults, MeasureSpectralConfig
 from ._distant import DistantMeasure
 from ._perspective import PerspectiveCameraMeasure
 from ._radiancemeter import RadiancemeterMeasure
@@ -8,6 +8,7 @@ __all__ = [
     "Measure",
     "MeasureSpectralConfig",
     "MeasureFactory",
+    "MeasureResults",
     "DistantMeasure",
     "PerspectiveCameraMeasure",
     "RadiancemeterMeasure",

--- a/eradiate/scenes/measure/_core.py
+++ b/eradiate/scenes/measure/_core.py
@@ -293,7 +293,9 @@ class MeasureResults:
                 "x": (
                     "x",
                     [float(x) for x in range(film_size[0])],  # Conversion to float is
-                    {"long_name": "film width coordinate"},   # intentional (interpolation)
+                    {
+                        "long_name": "film width coordinate"
+                    },  # intentional (interpolation)
                 ),
                 "y": (
                     "y",

--- a/eradiate/scenes/measure/_core.py
+++ b/eradiate/scenes/measure/_core.py
@@ -243,7 +243,7 @@ class MeasureResults:
             spectral_coords.add(spectral_coord)
             for sensor_id, data in val["values"].items():
                 sensor_ids.add(sensor_id)
-                film_size = np.maximum(film_size, data.shape)
+                film_size = np.maximum(film_size, data.shape[:2])
 
         spectral_coords = sorted(spectral_coords)
         sensor_ids = sorted(sensor_ids)
@@ -259,7 +259,9 @@ class MeasureResults:
                 # https://stackoverflow.com/questions/28676187/numpy-blit-copy-part-of-an-array-to-another-one-with-a-different-size
                 data[i_spectral, i_sensor] = self.raw[spectral_coord]["values"][
                     sensor_id
-                ]
+                ][..., 0]
+                # This latter indexing selects only one channel in the raw data
+                # array: this works with mono variants but will fail otherwise
 
         # Collect sample counts
         spps = np.full((len(spectral_coords), len(sensor_ids)), np.nan, dtype=int)

--- a/eradiate/scenes/measure/_core.py
+++ b/eradiate/scenes/measure/_core.py
@@ -269,7 +269,7 @@ class Measure(SceneElement, ABC):
         else:
             return [self.spp]
 
-    def _raw_results_empty(self) -> xarray.Dataset:
+    def raw_results_empty(self) -> xarray.Dataset:
         """
         Create an empty data set to store raw results.
 

--- a/eradiate/scenes/measure/_core.py
+++ b/eradiate/scenes/measure/_core.py
@@ -296,7 +296,7 @@ class Measure(SceneElement, ABC):
                 data_vars=(
                     {
                         "raw_results": (
-                            ["x", "y", "sensor", "wavelength"],
+                            ["x", "y", "sensor_id", "wavelength"],
                             np.full(
                                 (
                                     *self.film_resolution,

--- a/eradiate/scenes/measure/_core.py
+++ b/eradiate/scenes/measure/_core.py
@@ -217,8 +217,8 @@ class MeasureResults:
         * spectral coordinate (varies vs active mode)
         * ``sensor_id``: kernel sensor identified (for SPP split, dropped if
           ``aggregate_spps`` is ``True``)
-        * ``x``: film width
         * ``y``: film height
+        * ``x``: film width
 
         Parameter ``aggregate_spps`` (bool):
             If ``True``, perform split SPP aggregation (*i.e.* sum results using
@@ -258,7 +258,14 @@ class MeasureResults:
         sensor_ids = sorted(sensor_ids)
 
         # Collect values
-        data = np.full((len(spectral_coords), len(sensor_ids), *film_size), np.nan)
+        data = np.full(
+            (
+                len(spectral_coords),
+                len(sensor_ids),
+                *film_size,  # Note: Row-major order (width x comes last)
+            ),
+            np.nan,
+        )
 
         for i_spectral, spectral_coord in enumerate(spectral_coords):
             for i_sensor, sensor_id in enumerate(sensor_ids):
@@ -284,7 +291,7 @@ class MeasureResults:
             data_vars=(
                 {
                     "raw": (
-                        [spectral_coord_label, "sensor_id", "x", "y"],
+                        [spectral_coord_label, "sensor_id", "y", "x"],
                         data,
                         {"long name": "raw sensor values"},
                     ),
@@ -298,14 +305,17 @@ class MeasureResults:
             coords={
                 "x": (
                     "x",
-                    [float(x) for x in range(film_size[0])],  # Conversion to float is
+                    # Conversion to float is intentional (make interpolation possible)
+                    # As mentioned before, film size is (y, x)
+                    [float(x) for x in range(film_size[1])],
                     {
                         "long_name": "film width coordinate"
-                    },  # intentional (interpolation)
+                    },
                 ),
                 "y": (
                     "y",
-                    [float(x) for x in range(film_size[1])],
+                    # Conversion to float is intentional (make interpolation possible)
+                    [float(x) for x in range(film_size[0])],
                     {"long_name": "film height coordinate"},
                 ),
                 spectral_coord_label: (

--- a/eradiate/scenes/measure/_core.py
+++ b/eradiate/scenes/measure/_core.py
@@ -308,9 +308,7 @@ class MeasureResults:
                     # Conversion to float is intentional (make interpolation possible)
                     # As mentioned before, film size is (y, x)
                     [float(x) for x in range(film_size[1])],
-                    {
-                        "long_name": "film width coordinate"
-                    },
+                    {"long_name": "film width coordinate"},
                 ),
                 "y": (
                     "y",

--- a/eradiate/scenes/measure/_core.py
+++ b/eradiate/scenes/measure/_core.py
@@ -1,18 +1,24 @@
 from abc import ABC, abstractmethod
+from typing import Dict, Iterable
 
 import attr
 import numpy as np
+import pint
+import pinttr
 import xarray as xr
 
 import eradiate
 
 from ..core import SceneElement
-from ... import validators
+from ... import converters, validators
 from ..._attrs import documented, get_doc, parse_docs
 from ..._factory import BaseFactory
+from ..._units import unit_context_config as ucc
 from ..._units import unit_context_kernel as uck
+from ..._units import unit_registry as ureg
+from ..._util import ensure_array
+from ...contexts import MonoSpectralContext, SpectralContext
 from ...exceptions import ModeError
-from ...contexts import SpectralContext
 
 
 @parse_docs
@@ -35,6 +41,125 @@ class SensorInfo:
     )
 
 
+class MeasureSpectralConfig(ABC):
+    """
+    Data structure specifying the spectral configuration of a :class:`.Measure`
+    in monochromatic modes.
+
+    While this class is abstract, it should however be the main entry point
+    to create :class:`.MeasureSpectralConfig` child class objects through the
+    :meth:`.MeasureSpectralConfig.new` class method constructor.
+    """
+
+    @abstractmethod
+    def spectral_ctxs(self) -> Iterable[SpectralContext]:
+        """
+        This generator yields :class:`.SpectralContext` objects based on the
+        stored spectral configuration. These data structures can be used to
+        drive the evaluation of spectrally dependent components during a
+        spectral loop.
+        """
+        pass
+
+    @staticmethod
+    def new(**kwargs) -> "MeasureSpectralConfig":
+        """
+        Create a new instance of one of the :class:`SpectralContext` child
+        classes. *The instantiated class is defined based on the currently active
+        mode.* Keyword arguments are passed to the instantiated class's
+        constructor:
+
+        .. rubric:: Monochromatic modes [:class:`MonoMeasureSpectralConfig`]
+
+        Parameter ``wavelengths`` (:class:`pint.Quantity`):
+            List of wavelengths (automatically converted to a Numpy array).
+            Default: [550] nm.
+
+            Unit-enabled field (default: ucc[wavelength]).
+
+        .. seealso::
+
+           * :func:`eradiate.mode`
+           * :func:`eradiate.set_mode`
+        """
+        mode = eradiate.mode()
+
+        if mode.is_monochromatic():
+            return MonoMeasureSpectralConfig(**kwargs)
+
+        raise ModeError(f"unsupported mode '{mode.id}'")
+
+    @staticmethod
+    def from_dict(d: Dict) -> "MeasureSpectralConfig":
+        """
+        Create from a dictionary. This class method will additionally pre-process
+        the passed dictionary to merge any field with an associated ``"_units"``
+        field into a :class:`pint.Quantity` container.
+
+        Parameter ``d`` (dict):
+            Configuration dictionary used for initialisation.
+
+        Returns → instance of cls:
+            Created object.
+        """
+
+        # Pre-process dict: apply units to unit-enabled fields
+        d_copy = pinttr.interpret_units(d, ureg=ureg)
+
+        # Perform object creation
+        return MeasureSpectralConfig.new(**d_copy)
+
+    @staticmethod
+    def convert(value):
+        """
+        Object converter method.
+
+        If ``value`` is a dictionary, this method uses :meth:`from_dict` to
+        create a :class:`.SpectralContext`.
+
+        Otherwise, it returns ``value``.
+        """
+        if isinstance(value, dict):
+            return SpectralContext.from_dict(value)
+
+        return value
+
+
+@parse_docs
+@attr.s
+class MonoMeasureSpectralConfig(MeasureSpectralConfig):
+    """
+    A data structure specifying the spectral configuration of a :class:`.Measure`
+    in monochromatic modes.
+    """
+
+    _wavelengths: pint.Quantity = documented(
+        pinttr.ib(
+            default=ureg.Quantity([550.0], ureg.nm),
+            units=ucc.deferred("wavelength"),
+            converter=lambda x: converters.on_quantity(ensure_array)(
+                pinttr.converters.ensure_units(x, ucc.get("wavelength"))
+            ),
+        ),
+        doc="List of wavelengths on which to perform the monochromatic spectral "
+        "loop.\n\nUnit-enabled field (default: ucc[wavelength]).",
+        type=":class:`pint.Quantity`",
+        default="[550.0] nm",
+    )
+
+    @property
+    def wavelengths(self):
+        return self._wavelengths
+
+    @wavelengths.setter
+    def wavelengths(self, value):
+        self._wavelengths = value
+
+    def spectral_ctxs(self) -> Iterable[MonoSpectralContext]:
+        for wavelength in self._wavelengths:
+            yield MonoSpectralContext(wavelength=wavelength)
+
+
 @parse_docs
 @attr.s
 class Measure(SceneElement, ABC):
@@ -52,10 +177,14 @@ class Measure(SceneElement, ABC):
         default='"measure"',
     )
 
-    spectral_cfg = documented(
-        attr.ib(factory=SpectralContext.new, converter=SpectralContext.convert),
+    spectral_cfg: MeasureSpectralConfig = documented(
+        attr.ib(
+            factory=MeasureSpectralConfig.new,
+            converter=MeasureSpectralConfig.convert,
+        ),
         doc="Spectral configuration of the measure. Must match the current "
-        "operational mode.",
+        "operational mode. Can be passed as a dictionary, which will be "
+        "interpreted by :meth:`SpectralContext.from_dict`.",
         type=":meth:`SpectralContext.new() <.SpectralContext.new>`",
         default="None",
     )
@@ -79,13 +208,6 @@ class Measure(SceneElement, ABC):
     _spp_splitting_threshold = attr.ib(
         default=int(1e5), converter=int, validator=validators.is_positive, repr=False
     )
-
-    @property
-    def spectral_ctx(self):
-        """
-        Alias to :data:`self.spectral_cfg`.
-        """
-        return self.spectral_cfg
 
     @property
     @abstractmethod

--- a/eradiate/scenes/measure/_core.py
+++ b/eradiate/scenes/measure/_core.py
@@ -231,6 +231,9 @@ class MeasureResults:
                 "long_name": "wavelength",
                 "units": str(ucc.get("wavelength")),
             }
+            # TODO: Add channel dimension to dataset (string-labelled;
+            #  value 'intensity' in mono modes;
+            #  values 'R', 'G', 'B' in render modes)
         else:
             raise UnsupportedModeError(supported="monochromatic")
 

--- a/eradiate/scenes/measure/_core.py
+++ b/eradiate/scenes/measure/_core.py
@@ -226,7 +226,7 @@ class MeasureResults:
             raise ValueError("no raw results to convert to xarray.Dataset")
 
         if eradiate.mode().is_monochromatic():
-            spectral_coord_label = "w"
+            spectral_coord_label = eradiate.mode().spectral_coord_label
             spectral_coord_metadata = {
                 "long_name": "wavelength",
                 "units": str(ucc.get("wavelength")),
@@ -292,8 +292,8 @@ class MeasureResults:
             coords={
                 "x": (
                     "x",
-                    [float(x) for x in range(film_size[0])],
-                    {"long_name": "film width coordinate"},
+                    [float(x) for x in range(film_size[0])],  # Conversion to float is
+                    {"long_name": "film width coordinate"},   # intentional (interpolation)
                 ),
                 "y": (
                     "y",

--- a/eradiate/scenes/measure/_core.py
+++ b/eradiate/scenes/measure/_core.py
@@ -458,7 +458,7 @@ class Measure(SceneElement, ABC):
         """
         # Default implementation simply aggregates SPP-split raw results;
         # overloads can perform additional post-processing and add metadata
-        return self.results.to_dataset()
+        return self.results.to_dataset(aggregate_spps=True)
 
     @abstractmethod
     def _base_dicts(self):

--- a/eradiate/scenes/measure/_core.py
+++ b/eradiate/scenes/measure/_core.py
@@ -121,7 +121,7 @@ class MeasureSpectralConfig(ABC):
         Otherwise, it returns ``value``.
         """
         if isinstance(value, dict):
-            return SpectralContext.from_dict(value)
+            return MeasureSpectralConfig.from_dict(value)
 
         return value
 

--- a/eradiate/scenes/measure/_core.py
+++ b/eradiate/scenes/measure/_core.py
@@ -100,7 +100,7 @@ class MeasureSpectralConfig(ABC):
         Parameter ``d`` (dict):
             Configuration dictionary used for initialisation.
 
-        Returns → instance of cls:
+        Returns → :class:`.MeasureSpectralConfig`:
             Created object.
         """
 
@@ -192,18 +192,18 @@ class MeasureResults:
         "           },\n"
         "       },\n"
         "       spectral_key_1: {\n"
-        '               "values": {\n'
-        '                   "sensor_0": data_0,\n'
-        '                   "sensor_1": data_1,\n'
-        "                   ...\n"
-        "               },\n"
-        '               "spp": {\n'
-        '                   "sensor_0": sample_count_0,\n'
-        '                   "sensor_1": sample_count_1,\n'
-        "                   ...\n"
-        "               },\n"
-        "           }\n"
-        "       }\n"
+        '           "values": {\n'
+        '               "sensor_0": data_0,\n'
+        '               "sensor_1": data_1,\n'
+        "               ...\n"
+        "           },\n"
+        '           "spp": {\n'
+        '               "sensor_0": sample_count_0,\n'
+        '               "sensor_1": sample_count_1,\n'
+        "               ...\n"
+        "           },\n"
+        "       },\n"
+        "       ...\n"
         "   }\n",
         type="dict",
         default="{}",
@@ -211,13 +211,19 @@ class MeasureResults:
 
     def to_dataset(self, aggregate_spps=False) -> xarray.Dataset:
         """
-        Repack raw results as a :class:`xarray.Dataset`. Dimensions are as
-        follows:
+        Repack raw results as a :class:`xarray.Dataset`. Dimension coordinates are
+        as follows:
 
-        * spectral coordinate
-        * sensor (for SPP split)
-        * film width
-        * film height
+        * spectral coordinate (varies vs active mode)
+        * ``sensor_id``: kernel sensor identified (for SPP split, dropped if
+          ``aggregate_spps`` is ``True``)
+        * ``x``: film width
+        * ``y``: film height
+
+        Parameter ``aggregate_spps`` (bool):
+            If ``True``, perform split SPP aggregation (*i.e.* sum results using
+            SPP values as weights). This will result in the ``sensor_id``
+            dimension being dropped.
 
         Returns → :class:`~xarray.Dataset`:
             Raw sensor data repacked as a :class:`~xarray.Dataset`.
@@ -337,7 +343,7 @@ class Measure(SceneElement, ABC):
     Abstract base class for all measure scene elements.
     """
 
-    id = documented(
+    id: Optional[str] = documented(
         attr.ib(
             default="measure",
             validator=attr.validators.optional((attr.validators.instance_of(str))),
@@ -369,7 +375,7 @@ class Measure(SceneElement, ABC):
     results: MeasureResults = documented(
         attr.ib(factory=MeasureResults),
         doc="Storage for raw results yielded by the kernel.",
-        default=":class:`MeasureResults() <.MeasureResults>",
+        default=":class:`MeasureResults() <.MeasureResults>`",
         type=":class:`.MeasureResults`",
     )
 

--- a/eradiate/scenes/measure/_distant.py
+++ b/eradiate/scenes/measure/_distant.py
@@ -396,7 +396,7 @@ class DistantMeasure(Measure):
 
         return result
 
-    def postprocessed_results(self):
+    def postprocessed_results(self) -> xr.Dataset:
         # Fetch results (SPP-split aggregated) as a Dataset
         result = self.results.to_dataset(aggregate_spps=True)
 

--- a/eradiate/scenes/measure/_distant.py
+++ b/eradiate/scenes/measure/_distant.py
@@ -411,8 +411,8 @@ class DistantMeasure(Measure):
             for y in ys:
                 for x in xs:
                     sample = float(x + 0.5) / len(xs)
-                    theta[y, x] = 90.0 - 180.0 * sample
-                    phi[y, x] = self.orientation.m_as("deg")
+                    theta[int(y), int(x)] = 90.0 - 180.0 * sample
+                    phi[int(y), int(x)] = self.orientation.m_as("deg")
 
         else:  # Hemisphere case
             for y in ys:

--- a/eradiate/scenes/measure/_distant.py
+++ b/eradiate/scenes/measure/_distant.py
@@ -423,7 +423,9 @@ class DistantMeasure(Measure):
                         float((y + 0.5) / len(ys)),
                     ]
                     d = square_to_uniform_hemisphere(xy)
-                    theta[int(y), int(x)], phi[int(y), int(x)] = direction_to_angles(d).m_as("deg")
+                    theta[int(y), int(x)], phi[int(y), int(x)] = direction_to_angles(
+                        d
+                    ).m_as("deg")
 
         # Assign angles as non-dimension coords
         result["vza"] = (("y", "x"), theta, {"units": "deg"})

--- a/eradiate/scenes/measure/_distant.py
+++ b/eradiate/scenes/measure/_distant.py
@@ -400,8 +400,8 @@ class DistantMeasure(Measure):
         result = super(DistantMeasure, self).postprocessed_results()
 
         # Compute viewing angles at pixel locations
-        # Angle computation must correspond to the direction sampling done by the
-        # kernel plugin
+        # Angle computation must match the kernel plugin's direction sampling
+        # routine
         xs = result.coords["x"].data
         ys = result.coords["y"].data
         theta = np.full((len(ys), len(xs)), np.nan)
@@ -422,7 +422,7 @@ class DistantMeasure(Measure):
                         float((y + 0.5) / len(ys)),
                     ]
                     d = square_to_uniform_hemisphere(xy)
-                    theta[y, x], phi[y, x] = direction_to_angles(d).m_as("deg")
+                    theta[int(y), int(x)], phi[int(y), int(x)] = direction_to_angles(d).m_as("deg")
 
         # Assign angles as non-dimension coords
         result["vza"] = (("y", "x"), theta, {"units": "deg"})

--- a/eradiate/scenes/measure/_distant.py
+++ b/eradiate/scenes/measure/_distant.py
@@ -405,6 +405,11 @@ class DistantMeasure(Measure):
         # routine
         xs = result.coords["x"].data
         ys = result.coords["y"].data
+        if not np.allclose((len(xs), len(ys)), self.film_resolution):
+            raise ValueError(
+                f"raw data width and height ({len(xs)}, {len(ys)}) does not "
+                f"match film size ({self.film_resolution})"
+            )
         theta = np.full((len(ys), len(xs)), np.nan)
         phi = np.full_like(theta, np.nan)
 

--- a/eradiate/scenes/measure/_distant.py
+++ b/eradiate/scenes/measure/_distant.py
@@ -397,7 +397,8 @@ class DistantMeasure(Measure):
         return result
 
     def postprocessed_results(self):
-        result = super(DistantMeasure, self).postprocessed_results()
+        # Fetch results (SPP-split aggregated) as a Dataset
+        result = self.results.to_dataset(aggregate_spps=True)
 
         # Compute viewing angles at pixel locations
         # Angle computation must match the kernel plugin's direction sampling

--- a/eradiate/scenes/measure/tests/test_measure_core.py
+++ b/eradiate/scenes/measure/tests/test_measure_core.py
@@ -1,4 +1,22 @@
-from eradiate.scenes.measure._core import Measure, SensorInfo
+from eradiate.contexts import MonoSpectralContext
+from eradiate.scenes.measure._core import (
+    Measure,
+    MeasureSpectralConfig,
+    MonoMeasureSpectralConfig,
+    SensorInfo,
+)
+
+
+def test_spectral_config(mode_mono):
+    # The new() class method constructor selects an appropriate config class
+    # depending on the active mode
+    cfg = MeasureSpectralConfig.new(wavelengths=[500., 600.])
+    assert isinstance(cfg, MonoMeasureSpectralConfig)
+
+    # Generated spectral contexts are of the appropriate type and in correct numbers
+    ctxs = list(cfg.spectral_ctxs())
+    assert len(ctxs) == 2
+    assert all(isinstance(ctx, MonoSpectralContext) for ctx in ctxs)
 
 
 def test_measure(mode_mono):

--- a/eradiate/scenes/measure/tests/test_measure_core.py
+++ b/eradiate/scenes/measure/tests/test_measure_core.py
@@ -1,6 +1,9 @@
+import numpy as np
+
 from eradiate.contexts import MonoSpectralContext
 from eradiate.scenes.measure._core import (
     Measure,
+    MeasureResults,
     MeasureSpectralConfig,
     MonoMeasureSpectralConfig,
     SensorInfo,
@@ -20,6 +23,43 @@ def test_spectral_config(mode_mono):
     ctxs = cfg.spectral_ctxs()
     assert len(ctxs) == 2
     assert all(isinstance(ctx, MonoSpectralContext) for ctx in ctxs)
+
+
+def test_measure_results(mode_mono):
+    """
+    Unit tests for :class:`MeasureResults`.
+    """
+    results = MeasureResults(
+        # This is our test input
+        raw={
+            550.0: {
+                "values": {
+                    "sensor_0": np.zeros((3, 3)),
+                    "sensor_1": np.ones((3, 3)),
+                },
+                "spp": {
+                    "sensor_0": 100,
+                    "sensor_1": 50,
+                },
+            },
+            600.0: {
+                "values": {
+                    "sensor_0": np.ones((3, 3)),
+                    "sensor_1": np.zeros((3, 3)),
+                },
+                "spp": {
+                    "sensor_0": 100,
+                    "sensor_1": 50,
+                },
+            },
+        }
+    )
+
+    ds = results.to_dataset()
+    assert set(ds.data_vars) == {"raw", "spp"}
+    assert set(ds.coords) == {"sensor_id", "w", "x", "y"}
+    assert ds.raw.shape == (2, 2, 3, 3)
+    assert ds.spp.shape == (2, 2)
 
 
 def test_measure(mode_mono):

--- a/eradiate/scenes/measure/tests/test_measure_core.py
+++ b/eradiate/scenes/measure/tests/test_measure_core.py
@@ -8,13 +8,16 @@ from eradiate.scenes.measure._core import (
 
 
 def test_spectral_config(mode_mono):
+    """
+    Unit tests for :class:`.MeasureSpectralConfig` and child classes.
+    """
     # The new() class method constructor selects an appropriate config class
     # depending on the active mode
-    cfg = MeasureSpectralConfig.new(wavelengths=[500., 600.])
+    cfg = MeasureSpectralConfig.new(wavelengths=[500.0, 600.0])
     assert isinstance(cfg, MonoMeasureSpectralConfig)
 
     # Generated spectral contexts are of the appropriate type and in correct numbers
-    ctxs = list(cfg.spectral_ctxs())
+    ctxs = cfg.spectral_ctxs()
     assert len(ctxs) == 2
     assert all(isinstance(ctx, MonoSpectralContext) for ctx in ctxs)
 

--- a/eradiate/scenes/measure/tests/test_measure_core.py
+++ b/eradiate/scenes/measure/tests/test_measure_core.py
@@ -27,7 +27,7 @@ def test_spectral_config(mode_mono):
 
 def test_measure_results(mode_mono):
     """
-    Unit tests for :class:`MeasureResults`.
+    Unit tests for :class:`.MeasureResults`.
     """
     results = MeasureResults(
         # This is our test input
@@ -55,11 +55,20 @@ def test_measure_results(mode_mono):
         }
     )
 
+    # Check most raw form of results
     ds = results.to_dataset()
     assert set(ds.data_vars) == {"raw", "spp"}
     assert set(ds.coords) == {"sensor_id", "w", "x", "y"}
     assert ds.raw.shape == (2, 2, 3, 3)
     assert ds.spp.shape == (2, 2)
+
+    # Check SPP aggregation
+    ds = results.to_dataset(aggregate_spps=True)
+    assert set(ds.data_vars) == {"raw", "spp"}
+    assert set(ds.coords) == {"w", "x", "y"}
+    assert ds.raw.shape == (2, 3, 3)
+    assert ds.spp.shape == (2,)
+    assert np.allclose(ds["spp"], (150, 150))
 
 
 def test_measure(mode_mono):

--- a/eradiate/scenes/spectra/__init__.py
+++ b/eradiate/scenes/spectra/__init__.py
@@ -1,7 +1,7 @@
+from ._air_scattering_coefficient import AirScatteringCoefficientSpectrum
 from ._core import Spectrum, SpectrumFactory
 from ._solar_irradiance import SolarIrradianceSpectrum
 from ._uniform import UniformSpectrum
-from ._air_scattering_coefficient import AirScatteringCoefficientSpectrum
 
 __all__ = [
     "Spectrum",

--- a/eradiate/scenes/spectra/_solar_irradiance.py
+++ b/eradiate/scenes/spectra/_solar_irradiance.py
@@ -2,6 +2,7 @@ import attr
 import numpy as np
 
 import eradiate
+
 from ... import data
 from ... import unit_context_kernel as uck
 from ... import unit_registry as ureg

--- a/eradiate/scenes/surface/tests/test_surface_black.py
+++ b/eradiate/scenes/surface/tests/test_surface_black.py
@@ -1,5 +1,5 @@
-from eradiate.scenes.core import KernelDict
 from eradiate.contexts import KernelDictContext
+from eradiate.scenes.core import KernelDict
 from eradiate.scenes.surface import BlackSurface, LambertianSurface
 
 

--- a/eradiate/scenes/surface/tests/test_surface_lambertian.py
+++ b/eradiate/scenes/surface/tests/test_surface_lambertian.py
@@ -1,5 +1,5 @@
-from eradiate.scenes.core import KernelDict
 from eradiate.contexts import KernelDictContext
+from eradiate.scenes.core import KernelDict
 from eradiate.scenes.surface import LambertianSurface
 
 

--- a/eradiate/scenes/surface/tests/test_surface_rpv.py
+++ b/eradiate/scenes/surface/tests/test_surface_rpv.py
@@ -1,8 +1,8 @@
 import numpy as np
 
 from eradiate import unit_registry as ureg
-from eradiate.scenes.core import KernelDict
 from eradiate.contexts import KernelDictContext
+from eradiate.scenes.core import KernelDict
 from eradiate.scenes.surface import RPVSurface
 
 

--- a/eradiate/scenes/tests/test_core.py
+++ b/eradiate/scenes/tests/test_core.py
@@ -1,16 +1,16 @@
 import importlib
 
 import attr
+import mitsuba
 import numpy as np
 import pinttr
 import pytest
 
-import mitsuba
 from eradiate import unit_context_config as ucc
 from eradiate import unit_registry as ureg
+from eradiate.exceptions import KernelVariantError
 from eradiate.scenes.core import KernelDict, SceneElement
 from eradiate.validators import has_len, is_number, is_positive
-from eradiate.exceptions import KernelVariantError
 
 
 def test_kernel_dict():

--- a/eradiate/solvers/core/_runner.py
+++ b/eradiate/solvers/core/_runner.py
@@ -15,7 +15,7 @@ def _check_variant():
         raise KernelVariantError(f"unsupported kernel variant '{variant}'")
 
 
-def runner(kernel_dict: KernelDict, sensor_ids: Optional[List] = None) -> Dict:
+def runner(kernel_dict: KernelDict, sensor_ids: Optional[List[str]] = None) -> Dict:
     """
     Low-level runner function. Takes a kernel dictionary, instantiates the
     corresponding kernel scene and runs the integrator with all sensors.
@@ -25,6 +25,8 @@ def runner(kernel_dict: KernelDict, sensor_ids: Optional[List] = None) -> Dict:
 
     Parameter ``kernel_dict`` (:class:`.KernelDict`):
         Dictionary describing the kernel scene.
+
+    Parameter ``sensor_ids`` (list[str] or None)
 
     Returns → dict:
         Nested dictionaries with the following structure:

--- a/eradiate/solvers/core/_runner.py
+++ b/eradiate/solvers/core/_runner.py
@@ -1,9 +1,10 @@
-from typing import Dict, List, Mapping, Optional
+from typing import Dict, List, Optional
 
 import mitsuba
 import numpy as np
 
 from ...exceptions import KernelVariantError
+from ...scenes.core import KernelDict
 
 _SUPPORTED_VARIANTS = {"scalar_mono", "scalar_mono_double"}
 
@@ -14,7 +15,7 @@ def _check_variant():
         raise KernelVariantError(f"unsupported kernel variant '{variant}'")
 
 
-def runner(kernel_dict: Mapping, sensor_ids: Optional[List] = None) -> Dict:
+def runner(kernel_dict: KernelDict, sensor_ids: Optional[List] = None) -> Dict:
     """
     Low-level runner function. Takes a kernel dictionary, instantiates the
     corresponding kernel scene and runs the integrator with all sensors.
@@ -29,6 +30,7 @@ def runner(kernel_dict: Mapping, sensor_ids: Optional[List] = None) -> Dict:
         Nested dictionaries with the following structure:
 
         .. code:: python
+
            {
                "values": {
                    "sensor_0": data_0,
@@ -86,6 +88,6 @@ def runner(kernel_dict: Mapping, sensor_ids: Optional[List] = None) -> Dict:
         # Add sensor SPPs
         if "spp" not in results:
             results["spp"] = {}
-        results["spps"][sensor_id] = sensor.sampler().sample_count()
+        results["spp"][sensor_id] = sensor.sampler().sample_count()
 
     return results

--- a/eradiate/solvers/core/_runner.py
+++ b/eradiate/solvers/core/_runner.py
@@ -33,8 +33,8 @@ def runner(kernel_dict: KernelDict, sensor_ids: Optional[List] = None) -> Dict:
 
            {
                "values": {
-                   "sensor_0": data_0,
-                   "sensor_1": data_1,
+                   "sensor_0": data_0, # Arrays of shape (width, height, n_channels)
+                   "sensor_1": data_1, # (n_channels == 1 for mono variants, possibly more)
                    ...
                },
                "spp": {

--- a/eradiate/solvers/core/_solver_app.py
+++ b/eradiate/solvers/core/_solver_app.py
@@ -1,6 +1,7 @@
 import os
 from abc import ABC
 from pathlib import Path
+from typing import Optional
 
 import attr
 import numpy as np
@@ -15,7 +16,7 @@ from ..._units import unit_context_kernel as uck
 from ..._units import unit_registry as ureg
 from ...contexts import KernelDictContext
 from ...exceptions import ModeError, UnsupportedModeError
-from ...scenes.measure import MeasureResults
+from ...scenes.measure import Measure, MeasureResults
 from ...scenes.measure._distant import DistantMeasure
 
 
@@ -84,10 +85,10 @@ class SolverApp(ABC):
         # Instantiate class
         return cls.new(scene=scene)
 
-    def process(self, measure=None):
+    def process(self, measure: Optional[Measure] = None):
         """
         Run simulation on the configured scene. Raw results yielded by the
-        runner function are stored in ``measure.raw_results``.
+        runner function are stored in ``measure.results``.
 
         .. seealso:: :meth:`postprocess`, :meth:`run`
 
@@ -123,9 +124,9 @@ class SolverApp(ABC):
             # Store results
             measure.results.raw[spectral_coord] = run_results
 
-    def postprocess(self, measure=None):
+    def postprocess(self, measure: Optional[Measure] = None):
         """
-        Post-process raw results stored in measures' ``raw_results`` field. This
+        Post-process raw results stored in a measure's ``results`` field. This
         requires a successful execution of :meth:`process`. Post-processed results
         are stored in ``self.results``.
 
@@ -185,7 +186,7 @@ class SolverApp(ABC):
 
         self._results[measure.id] = ds
 
-    def run(self, measure=None):
+    def run(self, measure: Optional[Measure] = None):
         """
         Perform radiative transfer simulation and post-process results.
         Essentially chains :meth:`process` and :meth:`postprocess`.

--- a/eradiate/solvers/core/_solver_app.py
+++ b/eradiate/solvers/core/_solver_app.py
@@ -8,11 +8,13 @@ import pinttr
 from matplotlib import pyplot as plt
 
 import eradiate
+
 from ._runner import runner
 from ..._attrs import documented, parse_docs
-from ..._units import unit_context_kernel as uck, unit_registry as ureg
-from ...exceptions import ModeError, UnsupportedModeError
+from ..._units import unit_context_kernel as uck
+from ..._units import unit_registry as ureg
 from ...contexts import KernelDictContext
+from ...exceptions import ModeError, UnsupportedModeError
 from ...scenes.measure import MeasureResults
 from ...scenes.measure._distant import DistantMeasure
 
@@ -162,18 +164,20 @@ class SolverApp(ABC):
 
         # Collect illumination spectral data
         k_irradiance_units = uck.get("irradiance")
-        irradiances = np.array([
-            illumination.irradiance.eval(spectral_ctx=spectral_ctx).m_as(k_irradiance_units)
-            for spectral_ctx in measure.spectral_cfg.spectral_ctxs()
-        ])
+        irradiances = np.array(
+            [
+                illumination.irradiance.eval(spectral_ctx=spectral_ctx).m_as(
+                    k_irradiance_units
+                )
+                for spectral_ctx in measure.spectral_cfg.spectral_ctxs()
+            ]
+        )
         spectral_coord_label = eradiate.mode().spectral_coord_label
 
         # Add illumination-dependent variables
         ds["irradiance"] = (
             ("sza", "saa", spectral_coord_label),
-            np.array(irradiances * cos_sza).reshape(
-                (1, 1, len(irradiances))
-            ),
+            np.array(irradiances * cos_sza).reshape((1, 1, len(irradiances))),
         )
 
         ds["brdf"] = ds["lo"] / ds["irradiance"]

--- a/eradiate/solvers/onedim/_solver_app.py
+++ b/eradiate/solvers/onedim/_solver_app.py
@@ -3,6 +3,7 @@ import datetime
 import attr
 
 import eradiate
+
 from ._scene import OneDimScene
 from ..core._solver_app import SolverApp
 from ... import unit_context_kernel as uck

--- a/eradiate/solvers/rami/_solver_app.py
+++ b/eradiate/solvers/rami/_solver_app.py
@@ -3,6 +3,7 @@ import datetime
 import attr
 
 import eradiate
+
 from ._scene import RamiScene
 from ..core._solver_app import SolverApp
 from ... import unit_context_kernel as uck

--- a/eradiate/solvers/tests/test_onedim.py
+++ b/eradiate/solvers/tests/test_onedim.py
@@ -133,10 +133,10 @@ def test_onedim_solver_app_run(mode_mono):
     results = app.results["toa_hsphere"]
 
     # Post-processing creates expected variables ...
-    assert set(results.data_vars) == {"irradiance", "brf", "brdf", "lo"}
+    assert set(results.data_vars) == {"irradiance", "brf", "brdf", "lo", "spp"}
     # ... dimensions
-    assert set(results["lo"].dims) == {"sza", "saa", "x", "y", "wavelength"}
-    assert set(results["irradiance"].dims) == {"sza", "saa", "wavelength"}
+    assert set(results["lo"].dims) == {"sza", "saa", "x", "y", "w"}
+    assert set(results["irradiance"].dims) == {"sza", "saa", "w"}
     # ... and other coordinates
     assert set(results["lo"].coords) == {
         "sza",
@@ -145,9 +145,9 @@ def test_onedim_solver_app_run(mode_mono):
         "vaa",
         "x",
         "y",
-        "wavelength",
+        "w",
     }
-    assert set(results["irradiance"].coords) == {"sza", "saa", "wavelength"}
+    assert set(results["irradiance"].coords) == {"sza", "saa", "w"}
 
     # We just check that we record something as expected
     assert np.all(results["lo"].data > 0.0)

--- a/eradiate/solvers/tests/test_onedim.py
+++ b/eradiate/solvers/tests/test_onedim.py
@@ -4,9 +4,9 @@ import pytest
 import eradiate
 from eradiate import path_resolver
 from eradiate import unit_registry as ureg
+from eradiate.contexts import KernelDictContext
 from eradiate.exceptions import ModeError
 from eradiate.scenes.atmosphere import HomogeneousAtmosphere
-from eradiate.contexts import KernelDictContext
 from eradiate.scenes.measure._distant import DistantMeasure
 from eradiate.solvers.onedim import OneDimScene, OneDimSolverApp
 

--- a/eradiate/solvers/tests/test_postprocess.py
+++ b/eradiate/solvers/tests/test_postprocess.py
@@ -1,5 +1,6 @@
 import numpy as np
 import xarray as xr
+
 import eradiate.data as data
 from eradiate.solvers.core._postprocess import apply_srf
 
@@ -8,12 +9,11 @@ def test_apply_srf():
     da = xr.DataArray(
         np.random.random((4, 5)),
         dims=["w", "another"],
-        coords={"w": 515 + 80 * np.random.random(4)})
+        coords={"w": 515 + 80 * np.random.random(4)},
+    )
     output_da = apply_srf(da, "sentinel_3a-slstr-1")
 
-    dataset = data.open(
-        category="spectral_response_function",
-        id="sentinel_3a-slstr-1")
+    dataset = data.open(category="spectral_response_function", id="sentinel_3a-slstr-1")
     weights = dataset.srf.interp(w=da.w.values)
     weighted = da.weighted(weights)
     weighted_sum = weighted.sum(dim="w")

--- a/eradiate/solvers/tests/test_rami.py
+++ b/eradiate/solvers/tests/test_rami.py
@@ -5,9 +5,9 @@ import pytest
 
 import eradiate
 from eradiate import unit_registry as ureg
+from eradiate.contexts import KernelDictContext
 from eradiate.exceptions import ModeError
 from eradiate.scenes.biosphere import DiscreteCanopy
-from eradiate.contexts import KernelDictContext
 from eradiate.scenes.measure import DistantMeasure
 from eradiate.solvers.rami import RamiScene, RamiSolverApp
 

--- a/eradiate/solvers/tests/test_solvers_core.py
+++ b/eradiate/solvers/tests/test_solvers_core.py
@@ -34,10 +34,16 @@ def test_runner(mode_mono):
     )
     results = runner(kernel_dict)
 
+    # We store film values and SPPs
+    assert "values" in results
+    assert "spp" in results
+
     # Sensors without ID have a default key
-    assert "__sensor_0" in results
+    assert "__sensor_0" in results["values"]
+    assert "__sensor_0" in results["spp"]
     # Sensors with ID have their ID as key
-    assert "my_sensor" in results
+    assert "my_sensor" in results["values"]
+    assert "my_sensor" in results["spp"]
 
 
 def test_runner_fail():

--- a/eradiate/tests/system/test_basic.py
+++ b/eradiate/tests/system/test_basic.py
@@ -3,6 +3,7 @@
 import numpy as np
 import pytest
 
+from eradiate._util import onedict_value
 from eradiate.scenes.core import KernelDict
 from eradiate.solvers.core import runner
 
@@ -95,5 +96,5 @@ def test_radiometric_accuracy(mode_mono, illumination, spp, li):
     else:
         raise ValueError(f"unsupported illumination '{illumination}'")
 
-    result = runner(kernel_dict)["measure"]
+    result = runner(kernel_dict)["values"]["measure"]
     assert np.allclose(result, theoretical_solution, rtol=1e-3)

--- a/eradiate/tests/system/test_maximum_scene_size.py
+++ b/eradiate/tests/system/test_maximum_scene_size.py
@@ -81,7 +81,7 @@ def test_maximum_scene_size(mode_mono_double, json_metadata):
             }
         )
 
-        result = runner(kernel_dict)["measure"].squeeze()
+        result = runner(kernel_dict)["values"]["measure"].squeeze()
         results[scene_size] = np.allclose(result, expected, rtol=1e-5)
 
     # Report test metrics

--- a/eradiate/xarray/metadata.py
+++ b/eradiate/xarray/metadata.py
@@ -208,20 +208,19 @@ for coord_spec_id, coord_spec in [
     ("vaa", CoordSpec("viewing_azimuth_angle", "deg", "viewing azimuth angle")),
     ("sza", CoordSpec("solar_zenith_angle", "deg", "solar zenith angle")),
     ("saa", CoordSpec("solar_azimuth_angle", "deg", "solar azimuth angle")),
-    ("wavelength", CoordSpec("wavelength", "nm", "wavelength")),
     ("z_layer", CoordSpec("layer_altitude", "m", "layer altitude")),
     ("z_level", CoordSpec("level_altitude", "m", "level altitude")),
     ("species", CoordSpec("species", None, "species")),
-    ("w", CoordSpec("wavelength", "nm", "wavelength")),
+    ("w", CoordSpec("wavelength", "nanometer", "wavelength")),
     ("t", CoordSpec("time", None, "time")),
 ]:
     CoordSpecRegistry.register(coord_spec_id, coord_spec)
 
 # Register coordinate spec collections
 for collection_id, coord_spec_ids in [
-    ("angular_intrinsic", ("theta_i", "phi_i", "theta_o", "phi_o", "wavelength")),
-    ("angular_observation", ("sza", "saa", "vza", "vaa", "wavelength")),
-    ("angular_observation_pplane", ("sza", "saa", "vza", "wavelength")),
+    ("angular_intrinsic", ("theta_i", "phi_i", "theta_o", "phi_o", "w")),
+    ("angular_observation", ("sza", "saa", "vza", "vaa", "w")),
+    ("angular_observation_pplane", ("sza", "saa", "vza", "w")),
     ("atmospheric_profile", ("z_layer", "z_level", "species")),
     ("solar_irradiance_spectrum", ("w", "t")),
 ]:

--- a/eradiate/xarray/tests/conftest.py
+++ b/eradiate/xarray/tests/conftest.py
@@ -1,3 +1,4 @@
+
 import numpy as np
 import pytest
 import xarray as xr
@@ -7,13 +8,13 @@ import xarray as xr
 def dataarray_without_metadata():
     return xr.DataArray(
         data=np.random.random((1, 1, 1, 1, 1)),
-        dims=["vza", "vaa", "sza", "saa", "wavelength"],
+        dims=["vza", "vaa", "sza", "saa", "w"],
         coords={
             "vza": [0.0],
             "vaa": [0.0],
             "sza": [0.0],
             "saa": [0.0],
-            "wavelength": [500.0],
+            "w": [500.0],
         },
     )
 

--- a/eradiate/xarray/tests/test_make.py
+++ b/eradiate/xarray/tests/test_make.py
@@ -13,14 +13,14 @@ def test_make_dataarray():
             "vaa": [0.0],
             "sza": [0.0],
             "saa": [0.0],
-            "wavelength": [500.0],
+            "w": [500.0],
         },
-        dims=("vza", "vaa", "sza", "saa", "wavelength"),
+        dims=("vza", "vaa", "sza", "saa", "w"),
         var_spec=VarSpec(coord_specs="angular_observation"),
     )
 
-    assert da.dims == ("vza", "vaa", "sza", "saa", "wavelength")
-    assert set(da.coords.keys()) == {"vza", "vaa", "sza", "saa", "wavelength"}
+    assert da.dims == ("vza", "vaa", "sza", "saa", "w")
+    assert set(da.coords.keys()) == {"vza", "vaa", "sza", "saa", "w"}
 
     # Check that metadata are applied properly if required
     da = make_dataarray(
@@ -30,9 +30,9 @@ def test_make_dataarray():
             "vaa": [0.0],
             "sza": [0.0],
             "saa": [0.0],
-            "wavelength": [500.0],
+            "w": [500.0],
         },
-        dims=("vza", "vaa", "sza", "saa", "wavelength"),
+        dims=("vza", "vaa", "sza", "saa", "w"),
         var_spec=VarSpec(coord_specs="angular_observation"),
     )
 


### PR DESCRIPTION
# Description

This PR closes eradiate/eradiate-issues#75. It adds the basic infrastructure required to perform spectral loops.

- `Measure`s are now parametrised by a `MeasureSpectralConfig` mobject defining the list of spectral channels to loop on. A `MeasureSpectralConfig` can generate a list of `SpectralContext`s, which are in turned used to evaluate spectrum-dependent components.
- The `SolverApp` class was updated to add a spectral loop to it.
- The `runner()` function's output is now structured and documented.
- `Measure`s now store their results as a `MeasureResults` object, which can perform data repacking and yield an xarray data set.
- Redundant wavelength metadata specification was removed.
- Tutorial and API reference were updated accordingly.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
