### PR TITLE
Ellipsoid leaf cloud

### DIFF
--- a/docs/rst/reference/scenes.rst
+++ b/docs/rst/reference/scenes.rst
@@ -69,6 +69,7 @@ Biosphere [eradiate.scenes.biosphere]
 
       _discrete.CuboidLeafCloudParams
       _discrete.SphereLeafCloudParams
+      _discrete.EllipsoidLeafCloudParams
       _discrete.CylinderLeafCloudParams
       _discrete.ConeLeafCloudParams
 

--- a/eradiate/scenes/biosphere/tests/test_biosphere_discrete.py
+++ b/eradiate/scenes/biosphere/tests/test_biosphere_discrete.py
@@ -7,16 +7,16 @@ import pytest
 from eradiate import unit_registry as ureg
 from eradiate.contexts import KernelDictContext
 from eradiate.scenes.biosphere._discrete import (
+    AbstractTree,
     DiscreteCanopy,
     InstancedCanopyElement,
     LeafCloud,
-    AbstractTree,
     _inversebeta,
     _leaf_cloud_orientations,
     _leaf_cloud_positions_cuboid,
     _leaf_cloud_positions_cuboid_avoid_overlap,
     _leaf_cloud_positions_cylinder,
-    _leaf_cloud_positions_sphere,
+    _leaf_cloud_positions_ellipsoid,
     _leaf_cloud_radii,
 )
 from eradiate.scenes.core import KernelDict
@@ -78,11 +78,11 @@ def test_leaf_cloud_positions_cuboid_avoid_overlap(rng):
     assert positions.shape == (1000, 3)
 
 
-def test_leaf_cloud_positions_sphere(rng):
-    """Unit tests for :func:`_leaf_cloud_positions_sphere`."""
-    positions = _leaf_cloud_positions_sphere(1, 1.0 * ureg.m, rng)
+def test_leaf_cloud_positions_ellipsoid(rng):
+    """Unit tests for :func:`_leaf_cloud_positions_ellipsoid`."""
+    positions = _leaf_cloud_positions_ellipsoid(1, rng, 1.0 * ureg.m)
     assert positions.shape == (1, 3)
-    assert np.allclose(positions, [-0.212706, 0.477006, 0.602504] * ureg.m)
+    assert np.allclose(positions, [0.11039234, 0.76996928, 0.50481848] * ureg.m)
 
 
 def test_leaf_cloud_positions_cylinder(rng):


### PR DESCRIPTION
# Description

This MR extends the spherical leaf cloud generator to a more generalized ellipsoid leaf cloud, parametrized through its three half axes. It also introduces a new generator function to the `LeafCloud` class to instantiate a generic ellipsoid leaf cloud and modifies the generator for the spherical leaf cloud to properly use the new ellipsoid generator.

In the `Solver` base class the storage for SZA and SAA was modified to store them in in degrees instead of radians. This is in line with the other angular quantities stored in our computational results.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [ ] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
