### PR TITLE
Shettle and Fenn (1979) aerosol models

### DIFF
--- a/docs/references.bib
+++ b/docs/references.bib
@@ -202,6 +202,15 @@
     urldate = {2021-04-08},
 }
 
+@article{Shettle1979ModelsAerosolsLower,
+    author = {Shettle, Eric and Fenn, Robert},
+    year = {1979},
+    month = {09},
+    pages = {94},
+    title = {Models for the Aerosols of the Lower Atmosphere and the Effects of Humidity Variations on their Optical Properties},
+    journal = {Environ. Res.}
+}
+
 @book{Taine2014TransfertsThermiquesIntroduction,
     author = {Jean Taine and Estelle Iacona and Franck Enguehard},
     title = {Transferts thermiques: introduction aux transferts d'énergie : cours et exercices d'application},

--- a/eradiate/data/__init__.py
+++ b/eradiate/data/__init__.py
@@ -43,6 +43,7 @@ import xarray as xr
 
 from .absorption_spectra import _AbsorptionGetter
 from .chemistry import _ChemistryGetter
+from .microprops import _Microprops
 from .solar_irradiance_spectra import _SolarIrradianceGetter
 from .spectral_response_function import _SpectralResponseFunctionGetter
 from .thermoprops_profiles import _ThermoPropsProfilesGetter
@@ -51,6 +52,7 @@ from .. import path_resolver as _presolver
 _getters = {
     "absorption_spectrum": _AbsorptionGetter,
     "chemistry": _ChemistryGetter,
+    "microprops": _Microprops,
     "thermoprops_profiles": _ThermoPropsProfilesGetter,
     "solar_irradiance_spectrum": _SolarIrradianceGetter,
     "spectral_response_function": _SpectralResponseFunctionGetter,

--- a/eradiate/data/microprops.py
+++ b/eradiate/data/microprops.py
@@ -1,0 +1,21 @@
+"""
+Microphysical properties data sets.
+"""
+
+import pandas as pd
+import xarray as xr
+
+from .core import DataGetter
+from .._presolver import path_resolver
+
+
+class _Microprops(DataGetter):
+    PATHS = {
+        "shettle_fenn_1979_table_2": "microprops/shettle_fenn_1979_table_2.csv",
+        "shettle_fenn_1979_table_3": "microprops/shettle_fenn_1979_table3.csv",
+    }
+
+    @classmethod
+    def open(cls, id):
+        path = path_resolver.resolve(cls.path(id))
+        return pd.read_csv(path)

--- a/eradiate/data/microprops.py
+++ b/eradiate/data/microprops.py
@@ -11,11 +11,13 @@ from .._presolver import path_resolver
 
 class _Microprops(DataGetter):
     PATHS = {
-        "shettle_fenn_1979_table_2": "microprops/shettle_fenn_1979_table_2.csv",
-        "shettle_fenn_1979_table_3": "microprops/shettle_fenn_1979_table3.csv",
+        "shettle_fenn_1979_table_2": "microprops/shettle_fenn_1979_table_2.nc",
+        "shettle_fenn_1979_table_3": "microprops/shettle_fenn_1979_table_3.nc",
+        "shettle_fenn_1979_table_4a": "microprops/shettle_fenn_1979_table_4a.nc",
+        "shettle_fenn_1979_table_4b": "microprops/shettle_fenn_1979_table_4b.nc",
     }
 
     @classmethod
     def open(cls, id):
         path = path_resolver.resolve(cls.path(id))
-        return pd.read_csv(path, index_col=0).to_xarray()
+        return xr.open_dataset(path)

--- a/eradiate/data/microprops.py
+++ b/eradiate/data/microprops.py
@@ -18,4 +18,4 @@ class _Microprops(DataGetter):
     @classmethod
     def open(cls, id):
         path = path_resolver.resolve(cls.path(id))
-        return pd.read_csv(path)
+        return pd.read_csv(path, index_col=0).to_xarray()

--- a/eradiate/data/microprops.py
+++ b/eradiate/data/microprops.py
@@ -15,6 +15,9 @@ class _Microprops(DataGetter):
         "shettle_fenn_1979_table_3": "microprops/shettle_fenn_1979_table_3.nc",
         "shettle_fenn_1979_table_4a": "microprops/shettle_fenn_1979_table_4a.nc",
         "shettle_fenn_1979_table_4b": "microprops/shettle_fenn_1979_table_4b.nc",
+        "shettle_fenn_1979_table_5a": "microprops/shettle_fenn_1979_table_5a.nc",
+        "shettle_fenn_1979_table_5b": "microprops/shettle_fenn_1979_table_5b.nc",
+        "shettle_fenn_1979_table_6": "microprops/shettle_fenn_1979_table_6.nc",
     }
 
     @classmethod

--- a/eradiate/microprops/__init__.py
+++ b/eradiate/microprops/__init__.py
@@ -1,3 +1,3 @@
-    """
-    Particles microphysical properties.
-    """
+"""
+Particles microphysical properties.
+"""

--- a/eradiate/microprops/__init__.py
+++ b/eradiate/microprops/__init__.py
@@ -1,0 +1,3 @@
+    """
+    Particles microphysical properties.
+    """

--- a/eradiate/microprops/shettle_fenn_1979.py
+++ b/eradiate/microprops/shettle_fenn_1979.py
@@ -1,40 +1,40 @@
 """
 Aerosols models according to :cite:`Shettle1979ModelsAerosolsLower`.
 """
-from typing import Callable
-
 import numpy as np
+from scipy.stats import lognorm
 
 from ..units import unit_registry as ureg
 
 
+def lognorm(r: np.ndarray, ri: float, si: float, ni: float = 1.0):
+    """
+    Compute the log-normal distribution as in equation (1) of
+    :cite:`Shettle1979ModelsAerosolsLower`.
+    """
+    return (ni / (np.log(10) * r * si * np.sqrt(2 * np.pi))) * np.exp(
+        -np.square(np.log10(r) - np.log10(ri)) / (2 * np.square(si))
+    )
+
+
 @ureg.wraps(
     ret=None,
-    args=("micrometer", "cm^-3 * micrometer^-1", "dimensionless"),
+    args=(
+        "micrometer",
+        "micrometer",
+        "micrometer",
+        "cm^-3",
+        "cm^-3",
+        "dimensionless",
+        "dimensionless",
+    ),
     strict=False,
 )
-def size_distribution(mr: np.ndarray, nd: np.ndarray, std: np.ndarray) -> Callable:
+def size_distribution(
+    r: np.ndarray, r1: float, r2: float, n1: float, n2: float, s1: float, s2: float
+) -> np.ndarray:
     """
-    Return a function that evaluate the particle cumulative number density per
-    unit of radius.
-
-    This function implements the equation (1) in
+    Compute the aerosol size distribution according to equation (1) of
     :cite:`Shettle1979ModelsAerosolsLower`.
-
-    Parameter ``mr`` (:class:`~numpy.ndarray`):
-        Mode radius [micrometer].
-
-    Parameter ``nd`` (:class:`~numpy.ndarray`):
-        Number density per unit of radius [cm^-3 * micrometer^-1].
-
-    Parameter ``std`` (:class:`~numpy.ndarray`):
-        Standard deviation [dimensionless].
-
-    Returns → Callable:
-        A function :class:`~numpy.ndarray` → :class:`~numpy.ndarray` that
-        evaluate the particle cumulative number density per unit of radius.
     """
-
-    return lambda r: (nd / np.log(10) * r * std * np.sqrt(2)) * np.exp(
-        -(np.square(np.log10(r) - np.log10(mr))) / (2 * np.square(std))
-    )
+    return lognorm(r=r, ri=r1, si=s1, ni=n1) + lognorm(r=r, ri=r2, si=s2, ni=n2)

--- a/eradiate/microprops/shettle_fenn_1979.py
+++ b/eradiate/microprops/shettle_fenn_1979.py
@@ -50,9 +50,8 @@ def lognorm(r0: float, std: float = 0.4) -> Callable:
 # ------------------------------------------------------------------------------
 
 
-@ureg.wraps(ret=None, args=(""), strict=False)
 def rural_aerosol_large_particles_radius_distribution(
-    rh: Union[pint.Quantity, float] = 0.75
+    rh: pint.Quantity = 0.75 * ureg.dimensionless
 ) -> Callable:
     """
     Return the radius distribution of the large particles in the rural aerosol
@@ -65,24 +64,23 @@ def rural_aerosol_large_particles_radius_distribution(
     return n2 * lognorm(r0=r2, std=s2)
 
 
-@ureg.wraps(ret=None, args=(""), strict=False)
 def rural_aerosol_small_particles_radius_distribution(
-    rh: Union[pint.Quantity, float] = 0.75
+    rh: pint.Quantity = 0.75 * ureg.dimensionless
 ) -> Callable:
     """
     Return the radius distribution of the small particles in the rural aerosol
     model.
     """
     ds = data.open(category="microprops", id="shettle_fenn_1979_table_2")
-    r1 = to_quantity(ds.r.sel(model="rural", mode=1).interp(rh=rh))
+    r1 = to_quantity(ds.r.sel(model="rural", mode=1).interp(rh=rh.magnitude))
     n1 = ureg.Quantity(0.999875, "cm^-3")
     s1 = ureg.Quantity(0.35 * ureg.dimensionless)
     return n1 * lognorm(r0=r1, std=s1)
 
 
-@ureg.wraps(ret=None, args=("nm", ""), strict=False)
+
 def rural_aerosol_small_particles_refractive_index(
-    w: Union[pint.Quantity, float], rh: Union[pint.Quantity, float] = 0.75
+    w: pint.Quantity, rh: pint.Quantity = 0.75 * ureg.dimensionless
 ) -> pint.Quantity:
     """
     Return the refractive index of the small particles in the rural aerosol
@@ -90,12 +88,16 @@ def rural_aerosol_small_particles_refractive_index(
     """
     ds = data.open(category="microprops", id="shettle_fenn_1979_table_4a")
     refractive_index = ds.eta_r + 1j * ds.eta_i
-    return to_quantity(refractive_index.interp(w=w.to(ds.w.units), rh=rh))
+    refractive_index.attrs = dict(
+        standard_name="complex_refractive_index",
+        long_name="refractive index",
+        units="",
+    )
+    return to_quantity(refractive_index.interp(w=w.m_as(ds.w.units), rh=rh.magnitude))
 
 
-@ureg.wraps(ret=None, args=("nm", ""), strict=False)
 def rural_aerosol_large_particles_refractive_index(
-    w: Union[pint.Quantity, float], rh: Union[pint.Quantity, float] = 0.75
+    w: pint.Quantity, rh: pint.Quantity = 0.75 * ureg.dimensionless
 ) -> pint.Quantity:
     """
     Return the refractive index of the large particles in the rural aerosol
@@ -103,7 +105,12 @@ def rural_aerosol_large_particles_refractive_index(
     """
     ds = data.open(category="microprops", id="shettle_fenn_1979_table_4b")
     refractive_index = ds.eta_r + 1j * ds.eta_i
-    return to_quantity(refractive_index.interp(w=w.to(ds.w.units), rh=rh))
+    refractive_index.attrs = dict(
+        standard_name="complex_refractive_index",
+        long_name="refractive index",
+        units="",
+    )
+    return to_quantity(refractive_index.interp(w=w.m_as(ds.w.units), rh=rh.magnitude))
 
 
 # ------------------------------------------------------------------------------
@@ -111,16 +118,16 @@ def rural_aerosol_large_particles_refractive_index(
 # ------------------------------------------------------------------------------
 
 
-@ureg.wraps(ret=None, args=(""), strict=False)
+
 def urban_aerosol_large_particles_radius_distribution(
-    rh: Union[pint.Quantity, float] = 0.75
+    rh: pint.Quantity = 0.75 * ureg.dimensionless
 ) -> Callable:
     """
     Return the radius distribution of the large particles in the urban aerosol
     model.
     """
     ds = data.open(category="microprops", id="shettle_fenn_1979_table_2")
-    r2 = to_quantity(ds.r.sel(model="urban", mode=2).interp(rh=rh))
+    r2 = to_quantity(ds.r.sel(model="urban", mode=2).interp(rh=rh.magnitude))
     n2 = ureg.Quantity(0.000125, "cm^-3")
     s2 = ureg.Quantity(0.4 * ureg.dimensionless)
     return n2 * lognorm(r0=r2, std=s2)
@@ -128,22 +135,21 @@ def urban_aerosol_large_particles_radius_distribution(
 
 @ureg.wraps(ret=None, args=(""), strict=False)
 def urban_aerosol_small_particles_radius_distribution(
-    rh: Union[pint.Quantity, float] = 0.75
+    rh: pint.Quantity = 0.75 * ureg.dimensionless
 ) -> Callable:
     """
     Return the radius distribution of the small particles in the urban aerosol
     model.
     """
     ds = data.open(category="microprops", id="shettle_fenn_1979_table_2")
-    r1 = to_quantity(ds.r.sel(model="urban", mode=1).interp(rh=rh))
+    r1 = to_quantity(ds.r.sel(model="urban", mode=1).interp(rh=rh.magnitude))
     n1 = ureg.Quantity(0.999875, "cm^-3")
     s1 = ureg.Quantity(0.35 * ureg.dimensionless)
     return n1 * lognorm(r0=r1, std=s1)
 
 
-@ureg.wraps(ret=None, args=("nm", ""), strict=False)
 def urban_aerosol_small_particles_refractive_index(
-    w: Union[pint.Quantity, float], rh: Union[pint.Quantity, float] = 0.75
+    w: pint.Quantity, rh: pint.Quantity = 0.75 * ureg.dimensionless
 ) -> pint.Quantity:
     """
     Return the refractive index of the small particles in the urban aerosol
@@ -151,12 +157,16 @@ def urban_aerosol_small_particles_refractive_index(
     """
     ds = data.open(category="microprops", id="shettle_fenn_1979_table_5a")
     refractive_index = ds.eta_r + 1j * ds.eta_i
-    return to_quantity(refractive_index.interp(w=w.to(ds.w.units), rh=rh))
+    refractive_index.attrs = dict(
+        standard_name="complex_refractive_index",
+        long_name="refractive index",
+        units="",
+    )
+    return to_quantity(refractive_index.interp(w=w.m_as(ds.w.units), rh=rh.magnitude))
 
 
-@ureg.wraps(ret=None, args=("nm", ""), strict=False)
 def urban_aerosol_large_particles_refractive_index(
-    w: Union[pint.Quantity, float], rh: Union[pint.Quantity, float] = 0.75
+    w: pint.Quantity, rh: pint.Quantity = 0.75 * ureg.dimensionless
 ) -> pint.Quantity:
     """
     Return the refractive index of the large particles in the urban aerosol
@@ -164,7 +174,12 @@ def urban_aerosol_large_particles_refractive_index(
     """
     ds = data.open(category="microprops", id="shettle_fenn_1979_table_5b")
     refractive_index = ds.eta_r + 1j * ds.eta_i
-    return to_quantity(refractive_index.interp(w=w.to(ds.w.units), rh=rh))
+    refractive_index.attrs = dict(
+        standard_name="complex_refractive_index",
+        long_name="refractive index",
+        units="",
+    )
+    return to_quantity(refractive_index.interp(w=w.m_as(ds.w.units), rh=rh.magnitude))
 
 
 # ------------------------------------------------------------------------------
@@ -174,32 +189,31 @@ def urban_aerosol_large_particles_refractive_index(
 
 @ureg.wraps(ret=None, args=(""), strict=False)
 def maritime_aerosol_oceanic_component_radius_distribution(
-    rh: Union[pint.Quantity, float] = 0.75
+    rh: pint.Quantity = 0.75 * ureg.dimensionless
 ) -> Callable:
     """
     Return the radius distribution of the oceanic component in the maritime
     aerosol model.
     """
     ds = data.open(category="microprops", id="shettle_fenn_1979_table_2")
-    r2 = to_quantity(ds.r.sel(model="maritime", mode=2).interp(rh=rh))
+    r2 = to_quantity(ds.r.sel(model="maritime", mode=2).interp(rh=rh.magnitude))
     s2 = ureg.Quantity(0.4 * ureg.dimensionless)
     return lognorm(r0=r2, std=s2)
 
 
 @ureg.wraps(ret=None, args=(""), strict=False)
 def maritime_aerosol_continental_component_radius_distribution(
-    rh: Union[pint.Quantity, float] = 0.75
+    rh: pint.Quantity = 0.75 * ureg.dimensionless
 ) -> Callable:
     """
     Return the radius distribution of the continental component in the maritime
     aerosol model.
     """
-    return rural_aerosol_small_particles_radius_distribution(rh=rh)
+    return rural_aerosol_small_particles_radius_distribution(rh=rh.magnitude)
 
 
-@ureg.wraps(ret=None, args=("nm", ""), strict=False)
 def maritime_aerosol_oceanic_component_refractive_index(
-    w: Union[pint.Quantity, float], rh: Union[pint.Quantity, float] = 0.75
+    w: pint.Quantity, rh: pint.Quantity = 0.75 * ureg.dimensionless
 ) -> pint.Quantity:
     """
     Return the refractive index of the oceanic component in the maritime aerosol
@@ -207,12 +221,16 @@ def maritime_aerosol_oceanic_component_refractive_index(
     """
     ds = data.open(category="microprops", id="shettle_fenn_1979_table_6")
     refractive_index = ds.eta_r + 1j * ds.eta_i
-    return to_quantity(refractive_index.interp(w=w.to(ds.w.units), rh=rh))
+    refractive_index.attrs = dict(
+        standard_name="complex_refractive_index",
+        long_name="refractive index",
+        units="",
+    )
+    return to_quantity(refractive_index.interp(w=w.m_as(ds.w.units), rh=rh.magnitude))
 
 
-@ureg.wraps(ret=None, args=("nm", ""), strict=False)
 def maritime_aerosol_continental_refractive_index(
-    w: Union[pint.Quantity, float], rh: Union[pint.Quantity, float] = 0.75
+    w: pint.Quantity, rh: pint.Quantity = 0.75 * ureg.dimensionless
 ) -> pint.Quantity:
     """
     Return the refractive index of the continental component in the maritime
@@ -228,7 +246,7 @@ def maritime_aerosol_continental_refractive_index(
 
 @ureg.wraps(ret=None, args=(""), strict=False)
 def tropospheric_aerosol_radius_distribution(
-    rh: Union[pint.Quantity, float] = 0.75
+    rh: pint.Quantity = 0.75 * ureg.dimensionless
 ) -> Callable:
     """
     Return the radius distribution of the particles in the tropospheric aerosol
@@ -237,9 +255,8 @@ def tropospheric_aerosol_radius_distribution(
     return rural_aerosol_small_particles_radius_distribution(rh=rh)
 
 
-@ureg.wraps(ret=None, args=("nm", ""), strict=False)
 def tropospheric_aerosol_refractive_index(
-    w: Union[pint.Quantity, float], rh: Union[pint.Quantity, float] = 0.75
+    w: pint.Quantity, rh: pint.Quantity = 0.75 * ureg.dimensionless
 ) -> pint.Quantity:
     """
     Return the refractive index of the particles in the tropospheric aerosol

--- a/eradiate/microprops/shettle_fenn_1979.py
+++ b/eradiate/microprops/shettle_fenn_1979.py
@@ -1,4 +1,40 @@
+"""
+Aerosols models according to :cite:`Shettle1979ModelsAerosolsLower`.
+"""
+from typing import Callable
+
+import numpy as np
+
+from ..units import unit_registry as ureg
+
+
+@ureg.wraps(
+    ret=None,
+    args=("micrometer", "cm^-3 * micrometer^-1", "dimensionless"),
+    strict=False,
+)
+def size_distribution(mr: np.ndarray, nd: np.ndarray, std: np.ndarray) -> Callable:
     """
-    Aerosols models according to :cite:`Shettle1979ModelsAerosolsLower`.
+    Return a function that evaluate the particle cumulative number density per
+    unit of radius.
+
+    This function implements the equation (1) in
+    :cite:`Shettle1979ModelsAerosolsLower`.
+
+    Parameter ``mr`` (:class:`~numpy.ndarray`):
+        Mode radius [micrometer].
+
+    Parameter ``nd`` (:class:`~numpy.ndarray`):
+        Number density per unit of radius [cm^-3 * micrometer^-1].
+
+    Parameter ``std`` (:class:`~numpy.ndarray`):
+        Standard deviation [dimensionless].
+
+    Returns → Callable:
+        A function :class:`~numpy.ndarray` → :class:`~numpy.ndarray` that
+        evaluate the particle cumulative number density per unit of radius.
     """
-    
+
+    return lambda r: (nd / np.log(10) * r * std * np.sqrt(2)) * np.exp(
+        -(np.square(np.log10(r) - np.log10(mr))) / (2 * np.square(std))
+    )

--- a/eradiate/microprops/shettle_fenn_1979.py
+++ b/eradiate/microprops/shettle_fenn_1979.py
@@ -1,18 +1,19 @@
 """
 Aerosols models according to :cite:`Shettle1979ModelsAerosolsLower`.
 """
+from typing import Callable
+
 import numpy as np
-from scipy.stats import lognorm
 
 from ..units import unit_registry as ureg
 
 
-def lognorm(r: np.ndarray, ri: float, si: float, ni: float = 1.0):
+def lognorm(ri: float, si: float, ni: float = 1.0) -> Callable:
     """
-    Compute the log-normal distribution as in equation (1) of
+    Return a log-normal distribution as in equation (1) of
     :cite:`Shettle1979ModelsAerosolsLower`.
     """
-    return (ni / (np.log(10) * r * si * np.sqrt(2 * np.pi))) * np.exp(
+    return lambda r: (ni / (np.log(10) * r * si * np.sqrt(2 * np.pi))) * np.exp(
         -np.square(np.log10(r) - np.log10(ri)) / (2 * np.square(si))
     )
 
@@ -37,4 +38,4 @@ def size_distribution(
     Compute the aerosol size distribution according to equation (1) of
     :cite:`Shettle1979ModelsAerosolsLower`.
     """
-    return lognorm(r=r, ri=r1, si=s1, ni=n1) + lognorm(r=r, ri=r2, si=s2, ni=n2)
+    return lognorm(ri=r1, si=s1, ni=n1)(r) + lognorm(ri=r2, si=s2, ni=n2)(r)

--- a/eradiate/microprops/shettle_fenn_1979.py
+++ b/eradiate/microprops/shettle_fenn_1979.py
@@ -8,13 +8,24 @@ import numpy as np
 from ..units import unit_registry as ureg
 
 
-def lognorm(ri: float, si: float, ni: float = 1.0) -> Callable:
+@ureg.wraps(ret=None, args=("micrometer", "dimensionless"), strict=False)
+def lognorm(r0: float, std: float = 0.4) -> Callable:
     """
     Return a log-normal distribution as in equation (1) of
     :cite:`Shettle1979ModelsAerosolsLower`.
+
+    Parameter ``r0`` (float):
+        Mode radius [micrometer].
+
+    Parameter ``s`` (float):
+        Standard deviation of the distribution.
+
+    Returns → Callable:
+        A function (:class:`numpy.ndarray` → :class:`numpy.ndarray`)
+        that evaluates the log-normal distribution.
     """
-    return lambda r: (ni / (np.log(10) * r * si * np.sqrt(2 * np.pi))) * np.exp(
-        -np.square(np.log10(r) - np.log10(ri)) / (2 * np.square(si))
+    return lambda r: (1.0 / (np.log(10) * r * std * np.sqrt(2 * np.pi))) * np.exp(
+        -np.square(np.log10(r) - np.log10(r0)) / (2 * np.square(std))
     )
 
 
@@ -38,4 +49,4 @@ def size_distribution(
     Compute the aerosol size distribution according to equation (1) of
     :cite:`Shettle1979ModelsAerosolsLower`.
     """
-    return lognorm(ri=r1, si=s1, ni=n1)(r) + lognorm(ri=r2, si=s2, ni=n2)(r)
+    return lognorm(r0=r1, std=s1, n=n1)(r) + lognorm(r0=r2, std=s2, n=n2)(r)

--- a/eradiate/microprops/shettle_fenn_1979.py
+++ b/eradiate/microprops/shettle_fenn_1979.py
@@ -1,0 +1,4 @@
+    """
+    Aerosols models according to :cite:`Shettle1979ModelsAerosolsLower`.
+    """
+    


### PR DESCRIPTION
# Description

Add support for the aerosol models defined by _Shettle and Fenn (1979) - Models for the aerosols of the lower atmosphere and the effects of humdity variations on their optical properties_.

Shettle and Fenn (1979) define the following aerosol models:
* rural aerosol model
* urban aerosol model
* maritime aerosol model
* tropospheric aerosol model

:warning: this pull request depends on a `eradiate-data` submodule update with respect to the `shettle_fenn_1979` branch. 

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [ ] The code is tested to prove its function
- [ ] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
