### PR TITLE
Add config module and allow custom data locations

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -29,4 +29,5 @@ clean_generated:
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
+	python generate_extra_docs.py
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/generate_extra_docs.py
+++ b/docs/generate_extra_docs.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+from eradiate._config import EradiateConfig
+
+
+def format_help_dicts(help_dicts, display_defaults=False):
+    help_strs = []
+    for help_dict in help_dicts:
+        help_str = f"{help_dict['var_name']} ({'Required' if help_dict['required'] else 'Optional'}"
+
+        if help_dict.get("default") and display_defaults:
+            help_str += f", Default={help_dict['default']})"
+        else:
+            help_str += ")"
+
+        if help_dict.get("help_str"):
+            help_str += f"\n    {help_dict['help_str']}"
+        help_strs.append(help_str)
+
+    return "\n\n".join(help_strs)
+
+
+def main():
+    path = Path("rst/reference/generated/env_vars.rst").absolute()
+    print(f"Writing config variables to {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    with open(path, "w") as f:
+        f.write("Environment variables\n---------------------\n\n")
+        f.write(EradiateConfig.generate_help(formatter=format_help_dicts))
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/rst/reference/config.rst
+++ b/docs/rst/reference/config.rst
@@ -10,4 +10,6 @@ Configuration [eradiate._config]
 
    EradiateConfig
 
+.. _sec-config-env_vars:
+
 .. include:: generated/env_vars.rst

--- a/docs/rst/reference/config.rst
+++ b/docs/rst/reference/config.rst
@@ -1,0 +1,13 @@
+.. _sec-config:
+
+Configuration [eradiate._config]
+================================
+
+.. currentmodule:: eradiate._config
+
+.. autosummary::
+   :toctree: generated/
+
+   EradiateConfig
+
+.. include:: generated/env_vars.rst

--- a/docs/rst/reference/index.rst
+++ b/docs/rst/reference/index.rst
@@ -17,6 +17,7 @@ Eradiate's API reference documentation is generated automatically using Sphinx's
    :maxdepth: 2
 
    core
+   config
    contexts
    scenes
    solvers

--- a/docs/rst/reference/scenes.rst
+++ b/docs/rst/reference/scenes.rst
@@ -70,7 +70,7 @@ Biosphere [eradiate.scenes.biosphere]
       _discrete.CuboidLeafCloudParams
       _discrete.SphereLeafCloudParams
       _discrete.CylinderLeafCloudParams
-      _dicsrete.ConeLeafCloudParams
+      _discrete.ConeLeafCloudParams
 
 .. _sec-reference-scenes-surface:
 

--- a/eradiate/__init__.py
+++ b/eradiate/__init__.py
@@ -6,9 +6,17 @@ __version__ = "0.0.1"  #: Eradiate version number.
 
 __import__("xarray")
 
-# -- Operational mode definition -----------------------------------------------
+# -- Global configuration ------------------------------------------------------
 
-from ._mode import mode, set_mode, modes  # isort: skip
+from ._config import config  # isort: skip
+
+# -- Path resolver -------------------------------------------------------------
+
+# fmt: off
+from ._presolver import PathResolver  # isort: skip
+path_resolver = PathResolver()
+del PathResolver
+# fmt: on
 
 # -- Unit management facilities ------------------------------------------------
 
@@ -18,13 +26,9 @@ from .units import (  # isort: skip
     unit_registry,
 )
 
-# -- Path resolver -------------------------------------------------------------
+# -- Operational mode definition -----------------------------------------------
 
-# fmt: off
-from ._presolver import PathResolver  # isort: skip
-path_resolver = PathResolver()
-del PathResolver
-# fmt: on
+from ._mode import mode, set_mode, modes  # isort: skip
 
 # ------------------------------------------------------------------------------
 

--- a/eradiate/_config.py
+++ b/eradiate/_config.py
@@ -34,7 +34,7 @@ class EradiateConfig:
 
     data_path = environ.var(
         default=None,
-        converter=lambda x: [pathlib.Path(y) for y in x.split(":")]
+        converter=lambda x: [pathlib.Path(y) for y in x.split(":") if y]
         if isinstance(x, str)
         else x,
         help="A colon-separated list of paths where to search for data files.",

--- a/eradiate/_config.py
+++ b/eradiate/_config.py
@@ -1,0 +1,75 @@
+import pathlib
+import warnings
+
+import environ
+from environ.exceptions import ConfigError
+
+from eradiate.exceptions import ConfigWarning
+
+
+@environ.config(prefix="ERADIATE")
+class EradiateConfig:
+    """
+    Global configuration for Eradiate. This configuration object is written with
+    the `environ-config library <https://environ-config.readthedocs.io>`_.
+    """
+
+    dir = environ.var(
+        converter=lambda x: pathlib.Path(x).absolute(),
+        help="Path to the Eradiate source directory.",
+    )
+
+    @dir.validator
+    def _dir_validator(self, var, dir):
+        eradiate_init = dir / "eradiate" / "__init__.py"
+
+        if not eradiate_init.is_file():
+            raise ConfigError(
+                f"While configuring Eradiate: could not find {eradiate_init} file. "
+                "Please make sure the 'ERADIATE_DIR' environment variable is "
+                "correctly set to the Eradiate installation directory. If you are "
+                "using Eradiate directly from the sources, you can alternatively "
+                "source the provided setpath.sh script."
+            ) from FileNotFoundError(eradiate_init)
+
+    data_path = environ.var(
+        default=None,
+        converter=lambda x: [pathlib.Path(y) for y in x.split(":")]
+        if isinstance(x, str)
+        else x,
+        help="A colon-separated list of paths where to search for data files.",
+    )
+
+    @data_path.validator
+    def _data_path_validator(self, var, paths):
+        if paths is None:
+            return
+
+        do_not_exist = []
+
+        for path in paths:
+            if not path.is_dir():
+                do_not_exist.append(path)
+
+        if do_not_exist:
+            warnings.warn(
+                ConfigWarning(
+                    "While configuring Eradiate: 'ERADIATE_DATA_PATH' contains "
+                    f"paths to nonexisting directories {[str(x) for x in do_not_exist]}"
+                )
+            )
+
+
+try:
+    config = EradiateConfig.from_environ()
+
+except environ.exceptions.MissingEnvValueError as e:
+    if "ERADIATE_DIR" in e.args:
+        raise ConfigError(
+            f"While configuring Eradiate: environment variable '{e}' is missing. "
+            "Please set this variable to the absolute path to the Eradiate "
+            "installation directory. If you are using Eradiate directly from the "
+            "sources, you can alternatively source the provided setpath.sh script."
+        ) from e
+    else:
+        raise e

--- a/eradiate/_presolver.py
+++ b/eradiate/_presolver.py
@@ -1,8 +1,8 @@
 """A simple file resolver."""
 
-import os
 from pathlib import Path
 
+from ._config import config
 from ._util import Singleton
 
 
@@ -43,46 +43,25 @@ class PathResolver(metaclass=Singleton):
 
     def reset(self):
         """
-        Reset path list to default value: ``[$PWD, $ERADIATE_DIR/resources/data]``.
+        Reset path list to default value:
+        ``[$PWD, $ERADIATE_DATA_PATH, $ERADIATE_DIR/resources/data]``.
         """
 
-        eradiate_dir = os.getenv("ERADIATE_DIR")
-        if eradiate_dir is None:
-            raise ValueError(
-                "Environment variable ERADIATE_DIR is not set.\n"
-                "Please set this variable to the absolute path of the Eradiate "
-                "installation folder.\n"
-                "If you are running Eradiate directly from the sources, "
-                "then you can alternatively source the provided setpath.sh "
-                "script."
-            )
-
-        eradiate_path = Path(eradiate_dir).absolute()
-        eradiate_init = eradiate_path / "eradiate" / "__init__.py"
-        if not eradiate_init.exists():
-            raise ValueError(
-                f"Could not find {eradiate_init} file.\n"
-                "Please make sure the ERADIATE_DIR environment variable is "
-                "correctly set to the Eradiate "
-                "installation folder.\n"
-                "If you are running Eradiate directly from the sources, "
-                "then you can alternatively source the provided setpath.sh "
-                "script."
-            )
-
         self.clear()
-        for path in [
-            Path.cwd(),  # Current working directory
-            eradiate_path / "resources" / "data",  # Eradiate data directory
-        ]:
-            self.append(path)
+        self.append(Path.cwd())  # Current working directory
+
+        if config.data_path:
+            self.append(*config.data_path)  # Path list
+
+        self.append(config.dir / "resources" / "data")  # Eradiate data directory
 
     def clear(self):
         """Clear the list of search paths."""
         self.paths.clear()
 
     def contains(self, path):
-        """Check if a given path is included in the search path list.
+        """
+        Check if a given path is included in the search path list.
 
         Parameter ``path`` (path-like)
             Path to be searched for.
@@ -112,7 +91,8 @@ class PathResolver(metaclass=Singleton):
         self.paths.pop(index)
 
     def prepend(self, path):
-        """Prepend an entry at the beginning of the list of search paths.
+        """
+        Prepend an entry at the beginning of the list of search paths.
 
         Parameter ``path`` (path-like)
             Path to prepend to the path list.
@@ -124,7 +104,8 @@ class PathResolver(metaclass=Singleton):
         self.paths.insert(0, path_absolute)
 
     def append(self, *paths):
-        """Append an entry to the end of the list of search paths.
+        """
+        Append an entry to the end of the list of search paths.
 
         Parameter ``path`` (path-like):
             Path to append to the path list.
@@ -137,8 +118,8 @@ class PathResolver(metaclass=Singleton):
             self.paths.append(path_absolute)
 
     def resolve(self, path):
-        """Walk through the list of search paths and try to resolve the input
-        path.
+        """
+        Walk through the list of search paths and try to resolve the input path.
 
         Parameter ``path`` (path-like):
             Path to try and resolve.

--- a/eradiate/_presolver.py
+++ b/eradiate/_presolver.py
@@ -15,8 +15,10 @@ class PathResolver(metaclass=Singleton):
     """
 
     def __init__(self):
-        """Initialize a new file resolver with the current working directory
-        and Eradiate's data directory."""
+        """
+        Initialize a new file resolver with the current working directory
+        and Eradiate's data directory.
+        """
         self.paths = []
         self.reset()
 
@@ -45,6 +47,10 @@ class PathResolver(metaclass=Singleton):
         """
         Reset path list to default value:
         ``[$PWD, $ERADIATE_DATA_PATH, $ERADIATE_DIR/resources/data]``.
+
+        .. seealso::
+
+           :ref:`sec-config-env_vars`
         """
 
         self.clear()

--- a/eradiate/exceptions.py
+++ b/eradiate/exceptions.py
@@ -43,7 +43,9 @@ class UnsupportedModeError(ModeError):
 
 
 class KernelVariantError(Exception):
-    """Raised when encountering issues with Eradiate kernel variants."""
+    """
+    Raised when encountering issues with Eradiate kernel variants.
+    """
 
     pass
 

--- a/eradiate/scenes/biosphere/_discrete.py
+++ b/eradiate/scenes/biosphere/_discrete.py
@@ -465,7 +465,7 @@ class CylinderLeafCloudParams(LeafCloudParams):
 
 @parse_docs
 @attr.s
-class ConicalLeafCloudParams(LeafCloudParams):
+class ConeLeafCloudParams(LeafCloudParams):
     """
     Advanced parameter checking class for the cone :class:`.LeafCloud`
     generator.
@@ -678,7 +678,7 @@ class LeafCloud(CanopyElement):
         .. seealso:: :class:`.CuboidLeafCloudParams`
 
         The produced leaf cloud uniformly covers the
-        :math:`(x, y, z) \\in [-\\dfrac{l_h}{2}, + \\dfrac{l_h}{2}] \\times [-\\dfrac{l_h}{2}, + \\dfrac{l_h}{2}] \\times [0, l_v]`
+        :math:`(x, y, z) \\in \\left[ -\\dfrac{l_h}{2}, + \\dfrac{l_h}{2} \\right] \\times \\left[ -\\dfrac{l_h}{2}, + \\dfrac{l_h}{2} \\right] \\times [0, l_v]`
         region. Leaf orientation is controlled by the ``mu`` and ``nu`` parameters
         of an approximated inverse beta distribution
         :cite:`Ross1991MonteCarloMethods`.
@@ -740,7 +740,7 @@ class LeafCloud(CanopyElement):
 
         .. seealso:: :class:`.SphereLeafCloudParams`
 
-        The produced leaf cloud covers uniformly the :math:`r < \\mathit{radius}`
+        The produced leaf cloud covers uniformly the :math:`r < \\mathtt{radius}`
         region. Leaf orientation is controlled by the ``mu`` and ``nu`` parameters
         of an approximated inverse beta distribution
         :cite:`Ross1991MonteCarloMethods`.
@@ -778,7 +778,8 @@ class LeafCloud(CanopyElement):
 
         .. seealso:: :class:`.CylinderLeafCloudParams`
 
-        The produced leaf cloud covers uniformly the :math:`r < \\mathit{radius}, z \\in [0, l_v]`
+        The produced leaf cloud covers uniformly the
+        :math:`r < \\mathtt{radius}, z \\in [0, l_v]`
         region. Leaf orientation is controlled by the ``mu`` and ``nu`` parameters
         of an approximated inverse beta distribution
         :cite:`Ross1991MonteCarloMethods`.
@@ -812,11 +813,12 @@ class LeafCloud(CanopyElement):
     def cone(cls, seed=12345, **kwargs):
         """
         Generate a leaf cloud with a right conical shape (vertical orientation).
-        Parameters are checked by the :class:`.ConicalLeafCloudParams` class.
+        Parameters are checked by the :class:`.ConeLeafCloudParams` class.
 
-        .. seealso:: :class:`.ConicalLeafCloudParams`
+        .. seealso:: :class:`.ConeLeafCloudParams`
 
-        The produced leaf cloud covers uniformly the :math:`r < \\mathit{radius}\cdot\mathit{1 - \frac{z}{l_v}}, z \\in [0, l_v]`
+        The produced leaf cloud covers uniformly the
+        :math:`r < \\mathtt{radius} \\cdot \\left( 1 - \\frac{z}{l_v} \\right), z \\in [0, l_v]`
         region. Leaf orientation is controlled by the ``mu`` and ``nu`` parameters
         of an approximated inverse beta distribution
         :cite:`Ross1991MonteCarloMethods`.
@@ -827,7 +829,7 @@ class LeafCloud(CanopyElement):
             Seed for the random number generator.
         """
         rng = np.random.default_rng(seed=seed)
-        params = ConicalLeafCloudParams(**kwargs)
+        params = ConeLeafCloudParams(**kwargs)
         leaf_positions = _leaf_cloud_positions_cone(
             params.n_leaves, params.radius, params.l_vertical, rng
         )

--- a/eradiate/tests/unit/test_config.py
+++ b/eradiate/tests/unit/test_config.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+
+import pytest
+from environ.exceptions import ConfigError, MissingEnvValueError
+
+from eradiate._config import EradiateConfig
+from eradiate.exceptions import ConfigWarning
+
+
+def test_config(tmpdir):
+    # Create an appropriate file tree for tests
+    tmpdir_path = Path(tmpdir)
+    (tmpdir_path / "eradiate/eradiate").mkdir(parents=True)
+    (tmpdir_path / "eradiate/eradiate/__init__.py").touch()
+
+    # Raises if ERADIATE_DIR is missing
+    with pytest.raises(MissingEnvValueError):
+        EradiateConfig.from_environ({})
+
+    # When ERADIATE_DIR points to a correct path (i.e. contains eradiate.__init__.py),
+    # config init succeeds
+    assert EradiateConfig.from_environ({"ERADIATE_DIR": tmpdir_path / "eradiate"})
+
+    # Otherwise it raises
+    with pytest.raises(ConfigError):
+        EradiateConfig.from_environ({"ERADIATE_DIR": tmpdir_path})
+
+    # Warns if nonexisting paths are passed
+    with pytest.warns(ConfigWarning):
+        paths = [
+            f"{tmpdir_path / 'eradiate_data_0'}",
+            f"{tmpdir_path / 'eradiate_data_1'}",
+        ]
+
+        # Colon-separated paths are processed correctly
+        cfg = EradiateConfig.from_environ(
+            {
+                "ERADIATE_DIR": tmpdir_path / "eradiate",
+                "ERADIATE_DATA_PATH": ":".join(paths),
+            }
+        )
+
+        assert [str(x) for x in cfg.data_path] == paths
+
+        # Empty paths are omitted
+        cfg = EradiateConfig.from_environ(
+            {
+                "ERADIATE_DIR": tmpdir_path / "eradiate",
+                "ERADIATE_DATA_PATH": ":::" + "::".join(paths) + ":",
+            }
+        )
+
+        assert [str(x) for x in cfg.data_path] == paths

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -29,6 +29,7 @@ async-generator==1.10
 attrs==21.2.0
     # via
     #   -r requirements/main.in
+    #   environ-config
     #   jsonschema
     #   pinttrs
     #   pytest
@@ -78,7 +79,7 @@ coverage==5.5
     # via -r requirements/dev.in
 cycler==0.10.0
     # via matplotlib
-dask==2021.5.1
+dask==2021.6.0
     # via -r requirements/main.in
 decorator==5.0.9
     # via ipython
@@ -97,11 +98,13 @@ ensureconda==1.4.1
     # via conda-lock
 entrypoints==0.3
     # via nbconvert
+environ-config==21.2.0
+    # via -r requirements/main.in
 execnet==1.8.1
     # via pytest-xdist
 filelock==3.0.12
     # via ensureconda
-fsspec==2021.5.0
+fsspec==2021.6.0
     # via dask
 iapws==1.5.2
     # via -r requirements/main.in
@@ -111,7 +114,7 @@ idna==2.10
     #   requests
 imagesize==1.2.0
     # via sphinx
-importlib-metadata==4.4.0
+importlib-metadata==4.5.0
     # via
     #   click
     #   jsonschema
@@ -134,7 +137,7 @@ ipython-genutils==0.2.0
     #   nbformat
     #   notebook
     #   traitlets
-ipython==7.24.0
+ipython==7.24.1
     # via
     #   -r requirements/dev.in
     #   ipykernel
@@ -410,9 +413,9 @@ sphinx-copybutton==0.3.1
     # via -r requirements/docs.in
 sphinx-gallery==0.9.0
     # via -r requirements/docs.in
-sphinx-panels==0.5.2
+sphinx-panels==0.6.0
     # via -r requirements/docs.in
-sphinx==3.5.4
+sphinx==4.0.2
     # via
     #   -r requirements/docs.in
     #   -r requirements/tests.in

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -16,6 +16,7 @@ attrs==21.2.0
     # via
     #   -c requirements/dev.txt
     #   -r requirements/main.in
+    #   environ-config
     #   pinttrs
 babel==2.9.1
     # via
@@ -53,7 +54,7 @@ cycler==0.10.0
     # via
     #   -c requirements/dev.txt
     #   matplotlib
-dask==2021.5.1
+dask==2021.6.0
     # via
     #   -c requirements/dev.txt
     #   -r requirements/main.in
@@ -65,7 +66,11 @@ docutils==0.16
     #   sphinx
     #   sphinx-panels
     #   sphinxcontrib-bibtex
-fsspec==2021.5.0
+environ-config==21.2.0
+    # via
+    #   -c requirements/dev.txt
+    #   -r requirements/main.in
+fsspec==2021.6.0
     # via
     #   -c requirements/dev.txt
     #   dask
@@ -81,7 +86,7 @@ imagesize==1.2.0
     # via
     #   -c requirements/dev.txt
     #   sphinx
-importlib-metadata==4.4.0
+importlib-metadata==4.5.0
     # via
     #   -c requirements/dev.txt
     #   click
@@ -231,11 +236,11 @@ sphinx-gallery==0.9.0
     # via
     #   -c requirements/dev.txt
     #   -r requirements/docs.in
-sphinx-panels==0.5.2
+sphinx-panels==0.6.0
     # via
     #   -c requirements/dev.txt
     #   -r requirements/docs.in
-sphinx==3.5.4
+sphinx==4.0.2
     # via
     #   -c requirements/dev.txt
     #   -r requirements/docs.in

--- a/requirements/environment-linux-64.lock
+++ b/requirements/environment-linux-64.lock
@@ -1,5 +1,5 @@
 # platform: linux-64
-# env_hash: 3d9fd9b4c4c0c035cc6e35a67beea714a5c27bd9a79073449c9603898e75dad5
+# env_hash: bd10628eddf8770ef32469f0e727a61363d0e2f305e033230b339ff6ecffce64
 @EXPLICIT
 https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2#d7c89558ba9fa0495403155b64376d81
 https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2021.5.30-ha878542_0.tar.bz2#6a777890e94194dc94a29a76d2a7e721
@@ -74,7 +74,7 @@ https://conda.anaconda.org/conda-forge/noarch/decorator-5.0.9-pyhd8ed1ab_0.tar.b
 https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2#961b3a227b437d82ad7054484cfa71b2
 https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.3-pyhd8ed1ab_1003.tar.bz2#bbf9a201f6ce99a506f4955374d9a9f4
 https://conda.anaconda.org/conda-forge/noarch/filelock-3.0.12-pyh9f0ad1d_0.tar.bz2#7544ed05bbbe9bb687bc9bcbe4d6cb46
-https://conda.anaconda.org/conda-forge/noarch/fsspec-2021.5.0-pyhd8ed1ab_0.tar.bz2#da823f51ebb876dafbed1c892fd80956
+https://conda.anaconda.org/conda-forge/noarch/fsspec-2021.6.0-pyhd8ed1ab_0.tar.bz2#2568dbadce6148e58a9148de2c16a042
 https://conda.anaconda.org/conda-forge/linux-64/glib-2.68.2-h9c3ff4c_2.tar.bz2#0d68bad18ff4ce5231a7e535d3731277
 https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.10.6-nompi_h6a2412b_1114.tar.bz2#0a2984b78f51148d7ff6219abe73509e
 https://conda.anaconda.org/conda-forge/noarch/heapdict-1.0.1-py_0.tar.bz2#77242bfb1e74a627fb06319b5a2d3b95
@@ -122,7 +122,7 @@ https://conda.anaconda.org/conda-forge/noarch/tinydb-4.4.0-pyh44b312d_0.tar.bz2#
 https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhd8ed1ab_0.tar.bz2#f832c45a477c78bebd107098db465095
 https://conda.anaconda.org/conda-forge/noarch/toolz-0.11.1-py_0.tar.bz2#d1e66b58cb00b3817ad9f05eec098c00
 https://conda.anaconda.org/conda-forge/noarch/tqdm-4.61.0-pyhd8ed1ab_0.tar.bz2#3a71e435b54b3598c09427727215e8da
-https://conda.anaconda.org/conda-forge/noarch/typing_extensions-3.7.4.3-py_0.tar.bz2#12b96e382730541a4b332420227055ae
+https://conda.anaconda.org/conda-forge/noarch/typing_extensions-3.10.0.0-pyha770c72_0.tar.bz2#67c0cba6533b641f28946d7c16f361c8
 https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-py_1.tar.bz2#3563be4c5611a44210d9ba0c16113136
 https://conda.anaconda.org/conda-forge/noarch/wheel-0.36.2-pyhd3deb0d_0.tar.bz2#768bfbe026426d0e76b377997d1f2b98
 https://conda.anaconda.org/conda-forge/noarch/zipp-3.4.1-pyhd8ed1ab_0.tar.bz2#a4fa30eb74a326092b3d8078b1f1aae1
@@ -136,8 +136,9 @@ https://conda.anaconda.org/conda-forge/noarch/cycler-0.10.0-py_2.tar.bz2#f6d7c7e
 https://conda.anaconda.org/conda-forge/linux-64/cytoolz-0.11.0-py37h5e8e339_3.tar.bz2#2e89a6f3baf5eeb13763f61ea3d0601f
 https://conda.anaconda.org/conda-forge/linux-64/dbus-1.13.6-h48d8840_2.tar.bz2#eba672c69baf366fdedd1c6f702dbb81
 https://conda.anaconda.org/conda-forge/linux-64/docutils-0.15.2-py37h89c1867_2.tar.bz2#db1782ab62223524880c4a610274fc31
+https://conda.anaconda.org/conda-forge/noarch/environ-config-21.2.0-pyhd8ed1ab_0.tar.bz2#61e53d6eb24342f9440040a590909e85
 https://conda.anaconda.org/conda-forge/noarch/execnet-1.8.1-pyhd8ed1ab_0.tar.bz2#4172c92dcd744016feeaaaf8b28880a6
-https://conda.anaconda.org/conda-forge/linux-64/importlib-metadata-4.4.0-py37h89c1867_0.tar.bz2#f4c1cdfa39566fbe5ee58c831107d8da
+https://conda.anaconda.org/conda-forge/linux-64/importlib-metadata-4.5.0-py37h89c1867_0.tar.bz2#71a9d20403f28d15f7a94d0817584efa
 https://conda.anaconda.org/conda-forge/noarch/importlib_resources-5.1.4-pyhd8ed1ab_0.tar.bz2#6623391428e75e1ded2fc117b86a747e
 https://conda.anaconda.org/conda-forge/linux-64/jedi-0.18.0-py37h89c1867_2.tar.bz2#5e95b453f199caec4dd1bf6002ae0ce2
 https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.3.1-py37h2527ec5_1.tar.bz2#61149814e0ea71cb5b44881c65d25f7b
@@ -174,8 +175,8 @@ https://conda.anaconda.org/conda-forge/linux-64/cftime-1.5.0-py37h6f94858_0.tar.
 https://conda.anaconda.org/conda-forge/linux-64/click-8.0.1-py37h89c1867_0.tar.bz2#bb1ad97b5d8626f662b753f620c3c913
 https://conda.anaconda.org/conda-forge/linux-64/cmarkgfm-0.5.3-py37h5e8e339_0.tar.bz2#4f7e1171cb42a9336c84f1070d8caadd
 https://conda.anaconda.org/conda-forge/linux-64/cryptography-3.4.7-py37h5d9358c_0.tar.bz2#d811fb6a96ae0cf8c0a17457a8e67ff4
-https://conda.anaconda.org/conda-forge/noarch/dask-core-2021.5.1-pyhd8ed1ab_0.tar.bz2#bf8923574861d55110396b169f4978f7
-https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-4.4.0-hd8ed1ab_0.tar.bz2#cc623f404f4ea1e031890cca57e8f83c
+https://conda.anaconda.org/conda-forge/noarch/dask-core-2021.6.0-pyhd8ed1ab_0.tar.bz2#cea7be7ed76c4664498447ef35d2268c
+https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-4.5.0-hd8ed1ab_0.tar.bz2#37284dc55911fdf9b0b5e6fed56fb192
 https://conda.anaconda.org/conda-forge/noarch/jinja2-3.0.1-pyhd8ed1ab_0.tar.bz2#c647e77921fd3e245cdcc5b2d451a0f8
 https://conda.anaconda.org/conda-forge/linux-64/jupyter_core-4.7.1-py37h89c1867_0.tar.bz2#42202575ecb1cc9491d57a4ad25f14bb
 https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.2-pyhd8ed1ab_2.tar.bz2#0967e1db58b16e416464ca399f87df79
@@ -190,7 +191,7 @@ https://conda.anaconda.org/conda-forge/noarch/black-21.5b2-pyhd8ed1ab_0.tar.bz2#
 https://conda.anaconda.org/conda-forge/noarch/bleach-3.3.0-pyh44b312d_0.tar.bz2#abf6b76c39358ca36ca706c46f054f2a
 https://conda.anaconda.org/conda-forge/linux-64/bokeh-2.3.2-py37h89c1867_0.tar.bz2#2c0224d9598b7c4fef87536ecbfc87af
 https://conda.anaconda.org/conda-forge/noarch/click-default-group-1.2.2-pyhd8ed1ab_1.tar.bz2#72a46ffc25701c173932fd55cf0965d3
-https://conda.anaconda.org/conda-forge/linux-64/distributed-2021.5.1-py37h89c1867_0.tar.bz2#73b9cbad0494883ae5bedbf88f479aad
+https://conda.anaconda.org/conda-forge/linux-64/distributed-2021.6.0-py37h89c1867_0.tar.bz2#c8228e953e50cc4a62087c477f8efb02
 https://conda.anaconda.org/conda-forge/noarch/iapws-1.5.2-pyh9f0ad1d_0.tar.bz2#3aa31b761bc6aa3acc0d6d01e0bf2e01
 https://conda.anaconda.org/conda-forge/noarch/isort-5.8.0-pyhd8ed1ab_0.tar.bz2#c7535f0f6618cba5a5f1070c0edf8e2b
 https://conda.anaconda.org/conda-forge/noarch/jsonschema-3.2.0-pyhd8ed1ab_3.tar.bz2#66125e28711d8ffc04a207a2b170316d
@@ -206,7 +207,7 @@ https://conda.anaconda.org/conda-forge/noarch/pyopenssl-20.0.1-pyhd8ed1ab_0.tar.
 https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml-0.17.7-py37h5e8e339_0.tar.bz2#9d8842e644a182f94459bd4e013b530b
 https://conda.anaconda.org/conda-forge/linux-64/secretstorage-3.3.1-py37h89c1867_0.tar.bz2#533961f702ae5a1680dc363e6948be59
 https://conda.anaconda.org/conda-forge/noarch/xarray-0.18.2-pyhd8ed1ab_0.tar.bz2#379c1f2f90ff675742426373a81e5552
-https://conda.anaconda.org/conda-forge/noarch/dask-2021.5.1-pyhd8ed1ab_0.tar.bz2#6d88d5c849ba285e856125d6e4b79b6d
+https://conda.anaconda.org/conda-forge/noarch/dask-2021.6.0-pyhd8ed1ab_0.tar.bz2#554ef426ff0ef06641338b7a514d6354
 https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.1.2-pyh9f0ad1d_0.tar.bz2#2cbd910890bb328e8959246a1e16fac7
 https://conda.anaconda.org/conda-forge/linux-64/keyring-23.0.1-py37h89c1867_0.tar.bz2#04f9803236d39dac863b80b3c9f892e4
 https://conda.anaconda.org/conda-forge/linux-64/matplotlib-3.2.2-1.tar.bz2#6b8ed6d42771384dbd3f29af9078820e
@@ -225,7 +226,7 @@ https://conda.anaconda.org/conda-forge/noarch/pytest-forked-1.3.0-pyhd3deb0d_0.t
 https://conda.anaconda.org/conda-forge/noarch/pytest-metadata-1.11.0-pyhd3deb0d_0.tar.bz2#2e92f7ccb8d9a03966fc36e3861522ec
 https://conda.anaconda.org/conda-forge/noarch/requests-2.25.1-pyhd3deb0d_0.tar.bz2#ae687aba31a1c400192a86a2e993ffdc
 https://conda.anaconda.org/conda-forge/noarch/ensureconda-1.4.1-pyhd8ed1ab_0.tar.bz2#52a7f7cc9076e2c8a25e15e19ad42821
-https://conda.anaconda.org/conda-forge/linux-64/ipython-7.24.0-py37h085eea5_0.tar.bz2#afc35ae0af08796dfaafd6a5e3668593
+https://conda.anaconda.org/conda-forge/linux-64/ipython-7.24.1-py37h085eea5_0.tar.bz2#c149f03e7ba1af18546f0d7d30565d8b
 https://conda.anaconda.org/conda-forge/linux-64/nbconvert-6.0.7-py37h89c1867_3.tar.bz2#aa3710e0a8a44d7c7313b37775018446
 https://conda.anaconda.org/conda-forge/noarch/pytest-json-report-1.2.4-pyh9f0ad1d_0.tar.bz2#83018f154e27bf943a790e533272d092
 https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-2.2.1-pyhd8ed1ab_0.tar.bz2#340e7715aee434d2464a97e91ead6cca
@@ -238,7 +239,7 @@ https://conda.anaconda.org/conda-forge/noarch/pydata-sphinx-theme-0.6.3-pyhd8ed1
 https://conda.anaconda.org/conda-forge/noarch/sphinx-copybutton-0.3.1-pyhd8ed1ab_0.tar.bz2#decad13214a2a545944560eccf4a9815
 https://conda.anaconda.org/conda-forge/noarch/sphinx-gallery-0.9.0-pyhd8ed1ab_0.tar.bz2#5ef222a3e1b5904742e376e05046692b
 https://conda.anaconda.org/conda-forge/noarch/sphinx-panels-0.5.2-pyhd3deb0d_0.tar.bz2#1a871a63c4be1bd47a7aa48b7417a426
-https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-bibtex-2.2.1-pyhd8ed1ab_0.tar.bz2#927ecdc7ffaab15e45d908336ccc504c
+https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-bibtex-2.3.0-pyhd8ed1ab_0.tar.bz2#25a6f02d7790249ef3b491243568e52d
 https://conda.anaconda.org/conda-forge/noarch/twine-3.4.1-pyhd8ed1ab_0.tar.bz2#c7d4ab21a13c919f9ae59eae7bcebf2a
 https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.6.0-pyhd8ed1ab_0.tar.bz2#62e29ad8a1c72f2ec56dffef91870fe3
 https://conda.anaconda.org/conda-forge/noarch/notebook-6.4.0-pyha770c72_0.tar.bz2#1edbf3ee7482e201e572db0211e17f30

--- a/requirements/environment-osx-64.lock
+++ b/requirements/environment-osx-64.lock
@@ -1,5 +1,5 @@
 # platform: osx-64
-# env_hash: 39f126386521e63344342aca1c01e20608f29b41434f449576b92569d227c26e
+# env_hash: 9d7a5b8c5571276865e68d99758589b1b116baa417ddcbcc09b068d7583c2240
 @EXPLICIT
 https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h0d85af4_4.tar.bz2#37edc4e6304ca87316e160f5ca0bd1b5
 https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.17.1-h0d85af4_1.tar.bz2#786a1af1bc9194e43bb3a9e1ea0146ed
@@ -58,7 +58,7 @@ https://conda.anaconda.org/conda-forge/noarch/decorator-5.0.9-pyhd8ed1ab_0.tar.b
 https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2#961b3a227b437d82ad7054484cfa71b2
 https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.3-pyhd8ed1ab_1003.tar.bz2#bbf9a201f6ce99a506f4955374d9a9f4
 https://conda.anaconda.org/conda-forge/noarch/filelock-3.0.12-pyh9f0ad1d_0.tar.bz2#7544ed05bbbe9bb687bc9bcbe4d6cb46
-https://conda.anaconda.org/conda-forge/noarch/fsspec-2021.5.0-pyhd8ed1ab_0.tar.bz2#da823f51ebb876dafbed1c892fd80956
+https://conda.anaconda.org/conda-forge/noarch/fsspec-2021.6.0-pyhd8ed1ab_0.tar.bz2#2568dbadce6148e58a9148de2c16a042
 https://conda.anaconda.org/conda-forge/osx-64/hdf5-1.10.6-nompi_hc5d9132_1114.tar.bz2#b7f592b79c2c97646a6c7f874b0db33a
 https://conda.anaconda.org/conda-forge/noarch/heapdict-1.0.1-py_0.tar.bz2#77242bfb1e74a627fb06319b5a2d3b95
 https://conda.anaconda.org/conda-forge/noarch/idna-2.10-pyh9f0ad1d_0.tar.bz2#f95a12b4f435aae6680fe55ae2eb1b06
@@ -107,7 +107,7 @@ https://conda.anaconda.org/conda-forge/noarch/tinydb-4.4.0-pyh44b312d_0.tar.bz2#
 https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhd8ed1ab_0.tar.bz2#f832c45a477c78bebd107098db465095
 https://conda.anaconda.org/conda-forge/noarch/toolz-0.11.1-py_0.tar.bz2#d1e66b58cb00b3817ad9f05eec098c00
 https://conda.anaconda.org/conda-forge/noarch/tqdm-4.61.0-pyhd8ed1ab_0.tar.bz2#3a71e435b54b3598c09427727215e8da
-https://conda.anaconda.org/conda-forge/noarch/typing_extensions-3.7.4.3-py_0.tar.bz2#12b96e382730541a4b332420227055ae
+https://conda.anaconda.org/conda-forge/noarch/typing_extensions-3.10.0.0-pyha770c72_0.tar.bz2#67c0cba6533b641f28946d7c16f361c8
 https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-py_1.tar.bz2#3563be4c5611a44210d9ba0c16113136
 https://conda.anaconda.org/conda-forge/noarch/wheel-0.36.2-pyhd3deb0d_0.tar.bz2#768bfbe026426d0e76b377997d1f2b98
 https://conda.anaconda.org/conda-forge/noarch/zipp-3.4.1-pyhd8ed1ab_0.tar.bz2#a4fa30eb74a326092b3d8078b1f1aae1
@@ -121,8 +121,9 @@ https://conda.anaconda.org/conda-forge/osx-64/coverage-5.5-py37h271585c_0.tar.bz
 https://conda.anaconda.org/conda-forge/noarch/cycler-0.10.0-py_2.tar.bz2#f6d7c7e6d8f42cbbec7e07a8d879f91c
 https://conda.anaconda.org/conda-forge/osx-64/cytoolz-0.11.0-py37hf967b71_3.tar.bz2#476be4e1c4643e52eb01bba3f95fe4f8
 https://conda.anaconda.org/conda-forge/osx-64/docutils-0.15.2-py37hf985489_2.tar.bz2#78186522a37af21e9207497f423748bd
+https://conda.anaconda.org/conda-forge/noarch/environ-config-21.2.0-pyhd8ed1ab_0.tar.bz2#61e53d6eb24342f9440040a590909e85
 https://conda.anaconda.org/conda-forge/noarch/execnet-1.8.1-pyhd8ed1ab_0.tar.bz2#4172c92dcd744016feeaaaf8b28880a6
-https://conda.anaconda.org/conda-forge/osx-64/importlib-metadata-4.4.0-py37hf985489_0.tar.bz2#1bed896cd38555b6506a3351fcd37ceb
+https://conda.anaconda.org/conda-forge/osx-64/importlib-metadata-4.5.0-py37hf985489_0.tar.bz2#230b7a8b7757261f04a3d347378ef582
 https://conda.anaconda.org/conda-forge/noarch/importlib_resources-5.1.4-pyhd8ed1ab_0.tar.bz2#6623391428e75e1ded2fc117b86a747e
 https://conda.anaconda.org/conda-forge/osx-64/jedi-0.18.0-py37hf985489_2.tar.bz2#8cf41e3992c9d1ae8549dfaf03d4bc14
 https://conda.anaconda.org/conda-forge/osx-64/kiwisolver-1.3.1-py37h70f7d40_1.tar.bz2#2b3639e4db0eab6a502a11ff8ca9a1e8
@@ -159,8 +160,8 @@ https://conda.anaconda.org/conda-forge/osx-64/brotlipy-0.7.0-py37hf967b71_1001.t
 https://conda.anaconda.org/conda-forge/osx-64/click-8.0.1-py37hf985489_0.tar.bz2#64463aca7af971ba20b274b25fd4aea7
 https://conda.anaconda.org/conda-forge/osx-64/cmarkgfm-0.5.3-py37h271585c_0.tar.bz2#a8a67b88a17d949a716ae609a7260dd5
 https://conda.anaconda.org/conda-forge/osx-64/cryptography-3.4.7-py37hce4a858_0.tar.bz2#3d8dba99e6bba580b947da6daf8b1d94
-https://conda.anaconda.org/conda-forge/noarch/dask-core-2021.5.1-pyhd8ed1ab_0.tar.bz2#bf8923574861d55110396b169f4978f7
-https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-4.4.0-hd8ed1ab_0.tar.bz2#cc623f404f4ea1e031890cca57e8f83c
+https://conda.anaconda.org/conda-forge/noarch/dask-core-2021.6.0-pyhd8ed1ab_0.tar.bz2#cea7be7ed76c4664498447ef35d2268c
+https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-4.5.0-hd8ed1ab_0.tar.bz2#37284dc55911fdf9b0b5e6fed56fb192
 https://conda.anaconda.org/conda-forge/noarch/jinja2-3.0.1-pyhd8ed1ab_0.tar.bz2#c647e77921fd3e245cdcc5b2d451a0f8
 https://conda.anaconda.org/conda-forge/osx-64/jupyter_core-4.7.1-py37hf985489_0.tar.bz2#a49ae78b4a221744cca02dfed08a990f
 https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.2-pyhd8ed1ab_2.tar.bz2#0967e1db58b16e416464ca399f87df79
@@ -175,7 +176,7 @@ https://conda.anaconda.org/conda-forge/noarch/bleach-3.3.0-pyh44b312d_0.tar.bz2#
 https://conda.anaconda.org/conda-forge/osx-64/bokeh-2.3.2-py37hf985489_0.tar.bz2#823e93c0b7f68cb9191ad77063a15e8a
 https://conda.anaconda.org/conda-forge/osx-64/cftime-1.5.0-py37h238668a_0.tar.bz2#a45f6d03b65a9102279b3941aecb71ef
 https://conda.anaconda.org/conda-forge/noarch/click-default-group-1.2.2-pyhd8ed1ab_1.tar.bz2#72a46ffc25701c173932fd55cf0965d3
-https://conda.anaconda.org/conda-forge/osx-64/distributed-2021.5.1-py37hf985489_0.tar.bz2#899b9ad4d49ca1f7d898a932959fdf57
+https://conda.anaconda.org/conda-forge/osx-64/distributed-2021.6.0-py37hf985489_0.tar.bz2#7e8584890634c632a02fb2a77a50032e
 https://conda.anaconda.org/conda-forge/noarch/isort-5.8.0-pyhd8ed1ab_0.tar.bz2#c7535f0f6618cba5a5f1070c0edf8e2b
 https://conda.anaconda.org/conda-forge/noarch/jsonschema-3.2.0-pyhd8ed1ab_3.tar.bz2#66125e28711d8ffc04a207a2b170316d
 https://conda.anaconda.org/conda-forge/noarch/jupyter_client-6.1.12-pyhd8ed1ab_0.tar.bz2#f58b38ddb9f94fa3cafea4ba2b17f93b
@@ -190,7 +191,7 @@ https://conda.anaconda.org/conda-forge/noarch/pygments-2.9.0-pyhd8ed1ab_0.tar.bz
 https://conda.anaconda.org/conda-forge/noarch/pyopenssl-20.0.1-pyhd8ed1ab_0.tar.bz2#92371c25994d0f5d28a01c1fb75ebf86
 https://conda.anaconda.org/conda-forge/osx-64/ruamel.yaml-0.17.7-py37h271585c_0.tar.bz2#eb5def1338344e135841c21fb37e9cde
 https://conda.anaconda.org/conda-forge/osx-64/scipy-1.6.3-py37h866764c_0.tar.bz2#7532a6913961686990ca736ae5b65d4c
-https://conda.anaconda.org/conda-forge/noarch/dask-2021.5.1-pyhd8ed1ab_0.tar.bz2#6d88d5c849ba285e856125d6e4b79b6d
+https://conda.anaconda.org/conda-forge/noarch/dask-2021.6.0-pyhd8ed1ab_0.tar.bz2#554ef426ff0ef06641338b7a514d6354
 https://conda.anaconda.org/conda-forge/noarch/iapws-1.5.2-pyh9f0ad1d_0.tar.bz2#3aa31b761bc6aa3acc0d6d01e0bf2e01
 https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.1.2-pyh9f0ad1d_0.tar.bz2#2cbd910890bb328e8959246a1e16fac7
 https://conda.anaconda.org/conda-forge/osx-64/matplotlib-3.4.2-py37hf985489_0.tar.bz2#37b1833a741e6b0150876bf0d9be8c3a
@@ -211,7 +212,7 @@ https://conda.anaconda.org/conda-forge/noarch/pytest-forked-1.3.0-pyhd3deb0d_0.t
 https://conda.anaconda.org/conda-forge/noarch/pytest-metadata-1.11.0-pyhd3deb0d_0.tar.bz2#2e92f7ccb8d9a03966fc36e3861522ec
 https://conda.anaconda.org/conda-forge/noarch/requests-2.25.1-pyhd3deb0d_0.tar.bz2#ae687aba31a1c400192a86a2e993ffdc
 https://conda.anaconda.org/conda-forge/noarch/ensureconda-1.4.1-pyhd8ed1ab_0.tar.bz2#52a7f7cc9076e2c8a25e15e19ad42821
-https://conda.anaconda.org/conda-forge/osx-64/ipython-7.24.0-py37h85f7c60_0.tar.bz2#a0bf310cb8220167ed18542cb98843be
+https://conda.anaconda.org/conda-forge/osx-64/ipython-7.24.1-py37h85f7c60_0.tar.bz2#983116b27154bf14a8fd3ae2f047383d
 https://conda.anaconda.org/conda-forge/osx-64/nbconvert-6.0.7-py37hf985489_3.tar.bz2#cbf915c9d112392238f5ecc98555e132
 https://conda.anaconda.org/conda-forge/noarch/pytest-json-report-1.2.4-pyh9f0ad1d_0.tar.bz2#83018f154e27bf943a790e533272d092
 https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-2.2.1-pyhd8ed1ab_0.tar.bz2#340e7715aee434d2464a97e91ead6cca
@@ -224,7 +225,7 @@ https://conda.anaconda.org/conda-forge/noarch/pydata-sphinx-theme-0.6.3-pyhd8ed1
 https://conda.anaconda.org/conda-forge/noarch/sphinx-copybutton-0.3.1-pyhd8ed1ab_0.tar.bz2#decad13214a2a545944560eccf4a9815
 https://conda.anaconda.org/conda-forge/noarch/sphinx-gallery-0.9.0-pyhd8ed1ab_0.tar.bz2#5ef222a3e1b5904742e376e05046692b
 https://conda.anaconda.org/conda-forge/noarch/sphinx-panels-0.5.2-pyhd3deb0d_0.tar.bz2#1a871a63c4be1bd47a7aa48b7417a426
-https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-bibtex-2.2.1-pyhd8ed1ab_0.tar.bz2#927ecdc7ffaab15e45d908336ccc504c
+https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-bibtex-2.3.0-pyhd8ed1ab_0.tar.bz2#25a6f02d7790249ef3b491243568e52d
 https://conda.anaconda.org/conda-forge/noarch/twine-3.4.1-pyhd8ed1ab_0.tar.bz2#c7d4ab21a13c919f9ae59eae7bcebf2a
 https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.6.0-pyhd8ed1ab_0.tar.bz2#62e29ad8a1c72f2ec56dffef91870fe3
 https://conda.anaconda.org/conda-forge/noarch/notebook-6.4.0-pyha770c72_0.tar.bz2#1edbf3ee7482e201e572db0211e17f30

--- a/requirements/environment.yml
+++ b/requirements/environment.yml
@@ -10,6 +10,7 @@ dependencies:
   - click
   - cerberus
   - dask
+  - environ-config
   - iapws
   - matplotlib
   - netcdf4

--- a/requirements/main.in
+++ b/requirements/main.in
@@ -4,6 +4,7 @@ attrs
 click
 cerberus
 dask
+environ-config
 iapws
 matplotlib
 netcdf4

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -12,6 +12,7 @@ attrs==21.2.0
     # via
     #   -c requirements/dev.txt
     #   -r requirements/main.in
+    #   environ-config
     #   pinttrs
 cerberus==1.3.4
     # via
@@ -33,11 +34,15 @@ cycler==0.10.0
     # via
     #   -c requirements/dev.txt
     #   matplotlib
-dask==2021.5.1
+dask==2021.6.0
     # via
     #   -c requirements/dev.txt
     #   -r requirements/main.in
-fsspec==2021.5.0
+environ-config==21.2.0
+    # via
+    #   -c requirements/dev.txt
+    #   -r requirements/main.in
+fsspec==2021.6.0
     # via
     #   -c requirements/dev.txt
     #   dask
@@ -45,7 +50,7 @@ iapws==1.5.2
     # via
     #   -c requirements/dev.txt
     #   -r requirements/main.in
-importlib-metadata==4.4.0
+importlib-metadata==4.5.0
     # via
     #   -c requirements/dev.txt
     #   click

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -20,6 +20,7 @@ attrs==21.2.0
     # via
     #   -c requirements/dev.txt
     #   -r requirements/main.in
+    #   environ-config
     #   pinttrs
     #   pytest
 babel==2.9.1
@@ -54,7 +55,7 @@ cycler==0.10.0
     # via
     #   -c requirements/dev.txt
     #   matplotlib
-dask==2021.5.1
+dask==2021.6.0
     # via
     #   -c requirements/dev.txt
     #   -r requirements/main.in
@@ -63,11 +64,15 @@ docutils==0.16
     #   -c requirements/dev.txt
     #   rst2pdf
     #   sphinx
+environ-config==21.2.0
+    # via
+    #   -c requirements/dev.txt
+    #   -r requirements/main.in
 execnet==1.8.1
     # via
     #   -c requirements/dev.txt
     #   pytest-xdist
-fsspec==2021.5.0
+fsspec==2021.6.0
     # via
     #   -c requirements/dev.txt
     #   dask
@@ -83,7 +88,7 @@ imagesize==1.2.0
     # via
     #   -c requirements/dev.txt
     #   sphinx
-importlib-metadata==4.4.0
+importlib-metadata==4.5.0
     # via
     #   -c requirements/dev.txt
     #   click
@@ -255,7 +260,7 @@ snowballstemmer==2.1.0
     # via
     #   -c requirements/dev.txt
     #   sphinx
-sphinx==3.5.4
+sphinx==4.0.2
     # via
     #   -c requirements/dev.txt
     #   -r requirements/tests.in

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ install_requires =
     click
     cerberus
     dask
+    environ-config
     iapws
     matplotlib
     netcdf4


### PR DESCRIPTION
# Description

This PR introduces a new configuration data structure which parses environment variables automatically. Hopefully error messages should be comprehensive.

This PR also closes eradiate/eradiate-issues#86 by adding automatically the contents of the `ERADIATE_DATA_PATH` environment variable to the path resolver, between the current working directory and the `ERADIATE_DIR/resources/data` directory.

@wint3ria thoughts?

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
