### PR TITLE
Add python version parameter for the docker images

### DIFF
--- a/docker/eradiate-base/Dockerfile
+++ b/docker/eradiate-base/Dockerfile
@@ -3,6 +3,8 @@ ARG BASE_IMAGE_VERSION
 
 FROM ${BASE_IMAGE}:${BASE_IMAGE_VERSION}
 
+ARG PYTHON_VERSION=3.9.5
+
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
 
 # hadolint ignore=DL3008
@@ -42,7 +44,7 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-${CONDA_VERSION}
     find /opt/conda/ -follow -type f -name '*.js.map' -delete && \
     /opt/conda/bin/conda clean -afy
 
-RUN conda create --name docker
+RUN conda create --name docker python=${PYTHON_VERSION}
 ENV PATH /opt/conda/envs/docker/bin:$PATH
 
 SHELL ["conda", "run", "-n", "docker", "/bin/bash", "-c"]


### PR DESCRIPTION
# Description

Allow to change the Python version of the conda environment for Eradiate.
Default to 3.9.5

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
