### PR TITLE
Complete moving postprocessing to Measure

### DIFF
--- a/docs/examples/tutorials/solver_onedim/01_solver_onedim.py
+++ b/docs/examples/tutorials/solver_onedim/01_solver_onedim.py
@@ -89,7 +89,7 @@ atmosphere
 # """"""""""""
 #
 # Next up is the illumination of our scene. We will use a directional
-# illumination model [:class:`.DirectionalIllumination`], which consists of an
+# illumination model [:class:`.DirectionalIllumination`], which simulates an
 # infinitely distant collimated light source. This model is configured by
 # the zenith and azimuth angles; we can also specify the illumination spectrum,
 # which we will set to the default solar irradiance spectrum
@@ -109,23 +109,23 @@ illumination
 # The final piece of our scene is the observation. We are interested quantities
 # derived from the top-of-atmosphere leaving radiance, *e.g.* the
 # top-of-atmosphere bidirectional reflectance factor (BRF). Eradiate simulates
-# this using the distant measure [:class:`.DistantMeasure`] which, in practice,
-# records the radiance leaving the scene. By default, this measure records the
-# radiance in the entire hemisphere, which is mapped to its rectangular *film*.
+# this using the distant reflectance measure [:class:`.DistantReflectanceMeasure`]
+# which, in practice, records the radiance leaving the scene and derives
+# reflectance values from it.
 #
-# By default, :class:`.DistantMeasure` records the leaving radiance in the
-# entire hemisphere. Although this is of limited utility for a detailed
-# analysis, it is interesting to examine roughly results and orient more
-# detailed computations. We will therefore run a quick simulation with a
-# low-resolution (32×32) film and a rather low number of samples per pixels
-# (10000). We expect the result to be noisy, but we will see later how to run
-# a quick simulation with more samples and less noise.
+# By default, :class:`.DistantReflectanceMeasure` covers the entire hemisphere.
+# Although this is of limited utility for a detailed analysis, it is interesting
+# to examine roughly results and orient more detailed computations. We will
+# therefore run a quick simulation with a low-resolution (32×32) film and a
+# rather low number of samples per pixels (10000). We expect the result to be
+# noisy, but we will see later how to run a quick simulation with more samples
+# and less noise.
 #
 # In order to identify our results more easily afterwards, we will assign a
 # ``toa_hsphere`` identifier (for "top-of-atmosphere, hemisphere") to our
 # measure.
 
-measure = eradiate.scenes.measure.DistantMeasure(
+measure = eradiate.scenes.measure.DistantReflectanceMeasure(
     id="toa_hsphere",
     film_resolution=(32, 32),
     spp=10000,
@@ -237,7 +237,7 @@ scene = eradiate.solvers.onedim.OneDimScene(
         sigma_s=1e-6 * ureg.m ** -1,
     ),
     illumination=illumination,
-    measures=eradiate.scenes.measure.DistantMeasure(
+    measures=eradiate.scenes.measure.DistantReflectanceMeasure(
         id="toa_hsphere",
         film_resolution=(32, 32),
         spp=10000,
@@ -255,7 +255,7 @@ plt.show()
 # While the hemispherical views we have created so far are convenient for
 # basic checks, they are fairly noisy and we usually prefer visualising results
 # in the principal plane. For that purpose, we can configure our
-# :class:`.DistantMeasure` by assigning 1 to the film height. Since we are
+# :class:`.DistantReflectanceMeasure` by assigning 1 to the film height. Since we are
 # significantly reducing the number of pixels, we can increase the number of
 # samples we will take while (more or less) preserving our computational time.
 
@@ -266,7 +266,7 @@ scene = eradiate.solvers.onedim.OneDimScene(
         sigma_s=1e-4 * ureg.m ** -1,
     ),
     illumination=illumination,
-    measures=eradiate.scenes.measure.DistantMeasure(
+    measures=eradiate.scenes.measure.DistantReflectanceMeasure(
         id="toa_pplane",
         film_resolution=(32, 1),
         spp=1000000,
@@ -313,7 +313,7 @@ scene = eradiate.solvers.onedim.OneDimScene(
         "irradiance": {"type": "solar_irradiance"},
     },
     measures={
-        "type": "distant",
+        "type": "distant_reflectance",
         "id": "toa_hsphere",
         "film_resolution": (32, 1),
         "spp": 1000000,
@@ -342,7 +342,7 @@ scene = eradiate.solvers.onedim.OneDimScene.from_dict(
             "irradiance": {"type": "solar_irradiance"},
         },
         "measures": {
-            "type": "distant",
+            "type": "distant_reflectance",
             "id": "toa_hsphere",
             "film_resolution": (32, 1),
             "spp": 1000000,
@@ -374,7 +374,7 @@ config = {
         "irradiance": {"type": "solar_irradiance"},
     },
     "measures": {
-        "type": "distant",
+        "type": "distant_reflectance",
         "id": "toa_hsphere",
         "film_resolution": (32, 1),
         "spp": 1000000,

--- a/docs/examples/tutorials/solver_onedim/02_onedim_sim_hetero_atm.py
+++ b/docs/examples/tutorials/solver_onedim/02_onedim_sim_hetero_atm.py
@@ -36,19 +36,16 @@ from eradiate.solvers.onedim import OneDimSolverApp
 
 config = {
     "mode": "mono_double",
-    "atmosphere": {
-        "type": "heterogeneous",
-        "profile": {
-            "type": "us76_approx"
+    "atmosphere": {"type": "heterogeneous", "profile": {"type": "us76_approx"}},
+    "measures": [
+        {
+            "type": "distant_reflectance",
+            "id": "toa_plane",
+            "film_resolution": [90, 1],
+            "spp": 65536,
+            "spectral_cfg": {"wavelengths": [579.0]},
         }
-    },
-    "measures": [{
-        "type": "distant",
-        "id": "toa_plane",
-        "film_resolution": [90,1],
-        "spp": 65536,
-        "spectral_cfg": {"wavelengths": [579.0]},
-    }]
+    ],
 }
 app = OneDimSolverApp.from_dict(config)
 
@@ -100,19 +97,16 @@ print(app.scene.atmosphere.profile.albedo(spectral_ctx))
 
 config = {
     "mode": "mono_double",
-    "atmosphere": {
-        "type": "heterogeneous",
-        "profile": {
-            "type": "us76_approx"
+    "atmosphere": {"type": "heterogeneous", "profile": {"type": "us76_approx"}},
+    "measures": [
+        {
+            "type": "distant_reflectance",
+            "id": "toa_plane",
+            "film_resolution": [90, 1],
+            "spp": 65536,
+            "spectral_cfg": {"wavelengths": [1281.0]},
         }
-    },
-    "measures": [{
-        "type": "distant",
-        "id": "toa_plane",
-        "film_resolution": [90, 1],
-        "spp": 65536,
-        "spectral_cfg": {"wavelengths": [1281.0]},
-    }]
+    ],
 }
 app = OneDimSolverApp.from_dict(config)
 

--- a/docs/examples/tutorials/solver_rami/01_solver_rami.py
+++ b/docs/examples/tutorials/solver_rami/01_solver_rami.py
@@ -69,13 +69,13 @@ illumination
 #
 # All measures in Eradiate use an underlying kernel component called *sensor*.
 # All sensors record their results to a *film*, which consists of a set of
-# pixels arranged on a Cartesian grid, and the :class:`.DistantMeasure` features
-# a ``film_resolution`` parameter which controls the number of pixels on the
-# film. It should be a 2-element sequence of integers, the first one being the
-# width of the film, and the second being the height. We will configure our
-# measure to produce a global view of the scene's bidirectional reflectance
-# factor over the whole hemisphere and will set the film to a coarse resolution
-# of 32 × 32.
+# pixels arranged on a Cartesian grid, and :class:`.DistantReflectanceMeasure`
+# features a ``film_resolution`` parameter which controls the number of pixels
+# on the film. It should be a 2-element sequence of integers, the first one
+# being the width of the film, and the second being the height. We will
+# configure our measure to produce a global view of the scene's bidirectional
+# reflectance factor over the whole hemisphere and will set the film to a coarse
+# resolution of 32 × 32.
 #
 # When the simulation starts, the Monte Carlo algorithms traces a number rays
 # per film pixel controlled by the ``spp`` (for *samples per pixel*) parameter.
@@ -87,14 +87,14 @@ illumination
 # unique identifier: it will be used to reference the results. We will assign
 # the identifier `toa_brf` to our measure.
 #
-# The :class:`.DistantMeasure` class has other parameters, but we do not need to
-# modify them for now.
+# The :class:`.DistantReflectanceMeasure` class has other parameters, but we do
+# not need to modify them for now.
 
-measure = eradiate.scenes.measure.DistantMeasure(
+measure = eradiate.scenes.measure.DistantReflectanceMeasure(
     id="toa_brf",
     film_resolution=(32, 32),
     spp=1000,
-    spectral_cfg={"wavelengths": [550.0]}
+    spectral_cfg={"wavelengths": [550.0]},
 )
 measure
 
@@ -178,10 +178,10 @@ plt.show()
 # -----------------------------------
 #
 # We are now going to run a new simulation with a different measure
-# configuration. We will still use the :class:`.DistantMeasure` element, but we
-# will set its film height to 1 pixel. This will trigger a special behaviour
-# where the underlying kernel sensor will sample directions only on a plane
-# defined by the measure's ``orientation`` parameter. We will set
+# configuration. We will still use the :class:`.DistantReflectanceMeasure`
+# element, but we will set its film height to 1 pixel. This will trigger a
+# special behaviour where the underlying kernel sensor will sample directions
+# only on a plane defined by the measure's ``orientation`` parameter. We will set
 # ``orientation`` to the same value as the Sun azimuth angle: this will make our
 # sensor record radiance in the principal plane.
 #
@@ -189,7 +189,7 @@ plt.show()
 # SPP at a reasonable computational cost. Let's increase it up to 100000 to
 # reduce that noise.
 
-measure = eradiate.scenes.measure.DistantMeasure(
+measure = eradiate.scenes.measure.DistantReflectanceMeasure(
     id="toa_brf", film_resolution=(32, 1), spp=100000, orientation=45.0
 )
 

--- a/docs/rst/reference/scenes.rst
+++ b/docs/rst/reference/scenes.rst
@@ -144,6 +144,7 @@ Measures [eradiate.scenes.measure]
    :toctree: generated/
 
    DistantMeasure
+   DistantReflectanceMeasure
    PerspectiveCameraMeasure
    RadiancemeterMeasure
    RadiancemeterArrayMeasure

--- a/eradiate/scenes/measure/__init__.py
+++ b/eradiate/scenes/measure/__init__.py
@@ -1,5 +1,5 @@
 from ._core import Measure, MeasureFactory, MeasureResults, MeasureSpectralConfig
-from ._distant import DistantMeasure
+from ._distant import DistantMeasure, DistantReflectanceMeasure
 from ._perspective import PerspectiveCameraMeasure
 from ._radiancemeter import RadiancemeterMeasure
 from ._radiancemeterarray import RadiancemeterArrayMeasure
@@ -10,6 +10,7 @@ __all__ = [
     "MeasureFactory",
     "MeasureResults",
     "DistantMeasure",
+    "DistantReflectanceMeasure",
     "PerspectiveCameraMeasure",
     "RadiancemeterMeasure",
 ]

--- a/eradiate/scenes/measure/_core.py
+++ b/eradiate/scenes/measure/_core.py
@@ -14,11 +14,12 @@ from ..core import SceneElement
 from ... import converters, validators
 from ..._attrs import documented, get_doc, parse_docs
 from ..._factory import BaseFactory
-from ...units import unit_context_config as ucc
-from ...units import unit_registry as ureg
 from ..._util import ensure_array
 from ...contexts import KernelDictContext, MonoSpectralContext, SpectralContext
 from ...exceptions import ModeError, UnsupportedModeError
+from ...units import symbol
+from ...units import unit_context_config as ucc
+from ...units import unit_registry as ureg
 
 
 @parse_docs
@@ -240,7 +241,7 @@ class MeasureResults:
             spectral_coord_label = eradiate.mode().spectral_coord_label
             spectral_coord_metadata = {
                 "long_name": "wavelength",
-                "units": str(ucc.get("wavelength")),
+                "units": symbol(ucc.get("wavelength")),
             }
             # TODO: Add channel dimension to dataset (string-labelled;
             #  value 'intensity' in mono modes;
@@ -303,12 +304,12 @@ class MeasureResults:
                     "raw": (
                         [spectral_coord_label, "sensor_id", "y", "x"],
                         data,
-                        {"long name": "raw sensor values"},
+                        {"long_name": "raw sensor values"},
                     ),
                     "spp": (
                         [spectral_coord_label, "sensor_id"],
                         spps,
-                        {"long name": "sample count"},
+                        {"long_name": "sample count"},
                     ),
                 }
             ),
@@ -467,7 +468,7 @@ class Measure(SceneElement, ABC):
         )
         return ds.weighted(weights).mean(dim="sensor_id")
 
-    def postprocessed_results(self) -> xarray.Dataset:
+    def postprocess(self) -> xarray.Dataset:
         """
         Return post-processed raw sensor results.
 

--- a/eradiate/scenes/measure/tests/test_measure_distant.py
+++ b/eradiate/scenes/measure/tests/test_measure_distant.py
@@ -144,7 +144,7 @@ def test_distant_postprocessing(mode_mono):
     }
 
     # Postprocessing succeeds and viewing angles have correct bounds
-    ds = d.postprocessed_results()
+    ds = d.postprocess()
     assert "vza" in ds.coords
     assert np.allclose(ds.vza.min(), 5.06592926)  # Value calculated manually
     assert np.allclose(ds.vza.max(), 86.47273911)  # Value calculated manually
@@ -156,13 +156,13 @@ def test_distant_postprocessing(mode_mono):
     d._film_resolution = (32, 1)
     # Mismatched film size and raw data dimensions raises
     with pytest.raises(ValueError):
-        d.postprocessed_results()
+        d.postprocess()
 
     # Postprocessing succeeds and viewing angles have correct bounds
     d.results.raw = {
         550.0: {"values": {"sensor": np.ones((1, 32, 1))}, "spp": {"sensor": 128}}
     }
-    ds = d.postprocessed_results()
+    ds = d.postprocess()
     assert "vza" in ds.coords
     assert np.allclose(ds.vza.min(), -87.1875)  # Value manually calculated
     assert np.allclose(ds.vza.max(), 87.1875)  # Value manually calculated

--- a/eradiate/solvers/core/_scene.py
+++ b/eradiate/solvers/core/_scene.py
@@ -22,7 +22,7 @@ class Scene(SceneElement, ABC):
     Abstract class common to all scenes.
     """
 
-    illumination: Illumination = documented(
+    illumination: DirectionalIllumination = documented(
         attr.ib(
             factory=DirectionalIllumination,
             converter=IlluminationFactory.convert,
@@ -51,7 +51,8 @@ class Scene(SceneElement, ABC):
         "Optionally, a single :class:`.Measure` or dictionary specification "
         "may be passed and will automatically be wrapped into a list.\n"
         "\n"
-        "Allowed value types: :class:`DistantMeasure`.\n"
+        "Allowed value types: :class:`DistantMeasure`, "
+        ":class:`DistantReflectanceMeasure`.\n"
         "\n"
         ".. note:: The target zone will be overridden using canopy "
         "parameters if unset. If no canopy is specified, surface size "

--- a/eradiate/solvers/core/_solver_app.py
+++ b/eradiate/solvers/core/_solver_app.py
@@ -148,7 +148,7 @@ class SolverApp(ABC):
             measure = self.scene.measures[0]
 
         # Collect measure results
-        ds = measure.postprocessed_results()
+        ds = measure.postprocess()
 
         # Rename raw field to leaving radiance
         # (we don't use ds.rename to avoid copying metadata)

--- a/eradiate/solvers/onedim/_solver_app.py
+++ b/eradiate/solvers/onedim/_solver_app.py
@@ -54,28 +54,5 @@ class OneDimSolverApp(SolverApp):
             f"data creation - {__name__}.{self.__class__.__name__}.postprocess",
             source=f"eradiate, version {eradiate.__version__}",
             references="",
-            var_specs={
-                "irradiance": VarSpec(
-                    standard_name="toa_horizontal_solar_irradiance_per_unit_wavelength",
-                    units=symbol(uck.get("irradiance")),
-                    long_name="top-of-atmosphere horizontal spectral irradiance",
-                ),
-                "lo": VarSpec(
-                    standard_name="toa_outgoing_radiance_per_unit_wavelength",
-                    units=symbol(uck.get("radiance")),
-                    long_name="top-of-atmosphere outgoing spectral radiance",
-                ),
-                "brf": VarSpec(
-                    standard_name="toa_brf",
-                    units=symbol("dimensionless"),
-                    long_name="top-of-atmosphere bi-directional reflectance factor",
-                ),
-                "brdf": VarSpec(
-                    standard_name="toa_brdf",
-                    units=symbol("1/sr"),
-                    long_name="top-of-atmosphere bi-directional reflection distribution function",
-                ),
-            },
-            coord_specs="angular_observation",
         )
         ds.ert.normalize_metadata(dataset_spec)

--- a/eradiate/solvers/rami/_solver_app.py
+++ b/eradiate/solvers/rami/_solver_app.py
@@ -53,28 +53,5 @@ class RamiSolverApp(SolverApp):
             f"data creation - {__name__}.{self.__class__.__name__}.postprocess",
             source=f"eradiate, version {eradiate.__version__}",
             references="",
-            var_specs={
-                "irradiance": VarSpec(
-                    standard_name="toc_horizontal_solar_irradiance_per_unit_wavelength",
-                    units=symbol(uck.get("irradiance")),
-                    long_name="top-of-canopy horizontal spectral irradiance",
-                ),
-                "lo": VarSpec(
-                    standard_name="toc_outgoing_radiance_per_unit_wavelength",
-                    units=symbol(uck.get("radiance")),
-                    long_name="top-of-canopy outgoing spectral radiance",
-                ),
-                "brf": VarSpec(
-                    standard_name="toc_brf",
-                    units=symbol("dimensionless"),
-                    long_name="top-of-canopy bi-directional reflectance factor",
-                ),
-                "brdf": VarSpec(
-                    standard_name="toc_brdf",
-                    units=symbol("1/sr"),
-                    long_name="top-of-canopy bi-directional reflection distribution function",
-                ),
-            },
-            coord_specs="angular_observation",
         )
         ds.ert.normalize_metadata(dataset_spec)

--- a/eradiate/solvers/tests/test_onedim.py
+++ b/eradiate/solvers/tests/test_onedim.py
@@ -119,7 +119,7 @@ def test_onedim_solver_app_run(mode_mono):
         scene=OneDimScene(
             measures=[
                 {
-                    "type": "distant",
+                    "type": "distant_reflectance",
                     "id": "toa_hsphere",
                     "film_resolution": (32, 32),
                     "spp": 1000,
@@ -216,7 +216,7 @@ def test_onedim_solver_app_postprocessing(mode_mono):
     scene = OneDimScene.from_dict(
         {
             "measures": {
-                "type": "distant",
+                "type": "distant_reflectance",
                 "id": "toa_hsphere",
                 "film_resolution": (32, 32),
                 "spp": 1000,

--- a/eradiate/solvers/tests/test_rami.py
+++ b/eradiate/solvers/tests/test_rami.py
@@ -115,7 +115,7 @@ def test_rami_solver_app_run(mode_mono):
         scene=RamiScene(
             measures=[
                 {
-                    "type": "distant",
+                    "type": "distant_reflectance",
                     "id": "toa_hsphere",
                     "film_resolution": (32, 32),
                     "spp": 1000,

--- a/eradiate/tests/system/test_spp_splitting.py
+++ b/eradiate/tests/system/test_spp_splitting.py
@@ -55,7 +55,7 @@ def test_spp_splitting(mode_mono):
     surface = eradiate.scenes.surface.LambertianSurface(
         width=1.0 * ureg.m, reflectance=1.0
     )
-    measure = eradiate.scenes.measure.DistantMeasure(
+    measure = eradiate.scenes.measure.DistantReflectanceMeasure(
         target=[0, 0, 0],
         film_resolution=(1, 1),
     )


### PR DESCRIPTION
# Description

This PR finalises the transfer of post-processing to the `Measure` interface using a state-free design. Changes are as follows:

- A `DistantReflectanceMeasure` class was added. It is basically a `DistantMeasure` with extra post-processing steps.
- `Measure`: the `postprocessed_results()` method is replaced by a `postprocess()` "template" method with steps which can be inherited, overridden and included or excluded from the final implementation of the post-processing routine.
- `Measure.postprocess()` now accepts keyword arguments, which can be used to pass any kind of extra data required by the measure's post-processing pipeline (*e.g.* illumination in the case of `DistantReflectanceMeasure`).
- Metadata validation was simplified (the long-term idea is to drop this feature, which is difficult to maintain and not very beneficial).

# To do

- [x] Extra round of documentation

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
