### PR TITLE
Distant flux measures

### DIFF
--- a/docs/rst/reference/core.rst
+++ b/docs/rst/reference/core.rst
@@ -14,7 +14,9 @@ Mode control
    modes
    set_mode
 
-.. dropdown:: **Private: Mode implementation details**
+**Mode implementation details**
+
+.. dropdown:: Private
 
    .. autosummary::
       :toctree: generated/
@@ -61,7 +63,9 @@ Path resolver
    * - :data:`path_resolver`
      - Unique path resolver instance.
 
-.. dropdown:: **Private: Path resolver implementation**
+**Path resolver implementation**
+
+.. dropdown:: Private
 
    .. autosummary::
       :toctree: generated

--- a/docs/rst/reference/scenes.rst
+++ b/docs/rst/reference/scenes.rst
@@ -131,6 +131,7 @@ Measures [eradiate.scenes.measure]
 
    MeasureFactory
    Measure
+   DistantMeasure
 
 .. dropdown:: **Private: Sensor information data structure**
 
@@ -144,8 +145,10 @@ Measures [eradiate.scenes.measure]
 .. autosummary::
    :toctree: generated/
 
-   DistantMeasure
+   DistantRadianceMeasure
    DistantReflectanceMeasure
+   DistantFluxMeasure
+   DistantAlbedoMeasure
    PerspectiveCameraMeasure
    RadiancemeterMeasure
    RadiancemeterArrayMeasure

--- a/docs/rst/reference/scenes.rst
+++ b/docs/rst/reference/scenes.rst
@@ -62,7 +62,9 @@ Biosphere [eradiate.scenes.biosphere]
    InstancedCanopyElement
    DiscreteCanopy
 
-.. dropdown:: **Parameters for LeafCloud generators**
+**Parameters for LeafCloud generators**
+
+.. dropdown:: Private
 
    .. autosummary::
       :toctree: generated/
@@ -133,12 +135,28 @@ Measures [eradiate.scenes.measure]
    Measure
    DistantMeasure
 
-.. dropdown:: **Private: Sensor information data structure**
+**Sensor information data structure**
+
+.. dropdown:: Private
 
    .. autosummary::
       :toctree: generated/
 
       _core.SensorInfo
+
+**Measure spectral configuration**
+
+   .. autosummary::
+      :toctree: generated/
+
+      MeasureSpectralConfig
+
+**Result storage and processing**
+
+.. autosummary::
+   :toctree: generated/
+
+   MeasureResults
 
 **Scene elements**
 
@@ -153,14 +171,9 @@ Measures [eradiate.scenes.measure]
    RadiancemeterMeasure
    RadiancemeterArrayMeasure
 
-**Result storage and processing**
+**Target and origin specification for DistantMeasure**
 
-.. autosummary::
-   :toctree: generated/
-
-   MeasureResults
-
-.. dropdown:: **Private: Target and origin specification for DistantMeasure**
+.. dropdown:: Private
 
    .. autosummary::
       :toctree: generated/

--- a/docs/rst/reference/solvers.rst
+++ b/docs/rst/reference/solvers.rst
@@ -12,7 +12,9 @@ Core infrastructure [eradiate.solvers.core]
 
    runner
 
-.. dropdown:: **Private: Solver internals**
+**Solver internals**
+
+.. dropdown:: Private
 
    .. autosummary::
       :toctree: generated/

--- a/eradiate/scenes/measure/__init__.py
+++ b/eradiate/scenes/measure/__init__.py
@@ -1,5 +1,5 @@
 from ._core import Measure, MeasureFactory, MeasureResults, MeasureSpectralConfig
-from ._distant import DistantMeasure, DistantReflectanceMeasure
+from ._distant import DistantRadianceMeasure, DistantReflectanceMeasure
 from ._perspective import PerspectiveCameraMeasure
 from ._radiancemeter import RadiancemeterMeasure
 from ._radiancemeterarray import RadiancemeterArrayMeasure
@@ -9,7 +9,7 @@ __all__ = [
     "MeasureSpectralConfig",
     "MeasureFactory",
     "MeasureResults",
-    "DistantMeasure",
+    "DistantRadianceMeasure",
     "DistantReflectanceMeasure",
     "PerspectiveCameraMeasure",
     "RadiancemeterMeasure",

--- a/eradiate/scenes/measure/__init__.py
+++ b/eradiate/scenes/measure/__init__.py
@@ -1,5 +1,9 @@
 from ._core import Measure, MeasureFactory, MeasureResults, MeasureSpectralConfig
-from ._distant import DistantRadianceMeasure, DistantReflectanceMeasure
+from ._distant import (
+    DistantFluxMeasure,
+    DistantRadianceMeasure,
+    DistantReflectanceMeasure,
+)
 from ._perspective import PerspectiveCameraMeasure
 from ._radiancemeter import RadiancemeterMeasure
 from ._radiancemeterarray import RadiancemeterArrayMeasure
@@ -9,6 +13,7 @@ __all__ = [
     "MeasureSpectralConfig",
     "MeasureFactory",
     "MeasureResults",
+    "DistantFluxMeasure",
     "DistantRadianceMeasure",
     "DistantReflectanceMeasure",
     "PerspectiveCameraMeasure",

--- a/eradiate/scenes/measure/__init__.py
+++ b/eradiate/scenes/measure/__init__.py
@@ -1,6 +1,8 @@
 from ._core import Measure, MeasureFactory, MeasureResults, MeasureSpectralConfig
 from ._distant import (
+    DistantAlbedoMeasure,
     DistantFluxMeasure,
+    DistantMeasure,
     DistantRadianceMeasure,
     DistantReflectanceMeasure,
 )
@@ -13,6 +15,8 @@ __all__ = [
     "MeasureSpectralConfig",
     "MeasureFactory",
     "MeasureResults",
+    "DistantMeasure",
+    "DistantAlbedoMeasure",
     "DistantFluxMeasure",
     "DistantRadianceMeasure",
     "DistantReflectanceMeasure",

--- a/eradiate/scenes/measure/_core.py
+++ b/eradiate/scenes/measure/_core.py
@@ -1,3 +1,4 @@
+import warnings
 from abc import ABC, abstractmethod
 from typing import Dict, List, MutableMapping, Optional, Tuple
 
@@ -552,3 +553,18 @@ class MeasureFactory(BaseFactory):
 
     _constructed_type = Measure
     registry = {}
+
+    @classmethod
+    def create(cls, config_dict):
+        try:
+            if config_dict["type"] == "distant":
+                warnings.warn(
+                    "Using the 'distant' factory ID to create a "
+                    "DistantRadianceMeasure is deprecated. Use "
+                    "'distant_radiance'.",
+                    DeprecationWarning,
+                )
+        except KeyError:
+            pass
+
+        return super(MeasureFactory, cls).create(config_dict)

--- a/eradiate/scenes/measure/_core.py
+++ b/eradiate/scenes/measure/_core.py
@@ -45,8 +45,7 @@ class SensorInfo:
 
 class MeasureSpectralConfig(ABC):
     """
-    Data structure specifying the spectral configuration of a :class:`.Measure`
-    in monochromatic modes.
+    Data structure specifying the spectral configuration of a :class:`.Measure`.
 
     While this class is abstract, it should however be the main entry point
     to create :class:`.MeasureSpectralConfig` child class objects through the
@@ -66,12 +65,12 @@ class MeasureSpectralConfig(ABC):
     @staticmethod
     def new(**kwargs) -> "MeasureSpectralConfig":
         """
-        Create a new instance of one of the :class:`SpectralContext` child
+        Create a new instance of one of the :class:`.SpectralContext` child
         classes. *The instantiated class is defined based on the currently active
         mode.* Keyword arguments are passed to the instantiated class's
         constructor:
 
-        .. rubric:: Monochromatic modes [:class:`MonoMeasureSpectralConfig`]
+        .. rubric:: Monochromatic modes [:class:`.MonoMeasureSpectralConfig`]
 
         Parameter ``wavelengths`` (:class:`pint.Quantity`):
             List of wavelengths (automatically converted to a Numpy array).

--- a/eradiate/scenes/measure/_distant.py
+++ b/eradiate/scenes/measure/_distant.py
@@ -293,9 +293,10 @@ class DistantMeasure(Measure):
         doc="Target specification. If set to ``None``, default target point "
         "selection is used: rays will not target a particular region of the "
         "scene. The target can be specified using an array-like with 3 "
-        "elements (which will be converted to a :class:`TargetPoint`) or a "
-        "dictionary interpreted by :meth:`Target.convert`.",
-        type=":class:`TargetOrigin` or None",
+        "elements (which will be converted to a :class:`.TargetOriginPoint`) "
+        "or a dictionary interpreted by "
+        ":meth:`TargetOrigin.convert() <.TargetOrigin.convert>`.",
+        type=":class:`.TargetOrigin` or None",
         default="None",
     )
 
@@ -312,8 +313,9 @@ class DistantMeasure(Measure):
         "point selection strategy is used: ray origins will be projected to "
         "the scene's bounding sphere. Otherwise, ray origins are projected "
         "to the shape specified as origin. The origin can be specified using "
-        "a dictionary interpreted by :meth:`TargetOrigin.convert`.",
-        type=":class:`TargetOriginSphere` or None",
+        "a dictionary interpreted by "
+        ":meth:`TargetOrigin.convert() <.TargetOrigin.convert>`.",
+        type=":class:`.TargetOriginSphere` or None",
         default="None",
     )
 
@@ -387,9 +389,7 @@ class DistantMeasure(Measure):
 @attr.s
 class DistantRadianceMeasure(DistantMeasure):
     """
-    Distant measure scene element [:factorykey:`distant`].
-
-    This measure records radiance leaving the scene at infinite distance.
+    Record the radiance (in W/m²/sr(/nm)) leaving the scene at infinite distance.
     Depending on film resolution (*i.e.* storage discretisation), radiance is
     recorded for a single direction, in a plane or in an entire hemisphere.
 

--- a/eradiate/scenes/measure/_distant.py
+++ b/eradiate/scenes/measure/_distant.py
@@ -559,12 +559,9 @@ class DistantRadianceMeasure(DistantMeasure):
 @attr.s
 class DistantReflectanceMeasure(DistantRadianceMeasure):
     """
-    Distant reflectance  measure scene element
-    [:factorykey:`distant_reflectance`].
-
-    This measure is a specialised version of the :class:`.DistantMeasure`. It
-    implements similar functionality, with extra post-processing features to
-    derive reflectance values from the recorded radiance.
+    A specialised version of :class:`.DistantReflectanceMeasure` with extra
+    post-processing features to derive reflectance values from the recorded
+    radiance.
     """
 
     def postprocess(self, illumination=None) -> xr.Dataset:
@@ -622,6 +619,28 @@ class DistantReflectanceMeasure(DistantRadianceMeasure):
 @parse_docs
 @attr.s
 class DistantFluxMeasure(DistantMeasure):
+    """
+    Record the exitant flux density (in W/m²(/nm)) at infinite distance in a
+    hemisphere defined by its ``direction`` parameter.
+
+    When used with a backward tracing algorithm, rays traced by the sensor
+    target a shape which can be controlled through the ``target`` parameter.
+    This feature is useful if one wants to compute the average flux leaving
+    a particular subset of the scene.
+
+    .. admonition:: Notes
+       :class: note
+
+       * Setting the ``target`` parameter is required to get meaningful results.
+         Solver applications should take care of setting it appropriately.
+       * The film resolution can be adjusted to manually stratify film sampling
+         and reduce variance in results. The default 32x32 is generally a good
+         choice, but scenes with sharp reflection lobes may benefit from higher
+         values.
+       * This scene element is a thin wrapper around the ``distantflux``
+         sensor kernel plugin.
+    """
+
     direction = documented(
         attr.ib(
             default=[0, 0, 1],
@@ -703,6 +722,12 @@ class DistantFluxMeasure(DistantMeasure):
 @parse_docs
 @attr.s
 class DistantAlbedoMeasure(DistantFluxMeasure):
+    """
+    A specialised version of the :class:`.DistantFluxMeasure` with extra
+    post-processing features to derive albedo values from the recorded flux
+    density.
+    """
+
     def postprocess(self, illumination=None) -> xr.Dataset:
         """
         Return post-processed raw sensor results.

--- a/eradiate/scenes/measure/_distant.py
+++ b/eradiate/scenes/measure/_distant.py
@@ -735,7 +735,7 @@ class DistantAlbedoMeasure(DistantFluxMeasure):
         # Compute albedo
         # We assume that all quantities are stored in kernel units
         ds["albedo"] = ds["flux"] / ds["irradiance"]
-        ds["brdf"].attrs = {
+        ds["albedo"].attrs = {
             "standard_name": "albedo",
             "long_name": "surface albedo",
             "units": "",

--- a/eradiate/scenes/measure/_distant.py
+++ b/eradiate/scenes/measure/_distant.py
@@ -382,7 +382,7 @@ class DistantMeasure(Measure):
         return ds
 
 
-@MeasureFactory.register("distant")
+@MeasureFactory.register("distant", "distant_radiance")
 @parse_docs
 @attr.s
 class DistantRadianceMeasure(DistantMeasure):

--- a/eradiate/scenes/measure/_distant.py
+++ b/eradiate/scenes/measure/_distant.py
@@ -299,6 +299,24 @@ class DistantMeasure(Measure):
         default="None",
     )
 
+    origin = documented(
+        attr.ib(
+            default=None,
+            converter=attr.converters.optional(TargetOrigin.convert),
+            validator=attr.validators.optional(
+                attr.validators.instance_of((TargetOriginSphere,))
+            ),
+            on_setattr=attr.setters.pipe(attr.setters.convert, attr.setters.validate),
+        ),
+        doc="Ray origin specification. If set to ``None``, the default origin "
+        "point selection strategy is used: ray origins will be projected to "
+        "the scene's bounding sphere. Otherwise, ray origins are projected "
+        "to the shape specified as origin. The origin can be specified using "
+        "a dictionary interpreted by :meth:`TargetOrigin.convert`.",
+        type=":class:`TargetOriginSphere` or None",
+        default="None",
+    )
+
     def _postprocess_add_illumination(
         self, ds: xr.Dataset, illumination: DirectionalIllumination
     ) -> xr.Dataset:
@@ -397,24 +415,6 @@ class DistantRadianceMeasure(DistantMeasure):
         "plane.",
         type="array-like",
         default="(32, 32)",
-    )
-
-    origin = documented(
-        attr.ib(
-            default=None,
-            converter=attr.converters.optional(TargetOrigin.convert),
-            validator=attr.validators.optional(
-                attr.validators.instance_of((TargetOriginSphere,))
-            ),
-            on_setattr=attr.setters.pipe(attr.setters.convert, attr.setters.validate),
-        ),
-        doc="Ray origin specification. If set to ``None``, the default origin "
-        "point selection strategy is used: ray origins will be projected to "
-        "the scene's bounding sphere. Otherwise, ray origins are projected "
-        "to the shape specified as origin. The origin can be specified using "
-        "a dictionary interpreted by :meth:`TargetOrigin.convert`.",
-        type=":class:`TargetOriginSphere` or None",
-        default="None",
     )
 
     orientation = documented(
@@ -670,6 +670,9 @@ class DistantFluxMeasure(DistantMeasure):
 
             if self.target is not None:
                 d["target"] = self.target.kernel_item()
+
+            if self.origin is not None:
+                d["origin"] = self.origin.kernel_item()
 
             result.append(d)
 

--- a/eradiate/scenes/measure/_distant.py
+++ b/eradiate/scenes/measure/_distant.py
@@ -272,7 +272,7 @@ class TargetOriginSphere(TargetOrigin):
 @MeasureFactory.register("distant")
 @parse_docs
 @attr.s
-class DistantMeasure(Measure):
+class DistantRadianceMeasure(DistantMeasure):
     """
     Distant measure scene element [:factorykey:`distant`].
 
@@ -485,7 +485,7 @@ class DistantMeasure(Measure):
 @MeasureFactory.register("distant_reflectance")
 @parse_docs
 @attr.s
-class DistantReflectanceMeasure(DistantMeasure):
+class DistantReflectanceMeasure(DistantRadianceMeasure):
     """
     Distant reflectance  measure scene element
     [:factorykey:`distant_reflectance`].

--- a/eradiate/scenes/measure/_distant.py
+++ b/eradiate/scenes/measure/_distant.py
@@ -708,7 +708,7 @@ class DistantFluxMeasure(DistantMeasure):
         ds = self.results.to_dataset(aggregate_spps=True)
 
         # Add aggregate flux density field
-        ds["flux"] = ds["raw"].mean(dim=("x", "y"))
+        ds["flux"] = ds["raw"].sum(dim=("x", "y"))
         ds["flux"].attrs = {
             "standard_name": "toa_outgoing_flux_density_per_unit_wavelength",
             "long_name": "top-of-atmosphere outgoing spectral flux density",

--- a/eradiate/scenes/measure/tests/test_measure_distant.py
+++ b/eradiate/scenes/measure/tests/test_measure_distant.py
@@ -234,4 +234,4 @@ def test_distant_flux_postprocessing(mode_mono):
     ds = d.postprocess()
     assert "flux" in ds.data_vars
     assert ds["flux"].shape == (2,)
-    assert np.allclose(ds.flux, 1.0)
+    assert np.allclose(ds.flux, 1.0 * 16 * 32)

--- a/eradiate/scenes/measure/tests/test_measure_distant.py
+++ b/eradiate/scenes/measure/tests/test_measure_distant.py
@@ -190,6 +190,11 @@ def test_distant_flux(mode_mono):
     assert KernelDict.new(d).load() is not None
     print(d.kernel_dict())
 
+    # Test origin support
+    # -- Project origins to a sphere
+    d = DistantFluxMeasure(origin={"type": "sphere", "center": [0, 0, 0], "radius": 1})
+    assert KernelDict.new(d).load() is not None
+
 
 @pytest.mark.parametrize(
     ["direction", "frame"],

--- a/eradiate/scenes/measure/tests/test_measure_distant.py
+++ b/eradiate/scenes/measure/tests/test_measure_distant.py
@@ -8,7 +8,7 @@ from eradiate import unit_context_kernel as uck
 from eradiate import unit_registry as ureg
 from eradiate.scenes.core import KernelDict
 from eradiate.scenes.measure._distant import (
-    DistantMeasure,
+    DistantRadianceMeasure,
     TargetOrigin,
     TargetOriginPoint,
     TargetOriginRectangle,
@@ -111,32 +111,34 @@ def test_target_origin(mode_mono):
             TargetOrigin.convert({"xyz": [1, 1, 0]})
 
 
-def test_distant(mode_mono):
+def test_distant_radiance(mode_mono):
     # Test default constructor
-    d = DistantMeasure()
+    d = DistantRadianceMeasure()
     assert KernelDict.new(d).load() is not None
 
     # Test target support
     # -- Target a point
-    d = DistantMeasure(target=[0, 0, 0])
+    d = DistantRadianceMeasure(target=[0, 0, 0])
     assert KernelDict.new(d).load() is not None
 
     # -- Target an axis-aligned rectangular patch
-    d = DistantMeasure(
+    d = DistantRadianceMeasure(
         target={"type": "rectangle", "xmin": 0, "xmax": 1, "ymin": 0, "ymax": 1}
     )
     assert KernelDict.new(d).load() is not None
 
     # Test origin support
     # -- Project origins to a sphere
-    d = DistantMeasure(origin={"type": "sphere", "center": [0, 0, 0], "radius": 1})
+    d = DistantRadianceMeasure(
+        origin={"type": "sphere", "center": [0, 0, 0], "radius": 1}
+    )
     assert KernelDict.new(d).load() is not None
 
 
-def test_distant_postprocessing(mode_mono):
+def test_distant_radiance_postprocessing(mode_mono):
     # We use a peculiar rectangular film size to make sure that we get dimensions
     # right
-    d = DistantMeasure(film_resolution=(32, 16))
+    d = DistantRadianceMeasure(film_resolution=(32, 16))
 
     # Add test data to results
     d.results.raw = {

--- a/eradiate/solvers/core/_scene.py
+++ b/eradiate/solvers/core/_scene.py
@@ -6,13 +6,14 @@ import pinttr
 
 from ..._attrs import documented, parse_docs
 from ...scenes.core import SceneElement
-from ...scenes.illumination import (
-    DirectionalIllumination,
-    Illumination,
-    IlluminationFactory,
-)
+from ...scenes.illumination import DirectionalIllumination, IlluminationFactory
 from ...scenes.integrators import Integrator, IntegratorFactory, PathIntegrator
-from ...scenes.measure import DistantRadianceMeasure, Measure, MeasureFactory
+from ...scenes.measure import (
+    DistantMeasure,
+    DistantRadianceMeasure,
+    Measure,
+    MeasureFactory,
+)
 
 
 @parse_docs
@@ -65,7 +66,7 @@ class Scene(SceneElement, ABC):
     def _measures_validator(self, attribute, value):
         for element in value:
             # Check measure type
-            if not isinstance(element, DistantRadianceMeasure):
+            if not isinstance(element, DistantMeasure):
                 raise TypeError(
                     f"while validating {attribute.name}: must be a list of "
                     f"objects of one of the following types: "

--- a/eradiate/solvers/core/_scene.py
+++ b/eradiate/solvers/core/_scene.py
@@ -12,7 +12,7 @@ from ...scenes.illumination import (
     IlluminationFactory,
 )
 from ...scenes.integrators import Integrator, IntegratorFactory, PathIntegrator
-from ...scenes.measure import DistantMeasure, Measure, MeasureFactory
+from ...scenes.measure import DistantRadianceMeasure, Measure, MeasureFactory
 
 
 @parse_docs
@@ -38,7 +38,7 @@ class Scene(SceneElement, ABC):
 
     measures: List[Measure] = documented(
         attr.ib(
-            factory=lambda: [DistantMeasure()],
+            factory=lambda: [DistantRadianceMeasure()],
             converter=lambda value: [
                 MeasureFactory.convert(x) for x in pinttr.util.always_iterable(value)
             ]
@@ -65,7 +65,7 @@ class Scene(SceneElement, ABC):
     def _measures_validator(self, attribute, value):
         for element in value:
             # Check measure type
-            if not isinstance(element, DistantMeasure):
+            if not isinstance(element, DistantRadianceMeasure):
                 raise TypeError(
                     f"while validating {attribute.name}: must be a list of "
                     f"objects of one of the following types: "

--- a/eradiate/solvers/core/_solver_app.py
+++ b/eradiate/solvers/core/_solver_app.py
@@ -16,7 +16,7 @@ from ..._attrs import documented, parse_docs
 from ...contexts import KernelDictContext
 from ...exceptions import ModeError, UnsupportedModeError
 from ...scenes.measure import Measure, MeasureResults
-from ...scenes.measure._distant import DistantMeasure, DistantReflectanceMeasure
+from ...scenes.measure._distant import DistantRadianceMeasure, DistantReflectanceMeasure
 from ...units import unit_registry as ureg
 
 logger = logging.getLogger(__name__)
@@ -214,7 +214,7 @@ class SolverApp(ABC):
             measure_id = measure.id
             result = self._results[measure_id]
 
-            if isinstance(measure, DistantMeasure):
+            if isinstance(measure, DistantRadianceMeasure):
                 for quantity in result.data_vars:
                     if quantity == "irradiance":
                         continue

--- a/eradiate/solvers/core/_solver_app.py
+++ b/eradiate/solvers/core/_solver_app.py
@@ -16,7 +16,11 @@ from ..._attrs import documented, parse_docs
 from ...contexts import KernelDictContext
 from ...exceptions import ModeError, UnsupportedModeError
 from ...scenes.measure import Measure, MeasureResults
-from ...scenes.measure._distant import DistantRadianceMeasure, DistantReflectanceMeasure
+from ...scenes.measure._distant import (
+    DistantAlbedoMeasure,
+    DistantRadianceMeasure,
+    DistantReflectanceMeasure,
+)
 from ...units import unit_registry as ureg
 
 logger = logging.getLogger(__name__)
@@ -169,7 +173,7 @@ class SolverApp(ABC):
 
         # Prepare measure postprocessing arguments
         measure_kwargs = {}
-        if isinstance(measure, DistantReflectanceMeasure):
+        if isinstance(measure, (DistantReflectanceMeasure, DistantAlbedoMeasure)):
             measure_kwargs["illumination"] = self.scene.illumination
 
         # Collect measure results

--- a/eradiate/solvers/onedim/_scene.py
+++ b/eradiate/solvers/onedim/_scene.py
@@ -98,19 +98,16 @@ class OneDimScene(Scene):
 
                     measure.target = TargetOriginPoint(target_point)
 
-                try:  # TODO: Revisit when new kernel interface will be available
-                    if measure.origin is None:
-                        radius = (
-                            self.atmosphere.height() / 100.0
-                            if self.atmosphere is not None
-                            else 1.0 * ucc.get("length")
-                        )
+                if measure.origin is None:
+                    radius = (
+                        self.atmosphere.height() / 100.0
+                        if self.atmosphere is not None
+                        else 1.0 * ucc.get("length")
+                    )
 
-                        measure.origin = TargetOriginSphere(
-                            center=measure.target.xyz, radius=radius
-                        )
-                except AttributeError:
-                    pass
+                    measure.origin = TargetOriginSphere(
+                        center=measure.target.xyz, radius=radius
+                    )
 
     def kernel_dict(self, ctx: Optional[KernelDictContext] = None) -> MutableMapping:
         result = KernelDict.new(ctx=ctx)

--- a/eradiate/solvers/onedim/_scene.py
+++ b/eradiate/solvers/onedim/_scene.py
@@ -12,7 +12,7 @@ from ...scenes.atmosphere import Atmosphere, AtmosphereFactory, HomogeneousAtmos
 from ...scenes.core import KernelDict
 from ...scenes.integrators import Integrator, IntegratorFactory, VolPathIntegrator
 from ...scenes.measure._distant import (
-    DistantRadianceMeasure,
+    DistantMeasure,
     TargetOriginPoint,
     TargetOriginSphere,
 )
@@ -88,7 +88,7 @@ class OneDimScene(Scene):
         for measure in self.measures:
             # Override ray target and origin if relevant
             # Likely deserves more polishing
-            if isinstance(measure, DistantRadianceMeasure):
+            if isinstance(measure, DistantMeasure):
                 if measure.target is None:
                     if self.atmosphere is not None:
                         toa = self.atmosphere.height()
@@ -98,16 +98,19 @@ class OneDimScene(Scene):
 
                     measure.target = TargetOriginPoint(target_point)
 
-                if measure.origin is None:
-                    radius = (
-                        self.atmosphere.height() / 100.0
-                        if self.atmosphere is not None
-                        else 1.0 * ucc.get("length")
-                    )
+                try:  # TODO: Revisit when new kernel interface will be available
+                    if measure.origin is None:
+                        radius = (
+                            self.atmosphere.height() / 100.0
+                            if self.atmosphere is not None
+                            else 1.0 * ucc.get("length")
+                        )
 
-                    measure.origin = TargetOriginSphere(
-                        center=measure.target.xyz, radius=radius
-                    )
+                        measure.origin = TargetOriginSphere(
+                            center=measure.target.xyz, radius=radius
+                        )
+                except AttributeError:
+                    pass
 
     def kernel_dict(self, ctx: Optional[KernelDictContext] = None) -> MutableMapping:
         result = KernelDict.new(ctx=ctx)

--- a/eradiate/solvers/onedim/_scene.py
+++ b/eradiate/solvers/onedim/_scene.py
@@ -12,7 +12,7 @@ from ...scenes.atmosphere import Atmosphere, AtmosphereFactory, HomogeneousAtmos
 from ...scenes.core import KernelDict
 from ...scenes.integrators import Integrator, IntegratorFactory, VolPathIntegrator
 from ...scenes.measure._distant import (
-    DistantMeasure,
+    DistantRadianceMeasure,
     TargetOriginPoint,
     TargetOriginSphere,
 )
@@ -88,7 +88,7 @@ class OneDimScene(Scene):
         for measure in self.measures:
             # Override ray target and origin if relevant
             # Likely deserves more polishing
-            if isinstance(measure, DistantMeasure):
+            if isinstance(measure, DistantRadianceMeasure):
                 if measure.target is None:
                     if self.atmosphere is not None:
                         toa = self.atmosphere.height()

--- a/eradiate/solvers/rami/_scene.py
+++ b/eradiate/solvers/rami/_scene.py
@@ -11,7 +11,7 @@ from ...exceptions import OverriddenValueWarning
 from ...scenes.biosphere import BiosphereFactory, Canopy
 from ...scenes.core import KernelDict
 from ...scenes.integrators import Integrator, IntegratorFactory, PathIntegrator
-from ...scenes.measure import DistantMeasure
+from ...scenes.measure import DistantRadianceMeasure
 from ...scenes.surface import LambertianSurface, Surface, SurfaceFactory
 
 
@@ -96,7 +96,7 @@ class RamiScene(Scene):
         # Process measures
         for measure in self.measures:
             # Override ray target location if relevant
-            if isinstance(measure, DistantMeasure):
+            if isinstance(measure, DistantRadianceMeasure):
                 if measure.target is None:
                     if self.canopy is not None:
                         measure.target = dict(

--- a/eradiate/solvers/rami/_scene.py
+++ b/eradiate/solvers/rami/_scene.py
@@ -1,5 +1,4 @@
 import warnings
-from typing import Optional
 
 import attr
 
@@ -11,7 +10,7 @@ from ...exceptions import OverriddenValueWarning
 from ...scenes.biosphere import BiosphereFactory, Canopy
 from ...scenes.core import KernelDict
 from ...scenes.integrators import Integrator, IntegratorFactory, PathIntegrator
-from ...scenes.measure import DistantRadianceMeasure
+from ...scenes.measure import DistantMeasure
 from ...scenes.surface import LambertianSurface, Surface, SurfaceFactory
 
 
@@ -96,7 +95,7 @@ class RamiScene(Scene):
         # Process measures
         for measure in self.measures:
             # Override ray target location if relevant
-            if isinstance(measure, DistantRadianceMeasure):
+            if isinstance(measure, DistantMeasure):
                 if measure.target is None:
                     if self.canopy is not None:
                         measure.target = dict(

--- a/eradiate/solvers/tests/test_onedim.py
+++ b/eradiate/solvers/tests/test_onedim.py
@@ -7,7 +7,7 @@ from eradiate import unit_registry as ureg
 from eradiate.contexts import KernelDictContext
 from eradiate.exceptions import ModeError
 from eradiate.scenes.atmosphere import HomogeneousAtmosphere
-from eradiate.scenes.measure._distant import DistantMeasure
+from eradiate.scenes.measure._distant import DistantRadianceMeasure
 from eradiate.solvers.onedim import OneDimScene, OneDimSolverApp
 
 
@@ -23,7 +23,7 @@ def test_onedim_scene(mode_mono):
     # Test non-trivial init sequence steps
 
     # -- Init with a single measure (not wrapped in a sequence)
-    s = OneDimScene(measures=DistantMeasure())
+    s = OneDimScene(measures=DistantRadianceMeasure())
     assert s.kernel_dict(ctx=ctx).load() is not None
     # -- Init from a dict-based measure spec
     # ---- Correctly wrapped in a sequence

--- a/eradiate/solvers/tests/test_rami.py
+++ b/eradiate/solvers/tests/test_rami.py
@@ -8,7 +8,7 @@ from eradiate import unit_registry as ureg
 from eradiate.contexts import KernelDictContext
 from eradiate.exceptions import ModeError
 from eradiate.scenes.biosphere import DiscreteCanopy
-from eradiate.scenes.measure import DistantMeasure
+from eradiate.scenes.measure import DistantRadianceMeasure
 from eradiate.solvers.rami import RamiScene, RamiSolverApp
 
 
@@ -22,7 +22,7 @@ def test_rami_scene(mode_mono):
     # Test non-trivial init sequence steps
 
     # -- Init with a single measure (not wrapped in a sequence)
-    s = RamiScene(measures=DistantMeasure())
+    s = RamiScene(measures=DistantRadianceMeasure())
     assert s.kernel_dict(ctx=ctx).load() is not None
     # -- Init from a dict-based measure spec
     # ---- Correctly wrapped in a sequence
@@ -57,7 +57,7 @@ def test_rami_scene(mode_mono):
             l_horizontal=10.0 * ureg.m,
             l_vertical=2.0 * ureg.m,
         ),
-        measures=DistantMeasure(),
+        measures=DistantRadianceMeasure(),
     )
     target = s.measures[0].target
     canopy = s.canopy

--- a/eradiate/tests/system/test_albedo.py
+++ b/eradiate/tests/system/test_albedo.py
@@ -32,87 +32,120 @@ def test_albedo(mode_mono):
     * Geometry: A Lambertian surface with linearly varying reflectance for
       0 to 1 between 500 and 700 nm.
     * Illumination: Directional illumination from the zenith (default irradiance).
-    * Atmosphere: No atmosphere.
+    * Atmosphere/canopy: No atmosphere nor canopy.
     * Measure: Distant albedo measure with a film of size 64 x 64. This
       guarantees reasonable stratification of the film sampling and ensures
       quick converge to the expected value, thus allowing for a low sample
       count.
 
+    The test is run for the ``OneDimSolverApp`` and ``RamiSolverApp`` classes.
+
     Expected behaviour
     ------------------
 
-    We expect the albedo is equal to the reflectance of the surface.
+    We expect the albedo to be equal to the reflectance of the surface.
 
     Results
     -------
 
-    .. image:: generated/plots/albedo.png
+    .. image:: generated/plots/albedo_onedim.png
+       :width: 100%
+
+    .. image:: generated/plots/albedo_rami.png
        :width: 100%
 
     """
-    app = eradiate.solvers.onedim.OneDimSolverApp(
-        scene={
-            "measures": [
-                {
-                    "type": "distant_albedo",
-                    "spectral_cfg": {
-                        "wavelengths": [500.0, 550.0, 600.0, 650.0, 700.0]
+    apps = {
+        "onedim": eradiate.solvers.onedim.OneDimSolverApp(
+            scene={
+                "measures": [
+                    {
+                        "type": "distant_albedo",
+                        "spectral_cfg": {
+                            "wavelengths": [500.0, 550.0, 600.0, 650.0, 700.0]
+                        },
+                        "film_resolution": (64, 64),
+                        "spp": 100,
+                    }
+                ],
+                "atmosphere": None,
+                "surface": {
+                    "type": "lambertian",
+                    "reflectance": {
+                        "type": "interpolated",
+                        "wavelengths": [500.0, 700.0],
+                        "values": [0.0, 1.0],
                     },
-                    "film_resolution": (64, 64),
-                    "spp": 100,
-                }
-            ],
-            "atmosphere": None,
-            "surface": {
-                "type": "lambertian",
-                "reflectance": {
-                    "type": "interpolated",
-                    "wavelengths": [500.0, 700.0],
-                    "values": [0.0, 1.0],
                 },
-            },
-            "illumination": {"type": "directional", "zenith": 0.0},
-        }
-    )
+                "illumination": {"type": "directional", "zenith": 0.0},
+            }
+        ),
+        "rami": eradiate.solvers.rami.RamiSolverApp(
+            scene={
+                "measures": [
+                    {
+                        "type": "distant_albedo",
+                        "spectral_cfg": {
+                            "wavelengths": [500.0, 550.0, 600.0, 650.0, 700.0]
+                        },
+                        "film_resolution": (64, 64),
+                        "spp": 100,
+                    }
+                ],
+                "canopy": None,
+                "surface": {
+                    "type": "lambertian",
+                    "reflectance": {
+                        "type": "interpolated",
+                        "wavelengths": [500.0, 700.0],
+                        "values": [0.0, 1.0],
+                    },
+                },
+                "illumination": {"type": "directional", "zenith": 0.0},
+            }
+        ),
+    }
 
-    # Run simulation
-    app.run()
-    results = app.results["measure"]
+    for app_name, app in apps.items():
+        # Run simulation
+        app.run()
+        results = app.results["measure"]
 
-    # Plot results
-    fig, [ax1, ax2] = plt.subplots(1, 2, figsize=(10, 5))
-    wavelengths = results["albedo"].w.values
-    albedos = results["albedo"].values.squeeze()
-    expected = np.array([0.0, 0.25, 0.5, 0.75, 1.0])
+        # Plot results
+        fig, [ax1, ax2] = plt.subplots(1, 2, figsize=(10, 5))
+        wavelengths = results["albedo"].w.values
+        albedos = results["albedo"].values.squeeze()
+        expected = np.array([0.0, 0.25, 0.5, 0.75, 1.0])
 
-    ax1.plot(wavelengths, albedos, linestyle="--", marker="o")
-    ax1.set_title("Albedo")
-    ax1.set_xlabel("Wavelength [nm]")
+        ax1.plot(wavelengths, albedos, linestyle="--", marker="o")
+        ax1.set_title("Albedo")
+        ax1.set_xlabel("Wavelength [nm]")
 
-    rdiffs = (albedos - expected) / expected
-    ax2.plot(wavelengths, rdiffs, linestyle="--", marker="o")
-    ax2.set_title("Relative difference")
-    ax2.set_xlabel("Wavelength [nm]")
-    rdiffs_max = np.max(np.abs(rdiffs[~np.isnan(rdiffs)]))
-    exp = np.ceil(np.log10(rdiffs_max))
-    ax2.set_xlim(ax1.get_xlim())
-    ax2.set_ylim([-(10 ** exp), 10 ** exp])
-    ax2.yaxis.set_label_position("right")
-    ax2.yaxis.tick_right()
-    ax2.ticklabel_format(axis="y", style="sci", scilimits=[-3, 3])
-    # Hide offset label and add it as axis label
-    if abs(exp) >= 3:
-        ax2.yaxis.offsetText.set_visible(False)
-        ax2.yaxis.set_label_text(f"×$10^{{{int(exp)}}}$")
+        rdiffs = (albedos - expected) / expected
+        ax2.plot(wavelengths, rdiffs, linestyle="--", marker="o")
+        ax2.set_title("Relative difference")
+        ax2.set_xlabel("Wavelength [nm]")
+        rdiffs_max = np.max(np.abs(rdiffs[~np.isnan(rdiffs)]))
+        exp = np.ceil(np.log10(rdiffs_max))
+        ax2.set_xlim(ax1.get_xlim())
+        ax2.set_ylim([-(10 ** exp), 10 ** exp])
+        ax2.yaxis.set_label_position("right")
+        ax2.yaxis.tick_right()
+        ax2.ticklabel_format(axis="y", style="sci", scilimits=[-3, 3])
+        # Hide offset label and add it as axis label
+        if abs(exp) >= 3:
+            ax2.yaxis.offsetText.set_visible(False)
+            ax2.yaxis.set_label_text(f"×$10^{{{int(exp)}}}$")
 
-    plt.tight_layout()
+        plt.suptitle(str(app.__class__.__name__))
+        plt.tight_layout()
 
-    filename = f"albedo.png"
-    ensure_output_dir(os.path.join(output_dir, "plots"))
-    fname_plot = os.path.join(output_dir, "plots", filename)
+        filename = f"albedo_{app_name}.png"
+        ensure_output_dir(os.path.join(output_dir, "plots"))
+        fname_plot = os.path.join(output_dir, "plots", filename)
 
-    fig.savefig(fname_plot, dpi=200)
-    plt.close()
+        fig.savefig(fname_plot, dpi=200)
+        plt.close()
 
-    # Check results
-    assert np.allclose(results["albedo"].values, expected, atol=1e-3)
+        # Check results
+        assert np.allclose(results["albedo"].values, expected, atol=1e-3)

--- a/eradiate/tests/system/test_albedo.py
+++ b/eradiate/tests/system/test_albedo.py
@@ -1,0 +1,119 @@
+import os
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+import eradiate
+from eradiate import unit_registry as ureg
+
+eradiate_dir = eradiate.config.dir
+output_dir = os.path.join(eradiate_dir, "test_report", "generated")
+
+
+def ensure_output_dir(path):
+    if not os.path.isdir(path):
+        os.makedirs(path)
+
+
+def test_albedo(mode_mono):
+    """
+    Albedo
+    ======
+
+    This system test verifies the behaviour of the apps capable of albedo
+    computation.
+
+    Rationale
+    ---------
+
+    We use a scene consisting of a single surface with a diffuse, spectrally
+    non-uniform BRDF.
+
+    * Geometry: A Lambertian surface with linearly varying reflectance for
+      0 to 1 between 500 and 700 nm. Surface width is set to 1 m.
+    * Illumination: Directional illumination from the zenith (default irradiance).
+    * Atmosphere: No atmosphere.
+    * Measure: Distant albedo measure with a film of size 64 x 64. This
+      guarantees reasonable stratification of the film sampling and ensures
+      quick converge to the expected value, thus allowing for a low sample
+      count.
+
+    Expected behaviour
+    ------------------
+
+    We expect the albedo is equal to the reflectance of the surface.
+
+    Results
+    -------
+
+    .. image:: generated/plots/albedo.png
+       :width: 100%
+
+    """
+    app = eradiate.solvers.onedim.OneDimSolverApp(
+        scene={
+            "measures": [
+                {
+                    "type": "distant_albedo",
+                    "spectral_cfg": {
+                        "wavelengths": [500.0, 550.0, 600.0, 650.0, 700.0]
+                    },
+                    "film_resolution": (64, 64),
+                    "spp": 100,
+                }
+            ],
+            "atmosphere": None,
+            "surface": {
+                "type": "lambertian",
+                "reflectance": {
+                    "type": "interpolated",
+                    "wavelengths": [500.0, 700.0],
+                    "values": [0.0, 1.0],
+                },
+                "width": 1.0 * ureg.m,
+            },
+            "illumination": {"type": "directional", "zenith": 0.0},
+        }
+    )
+
+    # Run simulation
+    app.run()
+    results = app.results["measure"]
+
+    # Plot results
+    fig, [ax1, ax2] = plt.subplots(1, 2, figsize=(10, 5))
+    wavelengths = results["albedo"].w.values
+    albedos = results["albedo"].values.squeeze()
+    expected = np.array([0.0, 0.25, 0.5, 0.75, 1.0])
+
+    ax1.plot(wavelengths, albedos, linestyle="--", marker="o")
+    ax1.set_title("Albedo")
+    ax1.set_xlabel("Wavelength [nm]")
+
+    rdiffs = (albedos - expected) / expected
+    ax2.plot(wavelengths, rdiffs, linestyle="--", marker="o")
+    ax2.set_title("Relative difference")
+    ax2.set_xlabel("Wavelength [nm]")
+    rdiffs_max = np.max(np.abs(rdiffs[~np.isnan(rdiffs)]))
+    exp = np.ceil(np.log10(rdiffs_max))
+    ax2.set_xlim(ax1.get_xlim())
+    ax2.set_ylim([-(10 ** exp), 10 ** exp])
+    ax2.yaxis.set_label_position("right")
+    ax2.yaxis.tick_right()
+    ax2.ticklabel_format(axis="y", style="sci", scilimits=[-3, 3])
+    # Hide offset label and add it as axis label
+    if abs(exp) >= 3:
+        ax2.yaxis.offsetText.set_visible(False)
+        ax2.yaxis.set_label_text(f"×$10^{{{int(exp)}}}$")
+
+    plt.tight_layout()
+
+    filename = f"albedo.png"
+    ensure_output_dir(os.path.join(output_dir, "plots"))
+    fname_plot = os.path.join(output_dir, "plots", filename)
+
+    fig.savefig(fname_plot, dpi=200)
+    plt.close()
+
+    # Check results
+    assert np.allclose(results["albedo"].values, expected, atol=1e-3)

--- a/eradiate/tests/system/test_albedo.py
+++ b/eradiate/tests/system/test_albedo.py
@@ -30,7 +30,7 @@ def test_albedo(mode_mono):
     non-uniform BRDF.
 
     * Geometry: A Lambertian surface with linearly varying reflectance for
-      0 to 1 between 500 and 700 nm. Surface width is set to 1 m.
+      0 to 1 between 500 and 700 nm.
     * Illumination: Directional illumination from the zenith (default irradiance).
     * Atmosphere: No atmosphere.
     * Measure: Distant albedo measure with a film of size 64 x 64. This
@@ -70,7 +70,6 @@ def test_albedo(mode_mono):
                     "wavelengths": [500.0, 700.0],
                     "values": [0.0, 1.0],
                 },
-                "width": 1.0 * ureg.m,
             },
             "illumination": {"type": "directional", "zenith": 0.0},
         }

--- a/eradiate/tests/system/test_basic.py
+++ b/eradiate/tests/system/test_basic.py
@@ -3,7 +3,6 @@
 import numpy as np
 import pytest
 
-from eradiate._util import onedict_value
 from eradiate.scenes.core import KernelDict
 from eradiate.solvers.core import runner
 


### PR DESCRIPTION
# Description

This PR adds support for distant exitant flux and albedo measures. It should make the implementation of DHR measures for the RAMI test case series much simpler. It leverages the new [`distantflux` kernel sensor](https://eradiate-kernel.readthedocs.io/en/latest/generated/plugins.html#distant-fluxmeter-sensor-distantflux). Changes are as follows:

- All distant measures now derive from a `DistantMeasure` parent class, which holds common attributes and post-processing pipeline steps.
- `DistantMeasure` is now `DistantRadianceMeasure`; its factory ID is now `distant_radiance`, `distant` is also still kept for compatibility.
- A new `DistantFluxMeasure` class has been introduced. It records the exitant flux (in W/m²/nm) w.r.t a reference surface set by its `direction` parameter. Film resolution can be used to stratify film sampling even when using an `independent` sampler; the default film size should produce a reasonably accurate result.
- A new `DistantAlbedoMeasure` class has been introduced. It derives from `DistantFlux` and adds an extra post-processing step which computes the albedo of the scene. As for the `DistantRadianceMeasure` line, each subclass only adds post-processing steps to its parent and can therefore also output what the parent can.
- Integration with our solver apps is taken care of.
- Origin control is not integrated yet. I'll take care of this soon but I'll first submit that code to Mitsuba 2.
- A system test checks than the measure behaves as intended.

@schunkes since this is a significant change to the RAMI workflow, I'd appreciate some feedback.

# To do

- [x] Make a decision on `DistantRadianceMeasure` factory keys
- [x] Update docstrings
- [x] Check integration with `RamiSolverApp`
- [x] Add origin control

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license

Note: The code actually generates a bunch of `DeprecationWarning` intentionally. These shall be fixed in the future.