### PR TITLE
Updated metadata handling, storing SZA and VZA in degrees

### DIFF
--- a/eradiate/scenes/measure/_distant.py
+++ b/eradiate/scenes/measure/_distant.py
@@ -529,9 +529,9 @@ class DistantReflectanceMeasure(DistantMeasure):
         self, ds: xr.Dataset, illumination: DirectionalIllumination
     ) -> xr.Dataset:
         # Collect illumination angular data
-        saa = illumination.azimuth.m_as(ureg.rad)
-        sza = illumination.zenith.m_as(ureg.rad)
-        cos_sza = np.cos(sza)
+        saa = illumination.azimuth.m_as(ureg.deg)
+        sza = illumination.zenith.m_as(ureg.deg)
+        cos_sza = np.cos(np.deg2rad(sza))
 
         # Add angular dimensions
         ds = ds.expand_dims({"sza": [sza], "saa": [saa]}, axis=(0, 1))


### PR DESCRIPTION
# Description

The sun angle metadata suggests that the values are stored in degrees, however the were stored in radians.
Fixed this.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
