### PR TITLE
Fix default levels for standard atmospheric profiles

### DIFF
--- a/eradiate/radprops/rad_profile.py
+++ b/eradiate/radprops/rad_profile.py
@@ -494,13 +494,15 @@ class US76ApproxRadProfile(RadProfile):
 
     levels = documented(
         pinttr.ib(
-            factory=lambda: ureg.Quantity(np.linspace(0, 86, 87), "km"),
-            converter=pinttr.converters.to_units(ucc.deferred("length")),
-            validator=pinttr.validators.has_compatible_units,
+            factory=lambda: np.arange(0.0, 86.01, 1.0) * ureg.km,
             units=ucc.deferred("length"),
         ),
-        doc="Level altitudes.\n\nUnit-enabled field (ucc[length]).",
+        doc="Level altitudes. Default is regular mesh from 0 to 86 km with "
+        "1 km layer size.\n"
+        "\n"
+        "Unit-enabled field (ucc[length]).",
         type="array",
+        default="range(0, 87) km",
     )
 
     has_absorption = documented(
@@ -764,18 +766,15 @@ class AFGL1986RadProfile(RadProfile):
 
     levels = documented(
         pinttr.ib(
-            default=None,
-            converter=attr.converters.optional(
-                pinttr.converters.to_units(ucc.deferred("length"))
-            ),
-            validator=attr.validators.optional(pinttr.validators.has_compatible_units),
+            factory=lambda: np.arange(0.0, 120.01, 1.0) * ureg.km,
             units=ucc.deferred("length"),
         ),
-        doc="Level altitudes. The default level altitude mesh is a regular "
-        "mesh from 0 to 120 km with a step-altitude of 1 km. \n"
+        doc="Level altitudes. Default is a regular mesh from 0 to 120 km with "
+        "1 km layer size.\n"
         "\n"
         "Unit-enabled field (ucc[length]).",
         type="array",
+        default="range(0, 121) km",
     )
 
     concentrations = documented(

--- a/eradiate/scenes/atmosphere/tests/test_heterogeneous.py
+++ b/eradiate/scenes/atmosphere/tests/test_heterogeneous.py
@@ -193,7 +193,8 @@ def test_heterogeneous_default(mode_mono):
     # Default heterogeneous atmosphere uses the default radiative properties
     # profile
     a = HeterogeneousAtmosphere()
-    assert a.profile == AFGL1986RadProfile()
+    assert isinstance(a.profile, AFGL1986RadProfile)
+    assert np.allclose(a.profile.levels, ureg.Quantity(range(0, 121), "km"))
 
 
 def test_heterogeneous_us76(mode_mono, tmpdir):


### PR DESCRIPTION
# Description

This PR fixes a bug where the `AFGL1986RadProfile` would have incorrect default levels. It also harmonises documentation and code between the `AFGL1986RadProfile` and `US76ApproxRadProfile` classes.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
