### PR TITLE
Generalised use of to_quantity()

### DIFF
--- a/docs/rst/reference/core.rst
+++ b/docs/rst/reference/core.rst
@@ -30,7 +30,6 @@ Units and quantities
 .. toctree::
    :hidden:
    :maxdepth: 1
-
    imported_vars/unit_registry
    imported_vars/unit_context_config
    imported_vars/unit_context_kernel
@@ -51,6 +50,13 @@ Units and quantities
       :toctree: generated
 
        _units.PhysicalQuantity
+
+.. dropdown:: **Private: Quantity converter**
+
+   .. autosummary::
+      :toctree: generated/
+      
+      _units.to_quantity  
 
 Path resolver
 -------------

--- a/eradiate/_units.py
+++ b/eradiate/_units.py
@@ -103,3 +103,29 @@ unit_context_config = _make_unit_context()
 
 #: Unit context used when building kernel dictionaries
 unit_context_kernel = _make_unit_context()
+
+
+def to_quantity(variable: xarray.Variable) -> pint.Quantity:
+    """
+    Converts a :class:`~xarray.Variable` to a :class:`~pint.Quantity`.
+
+    Parameter ``variable`` (:class:`~xarray.Variable`):
+        Xarray variable. For example, a :class:`~xarray.Dataset`'s data
+        variable or coordinate, or a :class:`~xarray.DataArray` or a
+        :class:`~xarray.DataArray`'s coordinate.
+
+        .. note::
+            The variable's ``attrs`` must include a ``units`` key.
+
+    Returns → :class:`pint.Quantity`:
+        The corresponding quantity.
+
+    Raises → ValueError:
+        If the variable's ``attrs`` does not include a ``units`` key.
+    """
+    try:
+        units = variable.units
+    except KeyError:
+        raise ValueError(f"{variable} has no units.")
+    else:
+        return unit_registry.Quantity(variable.values, units)

--- a/eradiate/plot.py
+++ b/eradiate/plot.py
@@ -6,7 +6,7 @@ __all__ = [
     "make_ticks",
     "pcolormesh_polar",
     "remove_xyticks",
-    "remove_xylabels"
+    "remove_xylabels",
 ]
 
 import matplotlib.pyplot as _plt
@@ -16,9 +16,10 @@ from matplotlib.figure import Figure
 from xarray.plot import FacetGrid
 
 from . import unit_registry as ureg
-
+from ._units import to_quantity
 
 # -- Plotting wrappers ---------------------------------------------------------
+
 
 def pcolormesh_polar(darray, r=None, theta=None, **kwargs):
     """Create a polar pcolormesh plot. Wraps :func:`xarray.plot.pcolormesh`:
@@ -58,8 +59,10 @@ def pcolormesh_polar(darray, r=None, theta=None, **kwargs):
 
     if theta_units != ureg.rad:
         theta_rad = f"{theta}_rad"
-        theta_rad_values = ureg.Quantity(darray[theta].values, theta_units).to(ureg.rad).magnitude
-        darray_plot = darray.assign_coords(**{theta_rad: (theta_dims, theta_rad_values)})
+        theta_rad_values = to_quantity(darray[theta]).m_as("rad")
+        darray_plot = darray.assign_coords(
+            **{theta_rad: (theta_dims, theta_rad_values)}
+        )
         darray_plot[theta_rad].attrs = darray[theta].attrs
         darray_plot[theta_rad].attrs["units"] = "rad"
     else:
@@ -84,6 +87,7 @@ def pcolormesh_polar(darray, r=None, theta=None, **kwargs):
 
 
 # -- Utility functions ---------------------------------------------------------
+
 
 def detect_axes(from_=None):
     """Try and extract a :class:`~matplotlib.axes.Axes` list from a data structure.
@@ -144,16 +148,14 @@ def get_axes_from_facet_grid(facet_grid, exclude=None):
 
 
 def remove_xylabels(from_=None):
-    """Remove x and y axis labels from ``from_`` (processed by :func:`detect_axes`).
-    """
+    """Remove x and y axis labels from ``from_`` (processed by :func:`detect_axes`)."""
     for ax in detect_axes(from_):
         ax.set_xlabel("")
         ax.set_ylabel("")
 
 
 def remove_xyticks(from_=None):
-    """Remove x and y axis tick labels from ``from_`` (processed by :func:`detect_axes`).
-    """
+    """Remove x and y axis tick labels from ``from_`` (processed by :func:`detect_axes`)."""
     for ax in detect_axes(from_):
         ax.get_xaxis().set_visible(False)
         ax.get_yaxis().set_visible(False)

--- a/eradiate/radprops/absorption.py
+++ b/eradiate/radprops/absorption.py
@@ -4,6 +4,7 @@ import numpy as np
 import xarray as xr
 from scipy.constants import physical_constants
 
+from .._units import to_quantity
 from .._units import unit_registry as ureg
 
 _BOLTZMANN = ureg.Quantity(*physical_constants["Boltzmann constant"][:2])
@@ -138,7 +139,7 @@ def compute_sigma_a(
             ),
         )
 
-    xs = ureg.Quantity(interpolated.xs.values, interpolated.xs.units)
+    xs = to_quantity(interpolated.xs)
 
     # If 'n' is None, we compute it using the ideal gas state equation.
     if n is None:

--- a/eradiate/radprops/rad_profile.py
+++ b/eradiate/radprops/rad_profile.py
@@ -17,6 +17,7 @@ from .rayleigh import compute_sigma_s_air
 from .. import data
 from .._attrs import documented, parse_docs
 from .._factory import BaseFactory
+from .._units import to_quantity
 from .._units import unit_context_config as ucc
 from .._units import unit_registry as ureg
 from ..data.absorption_spectra import Absorber, Engine, find_dataset
@@ -28,15 +29,6 @@ from ..thermoprops.util import (
     rescale_concentration,
 )
 from ..validators import all_positive
-
-
-def _to_quantity(variable):
-    try:
-        units = variable.units
-    except KeyError:
-        raise ValueError(f"{variable} has no units.")
-    finally:
-        return ureg.Quantity(variable.values, units)
 
 
 @ureg.wraps(
@@ -393,10 +385,10 @@ class ArrayRadProfile(RadProfile):
     @classmethod
     def from_dataset(cls, path):
         ds = xr.open_dataset(path_resolver.resolve(path))
-        z_level = _to_quantity(ds.z_level)
+        z_level = to_quantity(ds.z_level)
         n_layers = ds.z_level.size - 1
-        albedo = _to_quantity(ds.albedo).reshape(1, 1, n_layers)
-        sigma_t = _to_quantity(ds.sigma_t).reshape(1, 1, n_layers)
+        albedo = to_quantity(ds.albedo).reshape(1, 1, n_layers)
+        sigma_t = to_quantity(ds.sigma_t).reshape(1, 1, n_layers)
         return cls(albedo_values=albedo, sigma_t_values=sigma_t, levels=z_level)
 
     def to_dataset(self, spectral_ctx=None):
@@ -634,8 +626,8 @@ class US76ApproxRadProfile(RadProfile):
         profile = self.eval_thermoprops_profile()
         return make_dataset(
             wavelength=spectral_ctx.wavelength,
-            z_level=_to_quantity(profile.z_level),
-            z_layer=_to_quantity(profile.z_layer),
+            z_level=to_quantity(profile.z_level),
+            z_layer=to_quantity(profile.z_layer),
             sigma_a=self.sigma_a(spectral_ctx).flatten(),
             sigma_s=self.sigma_s(spectral_ctx).flatten(),
         )
@@ -1012,8 +1004,8 @@ class AFGL1986RadProfile(RadProfile):
         """
         return make_dataset(
             wavelength=spectral_ctx.wavelength,
-            z_level=_to_quantity(self.eval_thermoprops_profile().z_level),
-            z_layer=_to_quantity(self.eval_thermoprops_profile().z_layer),
+            z_level=to_quantity(self.eval_thermoprops_profile().z_level),
+            z_layer=to_quantity(self.eval_thermoprops_profile().z_layer),
             sigma_a=self.sigma_a(spectral_ctx).flatten(),
             sigma_s=self.sigma_s(spectral_ctx).flatten(),
         )

--- a/eradiate/scenes/spectra/_solar_irradiance.py
+++ b/eradiate/scenes/spectra/_solar_irradiance.py
@@ -9,6 +9,7 @@ from ... import unit_context_kernel as uck
 from ... import unit_registry as ureg
 from ..._attrs import documented, parse_docs
 from ..._units import PhysicalQuantity
+from ..._units import to_quantity
 from ...contexts import SpectralContext
 from ...scenes.spectra import Spectrum, SpectrumFactory
 from ...validators import is_positive
@@ -92,21 +93,16 @@ class SolarIrradianceSpectrum(Spectrum):
         if eradiate.mode().is_monochromatic():
             wavelength = spectral_ctx.wavelength.m_as(self.data.w.attrs["units"])
 
-            irradiance_magnitude = float(
+            irradiance = to_quantity(
                 self.data.ssi.interp(
                     w=wavelength,
                     method="linear",
-                ).values
+                )
             )
 
             # Raise if out of bounds or ill-formed dataset
-            if np.isnan(irradiance_magnitude):
+            if np.isnan(irradiance.magnitude):
                 raise ValueError("dataset evaluation returned nan")
-
-            # Apply units
-            irradiance = ureg.Quantity(
-                irradiance_magnitude, self.data.ssi.attrs["units"]
-            )
 
         else:
             raise ValueError(f"unsupported mode {eradiate.mode().id}")


### PR DESCRIPTION
# Description

The `to_quantity()` method was introduced by eradiate/eradiate#71 but remained local to the `eradiate.radprops.rad_profile` module. This method is also useful for the following modules:

* `eradiate.plot`
* `eradiate.radprops.absorption`
* `eradiate.scenes.spectra._solar_irradiance`
* `eradiate.thermoprops.util`

I suggest to move `to_quantity()` from `eradiate.radprops.rad_profile` to `eradiate._util` and use it in all these modules.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
