### PR TITLE
Fix true_divide warning

### DIFF
--- a/eradiate/tests/system/test_albedo.py
+++ b/eradiate/tests/system/test_albedo.py
@@ -175,7 +175,12 @@ def test_albedo(mode_mono):
         ax1.set_title("Albedo")
         ax1.set_xlabel("Wavelength [nm]")
 
-        rdiffs = (albedos - expected) / expected
+        rdiffs = np.divide(
+            (albedos - expected),
+            expected,
+            where=expected != 0.0,
+            out=np.zeros_like(expected),
+        )
         ax2.plot(wavelengths, rdiffs, linestyle="--", marker="o")
         ax2.set_title("Relative difference")
         ax2.set_xlabel("Wavelength [nm]")


### PR DESCRIPTION
# Description

Fixes the following runtime warning when running the tests:

```shell
eradiate/eradiate/tests/system/test_albedo.py:178: RuntimeWarning: invalid value encountered in true_divide
    rdiffs = (albedos - expected) / expected
```

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
