### PR TITLE
Test report refactoring

### DIFF
--- a/test_report/conf.py
+++ b/test_report/conf.py
@@ -28,23 +28,23 @@ import sys
 
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 # source_suffix = ['.rst', '.md']
-source_suffix = '.rst'
+source_suffix = ".rst"
 
 # The encoding of source files.
 # source_encoding = 'utf-8-sig'
 
 # The master toctree document.
-master_doc = 'index'
+master_doc = "index"
 
 # General information about the project.
-project = 'Test report'
-copyright = '2020 The Eradiate Team'
-author = 'The Eradiate Team'
+project = "Test report"
+copyright = "2020--2021 The Eradiate Team"
+author = "The Eradiate Team"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -70,11 +70,17 @@ language = None
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['.build', 'generated', 'release.rst', 'section_bsdf.rst', 'section_emitter.rst']
+exclude_patterns = [
+    ".build",
+    "generated",
+    "release.rst",
+    "section_bsdf.rst",
+    "section_emitter.rst",
+]
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
-default_role = 'any'
+default_role = "any"
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
 # add_function_parentheses = True
@@ -99,134 +105,39 @@ default_role = 'any'
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
 
+extensions = ["sphinx_panels", "rst2pdf.pdfbuilder", "sphinx.ext.mathjax"]
+
 # -- Options for HTML output ----------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = "alabaster"
-# html_theme = "pydata_sphinx_theme"
-
-# Register the theme as an extension to generate a sitemap.xml
-extensions = ["alabaster", "rst2pdf.pdfbuilder"]
-extensions.append("sphinx.ext.mathjax")
-
-# Theme options are theme-specific and customize the look and feel of a theme
-# further.  For a list of options available for each theme, see the
-# documentation.
-html_theme_options = {
-    "page_width": "80em",
-    "logo": "eradiate-logo-dark-no_bg.png",
-    "font_family": "Roboto",
-    "head_font_family": "Roboto Slab",
-    "code_font_family": "Hack",
-}
-
-# Add any paths that contain custom themes here, relative to this directory.
-html_theme_path = []
-
-# The name for this set of Sphinx documents.  If None, it defaults to
-# "<project> v<release> documentation".
-# html_title = None
-
-# A shorter title for the navigation bar.  Default is the same as html_title.
-# html_short_title = None
-
-# The name of an image file (relative to this directory) to place at the top
-# of the sidebar.
-# html_logo = "images/eradiate-logo-dark-no_bg.png"
-
-# The name of an image file (within the static path) to use as favicon of the
-# docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
-# pixels large.
-# html_favicon = None
-
-# Add any paths that contain custom static files (such as style sheets) here,
-# relative to this directory. They are copied after the builtin static files,
-# so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static_html']
-
-# Add any extra paths that contain custom files (such as robots.txt or
-# .htaccess) here, relative to this directory. These files are copied
-# directly to the root of the documentation.
-# html_extra_path = []
-
-# If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
-# using the given strftime format.
-# html_last_updated_fmt = '%b %d, %Y'
-
-# Custom sidebar templates, maps document names to template names.
-# html_sidebars = {
-#      '**': ['navigation.html']
-# }
-
-# Additional templates that should be rendered to pages, maps page names to
-# template names.
-# html_additional_pages = {}
-
-# If false, no module index is generated.
-# html_domain_indices = True
-
-# If false, no index is generated.
-# html_use_index = True
-
-# If true, the index is split into individual pages for each letter.
-# html_split_index = False
+html_theme = "furo"
+html_static_path = ["_static_html"]
+html_logo = "_static_html/eradiate-logo-dark-no_bg.png"
+html_title = "Test report"
 
 # If true, links to the reST sources are added to the pages.
 html_show_sourcelink = False
 
-# If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
-# html_show_sphinx = True
-
-# If true, "(C) Copyright ..." is shown in the HTML footer. Default is True.
-# html_show_copyright = True
-
-# If true, an OpenSearch description file will be output, and all pages will
-# contain a <link> tag referring to it.  The value of this option must be the
-# base URL from which the finished HTML is served.
-# html_use_opensearch = ''
-
-# This is the file name suffix for HTML files (e.g. ".xhtml").
-# html_file_suffix = None
-
-# Language to be used for generating the HTML full-text search index.
-# Sphinx supports the following languages:
-#   'da', 'de', 'en', 'es', 'fi', 'fr', 'h', 'it', 'ja'
-#   'nl', 'no', 'pt', 'ro', 'r', 'sv', 'tr'
-# html_search_language = 'en'
-
-# A dictionary with options for the search language support, empty by default.
-# Now only 'ja' uses this config value
-# html_search_options = {'type': 'default'}
-
-# The name of a javascript file (relative to the configuration directory) that
-# implements a search results scorer. If empty, the default will be used.
-# html_search_scorer = 'scorer.js'
-
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'eradiate_testreport'
+htmlhelp_basename = "eradiate_testreport"
 
 # -- Options for LaTeX output ---------------------------------------------
 
 latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').
     "papersize": "a4paper",
-
     "classoptions": ",oneside",
-
     # The font size ("10pt", "11pt" or "12pt").
     "pointsize": "10pt",
-
     # Fonts
     "fontpkg": r"""
         \setmainfont{Charis SIL}[Scale=.98]
         \setsansfont{Source Sans Pro}[Scale=MatchLowercase]
         \setmonofont{Hack}[Scale=MatchLowercase]
     """,
-
     # Additional stuff for the LaTeX preamble.
     "preamble": "",
-
     # Latex figure (float) alignment
     # 'figure_align': 'htbp',
 }
@@ -243,7 +154,7 @@ latex_engine = "xelatex"
 
 # The name of an image file (relative to this directory) to place at the top of
 # the title page.
-latex_logo = '_static_html/eradiate-logo-dark-no_bg.png'
+latex_logo = "_static_html/eradiate-logo-dark-no_bg.png"
 
 # For "manual" documents, if this is true, then toplevel headings are parts,
 # not chapters.
@@ -266,10 +177,7 @@ latex_logo = '_static_html/eradiate-logo-dark-no_bg.png'
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [
-    (master_doc, 'eradiate', 'Eradiate Test Report',
-     [author], 1)
-]
+man_pages = [(master_doc, "eradiate", "Eradiate Test Report", [author], 1)]
 
 # If true, show URL addresses after external links.
 # man_show_urls = False
@@ -281,9 +189,15 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'eradiate', 'Eradiate Test Report',
-     author, 'eradiate', 'One line description of project.',
-     'Miscellaneous'),
+    (
+        master_doc,
+        "eradiate",
+        "Eradiate Test Report",
+        author,
+        "eradiate",
+        "One line description of project.",
+        "Miscellaneous",
+    ),
 ]
 
 # Documents to append as an appendix to all manuals.
@@ -298,10 +212,10 @@ texinfo_documents = [
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 # texinfo_no_detailmenu = False
 
-primary_domain = 'cpp'
-highlight_language = 'cpp'
+primary_domain = "cpp"
+highlight_language = "cpp"
 
-build_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'generated')
+build_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "generated")
 
 
 def generate_unittest_summary(app):
@@ -325,5 +239,5 @@ def parse_test_spec(app):
 def setup(app):
     app.connect("builder-inited", generate_unittest_summary)
     app.connect("builder-inited", parse_test_spec)
-    app.add_css_file('theme_overrides.css')
-    app.add_css_file('custom.css')
+    app.add_css_file("theme_overrides.css")
+    app.add_css_file("custom.css")


### PR DESCRIPTION
# Description

This PR greatly improves the look and feel of the test report. Changes are as follows:

* The generating code was refactored to eliminate duplicates.
* A dropdown-based report output specific to HTML was added.
* The list-based report code was cleaned up and its output fixed.
* The theme was changed to Furo (features a navbar to the right-hand side).

This introduces the following dependencies:

* [sphinx-panels](https://sphinx-panels.readthedocs.io) (already a dependency of the Eradiate docs)
* [Furo](https://pradyunsg.me/furo/) (not included with Eradiate)

The new Furo req won't be added to our dependency list since this piece of code should eventually become an external tool.

**Selected screenshots:**

![Screenshot 2021-06-24 at 17 12 48](https://user-images.githubusercontent.com/34740232/123288059-83f48d00-d50f-11eb-9f41-0c66692791eb.png)

![Screenshot 2021-06-24 at 17 13 12](https://user-images.githubusercontent.com/34740232/123288074-86ef7d80-d50f-11eb-8e26-68879c95ca53.png)


@schunkes can you please check if everything is fine?

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
