### PR TITLE
Updated the Atmosphere interface

### DIFF
--- a/docs/rst/user_guide/atmosphere/heterogeneous.rst
+++ b/docs/rst/user_guide/atmosphere/heterogeneous.rst
@@ -111,13 +111,13 @@ Kernel volume data files
 
 When the heterogeneous atmosphere object is created, the radiative properties
 are written to files, which can be accessed afterwards.
-The locations of these data files is stored in the ``albedo_fname`` and
-``sigma_t_fname`` attributes.
+The locations of these data files is stored in the ``albedo_filename`` and
+``sigma_t_filename`` attributes.
 By default, these files are placed in a temporary directory with a random name.
-To control where these files are saved, set the ``albedo_fname`` and
-``sigma_t_fname`` attributes by providing the paths to these files.
+To control where these files are saved, set the ``albedo_filename`` and
+``sigma_t_filename`` attributes by providing the paths to these files.
 Later, you can re-use these files to create the same heterogeneous atmosphere
-by setting the ``albedo_fname`` and ``sigma_t_fname`` attributes to the paths
+by setting the ``albedo_filename`` and ``sigma_t_filename`` attributes to the paths
 pointing to the files to use.
 
 .. warning::

--- a/eradiate/kernel/tests/test_transform.py
+++ b/eradiate/kernel/tests/test_transform.py
@@ -1,0 +1,73 @@
+import enoki as ek
+
+from eradiate.kernel.transform import map_cube, map_unit_cube
+
+
+def test_map_unit_cube(mode_mono):
+    """
+    Returns a transformation that maps old cube vertices to new cube vertices.
+    """
+    trafo = map_unit_cube(1, 2, 3, 4, 5, 6)
+
+    vertices = [
+        [0, 0, 0],
+        [1, 0, 0],
+        [0, 1, 0],
+        [1, 1, 0],
+        [0, 0, 1],
+        [1, 0, 1],
+        [0, 1, 1],
+        [1, 1, 1],
+    ]
+
+    new_vertices = [
+        [1, 3, 5],
+        [2, 3, 5],
+        [1, 4, 5],
+        [2, 4, 5],
+        [1, 3, 6],
+        [2, 3, 6],
+        [1, 4, 6],
+        [2, 4, 6],
+    ]
+
+    for vertex, new_vertex in zip(vertices, new_vertices):
+        assert ek.allclose(
+            trafo.transform_point(vertex),
+            new_vertex,
+        )
+
+
+def test_map_cube():
+    """
+    Returns a transformation that maps old cube vertices to new cube vertices.
+    """
+    trafo = map_cube(1, 2, 3, 4, 5, 6)
+
+    vertices = [
+        [-1, -1, -1],
+        [1, -1, -1],
+        [-1, 1, -1],
+        [1, 1, -1],
+        [-1, -1, 1],
+        [1, -1, 1],
+        [-1, 1, 1],
+        [1, 1, 1],
+    ]
+
+    new_vertices = [
+        [1, 3, 5],
+        [2, 3, 5],
+        [1, 4, 5],
+        [2, 4, 5],
+        [1, 3, 6],
+        [2, 3, 6],
+        [1, 4, 6],
+        [2, 4, 6],
+    ]
+
+    for vertex, new_vertex in zip(vertices, new_vertices):
+        assert ek.allclose(
+            trafo.transform_point(vertex),
+            new_vertex,
+        )

--- a/eradiate/kernel/transform.py
+++ b/eradiate/kernel/transform.py
@@ -1,0 +1,80 @@
+from typing import Any
+
+
+def map_unit_cube(
+    xmin: float, xmax: float, ymin: float, ymax: float, zmin: float, zmax: float
+) -> Any:
+    """
+    Map the unit cube to [xmin, xmax] x [ymin, ymax] x [zmin, zmax].
+
+    .. note::
+        You must select a Mitsuba variant before calling this function.
+
+    Parameter ``xmin`` (float):
+        Minimum X value.
+
+    Parameter ``xmax`` (float):
+        Maximum X value.
+
+    Parameter ``ymin`` (float):
+        Minimum Y value.
+
+    Parameter ``ymax`` (float):
+        Maximum Y value.
+
+    Parameter ``zmin`` (float):
+        Minimum Z value.
+
+    Parameter ``zmax`` (float):
+        Maximum Z value.
+
+    Returns → :class:`~mitsuba.core.ScalarTransform4f`
+        Transform matrix.
+    """
+    from mitsuba.core import ScalarTransform4f
+
+    scale_trafo = ScalarTransform4f.scale([xmax - xmin, ymax - ymin, zmax - zmin])
+    translate_trafo = ScalarTransform4f.translate([xmin, ymin, zmin])
+    return translate_trafo * scale_trafo
+
+
+def map_cube(
+    xmin: float, xmax: float, ymin: float, ymax: float, zmin: float, zmax: float
+) -> Any:
+    """
+    Map the cube [-1, 1]^3 to [xmin, xmax] x [ymin, ymax] x [zmin, zmax].
+
+    .. note::
+        You must select a Mitsuba variant before calling this function.
+
+    Parameter ``xmin`` (float):
+        Minimum X value.
+
+    Parameter ``xmax`` (float):
+        Maximum X value.
+
+    Parameter ``ymin`` (float):
+        Minimum Y value.
+
+    Parameter ``ymax`` (float):
+        Maximum Y value.
+
+    Parameter ``zmin`` (float):
+        Minimum Z value.
+
+    Parameter ``zmax`` (float):
+        Maximum Z value.
+
+    Returns → :class:`~mitsuba.core.ScalarTransform4f`
+        Transform matrix.
+    """
+    from mitsuba.core import ScalarTransform4f
+
+    half_dx = (xmax - xmin) * 0.5
+    half_dy = (ymax - ymin) * 0.5
+    half_dz = (zmax - zmin) * 0.5
+    scale_trafo = ScalarTransform4f.scale([half_dx, half_dy, half_dz])
+    translate_trafo = ScalarTransform4f.translate(
+        [xmin + half_dx, ymin + half_dy, half_dz + zmin]
+    )
+    return translate_trafo * scale_trafo

--- a/eradiate/scenes/atmosphere/_heterogeneous.py
+++ b/eradiate/scenes/atmosphere/_heterogeneous.py
@@ -1,14 +1,18 @@
 import struct
 import tempfile
 from pathlib import Path
+from typing import List, MutableMapping, Optional, Union
 
 import attr
 import numpy as np
+import pint
 import xarray as xr
 
+from eradiate.contexts import KernelDictContext, SpectralContext
+
 from ._core import Atmosphere, AtmosphereFactory
-from ... import validators
 from ...attrs import AUTO, documented, parse_docs
+from ...kernel.transform import map_cube, map_unit_cube
 from ...radprops import RadProfileFactory
 from ...radprops.rad_profile import RadProfile, US76ApproxRadProfile
 from ...units import unit_context_kernel as uck
@@ -91,13 +95,6 @@ def read_binary_grid3d(filename):
     return values
 
 
-def _dataarray_to_ndarray(value):
-    if isinstance(value, xr.DataArray):
-        return value.values
-    else:
-        return value
-
-
 @AtmosphereFactory.register("heterogeneous")
 @parse_docs
 @attr.s
@@ -105,139 +102,105 @@ class HeterogeneousAtmosphere(Atmosphere):
     """
     Heterogeneous atmosphere scene element [:factorykey:`heterogeneous`].
 
-    This class builds a one-dimensional heterogeneous atmosphere. It expands as
-    a ``heterogeneous`` kernel plugin, which takes as parameters a set of
-    paths to volume data files. The radiative properties used to configure
-    :class:`.HeterogeneousAtmosphere` can be specified in two ways:
-
-    - if the ``profile`` field is specified, kernel volume data files will be
-      created using those data;
-    - if the ``profile`` field is set to ``None`` and
-      the ``albedo_fname`` and ``sigma_t_fname`` fields are specified, kernel
-      volume data files will be read from locations set in the ``albedo_fname``
-      and ``sigma_t_fname`` attributes (which then must be set to paths
-      pointing to existing files).
-    - if the ``profile`` field is not specified and neither are the
-      ``albedo_fname`` and ``sigma_t_fname`` fields, then ``profile`` is set to
-      the default :class:`~eradiate.radprops.rad_profile.US76ApproxRadProfile`
-      radiative properties profile.
-
-    If ``profile`` is specified:
-
-    - if ``albedo_fname`` and ``sigma_t_fname`` are specified, data files will
-      be written to those paths;
-    - if ``albedo_fname`` and ``sigma_t_fname`` are not specified (*i.e.* set
-      to ``None``), filenames will be generated based on ``cache_dir``.
-
-    .. note::
-
-       Generated files are not destroyed after execution and can be accessed
-       using paths saved in the ``albedo_fname`` and ``sigma_t_fname`` fields.
-
-    .. warning::
-
-       While radiative properties specified using the ``profile`` field will be
-       scaled according to kernel default unit override, existing volume data
-       will not.
+    This class builds a one-dimensional heterogeneous atmosphere.
+    It expands as a ``heterogeneous`` kernel plugin, which takes as parameters
+    a phase function and a set of paths to volume data files.
+    The radiative properties used to configure
+    :class:`.HeterogeneousAtmosphere` are specified by a :class:`.RadProfile`
+    object.
+    The vertical extension of the atmosphere is automatically adjusted to
+    match that of the :class:`.RadProfile` object.
+    The atmosphere's bottom altitude is set to 0 km.
+    The phase function is set to :class:`.RayleighPhaseFunction`.
     """
 
-    profile = documented(
+    profile: RadProfile = documented(
         attr.ib(
             default=attr.Factory(US76ApproxRadProfile),
-            converter=attr.converters.optional(RadProfileFactory.convert),
-            validator=attr.validators.optional(attr.validators.instance_of(RadProfile)),
+            converter=RadProfileFactory.convert,
+            validator=attr.validators.instance_of(RadProfile),
         ),
         doc="Radiative property profile used. If set, volume data files will be "
         "created from profile data to initialise the corresponding kernel "
         "plugin.",
-        type=":class:`~eradiate.radprops.rad_profile.RadProfile` or None",
+        type=":class:`~eradiate.radprops.rad_profile.RadProfile`",
         default=":class:`US76ApproxRadProfile() <.US76ApproxRadProfile>`",
     )
 
-    @profile.validator
-    def _profile_validator(instance, attribute, value):
-        if instance.toa_altitude is not AUTO and value is not None:
-            raise ValueError("'profile' cannot be set if 'toa_altitude' is not AUTO.")
-
-    albedo_fname = documented(
+    albedo_filename: str = documented(
         attr.ib(
-            default=None,
-            converter=attr.converters.optional(Path),
-            validator=attr.validators.optional(validators.is_file),
+            default="albedo.vol",
+            converter=str,
+            validator=attr.validators.instance_of(str),
         ),
-        doc="Path to the single scattering albedo volume data file. If "
-        "``None``, a value will be created when the file will be "
-        "requested.",
-        type="path-like or None",
-        default="None",
+        doc="Name of the albedo volume data file.",
+        type="str",
+        default='"albedo.vol"',
     )
 
-    sigma_t_fname = documented(
+    sigma_t_filename: str = documented(
         attr.ib(
-            default=None,
-            converter=attr.converters.optional(Path),
-            validator=attr.validators.optional(validators.is_file),
+            default="sigma_t.vol",
+            converter=str,
+            validator=attr.validators.instance_of(str),
         ),
-        doc="Path to the extinction coefficient volume data file. If ``None``, "
-        "a value will be created when the file will be requested.",
-        type="path-like or None",
-        default="None",
+        doc="Name of the extinction coefficient volume data file.",
+        type="str",
+        default='"sigma_t.vol"',
     )
 
-    @albedo_fname.validator
-    @sigma_t_fname.validator
-    def _albedo_fname_and_sigma_t_fname_validator(instance, attribute, value):
-        if instance.profile is None and value is None:
-            raise ValueError(
-                f"{attribute.name} must be set when profile is set to None."
-            )
-        if (
-            instance.width is AUTO
-            and instance.albedo_fname is not None
-            and instance.sigma_t_fname is not None
-        ):
-            raise ValueError(
-                "'albedo_fname' and 'sigma_t_fname' cannot be set when 'width' is set to 'auto'"
-            )
-        if instance.toa_altitude is AUTO and value is not None:
-            raise ValueError(
-                "'albedo_fname' and 'sigma_t_fname' cannot be set when toa_altitude is set to 'auto'"
-            )
-
-    cache_dir = documented(
-        attr.ib(default=None, converter=attr.converters.optional(Path)),
-        doc="Path to a cache directory where volume data files will be "
-        "created. If ``None``, a temporary cache directory will be used.",
-        type="path-like or None",
-        default="None",
+    cache_dir: Path = documented(
+        attr.ib(
+            default=Path(tempfile.mkdtemp()),
+            converter=Path,
+            validator=attr.validators.instance_of(Path),
+        ),
+        doc="Path to a cache directory where volume data files will be created.",
+        type="path-like",
+        default="Temporary directory",
     )
 
     _quantities = {"albedo": "albedo", "sigma_t": "collision_coefficient"}
 
     def __attrs_post_init__(self):
         # Prepare cache directory in case we'd need it
-        if self.cache_dir is None:
-            self.cache_dir = Path(tempfile.mkdtemp())
-        else:
-            self.cache_dir.mkdir(parents=True, exist_ok=True)
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
 
-    def height(self):
-        if self.toa_altitude is AUTO:
-            return self.profile.levels.max()
-        else:
-            return self.toa_altitude
+    # --------------------------------------------------------------------------
+    #                             Properties
+    # --------------------------------------------------------------------------
 
-    def kernel_width(self, ctx=None):
+    @property
+    def albedo_file(self) -> Path:
+        return self.cache_dir / self.albedo_filename
+
+    @property
+    def sigma_t_file(self) -> Path:
+        return self.cache_dir / self.sigma_t_filename
+
+    @property
+    def bottom(self) -> pint.Quantity:
+        return ureg.Quantity(0.0, "km")
+
+    @property
+    def top(self) -> pint.Quantity:
+        return self.profile.levels.max()
+
+    # --------------------------------------------------------------------------
+    #                       Evaluation methods
+    # --------------------------------------------------------------------------
+
+    def eval_width(self, ctx: KernelDictContext) -> pint.Quantity:
         if self.width is AUTO:
             spectral_ctx = ctx.spectral_ctx if ctx is not None else None
 
             if self.profile is None:
                 albedo = ureg.Quantity(
-                    read_binary_grid3d(self.albedo_fname),
+                    read_binary_grid3d(self.albedo_filename),
                     ureg.dimensionless,
                 )
                 sigma_t = ureg.Quantity(
-                    read_binary_grid3d(self.sigma_t_fname),
+                    read_binary_grid3d(self.sigma_t_filename),
                     uck.get("collision_coefficient"),
                 )
                 min_sigma_s = (sigma_t * albedo).min()
@@ -255,14 +218,22 @@ class HeterogeneousAtmosphere(Atmosphere):
         else:
             return self.width
 
-    def make_volume_data(self, fields=None, spectral_ctx=None):
+    # --------------------------------------------------------------------------
+    #                       Kernel dictionary generation
+    # --------------------------------------------------------------------------
+
+    def make_volume_data(
+        self,
+        fields: Optional[Union[str, List[str]]] = None,
+        spectral_ctx: Optional[SpectralContext] = None,
+    ) -> None:
         """
         Create volume data files for requested fields.
 
         Parameter ``fields`` (str or list[str] or None):
             If str, field for which to create volume data file. If list,
             fields for which to create volume data files. If ``None``,
-            all supported fields are processed (``{"albedo", "sigma_t"}``).
+            all supported fields are processed (``["albedo", "sigma_t"]``).
             Default: ``None``.
 
         Parameter ``spectral_ctx`` (:class:`.SpectralContext`):
@@ -294,10 +265,7 @@ class HeterogeneousAtmosphere(Atmosphere):
                 raise ValueError(f"field {field} is empty, cannot create volume data")
 
             # If file name is not specified, we create one
-            field_fname = getattr(self, f"{field}_fname")
-            if field_fname is None:
-                field_fname = self.cache_dir / f"{field}.vol"
-                setattr(self, f"{field}_fname", field_fname)
+            field_fname = getattr(self, f"{field}_file")
 
             # We have the data and the filename: we can create the file
             field_quantity.m_as(uck.get(self._quantities[field]))
@@ -306,73 +274,68 @@ class HeterogeneousAtmosphere(Atmosphere):
                 field_quantity.m_as(uck.get(self._quantities[field])),
             )
 
-    def kernel_phase(self, ctx=None):
+    def kernel_phase(self, ctx: Optional[KernelDictContext] = None) -> MutableMapping:
         return {f"phase_{self.id}": {"type": "rayleigh"}}
 
-    def kernel_media(self, ctx=None):
-        from mitsuba.core import ScalarTransform4f
+    def kernel_media(self, ctx: Optional[KernelDictContext] = None) -> MutableMapping:
 
-        k_width = self.kernel_width(ctx).m_as(uck.get("length"))
-        k_height = self.kernel_height(ctx).m_as(uck.get("length"))
-        k_offset = self.kernel_offset(ctx).m_as(uck.get("length"))
-
-        # First, transform the [0, 1]^3 cube to the right dimensions
-        trafo = ScalarTransform4f(
-            [
-                [k_width, 0.0, 0.0, -0.5 * k_width],
-                [0.0, k_width, 0.0, -0.5 * k_width],
-                [0.0, 0.0, k_height + k_offset, -k_offset],
-                [0.0, 0.0, 0.0, 1.0],
-            ]
+        length_units = uck.get("length")
+        width = self.kernel_width(ctx).m_as(length_units)
+        top = self.top.m_as(length_units)
+        bottom = self.bottom.m_as(length_units)
+        trafo = map_unit_cube(
+            xmin=-width / 2.0,
+            xmax=width / 2.0,
+            ymin=-width / 2.0,
+            ymax=width / 2.0,
+            zmin=bottom,
+            zmax=top,
         )
 
-        # Create volume data files if possible
-        if self.profile is not None:
-            self.make_volume_data("albedo", spectral_ctx=ctx.spectral_ctx)
-            self.make_volume_data("sigma_t", spectral_ctx=ctx.spectral_ctx)
+        self.make_volume_data("albedo", spectral_ctx=ctx.spectral_ctx)
+        self.make_volume_data("sigma_t", spectral_ctx=ctx.spectral_ctx)
 
-        # Output kernel dict
         return {
             f"medium_{self.id}": {
                 "type": "heterogeneous",
                 "phase": {"type": "rayleigh"},
                 "sigma_t": {
                     "type": "gridvolume",
-                    "filename": str(self.sigma_t_fname),
+                    "filename": str(self.sigma_t_file),
                     "to_world": trafo,
                 },
                 "albedo": {
                     "type": "gridvolume",
-                    "filename": str(self.albedo_fname),
+                    "filename": str(self.albedo_file),
                     "to_world": trafo,
                 },
             }
         }
 
-    def kernel_shapes(self, ctx=None):
-        from mitsuba.core import ScalarTransform4f
-
+    def kernel_shapes(self, ctx: Optional[KernelDictContext] = None) -> MutableMapping:
         if ctx.ref:
             medium = {"type": "ref", "id": f"medium_{self.id}"}
         else:
             medium = self.kernel_media(ctx=None)[f"medium_{self.id}"]
 
-        k_length = uck.get("length")
-        k_width = self.kernel_width(ctx).m_as(k_length)
-        k_height = self.kernel_height(ctx).m_as(k_length)
-        k_offset = self.kernel_offset(ctx).m_as(k_length)
+        length_units = uck.get("length")
+        width = self.kernel_width(ctx).m_as(length_units)
+        bottom = self.bottom.m_as(length_units)
+        top = self.top.m_as(length_units)
+        offset = self.kernel_offset(ctx).m_as(length_units)
+        trafo = map_cube(
+            xmin=-width / 2.0,
+            xmax=width / 2.0,
+            ymin=-width / 2.0,
+            ymax=width / 2.0,
+            zmin=bottom - offset,
+            zmax=top,
+        )
 
         return {
             f"shape_{self.id}": {
                 "type": "cube",
-                "to_world": ScalarTransform4f(
-                    [
-                        [0.5 * k_width, 0.0, 0.0, 0.0],
-                        [0.0, 0.5 * k_width, 0.0, 0.0],
-                        [0.0, 0.0, 0.5 * k_height, 0.5 * k_height - k_offset],
-                        [0.0, 0.0, 0.0, 1.0],
-                    ]
-                ),
+                "to_world": trafo,
                 "bsdf": {"type": "null"},
                 "interior": medium,
             }

--- a/eradiate/scenes/atmosphere/tests/test_atmosphere_homogeneous.py
+++ b/eradiate/scenes/atmosphere/tests/test_atmosphere_homogeneous.py
@@ -1,45 +1,79 @@
 import numpy as np
+import pint
 import pinttr
 import pytest
 
 from eradiate import unit_registry as ureg
 from eradiate._util import onedict_value
-from eradiate.attrs import AUTO
 from eradiate.contexts import KernelDictContext
 from eradiate.radprops.rayleigh import compute_sigma_s_air
 from eradiate.scenes.atmosphere import HomogeneousAtmosphere
 from eradiate.scenes.core import KernelDict
-from eradiate.scenes.phase import PhaseFunctionFactory
+from eradiate.scenes.phase import PhaseFunctionFactory, RayleighPhaseFunction
 
 
-def test_atmosphere_homogeneous_construct(mode_mono):
-    # Constructing with defaults succeeds
+def test_atmosphere_homogeneous_default(mode_mono):
+    """
+    Applies default attributes values.
+    """
     r = HomogeneousAtmosphere()
-    assert r.toa_altitude is AUTO
-    assert r.kernel_offset() == 0.1 * ureg.km
-    assert r.kernel_height() == 100.1 * ureg.km
+    assert r.bottom == 0.0 * ureg.km
+    assert r.top == 10.0 * ureg.km
+    assert isinstance(r.phase, RayleighPhaseFunction)
 
-    # Constructing with custom extinction coefficient value succeeds
+
+def test_atmosphere_homogeneous_sigma_s(mode_mono):
+    """
+    Assigns custom 'sigma_s' value.
+    """
     r = HomogeneousAtmosphere(sigma_s=1e-5)
     assert r.eval_sigma_s() == ureg.Quantity(1e-5, ureg.m ** -1)
 
-    # Constructing with custom TOA altitude value succeeds
-    r = HomogeneousAtmosphere(toa_altitude=10.0 * ureg.km)
-    assert r.toa_altitude == 10.0 * ureg.km
 
-    #  Wrong attribute units or invalid values raise an error
-    with pytest.raises(pinttr.exceptions.UnitsError):
-        HomogeneousAtmosphere(toa_altitude=10 * ureg.s)
+def test_atmosphere_homogeneous_top(mode_mono):
+    """
+    Assigns custom 'top' value.
+    """
+    r = HomogeneousAtmosphere(top=8.0 * ureg.km)
+    assert r.top == 8.0 * ureg.km
 
+
+def test_atmosphere_homogeneous_top_invalid_units(mode_mono):
+    """
+    Raises when invalid units are passed to 'top'.
+    """
+    with pytest.raises(pint.errors.DimensionalityError):
+        HomogeneousAtmosphere(top=10 * ureg.s)
+
+
+def test_atmosphere_homogeneous_width_invalid_units(mode_mono):
+    """
+    Raises when invalid units are passed to 'width'.
+    """
     with pytest.raises(pinttr.exceptions.UnitsError):
         HomogeneousAtmosphere(width=5 * ureg.m ** 2)
 
+
+def test_atmosphere_homogeneous_sigma_s_invalid_units(mode_mono):
+    """
+    Raises when invalid units are passed to 'sigma_s'.
+    """
     with pytest.raises(pinttr.exceptions.UnitsError):
         HomogeneousAtmosphere(sigma_s=1e-7 * ureg.m)
 
-    with pytest.raises(ValueError):
-        HomogeneousAtmosphere(toa_altitude=-100.0)
 
+def test_atmosphere_homogeneous_top_invalid_value(mode_mono):
+    """
+    Raises when invalid value is passed to 'top'.
+    """
+    with pytest.raises(ValueError):
+        HomogeneousAtmosphere(top=-100.0)
+
+
+def test_atmosphere_homogeneous_top_invalid_value(mode_mono):
+    """
+    Raises when invalid value is passed to 'width'.
+    """
     with pytest.raises(ValueError):
         HomogeneousAtmosphere(width=-50.0)
 
@@ -47,7 +81,7 @@ def test_atmosphere_homogeneous_construct(mode_mono):
 @pytest.mark.parametrize("phase_id", PhaseFunctionFactory.registry.keys())
 @pytest.mark.parametrize("ref", (False, True))
 def test_atmosphere_homogeneous_phase_function(mode_mono, phase_id, ref):
-    # All available phase functions can be used to create an instance
+    """Supports all available phase function types."""
     r = HomogeneousAtmosphere(phase={"type": phase_id})
 
     # The resulting object produces a valid kernel dictionary
@@ -57,8 +91,10 @@ def test_atmosphere_homogeneous_phase_function(mode_mono, phase_id, ref):
 
 
 def test_atmosphere_homogeneous_width(mode_mono):
-    # Automatic width computation works as intended
-    r = HomogeneousAtmosphere(toa_altitude=10.0 * ureg.km)
+    """
+    Automatically sets width to ten times the scattering mean free path.
+    """
+    r = HomogeneousAtmosphere()
     ctx = KernelDictContext()
     wavelength = ctx.spectral_ctx.wavelength
     assert np.isclose(
@@ -68,11 +104,13 @@ def test_atmosphere_homogeneous_width(mode_mono):
 
 @pytest.mark.parametrize("ref", (False, True))
 def test_atmosphere_homogeneous_kernel_dict(mode_mono, ref):
+    """
+    Produces kernel dictionaries that can be loaded by the kernel.
+    """
     from mitsuba.core.xml import load_dict
 
     r = HomogeneousAtmosphere()
 
-    # Default kernel dict constructs can be loaded by the kernel
     ctx = KernelDictContext(ref=False)
 
     dict_phase = onedict_value(r.kernel_phase(ctx))
@@ -84,7 +122,6 @@ def test_atmosphere_homogeneous_kernel_dict(mode_mono, ref):
     dict_shape = onedict_value(r.kernel_shapes(ctx))
     assert load_dict(dict_shape) is not None
 
-    # Produced scene can be instantiated
     ctx = KernelDictContext(ref=ref)
     kernel_dict = KernelDict.new(r, ctx=ctx)
     assert kernel_dict.load() is not None

--- a/eradiate/scenes/atmosphere/tests/test_heterogeneous.py
+++ b/eradiate/scenes/atmosphere/tests/test_heterogeneous.py
@@ -5,12 +5,10 @@ import numpy as np
 import pinttr
 import pytest
 
-from eradiate import path_resolver, unit_context_config, unit_context_kernel
+from eradiate import path_resolver, unit_context_config
 from eradiate import unit_registry as ureg
-from eradiate._util import onedict_value
 from eradiate.contexts import KernelDictContext
-from eradiate.data import _presolver
-from eradiate.radprops import AFGL1986RadProfile, US76ApproxRadProfile
+from eradiate.radprops import US76ApproxRadProfile
 from eradiate.scenes.atmosphere._heterogeneous import (
     HeterogeneousAtmosphere,
     read_binary_grid3d,
@@ -30,50 +28,14 @@ def test_read_binary_grid3d():
     assert np.allclose(write_values, read_values)
 
 
-def test_heterogeneous_nowrite(mode_mono):
-    from mitsuba.core.xml import load_dict
-
-    # Constructor with volume data files
-    a = HeterogeneousAtmosphere(
-        width=ureg.Quantity(100.0, ureg.km),
-        toa_altitude=ureg.Quantity(100.0, ureg.km),
-        profile=None,
-        sigma_t_fname=_presolver.resolve(
-            "tests/textures/heterogeneous_atmosphere_mono/sigma_t.vol"
-        ),
-        albedo_fname=_presolver.resolve(
-            "tests/textures/heterogeneous_atmosphere_mono/albedo.vol"
-        ),
-    )
-
-    # Default output can be loaded
-    ctx = KernelDictContext(ref=False)
-
-    p = a.kernel_phase(ctx)
-    assert load_dict(onedict_value(p)) is not None
-
-    m = a.kernel_media(ctx)
-    assert load_dict(onedict_value(m)) is not None
-
-    s = a.kernel_shapes(ctx)
-    assert load_dict(onedict_value(s)) is not None
-
-    # Load all elements at once (and use references)
-    ctx = KernelDictContext(ref=True)
-
-    with unit_context_kernel.override({"length": "km"}):
-        kernel_dict = KernelDict.new()
-        kernel_dict.add(a, ctx=ctx)
-        scene = kernel_dict.load()
-        assert scene is not None
-
-
-def test_heterogeneous_write(mode_mono, tmpdir):
+def test_heterogeneous_write_volume_data_files(mode_mono, tmpdir):
+    """
+    Writes the volume data files and produces a kernel dictionary that can be
+    loaded by the kernel.
+    """
     ctx = KernelDictContext()
-
-    # Volume data file creation works as expected
     with unit_context_config.override({"length": "km"}):
-        a = HeterogeneousAtmosphere(
+        atmosphere = HeterogeneousAtmosphere(
             width=100.0,
             profile={
                 "type": "array",
@@ -84,159 +46,59 @@ def test_heterogeneous_write(mode_mono, tmpdir):
             cache_dir=tmpdir,
         )
 
-    a.kernel_dict(ctx)
     # If file creation is successful, volume data files must exist
-    assert a.albedo_fname.is_file()
-    assert a.sigma_t_fname.is_file()
+    atmosphere.make_volume_data(
+        fields=["albedo", "sigma_t"], spectral_ctx=ctx.spectral_ctx
+    )
+    assert atmosphere.albedo_file.is_file()
+    assert atmosphere.sigma_t_file.is_file()
 
     # Written files can be loaded
-    assert KernelDict.new(a, ctx=ctx).load() is not None
-
-
-def test_heterogeneous_file_does_not_exist(mode_mono, tmpdir):
-    # Non-existing volume data files raise an exception
-    with pytest.raises(FileNotFoundError):
-        a = HeterogeneousAtmosphere(
-            profile=None,
-            albedo_fname=tmpdir / "doesnt_exist.vol",
-            sigma_t_fname=tmpdir / "doesnt_exist.vol",
-        )
-
-
-def test_heterogeneous_missing_albedo_fname(mode_mono, tmpdir):
-    # Providing only 'sigma_t_fname' and not 'albedo_fname' when 'profile' is
-    # None is not valid
-    with pytest.raises(ValueError):
-        HeterogeneousAtmosphere(
-            profile=None,
-            toa_altitude=ureg.Quantity(100, "km"),
-            width=ureg.Quantity(1000, "km"),
-            sigma_t_fname=_presolver.resolve(
-                "tests/textures/heterogeneous_atmosphere_mono/sigma_t.vol"
-            ),
-        )
-
-
-def test_heterogeneous_missing_sigma_t_fname(mode_mono, tmpdir):
-    # Providing only 'albedo_fname' and not 'sigma_t_fname' when 'profile' is
-    # None is not valid
-    with pytest.raises(ValueError):
-        HeterogeneousAtmosphere(
-            profile=None,
-            toa_altitude=ureg.Quantity(100, "km"),
-            width=ureg.Quantity(1000, "km"),
-            albedo_fname=_presolver.resolve(
-                "tests/textures/heterogeneous_atmosphere_mono/albedo.vol"
-            ),
-        )
-
-
-def test_heterogeneous_missing_toa_altitude(mode_mono, tmpdir):
-    # Providing 'albedo_fname' and 'sigma_t_fname' but not 'toa_altitude'
-    # when 'profile' is None is not valid
-    with pytest.raises(ValueError):
-        HeterogeneousAtmosphere(
-            profile=None,
-            width=ureg.Quantity(1000, "km"),
-            albedo_fname=_presolver.resolve(
-                "tests/textures/heterogeneous_atmosphere_mono/albedo.vol"
-            ),
-            sigma_t_fname=_presolver.resolve(
-                "tests/textures/heterogeneous_atmosphere_mono/sigma_t.vol"
-            ),
-        )
-
-
-def test_heterogeneous_missing_width(mode_mono, tmpdir):
-    # Providing 'albedo_fname' and 'sigma_t_fname' but not 'width' when
-    # 'profile' is None is not valid
-    with pytest.raises(ValueError):
-        HeterogeneousAtmosphere(
-            profile=None,
-            toa_altitude=ureg.Quantity(100, "km"),
-            albedo_fname=_presolver.resolve(
-                "tests/textures/heterogeneous_atmosphere_mono/albedo.vol"
-            ),
-            sigma_t_fname=_presolver.resolve(
-                "tests/textures/heterogeneous_atmosphere_mono/sigma_t.vol"
-            ),
-        )
-
-
-def test_heterogeneous_toa_altitude_default_profile(mode_mono):
-    # Setting 'toa_altitude' when 'profile' is not None is not valid.
-    with pytest.raises(ValueError):
-        HeterogeneousAtmosphere(
-            toa_altitude=ureg.Quantity(100, "km"),
-        )
-
-
-def test_heterogeneous_toa_altitude_afgl1986_profile(mode_mono):
-    # Setting 'toa_altitude' when 'profile' is not None is not valid.
-    with pytest.raises(ValueError):
-        HeterogeneousAtmosphere(
-            profile=AFGL1986RadProfile(),
-            toa_altitude=ureg.Quantity(100, "km"),
-        )
-
-
-def test_heterogeneous_toa_altitude_us76_approx_profile(mode_mono):
-    # Setting 'toa_altitude' when 'profile' is not None is not valid.
-    with pytest.raises(ValueError):
-        HeterogeneousAtmosphere(
-            profile=US76ApproxRadProfile(),
-            toa_altitude=ureg.Quantity(100, "km"),
-        )
+    assert KernelDict.new(atmosphere, ctx=ctx).load() is not None
 
 
 def test_heterogeneous_default(mode_mono):
-    # Default heterogeneous atmosphere uses the default radiative properties
-    # profile
-    a = HeterogeneousAtmosphere()
-    assert isinstance(a.profile, US76ApproxRadProfile)
-    assert np.allclose(a.profile.levels, ureg.Quantity(range(0, 87), "km"))
+    """
+    Assigns default values.
+    """
+    atmosphere = HeterogeneousAtmosphere()
+    assert isinstance(atmosphere.profile, US76ApproxRadProfile)
+    assert atmosphere.albedo_filename == "albedo.vol"
+    assert atmosphere.sigma_t_filename == "sigma_t.vol"
+    assert atmosphere.cache_dir.is_dir()
 
 
-def test_heterogeneous_us76(mode_mono, tmpdir):
-    ctx = KernelDictContext()
+def test_heterogeneous_get_bottom():
+    """Returns 0.0 km."""
+    assert HeterogeneousAtmosphere().bottom == ureg.Quantity(0.0, "km")
 
-    # Volume data file creation works as expected
-    # Underlying radiative properties profile is correct
-    # Atmosphere height is correctly derived from the radiative
-    # properties profile
-    test_absorption_data_set = path_resolver.resolve(
+
+@pytest.fixture
+def test_absorption_data_set():
+    return path_resolver.resolve(
         "tests/spectra/absorption/us76_u86_4-spectra-4000_25711.nc"
     )
-    a = HeterogeneousAtmosphere(
-        width=ureg.Quantity(1000.0, "km"),
-        profile={
-            "type": "us76_approx",
-            "levels": ureg.Quantity(np.linspace(0, 86, 87), "km"),
-            "absorption_data_set": test_absorption_data_set,
-        },
+
+
+def test_heterogeneous_get_top_us76(mode_mono, tmpdir, test_absorption_data_set):
+    """
+    Sets the atmosphere top to the maximum altitude level value in the
+    underlying US76ApproxRadProfile.
+    """
+    profile = US76ApproxRadProfile(
+        levels=ureg.Quantity(np.linspace(0, 86, 87), "km"),
+        absorption_data_set=test_absorption_data_set,
+    )
+    atmosphere = HeterogeneousAtmosphere(
+        profile=profile,
         cache_dir=tmpdir,
     )
-    assert a.height() == ureg.Quantity(86, "km")
-    profile = a.profile
-    assert isinstance(profile, US76ApproxRadProfile)
-    assert profile.sigma_a(ctx.spectral_ctx).shape == (1, 1, 86)
-    assert profile.sigma_s(ctx.spectral_ctx).shape == (1, 1, 86)
-    assert profile.sigma_t(ctx.spectral_ctx).shape == (1, 1, 86)
-    assert profile.albedo(ctx.spectral_ctx).shape == (1, 1, 86)
-
-    a.kernel_dict(ctx)
-    # If file creation is successful, volume data files must exist
-    assert a.albedo_fname.is_file()
-    assert a.sigma_t_fname.is_file()
-
-    # Written files can be loaded
-    assert KernelDict.new(a, ctx=ctx).load() is not None
+    assert atmosphere.top == ureg.Quantity(86, "km")
 
 
-def test_heterogeneous_afgl1986(mode_mono, tmpdir):
-    # AFGL 1986 - US Standard atmosphere with custom level altitudes and
-    # absorbing species concentrations
-    test_absorption_data_sets = {
+@pytest.fixture
+def test_absorption_data_sets():
+    return {
         "CH4": path_resolver.resolve(
             "tests/spectra/absorption/CH4-spectra-4000_11502.nc"
         ),
@@ -257,47 +119,31 @@ def test_heterogeneous_afgl1986(mode_mono, tmpdir):
         ),
         "O3": path_resolver.resolve("tests/spectra/absorption/O3-spectra-4000_6997.nc"),
     }
-    n_layers = 100
+
+
+def test_heterogeneous_get_top_afgl1986(mode_mono, tmpdir, test_absorption_data_sets):
+    """
+    Sets the atmosphere top to the maximum altitude level value in the
+    underlying AFGL1986RadProfile.
+    """
     a = HeterogeneousAtmosphere(
         profile={
             "type": "afgl1986",
             "model": "us_standard",
-            "levels": ureg.Quantity(np.linspace(0, 100, n_layers + 1), "km"),
-            "concentrations": {
-                "H2O": ureg.Quantity(5e23, "m^-2"),
-                "O3": ureg.Quantity(0.5, "dobson_units"),
-                "CO2": ureg.Quantity(400e-6, ""),
-            },
+            "levels": ureg.Quantity(np.linspace(0, 100, 101), "km"),
             "absorption_data_sets": test_absorption_data_sets,
         }
     )
-    assert a.height() == ureg.Quantity(100, "km")
-    assert isinstance(a.profile, AFGL1986RadProfile)
+    assert a.top == ureg.Quantity(100.0, "km")
 
 
 def test_heterogeneous_invalid_width_units(mode_mono):
-    # Initialising a heterogeneous atmosphere with the invalid 'width' units
-    # raises an exception
+    """
+    Raises when the width units are invalid.
+    """
     with pytest.raises(pinttr.exceptions.UnitsError):
         HeterogeneousAtmosphere(
             width=ureg.Quantity(100.0, "m^2"),
-            toa_altitude=1000.0,
-            profile={
-                "type": "array",
-                "levels": np.linspace(0, 3, 4),
-                "sigma_t_values": np.ones((3, 3, 3)),
-                "albedo_values": np.ones((3, 3, 3)),
-            },
-        )
-
-
-def test_heterogeneous_invalid_toa_altitude_units(mode_mono):
-    # Initialising a heterogeneous atmosphere with the invalid 'toa_altitude'
-    # units raises an exception
-    with pytest.raises(pinttr.exceptions.UnitsError):
-        HeterogeneousAtmosphere(
-            width=100.0,
-            toa_altitude=ureg.Quantity(1000.0, "s"),
             profile={
                 "type": "array",
                 "levels": np.linspace(0, 3, 4),
@@ -308,29 +154,12 @@ def test_heterogeneous_invalid_toa_altitude_units(mode_mono):
 
 
 def test_heterogeneous_invalid_width_value(mode_mono, tmpdir):
-    # Initialising a heterogeneous atmosphere with invalid width value raises
-    # an exception
+    """
+    Raises when width value is negative.
+    """
     with pytest.raises(ValueError):
         HeterogeneousAtmosphere(
             width=-100.0,
-            toa_altitude=1000.0,
-            profile={
-                "type": "array",
-                "levels": np.linspace(0, 3, 4),
-                "sigma_t_values": np.ones((3, 3, 3)),
-                "albedo_values": np.ones((3, 3, 3)),
-            },
-            cache_dir=tmpdir,
-        )
-
-
-def test_heterogeneous_invalid_toa_altitude_value(mode_mono, tmpdir):
-    # Initialising a heterogeneous atmosphere with invalid 'toa_altitude'
-    # value raises an exception
-    with pytest.raises(ValueError):
-        HeterogeneousAtmosphere(
-            width=100.0,
-            toa_altitude=-1000.0,
             profile={
                 "type": "array",
                 "levels": np.linspace(0, 3, 4),

--- a/eradiate/solvers/onedim/_scene.py
+++ b/eradiate/solvers/onedim/_scene.py
@@ -91,7 +91,7 @@ class OneDimScene(Scene):
             if isinstance(measure, DistantMeasure):
                 if measure.target is None:
                     if self.atmosphere is not None:
-                        toa = self.atmosphere.height()
+                        toa = self.atmosphere.top
                         target_point = [0.0, 0.0, toa.m] * toa.units
                     else:
                         target_point = [0.0, 0.0, 0.0] * ucc.get("length")
@@ -100,7 +100,7 @@ class OneDimScene(Scene):
 
                 if measure.origin is None:
                     radius = (
-                        self.atmosphere.height() / 100.0
+                        self.atmosphere.top / 100.0
                         if self.atmosphere is not None
                         else 1.0 * ucc.get("length")
                     )

--- a/eradiate/tests/system/test_onedim_symmetry.py
+++ b/eradiate/tests/system/test_onedim_symmetry.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 
 import eradiate
+from eradiate import unit_registry as ureg
 from eradiate.plot import remove_xylabels
 
 eradiate_dir = os.environ["ERADIATE_DIR"]
@@ -83,7 +84,11 @@ def test_symmetry_zenith(mode_mono_double, surface, atmosphere):
         }[surface],
         atmosphere={
             "none": None,
-            "homogeneous": {"type": "homogeneous", "sigma_s": 1.0e-2},
+            "homogeneous": {
+                "type": "homogeneous",
+                "sigma_s": 1.0e-2 * ureg.km ** -1,
+                "top": 1.0e2 * ureg.km,
+            },
         }[atmosphere],
     )
 


### PR DESCRIPTION
# Description

This pull request updates the `Atmosphere` classes interface in anticipation of the ongoing work in #102.

# Changes

* `Atmosphere`:
  * `toa_altitude` attribute is removed from `Atmosphere`.
  * a `height` property is added.
  * following abstract properties are added:
    * `bottom`: returns the bottom altitude of the atmosphere
    * `top`: returns the top altitude of the atmosphere, i.e. the same value that `toa_altitude` hold
  * following abstract method is added:
    * `eval_width`; returns the width of the atmosphere
* `HomogeneousAtmosphere`:
  * added `_bottom` (defaults to 0 km) and `_top` (defaults to 10 km) attributes
  * implemented `bottom` and `top` properties and `eval_width()` method.
  * updated related tests
* `HeterogeneousAtmosphere`:
  * removed `height()` method
  * implemented `bottom` and `top` properties and `eval_width` method
  * changed `albedo_fname` and `sigma_t_fname` to hold only the file names (not the full path) : these parameters cannot be `None` (default to `"albedo.vol"` and `"sigma_t.vol"`)
  * added properties `albedo_file` `sigma_t_file` to return full path to these volume data files.
  * removed obsolete tests
* updated system test `test_onedim_symmetry`

`HeterogeneousAtmosphere` can no longer be instanciated with volume data files (this feature complicated the design a lot). `HeterogeneousAtmosphere` must have a non-`None` profile ; by default, `profile` is set to `US76ApproxRadProfile()`.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
