### PR TITLE
Updated AFGL1986RadProfile docstrings examples

### DIFF
--- a/eradiate/radprops/rad_profile.py
+++ b/eradiate/radprops/rad_profile.py
@@ -727,9 +727,9 @@ class AFGL1986RadProfile(RadProfile):
 
             AFGL1986RadProfile(
                 concentrations={
-                    "H2O": ureg.Quantity(15 , "g/m^2"),
+                    "H2O": ureg.Quantity(15 , "kg/m^2"),
                     "CO2": 420 * ureg.dimensionless,
-                    "O3": 0.5 * ureg.dobson_unit,
+                    "O3": 350 * ureg.dobson_unit,
                 }
             )
     """


### PR DESCRIPTION
# Description

The AFGL1986RadProfile docstrings examples about concentration rescaling used unrealistic for the H2O and O3 amounts. This pull request fixes that.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
