### PR TITLE
Mesh based canopy

### DIFF
--- a/eradiate/scenes/biosphere/__init__.py
+++ b/eradiate/scenes/biosphere/__init__.py
@@ -2,7 +2,8 @@ from ._canopy_element import CanopyElement
 from ._core import BiosphereFactory, Canopy
 from ._discrete import DiscreteCanopy, InstancedCanopyElement
 from ._leaf_cloud import LeafCloud
-from ._tree import AbstractTree
+from ._mesh_tree_element import MeshTreeElement
+from ._tree import AbstractTree, MeshTree
 
 __all__ = [
     "BiosphereFactory",

--- a/eradiate/scenes/biosphere/_mesh_tree_element.py
+++ b/eradiate/scenes/biosphere/_mesh_tree_element.py
@@ -1,0 +1,176 @@
+import os
+from pathlib import Path
+from typing import MutableMapping, Optional
+
+import attr
+import pint
+
+from ..core import SceneElement
+from ..spectra import Spectrum, SpectrumFactory
+from ... import validators
+from ..._attrs import documented, get_doc, parse_docs
+from ...contexts import KernelDictContext
+from ...units import unit_context_kernel as uck
+from ...units import unit_registry as ureg
+
+
+@parse_docs
+@attr.s
+class MeshTreeElement(SceneElement):
+    """
+    Container class for mesh based constituents of tree-like objects in a canopy.
+    Holds the filepath for the triangulated mesh and all parameters specifying
+    the associated BSDF.
+
+    .. important:: The triangulated mesh must be provided in .ply or .obj format.
+
+    Since mesh definition files cannot carry Pint units, the attribute ``mesh_units``
+    lets users provide the unit which their mesh is defined in. Upon kernel dict
+    creation the mesh is scaled to match the length unit used in the kernel.
+    If ``mesh_units` is not provided, no scaling of the mesh is performed.
+
+    The :meth:`MeshTreeElement.from_dict` constructor instantiates the class from
+    a configuration dictionary.
+    """
+
+    id = documented(
+        attr.ib(
+            default="mesh_tree_element",
+            validator=attr.validators.optional(attr.validators.instance_of(str)),
+        ),
+        doc=get_doc(SceneElement, "id", "doc"),
+        type=get_doc(SceneElement, "id", "type"),
+        default="'mesh_tree_element'",
+    )
+
+    mesh_filename = documented(
+        attr.ib(
+            converter=attr.converters.optional(Path),
+            default=None,
+        ),
+        doc="Path to the triangulated mesh data file. This parameter is required.",
+        type="path-like",
+    )
+
+    @mesh_filename.validator
+    def _mesh_filename_validator(self, attribute, value):
+        if value is None:
+            raise ValueError("'mesh_filename' is required")
+
+        validators.path_exists(self, attribute, value)
+
+        if not value.suffix in [".obj", ".ply"]:
+            raise ValueError(
+                f"While validating {attribute.name}: File extension must be '.obj'"
+                f"or '.ply', got {value.suffix}"
+            )
+
+    mesh_units = documented(
+        attr.ib(default=None, converter=attr.converters.optional(ureg.Unit)),
+        doc="Units the mesh was defined in. Used to convert to kernel units. "
+        "If this value is ``None``, the mesh is interpreted as being defined in"
+        "kernel units.",
+        type="str or :class:`pint.Unit` or None",
+        default="None",
+    )
+
+    @mesh_units.validator
+    def _mesh_units_validator(self, attribute, value):
+        if not isinstance(value, pint.unit.Unit):
+            raise ValueError(
+                f"While validating {attribute.name}: Mesh unit parameter must be "
+                f"a pint Unit object, got {type(value)}"
+            )
+
+    mesh_reflectance = documented(
+        attr.ib(
+            default=0.5,
+            converter=SpectrumFactory.converter("reflectance"),
+            validator=[
+                attr.validators.instance_of(Spectrum),
+                validators.has_quantity("reflectance"),
+            ],
+        ),
+        doc="Reflectance spectrum of the mesh. "
+        "Must be a reflectance spectrum (dimensionless).",
+        type=":class:`.Spectrum`",
+        default="0.5",
+    )
+
+    mesh_transmittance = documented(
+        attr.ib(
+            default=0.0,
+            converter=SpectrumFactory.converter("transmittance"),
+            validator=[
+                attr.validators.instance_of(Spectrum),
+                validators.has_quantity("transmittance"),
+            ],
+        ),
+        doc="Transmittance spectrum of the mesh. "
+        "Must be a transmittance spectrum (dimensionless).",
+        type=":class:`.Spectrum`",
+        default="0.0",
+    )
+
+    def shapes(self, ctx=None):
+        from mitsuba.core import ScalarTransform4f
+
+        if ctx.ref:
+            bsdf = {"type": "ref", "id": f"bsdf_{self.id}"}
+        else:
+            bsdf = self.bsdfs(ctx=ctx)[f"bsdf_{self.id}"]
+
+        if self.mesh_units is None:
+            scaling_factor = 1.0
+        else:
+            kernel_length = uck.get("length")
+            scaling_factor = (1.0 * self.mesh_units).m_as(kernel_length)
+
+        base_dict = {
+            "filename": str(self.mesh_filename),
+            "bsdf": bsdf,
+            "to_world": ScalarTransform4f.scale(scaling_factor),
+        }
+
+        if self.mesh_filename.suffix == ".obj":
+            base_dict["type"] = "obj"
+        elif self.mesh_filename.suffix == ".ply":
+            base_dict["type"] = "ply"
+        else:
+            raise ValueError(
+                f"unsupported file extension '{self.mesh_filename.suffix}'"
+            )
+
+        return {self.id: base_dict}
+
+    def bsdfs(self, ctx=None):
+        return {
+            f"bsdf_{self.id}": {
+                "type": "bilambertian",
+                "reflectance": self.mesh_reflectance.kernel_dict(ctx=ctx)["spectrum"],
+                "transmittance": self.mesh_transmittance.kernel_dict(ctx=ctx)[
+                    "spectrum"
+                ],
+            }
+        }
+
+    @staticmethod
+    def convert(value):
+        """
+        Object converter method.
+
+        If ``value`` is a dictionary, this method uses :meth:`from_dict` to
+        create an :class:`.MeshTreeElement`.
+
+        Otherwise, it returns ``value``.
+        """
+        if isinstance(value, dict):
+            return MeshTreeElement.from_dict(value)
+
+        return value
+
+    def kernel_dict(self, ctx: Optional[KernelDictContext] = None) -> MutableMapping:
+        if not ctx.ref:
+            return self.shapes(ctx=ctx)
+        else:
+            return {**self.bsdfs(ctx=ctx), **self.shapes(ctx=ctx)}

--- a/eradiate/scenes/biosphere/tests/test_biosphere_tree_mesh.py
+++ b/eradiate/scenes/biosphere/tests/test_biosphere_tree_mesh.py
@@ -1,0 +1,276 @@
+import os
+import tempfile
+
+import pytest
+
+from eradiate import unit_registry as ureg
+from eradiate.contexts import KernelDictContext
+from eradiate.scenes.biosphere import MeshTree, MeshTreeElement
+from eradiate.scenes.core import KernelDict
+
+# -- Fixture definitions -------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def tempfile_obj():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        filename = os.path.join(tmpdir, "tempfile_mesh.obj")
+        with open(filename, "w") as tf:
+            tf.write(
+                """o Cube
+v 1.000000 -1.000000 -1.000000
+v 1.000000 -1.000000 1.000000
+v -1.000000 -1.000000 1.000000
+v -1.000000 -1.000000 -1.000000
+v 1.000000 1.000000 -0.999999
+v 0.999999 1.000000 1.000001
+v -1.000000 1.000000 1.000000
+v -1.000000 1.000000 -1.000000
+vt 1.000000 0.333333
+vt 1.000000 0.666667
+vt 0.666667 0.666667
+vt 0.666667 0.333333
+vt 0.666667 0.000000
+vt 0.000000 0.333333
+vt 0.000000 0.000000
+vt 0.333333 0.000000
+vt 0.333333 1.000000
+vt 0.000000 1.000000
+vt 0.000000 0.666667
+vt 0.333333 0.333333
+vt 0.333333 0.666667
+vt 1.000000 0.000000
+vn 0.000000 -1.000000 0.000000
+vn 0.000000 1.000000 0.000000
+vn 1.000000 0.000000 0.000000
+vn -0.000000 0.000000 1.000000
+vn -1.000000 -0.000000 -0.000000
+vn 0.000000 0.000000 -1.000000
+s off
+f 2/1/1 3/2/1 4/3/1
+f 8/1/2 7/4/2 6/5/2
+f 5/6/3 6/7/3 2/8/3
+f 6/8/4 7/5/4 3/4/4
+f 3/9/5 7/10/5 8/11/5
+f 1/12/6 4/13/6 8/11/6
+f 1/4/1 2/1/1 4/3/1
+f 5/14/2 8/1/2 6/5/2
+f 1/12/3 5/6/3 2/8/3
+f 2/12/4 6/8/4 3/4/4
+f 4/13/5 3/9/5 8/11/5
+f 5/6/6 1/12/6 8/11/6"""
+            )
+        yield filename
+
+
+@pytest.fixture(scope="module")
+def tempfile_ply():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        filename = os.path.join(tmpdir, "tempfile_mesh.ply")
+        with open(filename, "w") as tf:
+            tf.write(
+                """ply 
+format ascii 1.0 
+element vertex 8 
+property float x 
+property float y 
+property float z 
+element face 12 
+property list uchar int32 vertex_index
+end_header 
+0 0 0 
+0 0 1 
+0 1 1 
+0 1 0 
+1 0 0 
+1 0 1 
+1 1 1 
+1 1 0  
+3 0 1 2
+3 0 2 3
+3 7 6 5
+3 7 5 4 
+3 0 4 5
+3 0 5 1 
+3 1 5 6
+3 1 6 2 
+3 2 6 7
+3 2 7 3 
+3 3 7 4
+3 3 4 0
+"""
+            )
+        yield filename
+
+
+@pytest.fixture(scope="module")
+def tempfile_stl():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        filename = os.path.join(tmpdir, "tempfile_mesh.stl")
+        with open(filename, "w") as tf:
+            tf.write("fake content\n")
+        yield filename
+
+
+def test_mesh_tree_element_instantiate(
+    mode_mono, tempfile_obj, tempfile_ply, tempfile_stl
+):
+
+    # empty constructor raises due to missing mesh description file
+    with pytest.raises(ValueError):
+        MeshTreeElement()
+
+    # obj file instantiation
+    assert MeshTreeElement(
+        id="mesh_tree_obj",
+        mesh_filename=tempfile_obj,
+        mesh_units=ureg.m,
+        mesh_reflectance=0.5,
+        mesh_transmittance=0.5,
+    )
+
+    # ply file instantiation
+    assert MeshTreeElement(
+        id="mesh_tree_ply",
+        mesh_filename=tempfile_ply,
+        mesh_units=ureg.m,
+        mesh_reflectance=0.5,
+        mesh_transmittance=0.5,
+    )
+
+    # unsupported file format raise
+    with pytest.raises(ValueError):
+        MeshTreeElement(
+            id="mesh_tree_stl",
+            mesh_filename=tempfile_stl,
+            mesh_units=ureg.m,
+            mesh_reflectance=0.5,
+            mesh_transmittance=0.5,
+        )
+
+
+def test_mesh_tree_element_load(mode_mono, tempfile_obj, tempfile_ply):
+    """
+    Instantiate MeshTreeElement objects from obj and ply files and load the
+    corresponding Mitsuba objects.
+    """
+    ctx = KernelDictContext()
+
+    # obj file instantiation
+    obj_tree = MeshTreeElement(
+        id="mesh_tree_obj",
+        mesh_filename=tempfile_obj,
+        mesh_units=ureg.m,
+        mesh_reflectance=0.5,
+        mesh_transmittance=0.5,
+    )
+
+    assert KernelDict.new(obj_tree, ctx=ctx).load()
+
+    # ply file instantiation
+    ply_tree = MeshTreeElement(
+        id="mesh_tree_ply",
+        mesh_filename=tempfile_ply,
+        mesh_units=ureg.m,
+        mesh_reflectance=0.5,
+        mesh_transmittance=0.5,
+    )
+
+    assert KernelDict.new(ply_tree, ctx=ctx).load()
+
+
+def test_mesh_tree_instantiate(mode_mono, tempfile_obj):
+    """
+    Instantiate a MeshTree object holding two MeshTreeElements and load the
+    corresponding Mitsuba objects.
+    """
+    ctx = KernelDictContext()
+
+    # Constructor based instantiation
+    assert MeshTree(
+        mesh_tree_elements=[
+            MeshTreeElement(
+                id="mesh_tree_obj",
+                mesh_filename=tempfile_obj,
+                mesh_units=ureg.m,
+                mesh_reflectance=0.5,
+                mesh_transmittance=0.5,
+            ),
+            MeshTreeElement(
+                id="mesh_tree_obj_2",
+                mesh_filename=tempfile_obj,
+                mesh_units=ureg.m,
+                mesh_reflectance=0.1,
+                mesh_transmittance=0.9,
+            ),
+        ]
+    )
+
+    tree = MeshTree(
+        mesh_tree_elements=[
+            MeshTreeElement(
+                id="mesh_tree_obj",
+                mesh_filename=tempfile_obj,
+                mesh_units=ureg.m,
+                mesh_reflectance=0.5,
+                mesh_transmittance=0.5,
+            ),
+            MeshTreeElement(
+                id="mesh_tree_obj_2",
+                mesh_filename=tempfile_obj,
+                mesh_units=ureg.m,
+                mesh_reflectance=0.1,
+                mesh_transmittance=0.9,
+            ),
+        ]
+    )
+
+    assert KernelDict.new(tree, ctx=ctx).load()
+
+    # dict API based instantiation
+
+    assert MeshTree.from_dict(
+        {
+            "id": "mesh_tree",
+            "mesh_tree_elements": [
+                {
+                    "id": "mesh_tree_obj",
+                    "mesh_filename": tempfile_obj,
+                    "mesh_reflectance": 0.5,
+                    "mesh_transmittance": 0.5,
+                    "mesh_units": ureg.m,
+                },
+                {
+                    "id": "mesh_tree_obj_2",
+                    "mesh_filename": tempfile_obj,
+                    "mesh_reflectance": 0.1,
+                    "mesh_transmittance": 0.9,
+                    "mesh_units": ureg.m,
+                },
+            ],
+        }
+    )
+
+    tree = MeshTree.from_dict(
+        {
+            "id": "mesh_tree",
+            "mesh_tree_elements": [
+                {
+                    "id": "mesh_tree_obj",
+                    "mesh_filename": tempfile_obj,
+                    "mesh_reflectance": 0.5,
+                    "mesh_transmittance": 0.5,
+                    "mesh_units": ureg.m,
+                },
+                {
+                    "id": "mesh_tree_obj_2",
+                    "mesh_filename": tempfile_obj,
+                    "mesh_reflectance": 0.1,
+                    "mesh_transmittance": 0.9,
+                    "mesh_units": ureg.m,
+                },
+            ],
+        }
+    )
+
+    assert KernelDict.new(tree, ctx=ctx).load()

--- a/eradiate/validators.py
+++ b/eradiate/validators.py
@@ -1,10 +1,11 @@
+import os
 from numbers import Number
 
 import attr
 import numpy as np
 
-from .units import unit_registry as ureg
 from .units import PhysicalQuantity
+from .units import unit_registry as ureg
 
 
 def is_number(_, attribute, value):
@@ -12,15 +13,16 @@ def is_number(_, attribute, value):
     Raises a ``TypeError`` in case of failure.
     """
     if not isinstance(value, Number):
-        raise TypeError(f"{attribute.name} must be a real number, "
-                        f"got {value} which is a {value.__class__}")
+        raise TypeError(
+            f"{attribute.name} must be a real number, "
+            f"got {value} which is a {value.__class__}"
+        )
 
 
 def is_vector3(instance, attribute, value):
     """Validates if ``value`` is convertible to a 3-vector."""
     return attr.validators.deep_iterable(
-        member_validator=is_number,
-        iterable_validator=has_len(3)
+        member_validator=is_number, iterable_validator=has_len(3)
     )(instance, attribute, value)
 
 
@@ -28,7 +30,7 @@ def is_positive(_, attribute, value):
     """Validates if ``value`` is a positive number.
     Raises a ``ValueError`` in case of failure.
     """
-    if value < 0.:
+    if value < 0.0:
         raise ValueError(f"{attribute} must be positive or zero, got {value}")
 
 
@@ -47,8 +49,9 @@ def path_exists(_, attribute, value):
     an existing target. Raises a ``FileNotFoundError`` otherwise.
     """
     if not value.exists():
-        raise FileNotFoundError(f"{attribute} points to '{str(value)}' "
-                                f"(path does not exist)")
+        raise FileNotFoundError(
+            f"{attribute} points to '{str(value)}' (path does not exist)"
+        )
 
 
 def is_file(_, attribute, value):
@@ -56,8 +59,7 @@ def is_file(_, attribute, value):
     an existing file. Raises a ``FileNotFoundError`` otherwise.
     """
     if not value.is_file():
-        raise FileNotFoundError(f"{attribute} points to '{str(value)}' "
-                                f"(not a file)")
+        raise FileNotFoundError(f"{attribute} points to '{str(value)}' (not a file)")
 
 
 def is_dir(_, attribute, value):
@@ -65,8 +67,9 @@ def is_dir(_, attribute, value):
     an existing file. Raises a ``FileNotFoundError`` otherwise.
     """
     if not value.is_dir():
-        raise FileNotFoundError(f"{attribute} points to '{str(value)}'"
-                                f"(not a directory)")
+        raise FileNotFoundError(
+            f"{attribute} points to '{str(value)}' (not a directory)"
+        )
 
 
 def has_len(size):
@@ -83,8 +86,10 @@ def has_len(size):
 
     def f(_, attribute, value):
         if len(value) != size:
-            raise ValueError(f"{attribute} must be have length {size}, "
-                             f"got {value} of length {len(value)}")
+            raise ValueError(
+                f"{attribute} must be have length {size}, "
+                f"got {value} of length {len(value)}"
+            )
 
     return f
 
@@ -97,9 +102,11 @@ def has_quantity(quantity):
 
     def f(_, attribute, value):
         if value.quantity != quantity:
-            raise ValueError(f"incompatible quantity '{value.quantity}' "
-                             f"used to set field '{attribute.name}' "
-                             f"(allowed: '{quantity}')")
+            raise ValueError(
+                f"incompatible quantity '{value.quantity}' "
+                f"used to set field '{attribute.name}' "
+                f"(allowed: '{quantity}')"
+            )
 
     return f
 


### PR DESCRIPTION
# Description

This PR introduces a mesh based canopy element.
It is actually made up of two classes: `MeshTree` and `MeshTreeElement`. The former simply holds a list of objects of the latter class, since one tree might be made up of multiple meshes (e.g. the leaves and the trunk/branches). The latter holds the mesh and its radiative properties.

The branch is not yet rebased on the current state of main because that is changing a lot right now, anyways.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
