### PR TITLE
Use keyword-only parameters and fields for required kwargs

### DIFF
--- a/eradiate/scenes/biosphere/_core.py
+++ b/eradiate/scenes/biosphere/_core.py
@@ -191,7 +191,7 @@ class InstancedCanopyElement(SceneElement):
     @classmethod
     def from_file(
         cls,
-        filename: t.Optional[os.PathLike] = None,
+        filename: os.PathLike,
         canopy_element: t.Optional[CanopyElement] = None,
     ):
         """
@@ -209,8 +209,7 @@ class InstancedCanopyElement(SceneElement):
 
         Parameter ``filename`` (path-like):
             Path to the text file specifying the leaves in the canopy.
-            Can be absolute or relative. Required (setting to ``None`` will
-            raise an exception).
+            Can be absolute or relative.
 
         Parameter ``canopy_element`` (:class:`.CanopyElement` or dict or None):
             :class:`.CanopyElement` to be instanced. If a dictionary is passed,
@@ -226,9 +225,6 @@ class InstancedCanopyElement(SceneElement):
         Raises → FileNotFoundError:
             If ``filename`` does not point to an existing file.
         """
-        if filename is None:
-            raise ValueError("parameter 'filename' is required")
-
         if not os.path.isfile(filename):
             raise FileNotFoundError(f"no file at {filename} found.")
 

--- a/eradiate/scenes/biosphere/_discrete.py
+++ b/eradiate/scenes/biosphere/_discrete.py
@@ -292,10 +292,10 @@ class DiscreteCanopy(Canopy):
     @classmethod
     def leaf_cloud_from_files(
         cls,
+        size: pint.Quantity,
+        leaf_cloud_dicts: t.List[t.MutableMapping],
         padding: int = 0,
         id: str = "discrete_canopy",
-        size: t.Optional[pint.Quantity] = None,
-        leaf_cloud_dicts: t.List[t.MutableMapping] = None,
     ):
         """
         Directly create a leaf cloud canopy from text file specifications,
@@ -316,6 +316,13 @@ class DiscreteCanopy(Canopy):
                   "leaf_transmittance": 0.5,  # optional, leaf transmittance (default: 0.5)
               }
 
+        Parameter ``size`` (array-like):
+            Canopy size as a 3-vector (in metres).
+
+        Parameter ``leaf_cloud_dicts`` (list[dict]):
+            List of dictionary specifying canopy elements and instances (see
+            format above).
+
         Parameter ``padding`` (int):
             Amount of padding around the canopy. Must be positive or zero.
             The resulting padded canopy is a grid of
@@ -324,25 +331,9 @@ class DiscreteCanopy(Canopy):
         Parameter ``id`` (str):
             Canopy ID.
 
-        Parameter ``size`` (array-like):
-            Canopy size as a 3-vector (in metres). Required (setting to ``None``
-            will raise).
-
-        Parameter ``leaf_cloud_dicts`` (list[dict]):
-            List of dictionary specifying canopy elements and instances (see format
-            above). Required (setting to ``None`` will raise).
-
         Returns → :class:`.DiscreteCanopy`:
             Created canopy object.
         """
-        # Check if required kwargs are provided (all args must be kwargs if we
-        # want to use this constructor through from_dict())
-        if size is None:
-            raise ValueError(f"parameter 'size' is required")
-
-        if leaf_cloud_dicts is None:
-            raise ValueError(f"parameter 'leaf_cloud_dicts' is required")
-
         instanced_canopy_elements = []
 
         for leaf_cloud_dict in leaf_cloud_dicts:

--- a/eradiate/scenes/biosphere/_leaf_cloud.py
+++ b/eradiate/scenes/biosphere/_leaf_cloud.py
@@ -754,6 +754,9 @@ class LeafCloud(CanopyElement):
             If ``avoid_overlap`` is ``True``, number of attempts made at placing
             a leaf without collision before giving up. Default: 1e5.
 
+        Parameter ``**kwargs``:
+            Keyword arguments interpreted by :class:`.CuboidLeafCloudParams`.
+
         Returns → :class:`.LeafCloud`:
             Generated leaf cloud.
         """
@@ -810,6 +813,9 @@ class LeafCloud(CanopyElement):
         Parameter ``seed`` (int):
             Seed for the random number generator.
 
+        Parameter ``**kwargs``:
+            Keyword arguments interpreted by :class:`.SphereLeafCloudParams`.
+
         Returns → :class:`.LeafCloud`:
             Generated leaf cloud.
         """
@@ -855,6 +861,9 @@ class LeafCloud(CanopyElement):
         Parameter ``seed`` (int):
             Seed for the random number generator.
 
+        Parameter ``**kwargs``:
+            Keyword arguments interpreted by :class:`.EllipsoidLeafCloudParams`.
+
         Returns → :class:`.LeafCloud`:
             Generated leaf cloud.
         """
@@ -896,6 +905,9 @@ class LeafCloud(CanopyElement):
 
         Parameter ``seed`` (int):
             Seed for the random number generator.
+
+        Parameter ``**kwargs``:
+            Keyword arguments interpreted by :class:`.CylinderLeafCloudParams`.
 
         Returns → :class:`.LeafCloud`:
             Generated leaf cloud.
@@ -939,6 +951,9 @@ class LeafCloud(CanopyElement):
         Parameter ``seed`` (int):
             Seed for the random number generator.
 
+        Parameter ``**kwargs``:
+            Keyword arguments interpreted by :class:`.ConeLeafCloudParams`.
+
         Returns → :class:`.LeafCloud`:
             Generated leaf cloud.
         """
@@ -967,9 +982,9 @@ class LeafCloud(CanopyElement):
     def from_file(
         cls,
         filename,
-        leaf_transmittance=0.5,
-        leaf_reflectance=0.5,
-        id="leaf_cloud",
+        leaf_transmittance: t.Union[float, Spectrum] = 0.5,
+        leaf_reflectance: t.Union[float, Spectrum] = 0.5,
+        id: str = "leaf_cloud",
     ) -> LeafCloud:
         """
         Construct a :class:`.LeafCloud` from a text file specifying the leaf

--- a/eradiate/scenes/biosphere/_leaf_cloud.py
+++ b/eradiate/scenes/biosphere/_leaf_cloud.py
@@ -966,7 +966,7 @@ class LeafCloud(CanopyElement):
     @classmethod
     def from_file(
         cls,
-        filename=None,
+        filename,
         leaf_transmittance=0.5,
         leaf_reflectance=0.5,
         id="leaf_cloud",
@@ -990,8 +990,7 @@ class LeafCloud(CanopyElement):
 
         Parameter ``filename`` (str or PathLike):
             Path to the text file specifying the leaves in the leaf cloud.
-            Can be absolute or relative. Required (setting to ``None`` will
-            raise an exception).
+            Can be absolute or relative.
 
         Parameter ``leaf_reflectance`` (float or :class:`.Spectrum`):
             Reflectance spectrum of the leaves in the cloud. Must be a reflectance
@@ -1013,9 +1012,6 @@ class LeafCloud(CanopyElement):
         Raises → FileNotFoundError:
             If ``filename`` does not point to an existing file.
         """
-        if filename is None:
-            raise ValueError("parameter 'filename' is required")
-
         if not os.path.isfile(filename):
             raise FileNotFoundError(f"no file at {filename} found.")
 

--- a/eradiate/scenes/biosphere/_tree.py
+++ b/eradiate/scenes/biosphere/_tree.py
@@ -290,7 +290,7 @@ class MeshTreeElement:
     mesh_filename: t.Optional[Path] = documented(
         attr.ib(
             converter=attr.converters.optional(Path),
-            default=None,
+            kw_only=True,
         ),
         doc="Path to the triangulated mesh data file. This parameter is required.",
         type="path-like",
@@ -298,9 +298,6 @@ class MeshTreeElement:
 
     @mesh_filename.validator
     def _mesh_filename_validator(self, attribute, value):
-        if value is None:
-            raise ValueError("'mesh_filename' is required")
-
         validators.path_exists(self, attribute, value)
 
         if not value.suffix in [".obj", ".ply"]:

--- a/eradiate/scenes/biosphere/tests/test_biosphere_tree_mesh.py
+++ b/eradiate/scenes/biosphere/tests/test_biosphere_tree_mesh.py
@@ -128,7 +128,7 @@ def test_mesh_tree_element_instantiate(mode_mono, tmp_file, request):
     tmp_file = request.getfixturevalue(tmp_file)
 
     # empty constructor raises due to missing mesh description file
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         MeshTreeElement()
 
     # instantiation with supported format succeeds, except for stl

--- a/eradiate/scenes/measure/_distant.py
+++ b/eradiate/scenes/measure/_distant.py
@@ -626,12 +626,12 @@ class DistantReflectanceMeasure(DistantRadianceMeasure):
     type).
     """
 
-    def postprocess(self, illumination=None) -> xr.Dataset:
+    def postprocess(self, illumination: DirectionalIllumination) -> xr.Dataset:
         """
         Return post-processed raw sensor results.
 
         Parameter ``illumination`` (:class:`.DirectionalIllumination`):
-            Incoming radiance value. *This keyword argument is required.*
+            Scene illumination.
 
         Returns → :class:`~xarray.Dataset`:
             Post-processed results.
@@ -639,9 +639,6 @@ class DistantReflectanceMeasure(DistantRadianceMeasure):
         Raises → TypeError:
             If ``illumination`` is missing or if it has an unsupported type.
         """
-        if illumination is None:
-            raise TypeError("missing required keyword argument 'illumination'")
-
         if not isinstance(illumination, DirectionalIllumination):
             TypeError(
                 "keyword argument 'illumination' must be a "
@@ -798,16 +795,13 @@ class DistantAlbedoMeasure(DistantFluxMeasure):
     """
 
     def postprocess(
-        self,
-        illumination: t.Optional[
-            t.Union[DirectionalIllumination, ConstantIllumination]
-        ] = None,
+        self, illumination: t.Union[DirectionalIllumination, ConstantIllumination]
     ) -> xr.Dataset:
         """
         Return post-processed raw sensor results.
 
         Parameter ``illumination`` (:class:`.DirectionalIllumination` or :class:`.ConstantIllumination`):
-            Incoming radiance value. *This keyword argument is required.*
+            Scene illumination.
 
         Returns → :class:`~xarray.Dataset`:
             Post-processed results.
@@ -815,14 +809,11 @@ class DistantAlbedoMeasure(DistantFluxMeasure):
         Raises → TypeError:
             If ``illumination`` is missing or if it has an unsupported type.
         """
-        if illumination is None:
-            raise TypeError("missing required keyword argument 'illumination'")
-
         if not isinstance(
             illumination, (DirectionalIllumination, ConstantIllumination)
         ):
             raise TypeError(
-                "keyword argument 'illumination' must be one of "
+                "parameter 'illumination' must be one of "
                 "(DirectionalIllumination, ConstantIllumination), got a "
                 f"{illumination.__class__.__name__}"
             )


### PR DESCRIPTION
# Description

In some places, we added checks to verify that required keyword function parameters are indeed passed by the user. This is awkward and Python 3 actually provides [keyword-only parameters](https://www.python.org/dev/peps/pep-3102/) which achieve this.

This PR replaces parameter value checks with kw-only params where relevant. In addition, since the `SceneElement` base class defines a keyword argument field `id`, it follows that every additional field declared by child classes must either have a default value or be kw-only: the same logic therefore applies.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
