### PR TITLE
Add extra canopy abstractions to represent trees

### DIFF
--- a/docs/examples/tutorials/biosphere/01_discrete_canopy.py
+++ b/docs/examples/tutorials/biosphere/01_discrete_canopy.py
@@ -75,18 +75,22 @@ def display_canopy(canopy, distance=85):
 # directly added to a scene and instantiated using the
 # :class:`.BiosphereFactory`.
 #
-# A :class:`.DiscreteCanopy` consists of one or several :class:`.LeafCloud` s,
-# *i.e.* sets of floating discs. Each leaf cloud can be made of a large number
-# of discs; if the requested :class:`.DiscreteCanopy` object contains too many
-# of them (say, several millions), the memory footprint of the resulting scene
-# will quickly become large.
+# A :class:`.DiscreteCanopy` consists of one or several
+# :class:`.CanopyElement`s, *i.e.* set of floating discs and possible trunks.
+# :class:`.CanopyElement` implements two sub-classes, :class:`.LeafCloud` and
+# :class:`.AbstractTree`, the latter holds a :class:`.LeafCloud` plus
+# specification for a cylindrical trunk. The leaf clouds can be made of a large
+# number of discs; if the requested :class:`.DiscreteCanopy` object contains
+# too many of them (say, several millions), the memory footprint of the
+# resulting scene will quickly become large.
 #
 # In many situations, however, we can simply define a small number of leaf
 # clouds and clone them at designated locations. Under the hood,
 # :class:`.DiscreteCanopy` does not reference directly a set of
-# :class:`.LeafCloud` objects; instead, they are wrapped into
-# :class:`.InstancedLeafCloud` instances which associate to a leaf cloud the
-# positions at which it should be *instanced* (*i.e.* cloned).
+# :class:`.CanopyElement` objects; instead, they are wrapped into
+# :class:`.InstancedCanopyElement` instances which associate to a leaf cloud
+# or abstract tree the positions at which it should be *instanced*
+# (*i.e.* cloned).
 
 # %%
 # Quickly create a homogeneous discrete canopy
@@ -190,9 +194,10 @@ instance_filename = eradiate.path_resolver.resolve(
     "tests/canopies/HET01_UNI_instances.def"
 )
 
-instanced_leaf_cloud = eradiate.scenes.biosphere.InstancedLeafCloud.from_file(
-    filename=instance_filename, leaf_cloud=leaf_cloud
-)
+instanced_leaf_cloud = \
+    eradiate.scenes.biosphere.InstancedCanopyElement.from_file(
+        filename=instance_filename, canopy_element=leaf_cloud
+    )
 instanced_leaf_cloud
 
 # %%
@@ -201,7 +206,7 @@ instanced_leaf_cloud
 canopy = eradiate.scenes.biosphere.DiscreteCanopy(
     id="floating_spheres",
     size=[100, 100, 30] * ureg.m,
-    instanced_leaf_clouds=instanced_leaf_cloud,
+    instanced_canopy_elements=instanced_leaf_cloud,
 )
 canopy
 
@@ -214,12 +219,12 @@ plt.show()
 # %%
 # This can be repeated to specify as many leaf clouds and associated instances
 # as needed. Since this use case is quite common, the
-# :meth:`.DiscreteCanopy.from_files` class method constructor
+# :meth:`.DiscreteCanopy.leaf_cloud_from_files` class method constructor
 # provides a more convenient interface (it notably takes care by itself of
 # setting scene element IDs consistently):
 
 
-canopy = eradiate.scenes.biosphere.DiscreteCanopy.from_files(
+canopy = eradiate.scenes.biosphere.DiscreteCanopy.leaf_cloud_from_files(
     id="floating_spheres",
     size=[100, 100, 30] * ureg.m,
     leaf_cloud_dicts=[
@@ -249,14 +254,14 @@ padded_canopy = canopy.padded(1)
 
 print(f"Canopy:")
 print(f"  size: {canopy.size}")
-print(f"  # instances: {canopy.instanced_leaf_clouds[0].instance_positions.shape[0]}")
+print(f"  # instances: {canopy.instanced_canopy_elements[0].instance_positions.shape[0]}")
 display_canopy(canopy, distance=50)
 plt.show()
 
 print(f"Padded canopy:")
 print(f"  size: {padded_canopy.size}")
 print(
-    f"  # instances: {padded_canopy.instanced_leaf_clouds[0].instance_positions.shape[0]}"
+    f"  # instances: {padded_canopy.instanced_canopy_elements[0].instance_positions.shape[0]}"
 )
 display_canopy(padded_canopy, distance=50)
 plt.show()

--- a/docs/rst/reference/scenes.rst
+++ b/docs/rst/reference/scenes.rst
@@ -56,8 +56,10 @@ Biosphere [eradiate.scenes.biosphere]
 .. autosummary::
    :toctree: generated/
 
+   CanopyElement
    LeafCloud
-   InstancedLeafCloud
+   AbstractTree
+   InstancedCanopyElement
    DiscreteCanopy
 
 .. dropdown:: **Parameters for LeafCloud generators**
@@ -68,6 +70,7 @@ Biosphere [eradiate.scenes.biosphere]
       _discrete.CuboidLeafCloudParams
       _discrete.SphereLeafCloudParams
       _discrete.CylinderLeafCloudParams
+      _dicsrete.ConeLeafCloudParams
 
 .. _sec-reference-scenes-surface:
 

--- a/eradiate/scenes/biosphere/__init__.py
+++ b/eradiate/scenes/biosphere/__init__.py
@@ -1,10 +1,18 @@
 from ._core import BiosphereFactory, Canopy
-from ._discrete import DiscreteCanopy, InstancedLeafCloud, LeafCloud
+from ._discrete import (
+    AbstractTree,
+    CanopyElement,
+    DiscreteCanopy,
+    InstancedCanopyElement,
+    LeafCloud,
+)
 
 __all__ = [
     "BiosphereFactory",
     "Canopy",
     "DiscreteCanopy",
-    "InstancedLeafCloud",
+    "InstancedCanopyElement",
     "LeafCloud",
+    "AbstractTree",
+    "CanopyElement",
 ]

--- a/eradiate/solvers/rami/_scene.py
+++ b/eradiate/solvers/rami/_scene.py
@@ -122,7 +122,7 @@ class RamiScene(Scene):
             if self.padding > 0:  # We must add extra instances if padding is requested
                 canopy = self.canopy.padded(self.padding)
                 ctx.override_surface_width = (
-                    max(self.canopy.size[:2]) * 2.0 * self.padding + 1.0
+                    max(self.canopy.size[:2]) * (2.0 * self.padding + 1.0)
                 )
             else:
                 canopy = self.canopy


### PR DESCRIPTION
# Description

Some abstract canopies in the RAMI framework are formed by leaf clouds plus trunks, this PR introduces a new abstraction that lets users combine the two and instantiate them with the currently existing machinery for discrete canopies.

I have added a class `Plant` that combines a `LeafCloud` with a cylindrical trunk and I refactored the `InstancedLeafCloud` into `InstancedPlant` to use the new class.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [ ] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
