### PR TITLE
Upgrade RPV interface

### DIFF
--- a/docs/references.bib
+++ b/docs/references.bib
@@ -157,6 +157,18 @@
     doi = {10.1364/JOSA.62.000958}
 }
 
+@article{Pinty2000SurfaceAlbedoRetrieval,
+  title = {Surface Albedo Retrieval from {{Meteosat}}: 1. {{Theory}}},
+  author = {Pinty, Bernard and Roveda, Fausto and Verstraete, Michel M. and Gobron, Nadine and Govaerts, Yves and Martonchik, John V. and Diner, David J. and Kahn, Ralph A.},
+  year = {2000},
+  journal = {Journal of Geophysical Research: Atmospheres},
+  volume = {105},
+  pages = {18099--18112},
+  issn = {2156-2202},
+  doi = {10.1029/2000JD900113},
+  number = {D14}
+}
+
 @article{Rahman1993CoupledSurfaceatmosphereReflectance,
     author = {Rahman, Hafizur and Pinty, Bernard and Verstraete, Michel M.},
     title = {Coupled Surface-Atmosphere Reflectance ( {{CSAR}} ) Model: 2. {{Semiempirical}} Surface Model Usable with {{NOAA}} Advanced Very High Resolution Radiometer Data},
@@ -263,16 +275,24 @@
 }
 
 @incollection{Ross1991MonteCarloMethods,
-  title = {Monte {{Carlo Methods}}},
-  booktitle = {Photon-{{Vegetation Interactions}}: {{Applications}} in {{Optical Remote Sensing}} and {{Plant Ecology}}},
-  author = {Ross, J. and Marshak, A.},
-  editor = {Myneni, Ranga B. and Ross, Juhan},
-  year = {1991},
-  pages = {441--467},
-  publisher = {{Springer}},
-  location = {{Berlin, Heidelberg}},
-  doi = {10.1007/978-3-642-75389-3_14},
-  url = {https://doi.org/10.1007/978-3-642-75389-3_14},
-  urldate = {2021-03-22},
-  isbn = {978-3-642-75389-3},
+    title = {Monte {{Carlo Methods}}},
+    booktitle = {Photon-{{Vegetation Interactions}}: {{Applications}} in {{Optical Remote Sensing}} and {{Plant Ecology}}},
+    author = {Ross, J. and Marshak, A.},
+    editor = {Myneni, Ranga B. and Ross, Juhan},
+    year = {1991},
+    pages = {441--467},
+    publisher = {{Springer}},
+    location = {{Berlin, Heidelberg}},
+    doi = {10.1007/978-3-642-75389-3_14},
+    url = {https://doi.org/10.1007/978-3-642-75389-3_14},
+    urldate = {2021-03-22},
+    isbn = {978-3-642-75389-3},
+}
+
+@techreport{EradiateScientificHandbook2020,
+    author = {Eradiate Team},
+    title = {Eradiate Scientific Handbook},
+    institution = {Eradiate},
+    year = {2020},
+    url = {https://www.eradiate.eu/site/docs/},
 }

--- a/eradiate/scenes/surface/tests/test_surface_rpv.py
+++ b/eradiate/scenes/surface/tests/test_surface_rpv.py
@@ -10,15 +10,27 @@ def test_rpv(mode_mono):
     ctx = KernelDictContext()
 
     # Default constructor
-    ls = RPVSurface()
+    surface = RPVSurface()
 
     # Check if produced scene can be instantiated
-    kernel_dict = KernelDict.new(ls, ctx=ctx)
+    kernel_dict = KernelDict.new(surface, ctx=ctx)
     assert kernel_dict.load() is not None
 
-    # Constructor with arguments
-    ls = RPVSurface(width=ureg.Quantity(1000.0, "km"), rho_0=0.3, k=1.4, ttheta=-0.23)
-    assert np.allclose(ls.width, ureg.Quantity(1e6, ureg.m))
+    # Construct from floats
+    surface = RPVSurface(width=ureg.Quantity(1000.0, "km"), rho_0=0.3, k=1.4, g=-0.23)
+    assert np.allclose(surface.width, ureg.Quantity(1e6, ureg.m))
+
+    # Construct from mixed spectrum types
+    surface = RPVSurface(
+        width=ureg.Quantity(1000.0, "km"),
+        rho_0=0.3,
+        k={"type": "uniform", "value": 0.3},
+        g={
+            "type": "interpolated",
+            "wavelengths": [300.0, 800.0],
+            "values": [-0.23, 0.23],
+        },
+    )
 
     # Check if produced scene can be instantiated
-    assert KernelDict.new(ls, ctx=ctx).load() is not None
+    assert KernelDict.new(surface, ctx=ctx).load() is not None

--- a/eradiate/tests/system/test_onedim_symmetry.py
+++ b/eradiate/tests/system/test_onedim_symmetry.py
@@ -77,7 +77,7 @@ def test_symmetry_zenith(mode_mono_double, surface, atmosphere):
         },
         surface={
             "lambertian": {"type": "lambertian", "reflectance": 0.5},
-            "rpv": {"type": "rpv", "rho_0": 0.183, "k": 0.780, "ttheta": -0.1},
+            "rpv": {"type": "rpv", "rho_0": 0.183, "k": 0.780, "g": -0.1},
         }[surface],
         atmosphere={
             "none": None,


### PR DESCRIPTION
# Description

This PR upgrades the RPV surface so as to support `Spectrum`-valued parameters. Changes are as follows:

- `RPVSurface` now supports `Spectrum`-valued parameters, which, in practice, makes it possible to properly leverage the spectral loop.
- `RPVSurface` fields were renamed and their defaults and docs were updated to match both the kernel implementation and the Scientific Handbook.

@schunkes @wint3ria this PR contains a breaking change: the `ttheta` param is now `g`. Please check the impact on your workflow, I'll merge this when you tell me you're okay with it.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
