### PR TITLE
Fixed apply_srf to compute a weighted mean instead of a weighted sum

### DIFF
--- a/eradiate/solvers/core/_postprocess.py
+++ b/eradiate/solvers/core/_postprocess.py
@@ -2,7 +2,7 @@ from ... import data
 
 
 def apply_srf(da, srf):
-    r"""Computes the weighted average of some data with a wavelength dimension,
+    r"""Computes the weighted mean of some data with a wavelength dimension,
     where the weights are taken from the values of an instrument spectral
     response function.
 
@@ -47,9 +47,9 @@ def apply_srf(da, srf):
         module.
 
     Return → :class:`~xarray.DataArray`:
-        Weighted-average of the data along the wavelength dimension.
+        Weighted-mean of the data along the wavelength dimension.
     """
     dataset = data.open(category="spectral_response_function", id=srf)
     weights = dataset.srf.interp(w=da.w.values)
     weighted = da.weighted(weights)
-    return weighted.sum(dim="w")
+    return weighted.mean(dim="w")


### PR DESCRIPTION
# Description

`eradiate.solvers.core._postprocess.apply_srf()` must compute the weighted mean of the results by the spectral response function but was computing a weighted sum instead. 
The present pull request fixes that.
Thanks @wint3ria for discovering this error!

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
