### PR TITLE
Explicit "auto" value for surface width

### DIFF
--- a/eradiate/contexts.py
+++ b/eradiate/contexts.py
@@ -160,10 +160,12 @@ class KernelDictContext:
         default="True",
     )
 
-    atmosphere_kernel_width: Optional[pint.Quantity] = documented(
+    override_surface_width: Optional[pint.Quantity] = documented(
         pinttr.ib(default=None, units=ucc.deferred("length")),
-        doc="If relevant, stores the width of the kernel object associated with "
-        "the atmosphere.",
+        doc="If relevant, value which must be used as the surface width "
+        "(*e.g.* when surface size must match atmosphere or canopy size).\n"
+        "\n"
+        "Unit-enabled field (default: cdu[length]).",
         type="float or None",
         default="None",
     )

--- a/eradiate/exceptions.py
+++ b/eradiate/exceptions.py
@@ -5,7 +5,6 @@ from pinttr.util import always_iterable
 
 import eradiate
 
-
 # -- Exceptions ----------------------------------------------------------------
 
 
@@ -54,5 +53,11 @@ class KernelVariantError(Exception):
 
 class ConfigWarning(UserWarning):
     """Used when encountering nonfatal configuration issues."""
+
+    pass
+
+
+class OverriddenValueWarning(UserWarning):
+    """Used when a user-defined value is overridden during execution."""
 
     pass

--- a/eradiate/scenes/surface/_black.py
+++ b/eradiate/scenes/surface/_black.py
@@ -2,6 +2,7 @@ import attr
 
 from ._core import Surface, SurfaceFactory
 from ..._attrs import parse_docs
+from ...contexts import KernelDictContext
 
 
 @SurfaceFactory.register("black")
@@ -14,7 +15,7 @@ class BlackSurface(Surface):
     This class creates a square surface with a black BRDF attached.
     """
 
-    def bsdfs(self, ctx=None):
+    def bsdfs(self, ctx: KernelDictContext = None):
         return {
             f"bsdf_{self.id}": {
                 "type": "diffuse",

--- a/eradiate/scenes/surface/_core.py
+++ b/eradiate/scenes/surface/_core.py
@@ -85,7 +85,7 @@ class Surface(SceneElement, ABC):
     def kernel_width(self, ctx=None):
         """
         Return width of kernel object, possibly overridden by
-        ``ctx.atmosphere_kernel_width``.
+        ``ctx.override_surface_width``.
 
         Parameter ``ctx`` (:class:`.KernelDictContext` or None):
             A context data structure containing parameters relevant for kernel
@@ -94,8 +94,8 @@ class Surface(SceneElement, ABC):
         Returns → :class:`pint.Quantity`:
             Kernel object width.
         """
-        if ctx.atmosphere_kernel_width is not None:
-            return ctx.atmosphere_kernel_width
+        if ctx.override_surface_width is not None:
+            return ctx.override_surface_width
         else:
             return self.width
 

--- a/eradiate/scenes/surface/_lambertian.py
+++ b/eradiate/scenes/surface/_lambertian.py
@@ -4,6 +4,7 @@ from ._core import Surface, SurfaceFactory
 from ..spectra import Spectrum, SpectrumFactory
 from ... import validators
 from ..._attrs import documented, parse_docs
+from ...contexts import KernelDictContext
 
 
 @SurfaceFactory.register("lambertian")
@@ -31,7 +32,7 @@ class LambertianSurface(Surface):
         default="0.5",
     )
 
-    def bsdfs(self, ctx=None):
+    def bsdfs(self, ctx: KernelDictContext = None):
         return {
             f"bsdf_{self.id}": {
                 "type": "diffuse",

--- a/eradiate/scenes/surface/_rpv.py
+++ b/eradiate/scenes/surface/_rpv.py
@@ -2,6 +2,7 @@ import attr
 
 from ._core import Surface, SurfaceFactory
 from ..._attrs import documented, parse_docs
+from ...contexts import KernelDictContext
 
 
 @SurfaceFactory.register("rpv")
@@ -20,6 +21,7 @@ class RPVSurface(Surface):
     """
 
     # TODO: check if there are bounds to default parameters
+    # TODO: match defaults with plugin defaults
     # TODO: add support for spectra
 
     rho_0 = documented(
@@ -43,7 +45,7 @@ class RPVSurface(Surface):
         default="-0.1",
     )
 
-    def bsdfs(self, ctx=None):
+    def bsdfs(self, ctx: KernelDictContext = None):
         return {
             f"bsdf_{self.id}": {
                 "type": "rpv",

--- a/eradiate/scenes/surface/tests/test_surface_core.py
+++ b/eradiate/scenes/surface/tests/test_surface_core.py
@@ -1,0 +1,57 @@
+import pytest
+
+from eradiate import unit_registry as ureg
+from eradiate.contexts import KernelDictContext
+from eradiate.exceptions import ConfigWarning, OverriddenValueWarning
+from eradiate.scenes.surface import Surface
+
+
+class MyBlackSurface(Surface):
+    """A basic implementation for the sake of testing."""
+
+    def bsdfs(self, ctx=None):
+        return {
+            f"bsdf_{self.id}": {
+                "type": "diffuse",
+                "reflectance": {"type": "uniform", "value": 0.0},
+            }
+        }
+
+
+def test_kernel_width(mode_mono):
+    obj = MyBlackSurface()
+
+    # Size value is appropriately used as kernel object size
+    obj.width = 1.0 * ureg.m
+    assert obj.kernel_width() == 1.0 * ureg.m
+
+    # Auto size yields 100 km kernel width
+    obj.width = "auto"
+    assert obj.kernel_width() == 100.0 * ureg.km
+
+    # Override constrains auto size
+    obj.width = "auto"
+    ctx = KernelDictContext(override_surface_width=100.0 * ureg.m)
+    assert obj.kernel_width(ctx) == 100.0 * ureg.m
+
+    # Override with set value raises a warning
+    obj.width = 1.0 * ureg.m
+    with pytest.warns(OverriddenValueWarning):
+        assert obj.kernel_width(ctx) == 100.0 * ureg.m
+
+
+def test_scale(mode_mono):
+    obj = MyBlackSurface()
+
+    # Scaling a surface with a set value yields a scaled copy
+    obj.width = 1.0 * ureg.m
+    obj_scaled = obj.scaled(2.0)
+    assert obj_scaled is not obj
+    assert obj_scaled.width == 2.0 * obj.width
+
+    # Scaling a surface with auto width returns an unmodified copy
+    obj.width = "auto"
+    with pytest.warns(ConfigWarning):
+        obj_scaled = obj.scaled(2.0)
+    assert obj_scaled is not obj
+    assert obj_scaled.width == "auto"

--- a/eradiate/solvers/onedim/_scene.py
+++ b/eradiate/solvers/onedim/_scene.py
@@ -106,7 +106,7 @@ class OneDimScene(Scene):
         if self.atmosphere is not None:
             result.add(self.atmosphere, ctx=ctx)
             ctx = attr.evolve(
-                ctx, atmosphere_kernel_width=self.atmosphere.kernel_width(ctx)
+                ctx, override_surface_width=self.atmosphere.kernel_width(ctx)
             )
 
         result.add(

--- a/eradiate/solvers/onedim/_scene.py
+++ b/eradiate/solvers/onedim/_scene.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Optional
 
 import attr
@@ -6,6 +7,7 @@ from ..core._scene import Scene
 from ... import unit_context_config as ucc
 from ..._attrs import documented, get_doc, parse_docs
 from ...contexts import KernelDictContext
+from ...exceptions import OverriddenValueWarning
 from ...scenes.atmosphere import Atmosphere, AtmosphereFactory, HomogeneousAtmosphere
 from ...scenes.core import KernelDict
 from ...scenes.integrators import Integrator, IntegratorFactory, VolPathIntegrator
@@ -53,6 +55,13 @@ class OneDimScene(Scene):
         type=":class:`.Surface` or dict",
         default=":class:`LambertianSurface() <.LambertianSurface>`",
     )
+
+    @surface.validator
+    def _surface_validator(self, attribute, value):
+        if self.atmosphere and value.width != "auto":
+            warnings.warn(
+                OverriddenValueWarning("surface size will be overridden by atmosphere")
+            )
 
     integrator: Integrator = documented(
         attr.ib(

--- a/eradiate/solvers/rami/_scene.py
+++ b/eradiate/solvers/rami/_scene.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Optional
 
 import attr
@@ -6,6 +7,7 @@ from ..core._scene import Scene
 from ... import validators
 from ..._attrs import documented, get_doc, parse_docs
 from ...contexts import KernelDictContext
+from ...exceptions import OverriddenValueWarning
 from ...scenes.biosphere import BiosphereFactory, Canopy
 from ...scenes.core import KernelDict
 from ...scenes.integrators import Integrator, IntegratorFactory, PathIntegrator
@@ -35,6 +37,13 @@ class RamiScene(Scene):
         type=":class:`.Surface` or dict",
         default=":class:`LambertianSurface() <.LambertianSurface>`",
     )
+
+    @surface.validator
+    def _surface_validator(self, attribute, value):
+        if self.canopy and value.width != "auto":
+            warnings.warn(
+                OverriddenValueWarning("surface size will be overridden by canopy")
+            )
 
     canopy: Canopy = documented(
         attr.ib(

--- a/eradiate/solvers/tests/test_rami.py
+++ b/eradiate/solvers/tests/test_rami.py
@@ -32,7 +32,7 @@ def test_rami_scene(mode_mono):
     s = RamiScene(measures={"type": "distant"})
     assert s.kernel_dict(ctx=ctx).load() is not None
 
-    # -- Surface size is appropriately inherited from canopy
+    # -- Surface size is appropriately overridden with canopy size
     s = RamiScene(
         canopy=DiscreteCanopy.homogeneous(
             lai=3.0,
@@ -41,7 +41,13 @@ def test_rami_scene(mode_mono):
             l_vertical=2.0 * ureg.m,
         )
     )
-    assert np.allclose(s.surface.width, ureg.Quantity(10.0, "m"))
+    ctx = KernelDictContext()
+    kernel_scene = s.kernel_dict(ctx)
+    assert np.allclose(ctx.override_surface_width, 10.0 * ureg.m)
+    assert np.allclose(
+        kernel_scene["surface"]["to_world"].transform_point([1, -1, 0]),
+        [5, -5, 0],
+    )
 
     # -- Distant sensor target zone is appropriately defined
     s = RamiScene(


### PR DESCRIPTION
# Description

This PR closes eradiate/eradiate-issues#83. It changes the way the surface's kernel object size is computed and allows for explicit setting of the `width` field to `"auto"`. Changes are as follows:

- `KernelDictContext`: `atmosphere_kernel_width` is renamed to a more general `override_surface_width`
- Added a `OverriddenValueWarning` used to notify the user that their configuration is being ignored
- `Surface.kernel_width()` now uses `override_surface_width` to force a kernel object value; it also issues warnings if relevant
- Added `Surface` unit tests
- Updated solvers to use surface face override infrastructure properly

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
