### PR TITLE
77 absorption switch

### DIFF
--- a/eradiate/radprops/tests/test_rad_profile.py
+++ b/eradiate/radprops/tests/test_rad_profile.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pytest
 
-import eradiate
 from eradiate import path_resolver
 from eradiate import unit_registry as ureg
 from eradiate.contexts import SpectralContext
@@ -18,6 +17,7 @@ from eradiate.thermoprops.util import (
 
 
 def test_rad_props_profile_factory(mode_mono):
+    # RadProfileFactory.create() works
     p = RadProfileFactory.create(
         {
             "type": "array",
@@ -30,6 +30,7 @@ def test_rad_props_profile_factory(mode_mono):
 
 
 def test_array_rad_props_profile(mode_mono):
+    # ArrayRadProfile works
     levels = ureg.Quantity(np.linspace(0, 100, 12), "km")
     albedo_values = ureg.Quantity(np.linspace(0.0, 1.0, 11), ureg.dimensionless)
     sigma_t_values = ureg.Quantity(np.linspace(0.0, 1e-5, 11), "m^-1")
@@ -58,14 +59,17 @@ def test_array_rad_props_profile(mode_mono):
         )
 
 
-def test_us76_approx_rad_profile(mode_mono):
+@pytest.fixture
+def us76_approx_test_absorption_data_set():
+    return path_resolver.resolve(
+        "tests/spectra/absorption/us76_u86_4-spectra-4000_25711.nc"
+    )
+
+def test_us76_approx_rad_profile(mode_mono, us76_approx_test_absorption_data_set):
     spectral_ctx = SpectralContext.new()
 
     # Default constructor with test absorption data set
-    test_absorption_data_set = path_resolver.resolve(
-        "tests/spectra/absorption/us76_u86_4-spectra-4000_25711.nc"
-    )
-    p = US76ApproxRadProfile(absorption_data_set=test_absorption_data_set)
+    p = US76ApproxRadProfile(absorption_data_set=us76_approx_test_absorption_data_set)
 
     for field in ["sigma_a", "sigma_s", "sigma_t", "albedo"]:
         x = getattr(p, field)(spectral_ctx)
@@ -75,16 +79,49 @@ def test_us76_approx_rad_profile(mode_mono):
     # Custom altitude levels
     p = US76ApproxRadProfile(
         levels=ureg.Quantity(np.linspace(0, 120, 121), "km"),
-        absorption_data_set=test_absorption_data_set,
+        absorption_data_set=us76_approx_test_absorption_data_set,
     )
     for field in ["sigma_a", "sigma_s", "sigma_t", "albedo"]:
         x = getattr(p, field)(spectral_ctx)
         assert x.shape == (1, 1, 120)
 
 
-@pytest.mark.slow
-def test_afgl1986_rad_profile(mode_mono):
-    test_absorption_data_sets = {
+def test_us76_approx_rad_profile_absorption_switch_default(mode_mono, us76_approx_test_absorption_data_set):
+    # default value for 'absorption_switch' is True, hence the absorption
+    # coefficient is computed and is not zero everywhere at 1650 nm
+    p = US76ApproxRadProfile(absorption_data_set=us76_approx_test_absorption_data_set)
+    spectral_ctx = SpectralContext.new(wavelength=1650.0)
+    ds = p.to_dataset(spectral_ctx)
+    assert (ds.sigma_a.values != 0.0).any()
+
+
+def test_us76_approx_rad_profile_absorption_switch_true(mode_mono, us76_approx_test_absorption_data_set):
+    # when 'absorption_switch' is True, the absorption coefficient is computed
+    # and is not zero everywhere at 1650 nm
+    p = US76ApproxRadProfile(
+        absorption_switch=True,
+        absorption_data_set=us76_approx_test_absorption_data_set
+    )
+    spectral_ctx = SpectralContext.new(wavelength=1650.0)
+    ds = p.to_dataset(spectral_ctx)
+    assert (ds.sigma_a.values != 0.0).any()
+
+
+def test_us76_approx_rad_profile_absorption_switch_false(mode_mono, us76_approx_test_absorption_data_set):
+    # when 'absorption_switch' is False, the absorption coefficient is not 
+    # computed and is zero everywhere
+    p = US76ApproxRadProfile(
+        absorption_switch=False,
+        absorption_data_set=us76_approx_test_absorption_data_set
+    )
+    spectral_ctx = SpectralContext.new(wavelength=1650.0)
+    ds = p.to_dataset(spectral_ctx)
+    assert (ds.sigma_a.values == 0.0).all()
+
+
+@pytest.fixture
+def afgl1986_test_absorption_data_sets():
+    return {
         "CH4": path_resolver.resolve(
             "tests/spectra/absorption/CH4-spectra-4000_11502.nc"
         ),
@@ -106,24 +143,35 @@ def test_afgl1986_rad_profile(mode_mono):
         "O3": path_resolver.resolve("tests/spectra/absorption/O3-spectra-4000_6997.nc"),
     }
 
+
+def test_afgl1986_rad_profile_default(mode_mono, afgl1986_test_absorption_data_sets):
     # Default constructor with test absorption data sets
     spectral_ctx = SpectralContext.new(
         wavelength=1500.0
     )  # in the infrared, all absorption data sets are opened
 
-    p = AFGL1986RadProfile(absorption_data_sets=test_absorption_data_sets)
+    p = AFGL1986RadProfile(
+        absorption_data_sets=afgl1986_test_absorption_data_sets
+    )
     for field in ["sigma_a", "sigma_s", "sigma_t", "albedo"]:
         x = getattr(p, field)(spectral_ctx)
         assert isinstance(x, ureg.Quantity)
         assert x.shape == (1, 1, 120)
 
+
+def test_afgl1986_rad_profile_levels(mode_mono, afgl1986_test_absorption_data_sets):
     # Custom level altitudes (in the visible, only the H2O data set is opened)
-    spectral_ctx.wavelength = 550.0
-    p = AFGL1986RadProfile(
-        levels=ureg.Quantity(np.linspace(0, 100, 101), "km"),
-        absorption_data_sets=test_absorption_data_sets,
+    spectral_ctx = SpectralContext.new(
+        wavelength=550.0
     )
 
+    p = AFGL1986RadProfile(
+        levels=ureg.Quantity(np.linspace(0, 100, 101), "km"),
+        absorption_data_sets=afgl1986_test_absorption_data_sets,
+    )
+
+
+def test_afgl1986_rad_profile_concentrations(mode_mono, afgl1986_test_absorption_data_sets):
     # Custom concentrations
     concentrations = {
         "H2O": ureg.Quantity(5e23, "m^-2"),  # column number density in S.I. units
@@ -135,7 +183,7 @@ def test_afgl1986_rad_profile(mode_mono):
     }
     p = AFGL1986RadProfile(
         concentrations=concentrations,
-        absorption_data_sets=test_absorption_data_sets,
+        absorption_data_sets=afgl1986_test_absorption_data_sets,
     )
 
     thermoprops = p.eval_thermoprops_profile()
@@ -149,10 +197,45 @@ def test_afgl1986_rad_profile(mode_mono):
     assert np.isclose(surface_amount_CO2, concentrations["CO2"], rtol=1e-9)
     assert np.isclose(surface_amount_CH4, concentrations["CH4"], rtol=1e-9)
 
+
+def test_afgl1986_rad_profile_concentrations_invalid(mode_mono, afgl1986_test_absorption_data_sets):
     # Too large concentrations raise
     p = AFGL1986RadProfile(
         concentrations={"CO2": ureg.Quantity(400, "")},
-        absorption_data_sets=test_absorption_data_sets,
+        absorption_data_sets=afgl1986_test_absorption_data_sets,
     )
     with pytest.raises(ValueError):
         p.eval_thermoprops_profile()
+
+
+def test_afgl1986_rad_profile_absorption_switch_default(mode_mono, afgl1986_test_absorption_data_sets):
+    # default value for 'absorption_switch' is True, hence the absorption
+    # coefficient is computed and is not zero everywhere at 1650 nm
+    p = AFGL1986RadProfile(absorption_data_sets=afgl1986_test_absorption_data_sets)
+    spectral_ctx = SpectralContext.new(wavelength=1650.0)
+    ds = p.to_dataset(spectral_ctx)
+    assert (ds.sigma_a.values != 0.0).any()
+
+
+def test_afgl1986_rad_profile_absorption_switch_true(mode_mono, afgl1986_test_absorption_data_sets):
+    # when 'absorption_switch' is True, the absorption coefficient is computed
+    # and is not zero everywhere at 1650 nm
+    p = AFGL1986RadProfile(
+        absorption_switch=True,
+        absorption_data_sets=afgl1986_test_absorption_data_sets
+    )
+    spectral_ctx = SpectralContext.new(wavelength=1650.0)
+    ds = p.to_dataset(spectral_ctx)
+    assert (ds.sigma_a.values != 0.0).any()
+
+
+def test_afgl1986_rad_profile_absorption_switch_false(mode_mono, afgl1986_test_absorption_data_sets):
+    # when 'absorption_switch' is False, the absorption coefficient is not 
+    # computed and is zero everywhere
+    p = AFGL1986RadProfile(
+        absorption_switch=False,
+        absorption_data_sets=afgl1986_test_absorption_data_sets
+    )
+    spectral_ctx = SpectralContext.new(wavelength=1650.0)
+    ds = p.to_dataset(spectral_ctx)
+    assert (ds.sigma_a.values == 0.0).all()


### PR DESCRIPTION
# Description

Resolves eradiate/eradiate-issues#77.

Also fixes the `to_dataset()` method of `US76ApproxRadProfile` and `AFGL1986RadProfile` classes.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
