### PR TITLE
Docker: Fix eradiate installation and ERADIATE_DIR variable setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,17 +50,17 @@ ENV ERADIATE_DIR=/sources/eradiate
 RUN mkdir -p /sources \
     && git clone --recursive https://github.com/eradiate/eradiate.git /sources/eradiate \
     && cd /sources/eradiate \
-    && wget -q https://eradiate.eu/data/solid_2017.zip # Silent and may take a while \
-    && wget -q https://eradiate.eu/data/us76_u86_4-spectra.zip # Silent and may take a while \
+    && wget https://eradiate.eu/data/solid_2017.zip \
+    && wget https://eradiate.eu/data/us76_u86_4-spectra.zip \
     && cd resources/data && (unzip ../../solid_2017.zip || true) \
-    && (unzip ../../spectra-us76_u86_4.zip || true) \
-    && cd /sources/eradiate && python3 setup.py install --single-version-externally-managed --root=/ \
-    && cp -r /sources/eradiate/resources /usr/local/lib/python3.8/dist-packages/eradiate/resources \
+    && (unzip ../../spectra-us76_u86_4.zip || true)
+RUN cd /sources/eradiate && python3 setup.py install --single-version-externally-managed --root=/ \
+    && cp -r /sources/eradiate/resources /usr/local/lib/python3.8/dist-packages/resources \
     && cd / && rm -rf /sources
 
 WORKDIR /app
 
-ENV ERADIATE_DIR=/usr/local/lib/python3.8/dist-packages/eradiate
+ENV ERADIATE_DIR=/usr/local/lib/python3.8/dist-packages
 
 RUN ln -sf /usr/bin/python3 /usr/bin/python
 RUN ln -sf /usr/bin/pip3 /usr/bin/pip


### PR DESCRIPTION
# Description

The Docker image had an invalid installation process for the eradiate python module.

This patch fixes this install procedure as well as the ERADIATE_DIR env variable inside the container.

# Checklist

- [ ] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [ ] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
