### PR TITLE
RadProfile mode safeguards

### DIFF
--- a/eradiate/radprops/rad_profile.py
+++ b/eradiate/radprops/rad_profile.py
@@ -788,7 +788,7 @@ class AFGL1986RadProfile(RadProfile):
 
     absorption_data_sets = documented(
         attr.ib(
-            default=None,
+            factory=dict,
             converter=attr.converters.optional(dict),
             validator=attr.validators.optional(attr.validators.instance_of(dict)),
         ),
@@ -801,6 +801,7 @@ class AFGL1986RadProfile(RadProfile):
         "thermophysical profile, the default data sets will be used to "
         "compute the absorption coefficient of the corresponding species.",
         type="dict",
+        default="{}",
     )
 
     def eval_thermoprops_profile(self):
@@ -913,8 +914,6 @@ class AFGL1986RadProfile(RadProfile):
                 Absorber.O2,
                 Absorber.O3,
             ]
-            if self.absorption_data_sets is None:
-                self.absorption_data_sets = {}
 
             for i, absorber in enumerate(absorbers):
                 n_absorber = n * mr.sel(species=absorber.value)


### PR DESCRIPTION
# Description

This PR adds missing mode safeguards to radiative profile generation components. These components will now raise an `UnsupportedModeError` if used in non-monochromatic modes.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
