### PR TITLE
Molecular absorption cross section computer using hapi

### DIFF
--- a/eradiate/radprops/sad.py
+++ b/eradiate/radprops/sad.py
@@ -1,0 +1,34 @@
+"""
+HAPI wrapper.
+"""
+
+import hapi
+import pint
+import xarray as xr
+
+# TODO: parse https://hitran.org/docs/iso-meta/ to automatically update isotopologues and corresponding abundances
+ISOTOPOLOGUES = dict(
+    H2O=[1, 2, 3, 4, 5, 6, 129],
+    CO2=[7, 8, 9, 10, 11, 12, 13, 14, 121, 15, 120, 122],
+    O3=[16, 17, 18, 19, 20],
+)
+
+
+def fetch_table(
+    molecule: str, wavelength_min: pint.Quantity, wavelength_max: pint.Quantity
+) -> None:
+    hapi.fetch_by_ids(
+        TableName="auto",
+        iso_id_list=ISOTOPOLOGUES[molecule],
+        numin=(1 / wavelength_max).m_as("cm^-1"),
+        numax=(1 / wavelength_min).m_as("cm^-1"),
+    )
+
+
+def compute_absorption_cross_section(
+    molecule: str, wavelength_min: pint.Quantity, wavelength_max: pint.Quantity
+) -> xr.DataArray:
+    fetch_table(
+        molecule=molecule, wavelength_min=wavelength_min, wavelength_max=wavelength_max
+    )
+    pass

--- a/eradiate/radprops/sad.py
+++ b/eradiate/radprops/sad.py
@@ -1,34 +1,252 @@
 """
-HAPI wrapper.
+Wrapper around hapi (https://github.com/hitranonline/hapi) to compute
+monochromatic absorption cross section spectra for molecules.
 """
+import contextlib
+import os
+import pathlib
+import typing as t
 
 import hapi
+import numpy as np
 import pint
 import xarray as xr
 
+from ..units import unit_registry as ureg
+
 # TODO: parse https://hitran.org/docs/iso-meta/ to automatically update isotopologues and corresponding abundances
-ISOTOPOLOGUES = dict(
+ISOTOPOLOGUE_IDS = dict(
     H2O=[1, 2, 3, 4, 5, 6, 129],
     CO2=[7, 8, 9, 10, 11, 12, 13, 14, 121, 15, 120, 122],
     O3=[16, 17, 18, 19, 20],
+    N2O=[21, 22, 23, 24, 25],
+    CO=[26, 27, 28, 29, 30, 31],
+    CH4=[32, 33, 34, 35],
+    O2=[36, 37, 38],
+    NO=[39, 40, 41],
+    SO2=[42, 43, 137, 138],
+    NO2=[44, 130],
 )
 
 
-def fetch_table(
-    molecule: str, wavelength_min: pint.Quantity, wavelength_max: pint.Quantity
-) -> None:
-    hapi.fetch_by_ids(
-        TableName="auto",
-        iso_id_list=ISOTOPOLOGUES[molecule],
-        numin=(1 / wavelength_max).m_as("cm^-1"),
-        numax=(1 / wavelength_min).m_as("cm^-1"),
+@contextlib.contextmanager
+def working_directory(path: str) -> t.Iterator[None]:
+    """
+    Changes working directory and returns to previous on exit.
+    """
+    prev_cwd = pathlib.Path.cwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(prev_cwd)
+
+
+def name_hitran_query(
+    molecules: t.List[str], wavenumber_min: pint.Quantity, wavenumber_max: pint.Quantity
+) -> str:
+    """
+    Name a HITRAN query.
+    """
+    return (
+        "_".join(molecules)
+        + "-"
+        + "_".join(
+            [str(int(w.m_as("cm^-1"))) for w in [wavenumber_min, wavenumber_max]]
+        )
+    )
+
+
+def query_hitran(
+    molecules: t.List[str],
+    wavenumber_min: pint.Quantity,
+    wavenumber_max: pint.Quantity,
+    path: str,
+) -> str:
+    """
+    Query HITRAN for given molecules and wavenumber range.
+
+    Fetched data is written in a directory specified by the parameter ``path``.
+    For each molecule, all isotopologues are selected.
+    """
+    # TODO: create one table per molecule?
+
+    isotopologue_ids = []
+    for molecule in molecules:
+        isotopologue_ids.extend(ISOTOPOLOGUE_IDS[molecule])
+
+    table_name = name_hitran_query(
+        molecules=molecules,
+        wavenumber_min=wavenumber_min,
+        wavenumber_max=wavenumber_max,
+    )
+
+    with working_directory(path):
+        hapi.fetch_by_ids(
+            TableName=table_name,
+            iso_id_list=isotopologue_ids,
+            numin=wavenumber_min.m_as("cm^-1"),
+            numax=wavenumber_max.m_as("cm^-1"),
+        )
+
+    return table_name
+
+
+def ensure_array(x: pint.Quantity) -> pint.Quantity:
+    if not isinstance(x.magnitude, np.ndarray):
+        return ureg.Quantity(np.atleast_1d(x.magnitude), x.units)
+    else:
+        return x
+
+
+def make_absorption_cross_section_data_array(
+    wavenumber: pint.Quantity,
+    absorption_cross_section: pint.Quantity,
+    molecule: str,
+    pressure: pint.Quantity,
+    temperature: pint.Quantity,
+) -> xr.DataArray:
+    """
+    Make an absorption cross section spectrum data array.
+    """
+    pressure = ensure_array(pressure)
+    temperature = ensure_array(temperature)
+    return xr.DataArray(
+        absorption_cross_section.magnitude.reshape(
+            wavenumber.size, pressure.size, temperature.size
+        ),
+        dims=["w", "p", "t"],
+        coords={
+            "w": (
+                "w",
+                wavenumber.magnitude,
+                dict(
+                    standard_name="radiation_wavenumber",
+                    long_name="wavenumber",
+                    units=wavenumber.units,
+                ),
+            ),
+            "p": (
+                "p",
+                pressure.magnitude,
+                dict(
+                    standard_name="air_pressure",
+                    long_name="pressure",
+                    units=pressure.units,
+                ),
+            ),
+            "t": (
+                "t",
+                temperature.magnitude,
+                dict(
+                    standard_name="air_temperature",
+                    long_name="temperature",
+                    units=temperature.units,
+                ),
+            ),
+        },
+        attrs=dict(
+            name=f"{molecule}_absorption_cross_section_spectrum",
+            standard_name="absorption_cross_section",
+            long_name="absorption cross section",
+            units=absorption_cross_section.units,
+            molecule=molecule,
+        ),
+    )
+
+
+def compute_absorption_cross_section_helper(
+    source_table: str,
+    molecule: str,
+    wavenumber_min: pint.Quantity,
+    wavenumber_max: pint.Quantity,
+    wavenumber_step: pint.Quantity = ureg.Quantity(0.01, "cm^-1"),
+    truncation_distance_in_hwhm: int = 50,
+    pressure: pint.Quantity = ureg.Quantity(101325, "Pa"),
+    temperature: pint.Quantity = ureg.Quantity(296.0, "K"),
+) -> xr.DataArray:
+    """
+    Compute the absorption cross section as a function of wavenumber for a
+    given molecule, pressure and temperature (single value).
+    """
+    # It seems that absorptionCoefficient_Voigt will use the natural relative
+    # abundances when mixing each molecule' isotopologues, so we do not
+    # need to specify these relative abundances.
+    nu, coef = hapi.absorptionCoefficient_Voigt(
+        SourceTables=source_table,
+        WavenumberRange=(wavenumber_min.m_as("cm^-1"), wavenumber_max.m_as("cm^-1")),
+        WavenumberStep=wavenumber_step.m_as("cm^-1"),
+        WavenumberWingHW=truncation_distance_in_hwhm,
+        Environment=dict(p=pressure.m_as("atm"), T=temperature.m_as("kelvin")),
+        GammaL="gamma_air",
+        IntensityThreshold=0.0,
+        HITRAN_units=True,  # that means the returned quantity is an absorption cross section with values in units of cm^2
+    )
+
+    return make_absorption_cross_section_data_array(
+        wavenumber=ureg.Quantity(nu, "cm^-1"),
+        absorption_cross_section=ureg.Quantity(coef, "cm^2"),
+        molecule=molecule,
+        pressure=pressure,
+        temperature=temperature,
     )
 
 
 def compute_absorption_cross_section(
-    molecule: str, wavelength_min: pint.Quantity, wavelength_max: pint.Quantity
+    molecule: str,
+    wavenumber_min: pint.Quantity,
+    wavenumber_max: pint.Quantity,
+    wavenumber_step: pint.Quantity = ureg.Quantity(0.01, "cm^-1"),
+    truncation_distance_in_hwhm: int = 50,
+    pressure: pint.Quantity = ureg.Quantity(101325.0, "Pa"),
+    temperature: pint.Quantity = ureg.Quantity(296.0, "K"),
 ) -> xr.DataArray:
-    fetch_table(
-        molecule=molecule, wavelength_min=wavelength_min, wavelength_max=wavelength_max
+    """
+    Compute the absorption cross section as a function of wavenumber, pressure
+    and temperature for a given molecule.
+
+    If ``pressure`` and ``temperature`` are arrays, we loop over the cartesian
+    product of the two arrays.
+    """
+    # query HITRAN
+    path = "./hapi_data"  # directory where to save the HITRAN query
+    source_table = query_hitran(
+        molecules=[molecule],
+        wavenumber_min=wavenumber_min,
+        wavenumber_max=wavenumber_max,
+        path=path,
     )
-    pass
+
+    data_sets_grid = []
+    for p in ensure_array(pressure):
+        inner_grid = []
+        for t in ensure_array(temperature):
+            _da = compute_absorption_cross_section_helper(
+                source_table=source_table,
+                molecule=molecule,
+                wavenumber_min=wavenumber_min,
+                wavenumber_max=wavenumber_max,
+                wavenumber_step=wavenumber_step,
+                truncation_distance_in_hwhm=truncation_distance_in_hwhm,
+                pressure=p,
+                temperature=t,
+            )
+            inner_grid.append(_da)
+        data_sets_grid.append(inner_grid)
+
+    da = xr.combine_nested(data_sets_grid, concat_dim=["p", "t"])
+
+    # update attrs for concatenation dimensions (i.e. 'p' and 't')
+    da.p.attrs.update(
+        dict(standard_name="air_pressure", long_name="pressure", units=pressure.units)
+    )
+    da.t.attrs.update(
+        standard_name="air_temperature",
+        long_name="temperature",
+        units=temperature.units,
+    )
+
+    # update general attributes
+    da.attrs.update(_da.attrs)
+
+    return da

--- a/eradiate/radprops/tests/test_sad.py
+++ b/eradiate/radprops/tests/test_sad.py
@@ -1,6 +1,7 @@
 import os
 
 import numpy as np
+import pytest
 import xarray as xr
 
 from eradiate import unit_registry as ureg
@@ -116,8 +117,13 @@ def test_compute_absorption_cross_section_helper(tmpdir):
     assert isinstance(da, xr.DataArray)
 
 
-def test_compute_absorption_cross_section(tmpdir):
-    molecule = "CO2"
+@pytest.mark.parametrize(
+    "molecule", ["H2O", "CO2", "O3", "N2O", "CO", "CH4", "O2", "NO", "SO2", "NO2"]
+)
+def test_compute_absorption_cross_section(tmpdir, molecule):
+    """
+    Returns a xarray.DataArray.
+    """
     wavenumber_min = ureg.Quantity(5000, "cm^-1")
     wavenumber_max = ureg.Quantity(5010, "cm^-1")
 

--- a/eradiate/radprops/tests/test_sad.py
+++ b/eradiate/radprops/tests/test_sad.py
@@ -1,0 +1,129 @@
+import os
+
+import numpy as np
+import xarray as xr
+
+from eradiate import unit_registry as ureg
+from eradiate.radprops.sad import (
+    compute_absorption_cross_section,
+    compute_absorption_cross_section_helper,
+    ensure_array,
+    make_absorption_cross_section_data_array,
+    name_hitran_query,
+    query_hitran,
+    working_directory,
+)
+
+
+def test_name_hitran_query():
+    """
+    Returns a str.
+    """
+    assert isinstance(
+        name_hitran_query(
+            molecules=["H2O", "CO2"],
+            wavenumber_min=ureg.Quantity(10000, "cm^-1"),
+            wavenumber_max=ureg.Quantity(11000, "cm^-1"),
+        ),
+        str,
+    )
+
+
+def test_working_directory(tmpdir):
+    """
+    Changes working directory and returns to previous on exit.
+    """
+    prev_dir = os.getcwd()
+    with working_directory(path=tmpdir):
+        assert os.getcwd() == tmpdir
+    assert os.getcwd() == prev_dir
+
+
+def test_query_hitran(tmpdir):
+    """
+    Returned table matches a key in HAPI tables local (dynamic) database.
+    """
+    import hapi
+
+    table = query_hitran(
+        molecules=["CO2"],
+        wavenumber_min=ureg.Quantity(8000, "cm^-1"),
+        wavenumber_max=ureg.Quantity(8010, "cm^-1"),
+        path=tmpdir,
+    )
+
+    assert table in hapi.getTableList()
+
+
+def test_ensure_array():
+    """
+    Float-, list- and numpy.ndarray- quantities are converted to numpy.ndarray
+    quantities and their units are left unchanged.
+    """
+    x = ureg.Quantity(5, "s")
+    assert isinstance(ensure_array(x).magnitude, np.ndarray)
+    assert ensure_array(x).units == x.units
+
+    y = ureg.Quantity([5, 6], "N")
+    assert isinstance(ensure_array(y).magnitude, np.ndarray)
+    assert ensure_array(y).units == y.units
+
+    z = ureg.Quantity(np.linspace(0, 1), "m")
+    assert isinstance(ensure_array(z).magnitude, np.ndarray)
+    assert ensure_array(z).units == z.units
+
+
+def test_make_absorption_cross_section_data_array():
+    """
+    Returns a xarray.DataArray.
+    """
+    wavenumber = ureg.Quantity(np.linspace(4000, 5000))
+    absorption_cross_section = ureg.Quantity(np.random.rand(len(wavenumber)), "m^2")
+    pressure = ureg.Quantity(0.8, "atm")
+    temperature = ureg.Quantity(280.15, "kelvin")
+
+    da = make_absorption_cross_section_data_array(
+        wavenumber=wavenumber,
+        absorption_cross_section=absorption_cross_section,
+        molecule="CH4",
+        pressure=pressure,
+        temperature=temperature,
+    )
+
+    assert isinstance(da, xr.DataArray)
+
+
+def test_compute_absorption_cross_section_helper():
+    """
+    Returns a xarray.DataArray.
+    """
+    molecule = "CO2"
+    wavenumber_min = ureg.Quantity(5000, "cm^-1")
+    wavenumber_max = ureg.Quantity(5010, "cm^-1")
+
+    da = compute_absorption_cross_section_helper(
+        source_table=query_hitran(
+            molecules=[molecule],
+            wavenumber_min=wavenumber_min,
+            wavenumber_max=wavenumber_max,
+        ),
+        molecule=molecule,
+        wavenumber_min=wavenumber_min,
+        wavenumber_max=wavenumber_max,
+    )
+
+    assert isinstance(da, xr.DataArray)
+
+
+def test_compute_absorption_cross_section():
+    molecule = "CO2"
+    wavenumber_min = ureg.Quantity(5000, "cm^-1")
+    wavenumber_max = ureg.Quantity(5010, "cm^-1")
+
+    da = compute_absorption_cross_section(
+        molecule=molecule,
+        wavenumber_min=wavenumber_min,
+        wavenumber_max=wavenumber_max,
+    )
+
+    assert isinstance(da, xr.DataArray)

--- a/eradiate/radprops/tests/test_sad.py
+++ b/eradiate/radprops/tests/test_sad.py
@@ -93,7 +93,7 @@ def test_make_absorption_cross_section_data_array():
     assert isinstance(da, xr.DataArray)
 
 
-def test_compute_absorption_cross_section_helper():
+def test_compute_absorption_cross_section_helper(tmpdir):
     """
     Returns a xarray.DataArray.
     """
@@ -106,6 +106,7 @@ def test_compute_absorption_cross_section_helper():
             molecules=[molecule],
             wavenumber_min=wavenumber_min,
             wavenumber_max=wavenumber_max,
+            path=tmpdir,
         ),
         molecule=molecule,
         wavenumber_min=wavenumber_min,
@@ -115,7 +116,7 @@ def test_compute_absorption_cross_section_helper():
     assert isinstance(da, xr.DataArray)
 
 
-def test_compute_absorption_cross_section():
+def test_compute_absorption_cross_section(tmpdir):
     molecule = "CO2"
     wavenumber_min = ureg.Quantity(5000, "cm^-1")
     wavenumber_max = ureg.Quantity(5010, "cm^-1")
@@ -124,6 +125,7 @@ def test_compute_absorption_cross_section():
         molecule=molecule,
         wavenumber_min=wavenumber_min,
         wavenumber_max=wavenumber_max,
+        hitran_data_dir=tmpdir,
     )
 
     assert isinstance(da, xr.DataArray)


### PR DESCRIPTION
Resolves eradiate/eradiate-issues#110

# Description

Adds a wrapper around [hapi](https://github.com/hitranonline/hapi) to compute molecular absorption cross section spectra dynamically.

# Checklist

- [x] The code follows the relevant coding guidelines
- [ ] The code generates no new warnings
- [ ] The code is appropriately documented
- [x] The code is tested to prove its function
- [ ] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
- [ ] add `hapi` to the dependencies (build and upload to anaconda first)
- [ ] cite HAPI
- [ ] better docstrings
- [ ] add module to documentation
