### PR TITLE
New heterogeneous atmosphere design

### DIFF
--- a/docs/rst/reference/scenes.rst
+++ b/docs/rst/reference/scenes.rst
@@ -40,6 +40,8 @@ Atmosphere [eradiate.scenes.atmosphere]
 
    HomogeneousAtmosphere
    HeterogeneousAtmosphere
+   HeterogeneousNewAtmosphere
+   MolecularAtmosphere
    ParticleLayer
 
 **Particle distribution**

--- a/eradiate/contexts.py
+++ b/eradiate/contexts.py
@@ -253,9 +253,9 @@ class KernelDictContext:
         default="True",
     )
 
-    override_surface_width: Optional[pint.Quantity] = documented(
+    override_scene_width: Optional[pint.Quantity] = documented(
         pinttr.ib(default=None, units=ucc.deferred("length")),
-        doc="If relevant, value which must be used as the surface width "
+        doc="If relevant, value which must be used as the scene width "
         "(*e.g.* when surface size must match atmosphere or canopy size).\n"
         "\n"
         "Unit-enabled field (default: cdu[length]).",

--- a/eradiate/scenes/atmosphere/__init__.py
+++ b/eradiate/scenes/atmosphere/__init__.py
@@ -1,13 +1,17 @@
 from ._core import Atmosphere, atmosphere_factory
 from ._heterogeneous import HeterogeneousAtmosphere
+from ._heterogeneous_new import HeterogeneousNewAtmosphere
 from ._homogeneous import HomogeneousAtmosphere
+from ._molecules import MolecularAtmosphere
 from ._particle_dist import ParticleDistribution, particle_distribution_factory
 from ._particles import ParticleLayer
 
 __all__ = [
     "Atmosphere",
     "HeterogeneousAtmosphere",
+    "HeterogeneousNewAtmosphere",
     "HomogeneousAtmosphere",
+    "MolecularAtmosphere",
     "atmosphere_factory",
     "particle_distribution_factory",
     "ParticleDistribution",

--- a/eradiate/scenes/atmosphere/_core.py
+++ b/eradiate/scenes/atmosphere/_core.py
@@ -14,7 +14,6 @@ from ... import converters, validators
 from ..._factory import Factory
 from ...attrs import AUTO, documented, get_doc, parse_docs
 from ...contexts import KernelDictContext
-from ...units import to_quantity
 from ...units import unit_context_config as ucc
 
 atmosphere_factory = Factory()

--- a/eradiate/scenes/atmosphere/_heterogeneous.py
+++ b/eradiate/scenes/atmosphere/_heterogeneous.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import tempfile
 from pathlib import Path
 from typing import MutableMapping, Optional

--- a/eradiate/scenes/atmosphere/_heterogeneous_new.py
+++ b/eradiate/scenes/atmosphere/_heterogeneous_new.py
@@ -1,0 +1,356 @@
+"""
+Heterogeneous atmospheres.
+"""
+from typing import List, MutableMapping, Optional, Tuple
+
+import attr
+import numpy as np
+import pint
+import xarray as xr
+
+from ._core import Atmosphere, atmosphere_factory, write_binary_grid3d
+from ._molecules import MolecularAtmosphere
+from ._particles import ParticleLayer
+from ...attrs import AUTO, documented, parse_docs
+from ...contexts import KernelDictContext
+from ...units import to_quantity
+from ...units import unit_registry as ureg
+
+
+@atmosphere_factory.register(type_id="heterogeneous_new")
+@parse_docs
+@attr.s
+class HeterogeneousNewAtmosphere(Atmosphere):
+    """
+    Heterogeneous atmosphere scene element [``heterogeneous_new``].
+    """
+
+    molecular_atmosphere: Optional[MolecularAtmosphere] = documented(
+        attr.ib(
+            default=None,
+            converter=attr.converters.optional(atmosphere_factory.convert),
+            validator=attr.validators.optional(
+                attr.validators.instance_of(MolecularAtmosphere)
+            ),
+        ),
+        doc="Molecular atmosphere.",
+        type=":class:`.MolecularAtmosphere` or None",
+        default="None",
+    )
+
+    particle_layers: List[ParticleLayer] = documented(
+        attr.ib(
+            factory=list,
+            converter=lambda value: [
+                ParticleLayer.convert(element) for element in value
+            ],
+            validator=attr.validators.deep_iterable(
+                attr.validators.instance_of(ParticleLayer)
+            ),
+        ),
+        doc="Particle layers.",
+        type="list[:class:`.ParticleLayer`]",
+        default="[]",
+    )
+
+    @molecular_atmosphere.validator
+    @particle_layers.validator
+    def _validate_ids(instance, attribute, value) -> None:
+        ids = set()
+
+        for component in instance.components:
+            if not component.id in ids:
+                ids.add(component.id)
+            else:
+                raise ValueError(
+                    f"while validating {attribute.name}: found duplicate component ID '{component.id}'; "
+                    f"all components (molecular atmosphere and particle layers) must have different IDs"
+                )
+
+    @molecular_atmosphere.validator
+    @particle_layers.validator
+    def _validate_widths(instance, attribute, value) -> None:
+        if not all([component.width is AUTO for component in instance.components]):
+            raise ValueError(
+                "all components must have their 'width' attribute set to 'AUTO'"
+            )
+
+    @property
+    def components(self):
+        result = [self.molecular_atmosphere] if self.molecular_atmosphere else []
+        result.extend(self.particle_layers)
+        return result
+
+    # --------------------------------------------------------------------------
+    #              Spatial extension and thermophysical properties
+    # --------------------------------------------------------------------------
+
+    @property
+    def bottom(self) -> pint.Quantity:
+        bottoms = [component.bottom for component in self.components]
+        if bottoms:
+            return min(bottoms)
+        else:
+            return 0.0 * ureg.km
+
+    @property
+    def top(self) -> pint.Quantity:
+        tops = [component.top for component in self.components]
+        if tops:
+            return max(tops)
+        else:
+            return 10.0 * ureg.km
+
+    def eval_width(self, ctx: Optional[KernelDictContext]) -> pint.Quantity:
+        widths = [component.eval_width(ctx=ctx) for component in self.components]
+
+        if widths:
+            return max(widths)
+        else:
+            return 1000.0 * ureg.km
+
+    # --------------------------------------------------------------------------
+    #                       Kernel dictionary generation
+    # --------------------------------------------------------------------------
+
+    def kernel_phase(self, ctx: Optional[KernelDictContext]) -> MutableMapping:
+        """
+        .. note::
+           One phase plugin specification per component (molecular atmosphere and
+           particle layers) is generated.
+           For example, if there are one molecular atmosphere and two particle
+           layers, the returned kernel dictionary has three entries.
+        """
+        phases = {}
+
+        if self.molecular_atmosphere is not None:
+            phases.update(self.molecular_atmosphere.kernel_phase(ctx=ctx))
+
+            # TODO: add support for overlapping layers
+            if self.particle_layers is not None:
+                for particle_layer in self.particle_layers:
+                    # blend molecular atmosphere with particle layer
+                    _, ratios = blend_radprops(
+                        background=self.molecular_atmosphere.eval_radprops(
+                            spectral_ctx=ctx.spectral_ctx
+                        ),
+                        foreground=particle_layer.eval_radprops(
+                            spectral_ctx=ctx.spectral_ctx
+                        ),
+                    )
+                    # write the weight volume data file
+                    write_binary_grid3d(
+                        filename=particle_layer.weight_file,
+                        values=ratios.values[np.newaxis, np.newaxis, ...],
+                    )
+                    phases.update(
+                        {
+                            f"phase_{particle_layer.id}": {
+                                "type": "blendphase",
+                                "weight": {
+                                    "type": "gridvolume",
+                                    "filename": str(particle_layer.weight_file),
+                                    "to_world": particle_layer._gridvolume_to_world_trafo(
+                                        ctx=ctx
+                                    ),
+                                },
+                                **self.molecular_atmosphere.kernel_phase(ctx=ctx),
+                                **particle_layer.kernel_phase(ctx=ctx),
+                            }
+                        }
+                    )
+        else:
+            if self.particle_layers is not None:
+                # TODO: add support for overlapping layers
+                for particle_layer in self.particle_layers:
+                    phases.update(**particle_layer.kernel_phase(ctx=ctx))
+
+        return phases
+
+    def kernel_media(self, ctx: Optional[KernelDictContext]) -> MutableMapping:
+        """
+        .. note::
+           One media plugin specification per component (molecular atmosphere and
+           particle layers) is generated.
+           For example, if there are one molecular atmosphere and two particle
+           layers, the returned kernel dictionary has three entries.
+        """
+        media = {}
+
+        if self.molecular_atmosphere is not None:
+            # override componments' widths
+            ctx.override_scene_width = self.eval_width(ctx=ctx)
+
+            media.update(self.molecular_atmosphere.kernel_media(ctx=ctx))
+
+            if not ctx.ref:
+                phases = self.kernel_phase(ctx=ctx)
+
+            # TODO: add support for overlapping layers
+            if self.particle_layers is not None:
+                for particle_layer in self.particle_layers:
+                    # blend molecular atmosphere with particle layer
+                    radprops, _ = blend_radprops(
+                        background=self.molecular_atmosphere.eval_radprops(
+                            spectral_ctx=ctx.spectral_ctx
+                        ),
+                        foreground=particle_layer.eval_radprops(
+                            spectral_ctx=ctx.spectral_ctx
+                        ),
+                    )
+                    # write the albedo volume data file
+                    write_binary_grid3d(
+                        filename=particle_layer.albedo_file,
+                        values=radprops.albedo.values[np.newaxis, np.newaxis, ...],
+                    )
+                    # write the sigma_t volume data file
+                    write_binary_grid3d(
+                        filename=particle_layer.sigma_t_file,
+                        values=radprops.sigma_t.values[np.newaxis, np.newaxis, ...],
+                    )
+                    trafo = particle_layer._gridvolume_to_world_trafo(ctx=ctx)
+                    if ctx.ref:
+                        phase = {"type": "ref", "id": f"phase_{particle_layer.id}"}
+                    else:
+                        phase = phases[f"phase_{particle_layer.id}"]
+                    media.update(
+                        {
+                            f"medium_{particle_layer.id}": {
+                                "type": "heterogeneous",
+                                "phase": phase,
+                                "sigma_t": {
+                                    "type": "gridvolume",
+                                    "filename": str(particle_layer.sigma_t_file),
+                                    "to_world": trafo,
+                                },
+                                "albedo": {
+                                    "type": "gridvolume",
+                                    "filename": str(particle_layer.albedo_file),
+                                    "to_world": trafo,
+                                },
+                            }
+                        }
+                    )
+        else:
+            if self.particle_layers is not None:
+                # TODO: add support for overlapping layers
+                for particle_layer in self.particle_layers:
+                    media.update(**particle_layer.kernel_media(ctx=ctx))
+
+        return media
+
+    def kernel_shapes(self, ctx: Optional[KernelDictContext]) -> MutableMapping:
+        """
+        .. note::
+           One shape plugin specification per component (molecular atmosphere and
+           particle layers) is generated.
+           For example, if there are one molecular atmosphere and two particle
+           layers, the returned kernel dictionary has three entries.
+        """
+        shapes = {}
+
+        # override componments' widths
+        ctx.override_scene_width = self.eval_width(ctx=ctx)
+
+        if self.molecular_atmosphere is not None:
+            shapes.update(self.molecular_atmosphere.kernel_shapes(ctx=ctx))
+
+        if self.particle_layers is not None:
+            for particle_layer in self.particle_layers:
+                shapes.update(particle_layer.kernel_shapes(ctx=ctx))
+
+        return shapes
+
+
+def blend_radprops(
+    background: xr.Dataset, foreground: xr.Dataset
+) -> Tuple[xr.Dataset, xr.DataArray]:
+    """
+    Blend radiative properties of two participating media.
+
+    .. note::
+       Assumes 'z_layer' is in same units in 'molecules' and in 'particles'.
+
+    Returns → Tuple[:class:`~xarray.Dataset`, :class:`~xarray.DataArray`]:
+        Radiative properties resulting from the blending of the two participating
+        media, in the altitude range of the foreground participating medium.
+    """
+    background = interpolate_radprops(
+        radprops=background, new_z_layer=to_quantity(foreground.z_layer)
+    )
+    blend_sigma_t = background.sigma_t + foreground.sigma_t
+    background_ratio = xr.where(
+        blend_sigma_t != 0.0, background.sigma_t / blend_sigma_t, 0.5
+    )  # broadcast 0.5
+    foreground_ratio = xr.where(
+        blend_sigma_t != 0.0, foreground.sigma_t / blend_sigma_t, 0.5
+    )  # broadcast 0.5
+    blend_albedo = (
+        background.albedo * background_ratio + foreground.albedo * foreground_ratio
+    )
+    blended_radprops = xr.Dataset(
+        data_vars={"sigma_t": blend_sigma_t, "albedo": blend_albedo}
+    )
+    return (blended_radprops, foreground_ratio)
+
+
+def interpolate_radprops(
+    radprops: xr.Dataset, new_z_layer: pint.Quantity
+) -> xr.Dataset:
+    """
+    Interpolate a radiative property data set onto a new level altitude grid.
+
+    Out of bounds values are replaced with zeros.
+
+    Parameter ``radprops`` (:class:`~xarray.Dataset`):
+        Radiative property data set.
+
+    Parameter ``new_z_layer`` (:class:`~pint.Quantity`):
+        Layer altitude grid to interpolate onto.
+
+    Returns → :class:`~xarray.Dataset`:
+        Interpolated radiative propery data set.
+    """
+    mask = (new_z_layer >= to_quantity(radprops.z_level).min()) & (
+        new_z_layer <= to_quantity(radprops.z_level).max()
+    )
+    masked = new_z_layer[mask]  # altitudes that fall within the bounds of radprops
+
+    # interpolate within radprops altitude bounds (safe)
+    interpolated_safe = radprops.interp(
+        z_layer=masked.m_as(radprops.z_layer.units),
+        kwargs=dict(fill_value="extrapolate"),  # handle floating point arithmetic issue
+        method="nearest",  # radiative properties are assumed uniform in altitude layers
+    )
+
+    # interpolate over the full range
+    interpolated = interpolated_safe.interp(
+        z_layer=new_z_layer.m_as(radprops.z_layer.units),
+        kwargs=dict(fill_value=0.0),
+        method="nearest",
+    )
+
+    return interpolated
+
+
+def overlapping(
+    particle_layers: List[ParticleLayer], particle_layer: ParticleLayer
+) -> List[ParticleLayer]:
+    """
+    Return the particle layers that are overlapping a given particle layer.
+
+    Parameter ``particle_layers`` (list[:class:`.ParticleLayer`]):
+        List of particle layers to check for overlap.
+
+    Parameter ``particle_layer`` (:class:`.ParticleLayer`):
+        The given particle layer.
+
+    Returns → list[:class:`.ParticleLayer`]:
+        Overlapping particle layers.
+    """
+    return [
+        layer
+        for layer in particle_layers
+        if particle_layer.top >= layer.top > particle_layer.bottom
+        or particle_layer.top > layer.bottom >= particle_layer.bottom
+    ]

--- a/eradiate/scenes/atmosphere/_molecules.py
+++ b/eradiate/scenes/atmosphere/_molecules.py
@@ -1,0 +1,438 @@
+"""
+Molecular atmospheres.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import tempfile
+from typing import MutableMapping, Optional
+
+import attr
+import numpy as np
+import pint
+import xarray as xr
+
+from ._core import Atmosphere, atmosphere_factory, write_binary_grid3d
+from ..phase import PhaseFunction, RayleighPhaseFunction, phase_function_factory
+from ..._util import onedict_value
+from ...attrs import AUTO, documented, parse_docs
+from ...contexts import KernelDictContext, SpectralContext
+from ...kernel.transform import map_cube, map_unit_cube
+from ...radprops.rad_profile import AFGL1986RadProfile, RadProfile, US76ApproxRadProfile
+from ...thermoprops import afgl1986, us76
+from ...thermoprops.util import (
+    compute_scaling_factors,
+    interpolate,
+    rescale_concentration,
+)
+from ...units import to_quantity
+from ...units import unit_context_kernel as uck
+from ...units import unit_registry as ureg
+
+
+@atmosphere_factory.register(
+    type_id="molecular_atmosphere", dict_constructor="afgl1986"
+)
+@parse_docs
+@attr.s
+class MolecularAtmosphere(Atmosphere):
+    """
+    Molecular atmosphere.
+
+    .. admonition:: Class method constructors
+
+       .. autosummary::
+
+          afgl1986
+          ussa1976
+    """
+
+    _thermoprops: xr.Dataset = documented(
+        attr.ib(
+            factory=us76.make_profile,
+            validator=attr.validators.instance_of(xr.Dataset),
+        ),
+        doc="Thermophysical properties.",
+        type=":class:`~xarray.Dataset`",
+    )
+
+    phase: PhaseFunction = documented(
+        attr.ib(
+            factory=lambda: RayleighPhaseFunction(),
+            converter=phase_function_factory.convert,
+            validator=attr.validators.instance_of(PhaseFunction),
+        )
+    )
+
+    has_absorption: bool = documented(
+        attr.ib(
+            default=True,
+            converter=bool,
+            validator=attr.validators.instance_of(bool),
+        ),
+        doc="Absorption switch. If ``True``, the absorption coefficient is "
+        "computed. Else, the absorption coefficient is not computed and "
+        "instead set to zero.",
+        type="bool",
+        default="True",
+    )
+
+    has_scattering: bool = documented(
+        attr.ib(
+            default=True,
+            converter=bool,
+            validator=attr.validators.instance_of(bool),
+        ),
+        doc="Scattering switch. If ``True``, the scattering coefficient is "
+        "computed. Else, the scattering coefficient is not computed and "
+        "instead set to zero.",
+        type="bool",
+        default="True",
+    )
+
+    absorption_data_sets: Optional[MutableMapping[str, str]] = documented(
+        attr.ib(
+            default=None,
+            converter=attr.converters.optional(dict),
+            validator=attr.validators.optional(attr.validators.instance_of(dict)),
+        ),
+        doc="Mapping of species and absorption data set files paths. If "
+        "``None``, the default absorption data sets are used to compute "
+        "the absorption coefficient. If not ``None``, the absorption data "
+        "set files whose paths are provided in the mapping will be used to "
+        "compute the absorption coefficient. If the mapping does not "
+        "include all species from the atmospheric "
+        "thermophysical profile, the default data sets will be used to "
+        "compute the absorption coefficient of the corresponding species.",
+        type="dict",
+    )
+
+    albedo_filename: str = documented(
+        attr.ib(
+            default="albedo.vol",
+            converter=str,
+            validator=attr.validators.instance_of(str),
+        ),
+        doc="Name of the albedo volume data file.",
+        type="str",
+        default='"albedo.vol"',
+    )
+
+    sigma_t_filename: str = documented(
+        attr.ib(
+            default="sigma_t.vol",
+            converter=str,
+            validator=attr.validators.instance_of(str),
+        ),
+        doc="Name of the extinction coefficient volume data file.",
+        type="str",
+        default='"sigma_t.vol"',
+    )
+
+    cache_dir: pathlib.Path = documented(
+        attr.ib(
+            default=pathlib.Path(tempfile.mkdtemp()),
+            converter=pathlib.Path,
+            validator=attr.validators.instance_of(pathlib.Path),
+        ),
+        doc="Path to a cache directory where volume data files will be created.",
+        type="path-like",
+        default="Temporary directory",
+    )
+
+    def __attrs_post_init__(self) -> None:
+        # Prepare cache directory in case we'd need it
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+
+        self.update()
+
+    def update(self) -> None:
+        self.phase.id = f"phase_{self.id}"
+
+    # --------------------------------------------------------------------------
+    #              Spatial extension and thermophysical properties
+    # --------------------------------------------------------------------------
+
+    @property
+    def bottom(self) -> pint.Quantity:
+        return to_quantity(self.thermoprops.z_level).min()
+
+    @property
+    def top(self) -> pint.Quantity:
+        return to_quantity(self.thermoprops.z_level).max()
+
+    @property
+    def thermoprops(self) -> xr.Dataset:
+        return self._thermoprops
+
+    def eval_width(self, ctx: Optional[KernelDictContext] = None) -> pint.Quantity:
+        if self.width is AUTO:
+            spectral_ctx = ctx.spectral_ctx if ctx is not None else None
+            min_sigma_s = self.radprops_profile.eval_sigma_s(spectral_ctx).min()
+
+            if min_sigma_s <= 0.0:
+                raise ValueError(
+                    "cannot compute width automatically when scattering "
+                    "coefficient reaches zero"
+                )
+
+            return min(10.0 / min_sigma_s, ureg.Quantity(1e3, "km"))
+        else:
+            return self.width
+
+    # --------------------------------------------------------------------------
+    #                             Radiative properties
+    # --------------------------------------------------------------------------
+
+    @property
+    def radprops_profile(self) -> RadProfile:
+        if self.thermoprops.title == "U.S. Standard Atmosphere 1976":
+            if self.absorption_data_sets is not None:
+                absorption_data_set = self.absorption_data_sets["us76_u86_4"]
+            else:
+                absorption_data_set = None
+            return US76ApproxRadProfile(
+                thermoprops=self.thermoprops,
+                has_scattering=self.has_scattering,
+                has_absorption=self.has_absorption,
+                absorption_data_set=absorption_data_set,
+            )
+        elif "AFGL (1986)" in self.thermoprops.title:
+            return AFGL1986RadProfile(
+                thermoprops=self.thermoprops,
+                has_scattering=self.has_scattering,
+                has_absorption=self.has_absorption,
+                absorption_data_sets=self.absorption_data_sets,
+            )
+        else:
+            raise NotImplementedError("Unsupported thermophysical properties data set.")
+
+    def eval_radprops(self, spectral_ctx: SpectralContext) -> xr.Dataset:
+        """
+        Evaluates the molecular atmosphere's radiative properties.
+
+        Parameter ``spectral_ctx`` (:class:`SpectralContext`):
+            Spectral context.
+
+        Returns → :class:`~xarray.Dataset`:
+            Radiative properties dataset.
+        """
+        return self.radprops_profile.to_dataset(spectral_ctx=spectral_ctx)
+
+    # --------------------------------------------------------------------------
+    #                             Kernel dictionary
+    # --------------------------------------------------------------------------
+
+    @property
+    def albedo_file(self) -> pathlib.Path:
+        return self.cache_dir / self.albedo_filename
+
+    @property
+    def sigma_t_file(self) -> pathlib.Path:
+        return self.cache_dir / self.sigma_t_filename
+
+    def kernel_phase(self, ctx: Optional[KernelDictContext] = None) -> MutableMapping:
+        return self.phase.kernel_dict(ctx=ctx)
+
+    def kernel_media(self, ctx: KernelDictContext) -> MutableMapping:
+        length_units = uck.get("length")
+        width = self.kernel_width(ctx).m_as(length_units)
+        top = self.top.m_as(length_units)
+        bottom = self.bottom.m_as(length_units)
+        trafo = map_unit_cube(
+            xmin=-width / 2.0,
+            xmax=width / 2.0,
+            ymin=-width / 2.0,
+            ymax=width / 2.0,
+            zmin=bottom,
+            zmax=top,
+        )
+
+        radprops = self.radprops_profile.to_dataset(spectral_ctx=ctx.spectral_ctx)
+        albedo = to_quantity(radprops.albedo).m_as(uck.get("albedo"))
+        sigma_t = to_quantity(radprops.sigma_t).m_as(uck.get("collision_coefficient"))
+        write_binary_grid3d(
+            filename=str(self.albedo_file), values=albedo[np.newaxis, np.newaxis, ...]
+        )
+        write_binary_grid3d(
+            filename=str(self.sigma_t_file), values=sigma_t[np.newaxis, np.newaxis, ...]
+        )
+        if ctx.ref:
+            phase = {"type": "ref", "id": f"phase_{self.id}"}
+        else:
+            phase = onedict_value(self.kernel_phase(ctx=ctx))
+        return {
+            f"medium_{self.id}": {
+                "type": "heterogeneous",
+                "phase": phase,
+                "albedo": {
+                    "type": "gridvolume",
+                    "filename": str(self.albedo_file),
+                    "to_world": trafo,
+                },
+                "sigma_t": {
+                    "type": "gridvolume",
+                    "filename": str(self.sigma_t_file),
+                    "to_world": trafo,
+                },
+            }
+        }
+
+    def kernel_shapes(self, ctx: KernelDictContext) -> MutableMapping:
+        if ctx.ref:
+            medium = {"type": "ref", "id": f"medium_{self.id}"}
+        else:
+            medium = self.kernel_media(ctx=None)[f"medium_{self.id}"]
+
+        length_units = uck.get("length")
+        width = self.kernel_width(ctx).m_as(length_units)
+        bottom = self.bottom.m_as(length_units)
+        top = self.top.m_as(length_units)
+        offset = self.kernel_offset(ctx).m_as(length_units)
+        trafo = map_cube(
+            xmin=-width / 2.0,
+            xmax=width / 2.0,
+            ymin=-width / 2.0,
+            ymax=width / 2.0,
+            zmin=bottom - offset,
+            zmax=top,
+        )
+
+        return {
+            f"shape_{self.id}": {
+                "type": "cube",
+                "to_world": trafo,
+                "bsdf": {"type": "null"},
+                "interior": medium,
+            }
+        }
+
+    # --------------------------------------------------------------------------
+    #                               Constructors
+    # --------------------------------------------------------------------------
+
+    @classmethod
+    def afgl1986(
+        cls: MolecularAtmosphere,
+        model: str = "us_standard",
+        levels: Optional[pint.Quantity] = None,
+        concentrations: Optional[MutableMapping[str, pint.Quantity]] = None,
+        **kwargs: MutableMapping[str],
+    ) -> MolecularAtmosphere:
+        """
+        Molecular atmosphere based on the AFGL (1986) atmospheric
+        thermophysical properties profiles
+        :cite:`Anderson1986AtmosphericConstituentProfiles`.
+
+        :cite:`Anderson1986AtmosphericConstituentProfiles` defines six models,
+        listed in the table below.
+
+        .. list-table:: AFGL (1986) atmospheric thermophysical properties profiles models
+           :widths: 2 4 4
+           :header-rows: 1
+
+           * - Model number
+             - Model identifier
+             - Model name
+           * - 1
+             - ``tropical``
+             - Tropic (15N Annual Average)
+           * - 2
+             - ``midlatitude_summer``
+             - Mid-Latitude Summer (45N July)
+           * - 3
+             - ``midlatitude_winter``
+             - Mid-Latitude Winter (45N Jan)
+           * - 4
+             - ``subarctic_summer``
+             - Sub-Arctic Summer (60N July)
+           * - 5
+             - ``subarctic_winter``
+             - Sub-Arctic Winter (60N Jan)
+           * - 6
+             - ``us_standard``
+             - U.S. Standard (1976)
+
+        .. attention::
+
+            The original altitude mesh specified by
+            :cite:`Anderson1986AtmosphericConstituentProfiles` is a piece-wise
+            regular altitude mesh with an altitude step of 1 km from 0 to 25 km,
+            2.5 km from 25 km to 50 km and 5 km from 50 km to 120 km.
+            Since the Eradiate kernel only supports regular altitude mesh, the
+            original atmospheric thermophysical properties profiles were
+            interpolated on the regular altitude mesh with an altitude step of 1 km
+            from 0 to 120 km.
+
+        Although the altitude meshes of the interpolated
+        :cite:`Anderson1986AtmosphericConstituentProfiles` profiles is fixed,
+        this class lets you define a custom altitude mesh (regular or
+        irregular).
+
+        All six models include the following six absorbing molecular species:
+        H2O, CO2, O3, N2O, CO, CH4 and O2.
+        The concentrations of these species in the atmosphere is fixed by
+        :cite:`Anderson1986AtmosphericConstituentProfiles`.
+        However, this class allows you to rescale the concentrations of each
+        individual molecular species to custom concentration values.
+        Custom concentrations can be provided in different units.
+
+        Parameter ``model`` (str):
+            AFGL (1986) model identifier.
+
+        Parameter ``levels`` (:class:`pint.Quantity`):
+            Altitude levels.
+
+        Parameter ``concentrations`` (Dict[str, :class:`pint.Quantity`]):
+            Molecules concentrations.
+
+        Parameter ``kwargs`` (Dict[str]):
+            Keyword arguments passed to :class:`MolecularAtmosphere`'s
+            constructor.
+
+        Returns → :class:`MolecularAtmosphere`:
+            AFGL (1986) molecular atmosphere.
+        """
+        ds = afgl1986.make_profile(model_id=model)
+
+        if levels is not None:
+            ds = interpolate(ds=ds, z_level=levels, conserve_columns=True)
+
+        if concentrations is not None:
+            factors = compute_scaling_factors(ds=ds, concentration=concentrations)
+            ds = rescale_concentration(ds=ds, factors=factors)
+
+        return MolecularAtmosphere(thermoprops=ds, **kwargs)
+
+    @classmethod
+    def ussa1976(
+        cls: MolecularAtmosphere,
+        levels: Optional[pint.Quantity] = np.linspace(0, 100, 101) * ureg.km,
+        concentrations: Optional[MutableMapping[str, pint.Quantity]] = None,
+        **kwargs: MutableMapping[str],
+    ) -> MolecularAtmosphere:
+        """
+        Molecular atmosphere based on the US Standard Atmosphere (1976) model
+        :cite:`NASA1976USStandardAtmosphere`.
+
+        Parameter ``levels`` (:class:`pint.Quantity`):
+            Altitude levels.
+
+        Parameter ``concentrations`` (Dict[str, :class:`pint.Quantity`])
+            Molecules concentrations.
+
+        Parameter ``kwargs`` (Dict[str]):
+            Keyword arguments passed to :class:`MolecularAtmosphere`'s
+            constructor.
+
+        Returns → :class:`MolecularAtmosphere`:
+            U.S. Standard Atmosphere (1976) molecular atmosphere object.
+        """
+        ds = us76.make_profile(levels=levels)
+
+        if concentrations is not None:
+            factors = compute_scaling_factors(ds=ds, concentration=concentrations)
+            ds = rescale_concentration(ds=ds, factors=factors)
+
+        return MolecularAtmosphere(thermoprops=ds, **kwargs)

--- a/eradiate/scenes/atmosphere/tests/test_atmosphere_core.py
+++ b/eradiate/scenes/atmosphere/tests/test_atmosphere_core.py
@@ -1,0 +1,26 @@
+import pathlib
+import tempfile
+
+import numpy as np
+import pytest
+
+from eradiate.contexts import SpectralContext
+from eradiate.radprops.rad_profile import US76ApproxRadProfile
+from eradiate.scenes.atmosphere._core import read_binary_grid3d, write_binary_grid3d
+
+
+@pytest.fixture
+def test_radprops(mode_mono):
+    spectral_ctx = SpectralContext.new(wavelength=550.0)
+    return US76ApproxRadProfile().to_dataset(spectral_ctx=spectral_ctx)
+
+
+def test_write_read_binary_grid3d() -> None:
+    """Reads what was written."""
+    write_values = np.random.random(10).reshape(1, 1, 10)
+    tmp_dir = pathlib.Path(tempfile.mkdtemp())
+    tmp_dir.mkdir(parents=True, exist_ok=True)
+    tmp_filename = pathlib.Path(tmp_dir, "test.vol")
+    write_binary_grid3d(filename=tmp_filename, values=write_values)
+    read_values = read_binary_grid3d(tmp_filename)
+    assert np.allclose(write_values, read_values)

--- a/eradiate/scenes/atmosphere/tests/test_heterogeneous_new.py
+++ b/eradiate/scenes/atmosphere/tests/test_heterogeneous_new.py
@@ -1,0 +1,375 @@
+from typing import List
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from eradiate.contexts import KernelDictContext
+from eradiate.scenes.atmosphere import (
+    HeterogeneousNewAtmosphere,
+    MolecularAtmosphere,
+    ParticleLayer,
+)
+from eradiate.scenes.atmosphere._heterogeneous_new import blend_radprops, overlapping
+from eradiate.units import unit_registry as ureg
+
+
+def test_heterogeneous_new_ids():
+    """
+    Validator raises when two components have the same id.
+    """
+    with pytest.raises(ValueError):
+        atmosphere = HeterogeneousNewAtmosphere(
+            molecular_atmosphere=MolecularAtmosphere(id="qwerty"),
+            particle_layers=[ParticleLayer(id="qwerty")],
+        )
+
+    with pytest.raises(ValueError):
+        atmosphere = HeterogeneousNewAtmosphere(
+            molecular_atmosphere=MolecularAtmosphere(id="azerty"),
+            particle_layers=[ParticleLayer(id="qwerty"), ParticleLayer(id="qwerty")],
+        )
+
+
+def test_heterogeneous_new_kernel_phase_0(mode_mono):
+    """
+    If there is no molecular atmosphere and no particle layers, 'kernel_phase'
+    returns an empty dictionary.
+    """
+    atmosphere = HeterogeneousNewAtmosphere()
+    assert atmosphere.kernel_phase(ctx=KernelDictContext()) == {}
+
+
+def test_heterogeneous_new_kernel_phase_1(mode_mono):
+    """
+    If there is a molecular atmosphere but no particle layers, 'kernel_phase'
+    returns a dictionary that matches the dictionary returned by the molecular
+    atmosphere's 'kernel_phase' method.
+    """
+    ctx = KernelDictContext()
+    molecular_atmosphere = MolecularAtmosphere()
+    atmosphere = HeterogeneousNewAtmosphere(molecular_atmosphere=molecular_atmosphere)
+    assert atmosphere.kernel_phase(ctx=ctx) == molecular_atmosphere.kernel_phase(
+        ctx=ctx
+    )
+
+
+def test_heterogeneous_new_kernel_phase_2(mode_mono):
+    """
+    If there is no molecular atmosphere but one particle layer, 'kernel_phase'
+    returns a dictionary that matches the dictionary returned by the particle
+    layer's 'kernel_phase' method.
+    """
+    ctx = KernelDictContext()
+    particle_layer = ParticleLayer()
+    atmosphere = HeterogeneousNewAtmosphere(particle_layers=[particle_layer])
+    assert atmosphere.kernel_phase(ctx=ctx) == particle_layer.kernel_phase(ctx=ctx)
+
+
+def test_heterogeneous_new_kernel_phase_3(mode_mono):
+    """
+    If there is a molecular atmosphere and one particle layer, 'kernel_phase'
+    returns a dictionary with two entries:
+      * the first entry matches the molecular atmosphere 'kernel_phase' output.
+      * the second entry is a 'blendphase' plugin specification dictionary.
+    """
+    ctx = KernelDictContext()
+    molecular_atmosphere = MolecularAtmosphere(id="molecules")
+    particle_layer = ParticleLayer(id="particles")
+    atmosphere = HeterogeneousNewAtmosphere(
+        molecular_atmosphere=molecular_atmosphere, particle_layers=[particle_layer]
+    )
+    phases = atmosphere.kernel_phase(ctx=ctx)
+    assert len(list(phases.keys())) == 2
+    assert all(
+        [
+            phase in phases
+            for phase in [
+                f"phase_{molecular_atmosphere.id}",
+                f"phase_{particle_layer.id}",
+            ]
+        ]
+    )
+    assert (
+        phases[f"phase_{molecular_atmosphere.id}"]
+        == molecular_atmosphere.kernel_phase(ctx=ctx)[
+            f"phase_{molecular_atmosphere.id}"
+        ]
+    )
+    assert phases[f"phase_{particle_layer.id}"]["type"] == "blendphase"
+
+
+def test_heterogeneous_new_kernel_media_0(mode_mono):
+    """
+    If there is no molecular atmosphere and no particle layers, 'kernel_media'
+    returns an empty dictionary.
+    """
+    atmosphere = HeterogeneousNewAtmosphere()
+    assert atmosphere.kernel_media(ctx=KernelDictContext()) == {}
+
+
+def test_heterogeneous_new_kernel_media_1(mode_mono):
+    """
+    If there is a molecular atmosphere but no particle layers, 'kernel_media'
+    returns a dictionary that matches the dictionary returned by the molecular
+    atmosphere's 'kernel_media' method.
+    """
+    ctx = KernelDictContext()
+    molecular_atmosphere = MolecularAtmosphere()
+    atmosphere = HeterogeneousNewAtmosphere(molecular_atmosphere=molecular_atmosphere)
+    assert atmosphere.kernel_media(ctx=ctx) == molecular_atmosphere.kernel_media(
+        ctx=ctx
+    )
+
+
+def test_heterogeneous_new_kernel_media_2(mode_mono):
+    """
+    If there is no molecular atmosphere but one particle layer, 'kernel_media'
+    returns a dictionary that matches the dictionary returned by the particle
+    layer's 'kernel_media' method.
+    """
+    ctx = KernelDictContext()
+    particle_layer = ParticleLayer()
+    atmosphere = HeterogeneousNewAtmosphere(particle_layers=[particle_layer])
+    assert atmosphere.kernel_media(ctx=ctx) == particle_layer.kernel_media(ctx=ctx)
+
+
+def test_heterogeneous_new_kernel_media_3(mode_mono):
+    """
+    If there is a molecular atmosphere and one particle layer, 'kernel_media'
+    returns a dictionary with two entries:
+      * the first entry matches the molecular atmosphere 'kernel_media' output.
+      * the second entry matches the particle layer's 'kernel_media' output.
+    """
+    ctx = KernelDictContext()
+    molecular_atmosphere = MolecularAtmosphere(id="molecules")
+    particle_layer = ParticleLayer(id="particles")
+    atmosphere = HeterogeneousNewAtmosphere(
+        molecular_atmosphere=molecular_atmosphere, particle_layers=[particle_layer]
+    )
+    media = atmosphere.kernel_media(ctx=ctx)
+    assert len(list(media.keys())) == 2
+    assert all(
+        [
+            medium in media
+            for medium in [
+                f"medium_{molecular_atmosphere.id}",
+                f"medium_{particle_layer.id}",
+            ]
+        ]
+    )
+    assert (
+        media[f"medium_{molecular_atmosphere.id}"]
+        == molecular_atmosphere.kernel_media(ctx=ctx)[
+            f"medium_{molecular_atmosphere.id}"
+        ]
+    )
+    assert (
+        media[f"medium_{particle_layer.id}"]
+        == particle_layer.kernel_media(ctx=ctx)[f"medium_{particle_layer.id}"]
+    )
+
+
+@pytest.fixture
+def test_molecules_radprops():
+    """
+    Test molecules radiative property data set.
+    """
+    z_level = np.linspace(0, 10, 11)
+    z_layer = (z_level[:-1] + z_level[1:]) / 2.0
+    return xr.Dataset(
+        data_vars={
+            "albedo": ("z_layer", np.ones(10), dict(units="dimensionless")),
+            "sigma_t": ("z_layer", 1.0 + np.random.random(10), dict(units="km^-1")),
+        },
+        coords={
+            "z_layer": ("z_layer", z_layer, dict(units="km")),
+            "z_level": ("z_level", z_level, dict(units="km")),
+        },
+    )
+
+
+@pytest.fixture
+def test_particles_radprops():
+    """
+    Test particles radiative property data set.
+    """
+    z_level = np.linspace(0, 10, 11)
+    z_layer = (z_level[:-1] + z_level[1:]) / 2.0
+    return xr.Dataset(
+        data_vars={
+            "albedo": ("z_layer", np.ones(10), dict(units="dimensionless")),
+            "sigma_t": ("z_layer", 1.0 + np.random.random(10), dict(units="km^-1")),
+        },
+        coords={
+            "z_layer": ("z_layer", z_layer, dict(units="km")),
+            "z_level": ("z_level", z_level, dict(units="km")),
+        },
+    )
+
+
+def test_blend_radprops_sigma_t(
+    mode_mono, test_molecules_radprops, test_particles_radprops
+):
+    """
+    Returned radiative property data set has a 'sigma_t' that matches
+    the sum of 'sigma_t's of the molecules and particles' radiative
+    property data sets.
+    """
+    molecules = test_molecules_radprops
+    particles = test_particles_radprops
+    blended, _ = blend_radprops(background=molecules, foreground=particles)
+
+    assert np.allclose(
+        blended.sigma_t.values,
+        molecules.sigma_t.values + particles.sigma_t.values,
+    )
+
+
+def test_blend_radprops_albedo(
+    mode_mono, test_molecules_radprops, test_particles_radprops
+):
+    """
+    Returned radiative property data set has an 'albedo' that matches
+    the weighted sum of 'albedo's of the molecules and particles' radiative
+    property data sets, where the weights are given by the ratio of the
+    molecules and particles extinction coefficient to the total extinction
+    coefficient.
+    """
+    molecules = test_molecules_radprops
+    particles = test_particles_radprops
+    blended, _ = blend_radprops(background=molecules, foreground=molecules)
+    sigma_t_molecules = molecules.sigma_t
+    sigma_t_particles = particles.sigma_t
+    sigma_t_total = sigma_t_molecules + sigma_t_particles
+    albedo_molecules = molecules.albedo
+    albedo_particles = particles.albedo
+    expected_albedo = (sigma_t_molecules / sigma_t_total) * albedo_molecules + (
+        sigma_t_particles / sigma_t_total
+    ) * albedo_particles
+
+    assert np.allclose(
+        blended.albedo.values,
+        expected_albedo.values,
+    )
+
+
+def test_blend_radprops_ratio(
+    mode_mono, test_molecules_radprops, test_particles_radprops
+):
+    """
+    Returned blending ratio matches the ratio of the particles' extinction
+    coefficient with the molecules's extinction coefficient.
+    """
+    molecules = test_molecules_radprops
+    particles = test_particles_radprops
+    _, ratio = blend_radprops(background=molecules, foreground=particles)
+    expected_ratio = particles.sigma_t / (particles.sigma_t + molecules.sigma_t)
+
+    assert np.allclose(
+        ratio.values,
+        expected_ratio.values,
+    )
+
+
+def test_blend_radprops_zeros_radprops(
+    mode_mono, test_molecules_radprops, test_particles_radprops
+):
+    """
+    Returns a data set filled with zeros when the molecules and particles radiative
+    property data sets both have a zero extinction coefficient.
+    """
+    z_level = np.linspace(0, 10, 11)
+    z_layer = (z_level[:-1] + z_level[1:]) / 2.0
+    molecules = xr.Dataset(
+        data_vars={
+            "albedo": ("z_layer", np.zeros(10), dict(units="dimensionless")),
+            "sigma_t": ("z_layer", np.zeros(10), dict(units="km^-1")),
+        },
+        coords={
+            "z_layer": ("z_layer", z_layer, dict(units="km")),
+            "z_level": ("z_level", z_level, dict(units="km")),
+        },
+    )
+
+    particles = xr.Dataset(
+        data_vars={
+            "albedo": ("z_layer", np.zeros(10), dict(units="dimensionless")),
+            "sigma_t": ("z_layer", np.zeros(10), dict(units="km^-1")),
+        },
+        coords={
+            "z_layer": ("z_layer", z_layer, dict(units="km")),
+            "z_level": ("z_level", z_level, dict(units="km")),
+        },
+    )
+
+    blended, ratio = blend_radprops(background=molecules, foreground=particles)
+
+    assert np.allclose(blended.sigma_t.values, 0.0)
+    assert np.allclose(blended.albedo, 0.0)
+    assert np.allclose(ratio, 0.5)
+
+
+def test_interpolate_radprops():
+    pass
+
+
+@pytest.fixture
+def test_particle_layers() -> List[ParticleLayer]:
+    """
+    Fixture producing ten particle layers from 0 to 10 km (1km thick each).
+    """
+    return [
+        ParticleLayer(id=f"layer_{int(z)}", bottom=z * ureg.km, top=(z + 1.0) * ureg.km)
+        for z in np.linspace(0.0, 10.0, 11)
+    ]
+
+
+def test_overlapping_0():
+    """
+    Returns empty list if 'particle_layers' is an empty list.
+    """
+    particle_layer = ParticleLayer(
+        id="my_layer", bottom=0.0 * ureg.km, top=1.0 * ureg.km
+    )
+    assert overlapping(particle_layers=[], particle_layer=particle_layer) == []
+
+
+def test_overlapping_1(test_particle_layers: List[ParticleLayer]):
+    """
+    A layer at [0.5, 1.5] km overlaps the layer at [0.0, 1.0] km and the
+    layer at [1.0, 2.0].
+    """
+    particle_layer = ParticleLayer(
+        id="my_layer", bottom=0.5 * ureg.km, top=1.5 * ureg.km
+    )
+    assert (
+        overlapping(particle_layers=test_particle_layers, particle_layer=particle_layer)
+        == test_particle_layers[:2]
+    )
+
+
+def test_overlapping_2(test_particle_layers: List[ParticleLayer]):
+    """
+    A layer at [15.0, 16.0] km does not overlap layers below 10 km.
+    """
+    particle_layer = ParticleLayer(
+        id="my_layer", bottom=15.0 * ureg.km, top=16.0 * ureg.km
+    )
+    assert (
+        overlapping(particle_layers=test_particle_layers, particle_layer=particle_layer)
+        == []
+    )
+
+
+def test_overlapping_3(test_particle_layers: List[ParticleLayer]):
+    """
+    A layer at [0.0, 1.0] km overlaps the layer at [0.0, 1.0] km.
+    """
+    particle_layer = ParticleLayer(
+        id="my_layer", bottom=0.0 * ureg.km, top=1.0 * ureg.km
+    )
+    assert (
+        overlapping(particle_layers=test_particle_layers, particle_layer=particle_layer)
+        == test_particle_layers[0:1]
+    )

--- a/eradiate/scenes/atmosphere/tests/test_molecules.py
+++ b/eradiate/scenes/atmosphere/tests/test_molecules.py
@@ -1,0 +1,78 @@
+"""Test cases of the _molecules module."""
+import pytest
+
+from eradiate import path_resolver
+from eradiate.contexts import KernelDictContext, SpectralContext
+from eradiate.scenes.atmosphere import MolecularAtmosphere
+from eradiate.scenes.core import KernelDict
+
+
+def test_molecular_atmosphere_default(mode_mono, tmpdir):
+    """Default MolecularAtmosphere constructor produces a valid kernel
+    dictionary."""
+    spectral_ctx = SpectralContext.new(wavelength=550.0)
+    ctx = KernelDictContext(spectral_ctx=spectral_ctx)
+    atmosphere = MolecularAtmosphere()
+    assert KernelDict.new(atmosphere, ctx=ctx).load() is not None
+
+
+@pytest.fixture
+def afgl1986_test_absorption_data_sets():
+    return {
+        "CH4": path_resolver.resolve(
+            "tests/spectra/absorption/CH4-spectra-4000_11502.nc"
+        ),
+        "CO2": path_resolver.resolve(
+            "tests/spectra/absorption/CO2-spectra-4000_14076.nc"
+        ),
+        "CO": path_resolver.resolve(
+            "tests/spectra/absorption/CO-spectra-4000_14478.nc"
+        ),
+        "H2O": path_resolver.resolve(
+            "tests/spectra/absorption/H2O-spectra-4000_25711.nc"
+        ),
+        "N2O": path_resolver.resolve(
+            "tests/spectra/absorption/N2O-spectra-4000_10364.nc"
+        ),
+        "O2": path_resolver.resolve(
+            "tests/spectra/absorption/O2-spectra-4000_17273.nc"
+        ),
+        "O3": path_resolver.resolve("tests/spectra/absorption/O3-spectra-4000_6997.nc"),
+    }
+
+
+def test_molecular_atmosphere_afgl1986(
+    mode_mono,
+    tmpdir,
+    afgl1986_test_absorption_data_sets,
+):
+    """MolecularAtmosphere 'afgl1986' constructor produces a valid kernel
+    dictionary."""
+    spectral_ctx = SpectralContext.new(wavelength=550.0)
+    ctx = KernelDictContext(spectral_ctx=spectral_ctx)
+    atmosphere = MolecularAtmosphere.afgl1986(
+        absorption_data_sets=afgl1986_test_absorption_data_sets
+    )
+    assert KernelDict.new(atmosphere, ctx=ctx).load() is not None
+
+
+@pytest.fixture
+def ussa76_approx_test_absorption_data_set():
+    return path_resolver.resolve(
+        "tests/spectra/absorption/us76_u86_4-spectra-4000_25711.nc"
+    )
+
+
+def test_molecular_atmosphere_ussa1976(
+    mode_mono,
+    tmpdir,
+    ussa76_approx_test_absorption_data_set,
+):
+    """MolecularAtmosphere 'ussa1976' constructor produces a valid kernel
+    dictionary."""
+    spectral_ctx = SpectralContext.new(wavelength=550.0)
+    ctx = KernelDictContext(spectral_ctx=spectral_ctx)
+    atmosphere = MolecularAtmosphere.ussa1976(
+        absorption_data_sets=dict(us76_u86_4=ussa76_approx_test_absorption_data_set)
+    )
+    assert KernelDict.new(atmosphere, ctx=ctx).load() is not None

--- a/eradiate/scenes/atmosphere/tests/test_particles.py
+++ b/eradiate/scenes/atmosphere/tests/test_particles.py
@@ -9,14 +9,14 @@ from eradiate.scenes.atmosphere._particles import ParticleLayer
 from eradiate.scenes.core import KernelDict
 
 
-def test_particle_load(mode_mono) -> None:
+def test_particle_load(mode_mono):
     """Produces a kernel dictionary that can be loaded by the kernel."""
     ctx = KernelDictContext()
     particle_layer = ParticleLayer(n_layers=9)
     assert KernelDict.new(particle_layer, ctx=ctx).load() is not None
 
 
-def test_particle_layer() -> None:
+def test_particle_layer():
     """Assigns parameters to expected values."""
     bottom = ureg.Quantity(1.2, "km")
     top = ureg.Quantity(1.8, "km")
@@ -37,18 +37,18 @@ def test_particle_layer() -> None:
     assert layer.dataset == "tests/radprops/rtmom_aeronet_desert.nc"
 
 
-def test_particle_layer_altitude_units() -> None:
+def test_particle_layer_altitude_units():
     """Accept different units for bottom and top altitudes."""
     assert ParticleLayer(bottom=ureg.Quantity(1, "km"), top=ureg.Quantity(2000.0, "m"))
 
 
-def test_particle_layer_invalid_bottom_top() -> None:
+def test_particle_layer_invalid_bottom_top():
     """Raises when 'bottom' is larger that 'top'."""
     with pytest.raises(ValueError):
         ParticleLayer(top=ureg.Quantity(1.2, "km"), bottom=ureg.Quantity(1.8, "km"))
 
 
-def test_particle_layer_invalid_tau_550() -> None:
+def test_particle_layer_invalid_tau_550():
     """Raises when 'tau_550' is invalid."""
     with pytest.raises(ValueError):
         ParticleLayer(
@@ -61,7 +61,7 @@ def test_dataset():
     return path_resolver.resolve("tests/radprops/rtmom_aeronet_desert.nc")
 
 
-def test_particle_layer_radprops(mode_mono, test_dataset) -> None:
+def test_particle_layer_radprops(mode_mono, test_dataset):
     """Method 'radprops' returns data set with expected data_vars and coords."""
     layer = ParticleLayer(dataset=test_dataset)
     spectral_ctx = SpectralContext.new()
@@ -73,7 +73,7 @@ def test_particle_layer_radprops(mode_mono, test_dataset) -> None:
     )
 
 
-def test_particle_layer_eval_phase(test_dataset) -> None:
+def test_particle_layer_eval_phase(test_dataset):
     """Method 'eval_phase' returns a 'DataArray'."""
     layer = ParticleLayer(dataset=test_dataset)
     spectral_ctx = SpectralContext.new()

--- a/eradiate/scenes/surface/_core.py
+++ b/eradiate/scenes/surface/_core.py
@@ -123,7 +123,7 @@ class Surface(SceneElement, ABC):
     def kernel_width(self, ctx: KernelDictContext = None):
         """
         Return width of kernel object, possibly overridden by
-        ``ctx.override_surface_width``.
+        ``ctx.override_scene_width``.
 
         Parameter ``ctx`` (:class:`.KernelDictContext` or None):
             A context data structure containing parameters relevant for kernel
@@ -132,10 +132,10 @@ class Surface(SceneElement, ABC):
         Returns → :class:`pint.Quantity`:
             Kernel object width.
         """
-        if ctx is not None and ctx.override_surface_width is not None:
+        if ctx is not None and ctx.override_scene_width is not None:
             if self.width is not AUTO:
                 warnings.warn(OverriddenValueWarning("Overriding surface width"))
-            return ctx.override_surface_width
+            return ctx.override_scene_width
         else:
             if self.width is not AUTO:
                 return self.width

--- a/eradiate/scenes/surface/tests/test_surface_core.py
+++ b/eradiate/scenes/surface/tests/test_surface_core.py
@@ -32,7 +32,7 @@ def test_kernel_width(mode_mono):
 
     # Override constrains auto size
     obj.width = AUTO
-    ctx = KernelDictContext(override_surface_width=100.0 * ureg.m)
+    ctx = KernelDictContext(override_scene_width=100.0 * ureg.m)
     assert obj.kernel_width(ctx) == 100.0 * ureg.m
 
     # Override with set value raises a warning

--- a/eradiate/solvers/onedim/_scene.py
+++ b/eradiate/solvers/onedim/_scene.py
@@ -119,7 +119,7 @@ class OneDimScene(Scene):
         if self.atmosphere is not None:
             result.add(self.atmosphere, ctx=ctx)
             ctx = attr.evolve(
-                ctx, override_surface_width=self.atmosphere.kernel_width(ctx)
+                ctx, override_scene_width=self.atmosphere.kernel_width(ctx)
             )
 
         result.add(

--- a/eradiate/solvers/rami/_scene.py
+++ b/eradiate/solvers/rami/_scene.py
@@ -126,12 +126,12 @@ class RamiScene(Scene):
         if self.canopy is not None:
             if self.padding > 0:  # We must add extra instances if padding is requested
                 canopy = self.canopy.padded_copy(self.padding)
-                ctx.override_surface_width = max(self.canopy.size[:2]) * (
+                ctx.override_scene_width = max(self.canopy.size[:2]) * (
                     2.0 * self.padding + 1.0
                 )
             else:
                 canopy = self.canopy
-                ctx.override_surface_width = max(self.canopy.size[:2])
+                ctx.override_scene_width = max(self.canopy.size[:2])
 
             result.add(canopy.kernel_dict(ctx=ctx))
 

--- a/eradiate/solvers/tests/test_rami.py
+++ b/eradiate/solvers/tests/test_rami.py
@@ -41,7 +41,7 @@ def test_rami_scene(mode_mono):
     )
     ctx = KernelDictContext()
     kernel_scene = s.kernel_dict(ctx)
-    assert np.allclose(ctx.override_surface_width, 10.0 * ureg.m)
+    assert np.allclose(ctx.override_scene_width, 10.0 * ureg.m)
     assert np.allclose(
         kernel_scene["surface"]["to_world"].transform_point([1, -1, 0]),
         [5, -5, 0],

--- a/eradiate/thermoprops/util.py
+++ b/eradiate/thermoprops/util.py
@@ -268,7 +268,8 @@ def rescale_concentration(ds, factors, inplace=False):
         if species in factors:
             mr[i] *= factors[species]
 
-    if any(mr.sum(axis=0) > 1.0):
+    machine_epsilon = np.finfo(float).eps
+    if any(mr.sum(axis=0) > 1.0 + machine_epsilon):
         raise ValueError(
             f"Cannot rescale concentration with these factors "
             f"({factors}) because the sum of mixing ratios would "


### PR DESCRIPTION
Resolves eradiate/eradiate-issues#74.

# Description

This pull request introduces a new heterogeneous atmosphere design. 

Prerequisite pull requests:

* #111 
* #112

## Motivation

This new design was motivated by the need to integrate `ParticleLayer` objects in the heterogeneous atmosphere. The integration proved to be rather complex, for various reasons including:

* the level altitude meshes do not align
* the radiative properties must be "blended" together, including the phase functions

which is why this new design is suggested.

## New design layout

The new design is illustrated by the UML diagram below:

![uml_diagram](https://user-images.githubusercontent.com/62285993/129033682-082368d0-4bbb-4f22-a9eb-dfc31324a4fc.png)


* `MolecularAtmosphere` is the molecular part of the atmosphere, i.e. without particles. Each type of molecular atmospheres (e.g. AFGL1986) is associated to a specific class method (specified by `"construct"` in the corresponding kernel dict).
* `ParticleLayer` objects are 1D layers of particles (e.g. a cloud layer).
* `HeterogeneousAtmosphere` is an object that blends a `MolecularAtmosphere` object with one or more `ParticleLayer` objects. It has special methods that lets it align the altitude meshes of its components, compute the total collision coefficients and phase function blending ratios based on the individual radiative properties of each component, etc.

## Changes

* added a module `scenes.atmosphere._heterogeneous_new` where `HeterogeneousAtmosphereNew` is defined. We append __new_ or _New_ where necessary, in order to avoid breaking the existing implementation of `HeterogeneousAtmosphere`. Once the new design is completely implemented and tested, then it will be time to rename these. Corresponding tests are in `scenes/atmosphere/tests/test_heterogeneous_new.py`.
* added a module `_molecules` where `MolecularAtmosphere` is defined. Corresponding tests are in `scenes/atmosphere/tests/test_molecules.py`.
* fixed a typo to `_ROOTDIR` value in `eradiate/data/absorption_spectra.py`
* updated documentation

## Details

### `ParticleLayer`

`ParticleLayer` now inherits `Atmosphere` as indicated in the UML diagram above.
`ParticleLayer` is then now a scene element, which means

```python
from eradiate.contexts import KernelDictContext
from eradiate.scenes.atmosphere import ParticleLayer
from eradiate.units import unit_registry as ureg

ctx = KernelDictContext()
particle_layer = ParticleLayer(
    bottom = 0.0 * ureg.km,
    top = 1.5 * ureg.km,
    tau_550 = 0.1 * ureg.dimensionless,
    n_layers=9,
)
KernelDict.new(particle_layer, ctx=ctx)
```

produces a valid kernel dictionary.

### `MolecularAtmosphere`

```python
from eradiate.scenes.atmosphere import MolecularAtmosphere

molecular_atmosphere = MolecularAtmosphere()
```

### `HeterogeneousNewAtmosphere`

Empty atmosphere:
```python
from eradiate.scenes.atmosphere import HeterogeneousNewAtmosphere

atmosphere = HeterogeneousNewAtmosphere()
```

Atmosphere with only a molecular component:
```python
from eradiate.scenes.atmosphere import HeterogeneousNewAtmosphere, MolecularAtmosphere

atmosphere = HeterogeneousNewAtmosphere(molecular_atmosphere=MolecularAtmosphere())
```

Atmosphere with only a particles component:
```python
from eradiate.scenes.atmosphere import HeterogeneousNewAtmosphere, ParticleLayer

atmosphere = HeterogeneousNewAtmosphere(particle_layers=[ParticleLayer()])
```

Atmosphere with a molecular component and a particles component (one particle layer):
```python
from eradiate.scenes.atmosphere import HeterogeneousNewAtmosphere, MolecularAtmosphere, ParticleLayer
from eradiate.units import unit_registry as ureg

atmosphere = HeterogeneousNewAtmosphere(
    molecular_atmosphere=MolecularAtmosphere(id="molecules"),
    particle_layers=[ParticleLayer(id="particles")]
)
```

Atmosphere with a molecular component and a particles component (two particle layers):
```python
from eradiate.scenes.atmosphere import HeterogeneousNewAtmosphere, MolecularAtmosphere, ParticleLayer

atmosphere = HeterogeneousNewAtmosphere(
    molecular_atmosphere=MolecularAtmosphere(id="molecules"),
    particle_layers=[
        ParticleLayer(id="particles_1", bottom=0.0 * ureg.km, top=1.0 * ureg.km),
        ParticleLayer(id="particles_2", bottom=6.0 * ureg.km, top=7.0 * ureg.km),
    ]
)
```

#### :warning:  Disclaimer

There is no support for overlapping layers just yet.
Support for overlapping layers would be easier to add if the `blendphase` plugin would accept an arbitrary number of components.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
