### PR TITLE
Refactoring of rad_profile module

### DIFF
--- a/eradiate/scenes/atmosphere/_core.py
+++ b/eradiate/scenes/atmosphere/_core.py
@@ -16,7 +16,6 @@ from ...attrs import AUTO, documented, get_doc, parse_docs
 from ...contexts import KernelDictContext
 from ...units import to_quantity
 from ...units import unit_context_config as ucc
-from ...units import unit_context_kernel as uck
 
 atmosphere_factory = Factory()
 

--- a/eradiate/scenes/atmosphere/_heterogeneous.py
+++ b/eradiate/scenes/atmosphere/_heterogeneous.py
@@ -132,7 +132,7 @@ class HeterogeneousAtmosphere(Atmosphere):
                 )
                 min_sigma_s = (sigma_t * albedo).min()
             else:
-                min_sigma_s = self.profile.sigma_s(spectral_ctx).min()
+                min_sigma_s = self.profile.eval_sigma_s(spectral_ctx).min()
 
             if min_sigma_s <= 0.0:
                 raise ValueError(

--- a/eradiate/thermoprops/afgl1986.py
+++ b/eradiate/thermoprops/afgl1986.py
@@ -1,16 +1,77 @@
 """
 Atmospheric thermophysical properties profiles models according to
 :cite:`Anderson1986AtmosphericConstituentProfiles`.
-
-These atmospheric profiles may be referred to as the AFGL 1986 atmospheric
-profiles in other parts of the documentation.
 """
-import eradiate.data as data
+from typing import MutableMapping, Optional
+
+import pint
+import xarray as xr
+
+from ..data import open
+from .util import interpolate, compute_scaling_factors, rescale_concentration
 
 
-def make_profile(model_id="us_standard"):
+def make_profile(
+    model_id: str = "us_standard",
+    levels: Optional[pint.Quantity] = None,
+    concentrations: Optional[MutableMapping[str, pint.Quantity]] = None,
+) -> xr.Dataset:
     """Makes the atmospheric profiles from the AFGL's 1986 technical report
     :cite:`Anderson1986AtmosphericConstituentProfiles`.
+
+    :cite:`Anderson1986AtmosphericConstituentProfiles` defines six models,
+    listed in the table below.
+
+    .. list-table:: AFGL (1986) atmospheric thermophysical properties profiles models
+       :widths: 2 4 4
+       :header-rows: 1
+
+       * - Model number
+         - Model identifier
+         - Model name
+       * - 1
+         - ``tropical``
+         - Tropic (15N Annual Average)
+       * - 2
+         - ``midlatitude_summer``
+         - Mid-Latitude Summer (45N July)
+       * - 3
+         - ``midlatitude_winter``
+         - Mid-Latitude Winter (45N Jan)
+       * - 4
+         - ``subarctic_summer``
+         - Sub-Arctic Summer (60N July)
+       * - 5
+         - ``subarctic_winter``
+         - Sub-Arctic Winter (60N Jan)
+       * - 6
+         - ``us_standard``
+         - U.S. Standard (1976)
+
+    .. attention::
+        The original altitude mesh specified by
+        :cite:`Anderson1986AtmosphericConstituentProfiles` is a piece-wise
+        regular altitude mesh with an altitude step of 1 km from 0 to 25 km,
+        2.5 km from 25 km to 50 km and 5 km from 50 km to 120 km.
+        Since the Eradiate kernel only supports regular altitude mesh, the
+        original atmospheric thermophysical properties profiles were
+        interpolated on the regular altitude mesh with an altitude step of 1 km
+        from 0 to 120 km.
+
+    Although the altitude meshes of the interpolated
+    :cite:`Anderson1986AtmosphericConstituentProfiles` profiles is fixed,
+    this function lets you define a custom altitude mesh (regular or irregular).
+
+    All six models include the following six absorbing molecular species:
+    H2O, CO2, O3, N2O, CO, CH4 and O2.
+    The concentrations of these species in the atmosphere is fixed by
+    :cite:`Anderson1986AtmosphericConstituentProfiles`.
+    However, this function allows you to rescale the concentrations of each
+    individual molecular species to custom concentration values.
+    Custom concentrations can be provided in different units.
+    For more information about rescaling process and the supported
+    concentration units, refer to the documentation of
+    :func:`~eradiate.thermoprops.util.compute_scaling_factors`.
 
     Parameter ``model_id`` (str):
         Choose from ``"midlatitude_summer"``, ``"midlatitude_winter"``,
@@ -19,7 +80,21 @@ def make_profile(model_id="us_standard"):
 
         Default: ``"us_standard"``
 
-    Returns → :class:`xarray.Dataset`:
+    Parameter ``levels`` (:class:`~pint.Quantity`):
+        Altitude levels.
+
+    Parameter ``concentrations`` (Dict[str, :class:`~pint.Quantity`]):
+        Molecules concentrations.
+
+    Returns → :class:`~xarray.Dataset`:
         Atmospheric profile.
     """
-    return data.open(category="thermoprops_profiles", id="afgl1986-" + model_id)
+    thermoprops = open(category="thermoprops_profiles", id="afgl1986-" + model_id)
+    if levels is not None:
+        thermoprops = interpolate(ds=thermoprops, z_level=levels, conserve_columns=True)
+
+    if concentrations is not None:
+        factors = compute_scaling_factors(ds=thermoprops, concentration=concentrations)
+        thermoprops = rescale_concentration(ds=thermoprops, factors=factors)
+
+    return thermoprops

--- a/eradiate/thermoprops/tests/test_afgl1986.py
+++ b/eradiate/thermoprops/tests/test_afgl1986.py
@@ -1,15 +1,133 @@
+import numpy as np
+import pint
+import pytest
+import xarray as xr
+
 from eradiate.thermoprops.afgl1986 import make_profile
+from eradiate.thermoprops.util import (
+    compute_column_number_density,
+    compute_number_density_at_surface,
+)
+from eradiate.units import unit_registry as ureg
 
 
-def test_make_profile():
-    # All thermophysical properties profile can be made
-    model_ids = [
+@pytest.mark.parametrize(
+    "model_id",
+    [
         "midlatitude_summer",
         "midlatitude_winter",
         "subarctic_summer",
         "subarctic_summer",
         "subarctic_winter",
         "us_standard",
-    ]
-    for model_id in model_ids:
-        ds = make_profile(model_id=model_id)
+    ],
+)
+def test_make_profile(model_id: str) -> None:
+    """
+    All thermophysical properties profile can be made.
+    """
+    ds = make_profile(model_id=model_id)
+    assert isinstance(ds, xr.Dataset)
+
+
+@pytest.mark.parametrize(
+    "model_id",
+    [
+        "midlatitude_summer",
+        "midlatitude_winter",
+        "subarctic_summer",
+        "subarctic_summer",
+        "subarctic_winter",
+        "us_standard",
+    ],
+)
+@pytest.mark.parametrize(
+    "levels",
+    [
+        ureg.Quantity(np.linspace(0, 120, 121), "km"),
+        ureg.Quantity(np.linspace(0, 86, 87), "km"),
+        ureg.Quantity(np.linspace(0, 40, 41), "km"),
+    ],
+)
+def test_make_profile_levels(model_id: str, levels: pint.Quantity) -> None:
+    """
+    Atmospheric thermophysical profile altitude levels array has the same
+    shape as the input 'levels'.
+    """
+    ds = make_profile(model_id=model_id, levels=levels)
+    assert ds.z_level.shape == levels.shape
+
+
+@pytest.mark.parametrize(
+    "model_id",
+    [
+        "midlatitude_summer",
+        "midlatitude_winter",
+        "subarctic_summer",
+        "subarctic_summer",
+        "subarctic_winter",
+        "us_standard",
+    ],
+)
+@pytest.mark.parametrize(
+    "levels",
+    [
+        ureg.Quantity(np.linspace(0, 120, 121), "km"),
+        ureg.Quantity(np.linspace(0, 86, 87), "km"),
+        ureg.Quantity(np.linspace(0, 40, 41), "km"),
+    ],
+)
+def test_make_profile_concentrations(model_id: str, levels: pint.Quantity) -> None:
+    """
+    Concentration-rescaled profile concentrations match the input concentrations.
+    """
+    concentrations = {
+        "H2O": ureg.Quantity(5e23, "m^-2"),
+        "O3": ureg.Quantity(0.5, "dobson_unit"),
+        "CH4": ureg.Quantity(4e19, "m^-3"),
+        "CO2": ureg.Quantity(400e-6, ""),
+    }
+    ds = make_profile(model_id=model_id, levels=levels, concentrations=concentrations)
+
+    column_amount_H2O = compute_column_number_density(ds=ds, species="H2O")
+    column_amount_O3 = compute_column_number_density(ds=ds, species="O3")
+    surface_amount_CH4 = compute_number_density_at_surface(ds=ds, species="CH4")
+    surface_amount_CO2 = ds.mr.sel(species="CO2").values[0]
+
+    assert np.isclose(column_amount_H2O, concentrations["H2O"], rtol=1e-9)
+    assert np.isclose(column_amount_O3, concentrations["O3"], rtol=1e-9)
+    assert np.isclose(surface_amount_CO2, concentrations["CO2"], rtol=1e-9)
+    assert np.isclose(surface_amount_CH4, concentrations["CH4"], rtol=1e-9)
+
+
+@pytest.mark.parametrize(
+    "model_id",
+    [
+        "midlatitude_summer",
+        "midlatitude_winter",
+        "subarctic_summer",
+        "subarctic_summer",
+        "subarctic_winter",
+        "us_standard",
+    ],
+)
+@pytest.mark.parametrize(
+    "levels",
+    [
+        ureg.Quantity(np.linspace(0, 120, 121), "km"),
+        ureg.Quantity(np.linspace(0, 86, 87), "km"),
+        ureg.Quantity(np.linspace(0, 40, 41), "km"),
+    ],
+)
+def test_make_profile_concentrations_invalid(
+    model_id: str, levels: pint.Quantity
+) -> None:
+    """
+    Too large concentrations raise.
+    """
+    with pytest.raises(ValueError):
+        make_profile(
+            model_id=model_id,
+            levels=levels,
+            concentrations={"CO2": ureg.Quantity(400, "")},
+        )


### PR DESCRIPTION
# Description

Refactored `eradiate.radprops.rad_profile` module so that radiative property profiles can be instanciated from a thermophysical properties data set, instead of (previously) from parameters used for generating thermophysical properties data set.

:warning: This pull request is a prerequisite for #102.

This pull request should be merged **after** #111 (this will probably requires some alignment work).

## Example

Create a `type="afgl_1986"` radiative property profile using:

```python
import numpy as np

from eradiate.units import unit_registry as ureg
from eradiate.radprops.rad_profile import AFGL1986RadProfile
from eradiate.thermoprops.afgl_1986 import make_profile

thermoprops = make_profile(
    model_id="us_standard",
    levels=np.linspace(0, 120, 121) * ureg.km,
    concentrations={"CO2": 400 * ureg.dimensionless}
)
AFGL1986RadProfile(thermoprops=thermoprops)
```

or, equivalently:

```python
AFGL1986RadProfile(
    thermoprops=dict(
        model_id="us_standard",
        levels=np.linspace(0, 120, 121) * ureg.km,
        concentrations={"CO2": 400 * ureg.dimensionless},
    )
)
```

## Changes

* Removed `levels` attribute from `US76ApproxRadProfile`
* Removed `model`, `levels` and `concentrations` attributes from `AFGL1986RadProfile`
* Added `thermoprops` attribute to `US76ApproxRadProfile` and `AFGL1986RadProfile`
* Renamed RadProfile's methods that have a `spectral_ctx` argument:
  * `sigma_a()` -> `eval_sigma_a()`
  * `sigma_s()` -> `eval_sigma_s()`
  * `sigma_t()` -> `eval_sigma_t()`
  * `albedo()` -> `eval_albedo()`
* updated `ArrayRadProfile` to support 1D profiles only for consistency
* Added a `from_thermoprops_params` classmethod to `US76ApproxRadProfile` and `AFGL1986RadProfile`: these constructors forward their `model_id`, `levels` and `concentrations`  parameters to the functions that generate the corresponding thermophysical properties data set.
* updated `eradiate.thermoprops.afgl1986.make_profile()` to accept `levels` and `concentrations` parameters
* Added type annotations
* Updated docstrings
* Updated/added tests:
  * updated `rad_profile` tests according to the changes in `RadProfile` classes
  * added test cases for the module `thermoprops.afgl1986`

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
