### PR TITLE
Added surface altitude attribute

### DIFF
--- a/eradiate/scenes/surface/_core.py
+++ b/eradiate/scenes/surface/_core.py
@@ -103,14 +103,16 @@ class Surface(SceneElement, ABC):
         else:
             bsdf = self.bsdfs()[f"bsdf_{self.id}"]
 
-        width = self.kernel_width(ctx=ctx).m_as(uck.get("length"))
+        w = self.kernel_width(ctx=ctx).m_as(uck.get("length"))
+        z = self.altitude.m_as(uck.get("length"))
+        translate_trafo = ScalarTransform4f.translate(ScalarVector3f(0.0, 0.0, z))
+        scale_trafo = ScalarTransform4f.scale(ScalarVector3f(w / 2.0, w / 2.0, 1.0))
+        trafo = translate_trafo * scale_trafo
 
         return {
             f"shape_{self.id}": {
                 "type": "rectangle",
-                "to_world": ScalarTransform4f.scale(
-                    ScalarVector3f(width * 0.5, width * 0.5, 1.0)
-                ),
+                "to_world": trafo,
                 "bsdf": bsdf,
             }
         }

--- a/eradiate/scenes/surface/_core.py
+++ b/eradiate/scenes/surface/_core.py
@@ -40,7 +40,7 @@ class Surface(SceneElement, ABC):
             default=ureg.Quantity(0.0, "km"),
             units=ucc.deferred("length"),
             converter=pinttr.converters.to_units(ucc.deferred("length")),
-            validator=pinttr.validators.has_compatible_units,
+            validator=[validators.is_positive, pinttr.validators.has_compatible_units],
         ),
         doc="Surface altitude with respect to mean sea level.",
         type="float",

--- a/eradiate/scenes/surface/_core.py
+++ b/eradiate/scenes/surface/_core.py
@@ -35,6 +35,18 @@ class Surface(SceneElement, ABC):
         default='"surface"',
     )
 
+    altitude: pint.Quantity = documented(
+        pinttr.ib(
+            default=ureg.Quantity(0.0, "km"),
+            units=ucc.deferred("length"),
+            converter=pinttr.converters.to_units(ucc.deferred("length")),
+            validator=pinttr.validators.has_compatible_units,
+        ),
+        doc="Surface altitude with respect to mean sea level.",
+        type="float",
+        default="0.0 km",
+    )
+
     width: Union[pint.Quantity, str] = documented(
         pinttr.ib(
             default="auto",

--- a/eradiate/scenes/surface/_core.py
+++ b/eradiate/scenes/surface/_core.py
@@ -42,7 +42,7 @@ class Surface(SceneElement, ABC):
             converter=pinttr.converters.to_units(ucc.deferred("length")),
             validator=[validators.is_positive, pinttr.validators.has_compatible_units],
         ),
-        doc="Surface altitude with respect to mean sea level.",
+        doc="Surface geopotential altitude (referenced to Earth's mean sea level).",
         type="float",
         default="0.0 km",
     )

--- a/eradiate/scenes/surface/tests/test_surface_core.py
+++ b/eradiate/scenes/surface/tests/test_surface_core.py
@@ -57,7 +57,18 @@ def test_scale(mode_mono):
     assert obj_scaled.width == "auto"
 
 
+def test_default_altitude():
+    """
+    Sets the altitude to 0.0 km by default.
+    """
+    obj = MyBlackSurface()
+    assert obj.altitude == 0.0 * ureg.km
+
+
 def test_negative_altitude():
+    """
+    Raises when altitude is set to negative value.
+    """
     obj = MyBlackSurface()
 
     with pytest.raises(ValueError):

--- a/eradiate/scenes/surface/tests/test_surface_core.py
+++ b/eradiate/scenes/surface/tests/test_surface_core.py
@@ -55,3 +55,10 @@ def test_scale(mode_mono):
         obj_scaled = obj.scaled(2.0)
     assert obj_scaled is not obj
     assert obj_scaled.width == "auto"
+
+
+def test_negative_altitude():
+    obj = MyBlackSurface()
+
+    with pytest.raises(ValueError):
+        obj.altitude = -1 * ureg.km


### PR DESCRIPTION
# Description

This pull request adds an `altitude` attribute to the surface scene element. This attribute positions the surface with respect to the mean sea level.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
