### PR TITLE
Mie scattering properties computer

### DIFF
--- a/eradiate/radprops/mie.py
+++ b/eradiate/radprops/mie.py
@@ -1,5 +1,5 @@
 """
-Core module.
+Mie scattering properties computation.
 """
 import typing as t
 

--- a/eradiate/radprops/mie.py
+++ b/eradiate/radprops/mie.py
@@ -1,0 +1,305 @@
+"""
+Core module.
+"""
+import typing as t
+
+import miepython
+import numpy as np
+import pint
+import xarray as xr
+
+
+from ..units import unit_registry as ureg
+
+_DEFAULT_MU = np.linspace(-1, 1, 201)
+
+
+@ureg.wraps(ret=None, args=("nm", None, None, "dimensionless"), strict=False)
+def compute_properties(
+    w: t.Union[ureg.Quantity, np.ndarray],
+    rdist: xr.DataArray,
+    m: xr.DataArray,
+    mu: t.Union[ureg.Quantity, np.ndarray] = _DEFAULT_MU,
+) -> xr.DataArray:
+    """
+    Compute multi-wavelength radiative properties of spherical particles with
+    a radius distribution.
+
+    Parameters
+    ----------
+    w: :class:`~pint.Quantity` or :class:`~numpy.ndarray`
+        Wavelength values [nm].
+
+    rdist: :class:`~xarray.DataArray`
+        Particle radius probability distribution.
+
+    m: :class:`~xarray.DataArray`
+        Complex refractive index.
+
+    mu: :class:`~pint.Quantity` or :class:`~numpy.ndarray`
+        Scattering angle cosines [dimensionless].
+
+    Returns
+    -------
+    :class:`~xarray.DataArray`
+        Radiative properties.
+    """
+    dsi = []
+    for wavelength in w:
+        dsi.append(compute_mono_properties(w=wavelength, rdist=rdist, m=m, mu=mu))
+    return xr.concat(dsi, dim="w")
+
+
+@ureg.wraps(
+    ret=None,
+    args=("nanometer", None, "dimensionless", "dimensionless"),
+    strict=False,
+)
+def compute_mono_properties(
+    w: t.Union[ureg.Quantity, float],
+    rdist: xr.DataArray,
+    m: t.Union[ureg.Quantity, complex],
+    mu: t.Union[ureg.Quantity, np.ndarray] = _DEFAULT_MU,
+):
+    """
+    Compute the mono-wavelength radiative properties of spherical particles
+    with radii specified by a probabiblity distribution.
+
+    Parameters
+    ----------
+    w: :class:`~pint.Quantity` or float
+        Wavelength [nanometer].
+
+    rdist: :class:`~xarray.DataArray`
+        Radius probability distribution.
+
+    m: :class:`~pint.Quantity` or complex
+        Complex refractive index [dimensionless].
+
+    mu: :class:`~pint.Quantity` or :class:`numpy.ndarray`
+        Scattering angle cosines [dimensionless].
+
+    Returns
+    -------
+    :class:`~xarray.Dataset`
+         Monochromatic radii-averaged radiative properties.
+    """
+    ds = compute_mono_properties_multiple_radius(w=w, r=rdist.r.values, m=m, mu=mu)
+    return ds.weighted(rdist).mean(dim="r")
+
+
+@ureg.wraps(
+    ret=None,
+    args=("nanometer", "micrometer", "dimensionless", "dimensionless"),
+    strict=False,
+)
+def compute_mono_properties_multiple_radius(
+    w: t.Union[ureg.Quantity, float],
+    r: t.Union[ureg.Quantity, np.ndarray],
+    m: t.Union[ureg.Quantity, complex],
+    mu: t.Union[ureg.Quantity, np.ndarray] = _DEFAULT_MU,
+) -> xr.Dataset:
+    """
+    Compute the mono-wavelength multiple-radius radiative properties of
+    spherical particles.
+
+    Parameters
+    ----------
+    w: :class:`~pint.Quantity` or float
+        Wavelength [nanometer].
+
+    r: :class:`~pint.Quantity` or :class:`~numpy.ndarray`
+        Radius values [micrometer].
+
+    m: :class:`~pint.Quantity` or complex
+        Complex refractive index [dimensionless].
+
+    mu: :class:`~pint.Quantity` or :class:`numpy.ndarray`
+        Scattering angle cosines [dimensionless].
+
+    Returns
+    -------
+    :class:`~xarray.Dataset`
+         Multiple-radius monochromatic radiative properties.
+    """
+    dsi = []
+    for ri in r:
+        dsi.append(compute_mono_properties_single_radius(w=w, r=ri, m=m, mu=mu))
+    return xr.concat(dsi, dim="r")
+
+
+@ureg.wraps(ret=None, args=("nanometer", "micrometer", "", ""), strict=False)
+def compute_mono_properties_single_radius(
+    w: t.Union[float, ureg.Quantity],
+    r: t.Union[float, ureg.Quantity],
+    m: t.Union[complex, ureg.Quantity],
+    mu: t.Union[np.ndarray] = _DEFAULT_MU,
+) -> xr.Dataset:
+    """
+    Compute monochromatic radiative properties for one given particle radius.
+
+    The radiative properties are computed for one particle radius value and at
+    a single wavelength.
+    The computed radiative properties are the extinction cross section, the
+    albedo and the scattering phase function.
+    The phase function is normalised so that its integral over the unit sphere
+    is 1.
+
+    Parameters
+    ----------
+    w: float or :class:`pint.Quantity`
+        wavelength in a vacuum [nm].
+
+    r: float or :class:`pint.Quantity`
+        radius of the spherical scatterer [micrometer].
+
+    m: complex
+        index of refraction [dimensionless].
+
+    mu: array
+        Cosine of the scattering angle [dimensionless].
+
+    Returns
+    -------
+    :class:`~xarray.Dataset`
+        Computed monochromatic radiative properties.
+    """
+    # make input parameters physical quantities (except 'm' and 'mu')
+    w = ureg.Quantity(w, "nanometer")
+    r = ureg.Quantity(r, "micrometer")
+
+    # compute size parameter
+    x = (2 * np.pi * r / w).m_as(ureg.dimensionless)
+
+    # compute efficiencies
+    qext, qsca, _, _ = miepython.mie(m=m, x=x)
+
+    # compute extinction cross section and albedo
+    area = np.array(np.pi) * (r.to("m")) ** 2
+    sigma_t = qext * area
+    albedo = ureg.Quantity(qsca / qext, "")
+
+    # compute phase function
+    phase = miepython.i_unpolarized(m=m, x=x, mu=mu)
+
+    # re-normalise phase function
+    phase = ureg.Quantity(phase * 1 / albedo.magnitude, "steradian^-1")
+
+    return make_data_set(
+        phase=phase,
+        sigma_t=sigma_t,
+        albedo=albedo,
+        w=w,
+        r=r,
+        m=m,
+        mu=mu,
+    )
+
+
+@ureg.wraps(
+    ret=None, args=("steradian^-1", "m^2", "", "nm", "micrometer", "", ""), strict=False
+)
+def make_data_set(
+    phase: t.Union[pint.Quantity, np.ndarray],
+    sigma_t: t.Union[pint.Quantity, float],
+    albedo: t.Union[pint.Quantity, float],
+    w: t.Union[pint.Quantity, float],
+    r: t.Union[pint.Quantity, float],
+    m: t.Union[pint.Quantity, complex],
+    mu: t.Union[pint.Quantity, np.ndarray],
+) -> xr.Dataset:
+    """
+    Make a radiative properties data set.
+
+    Parameters
+    ----------
+    phase: :class:`~pint.Quantity` or :class:`~numpy.ndarray`
+        Scattering phase function [steradian^-1].
+
+    sigma_t: :class:`~pint.Quantity` or float
+        Extinction cross section [m^2].
+
+    albedo: :class:`~pint.Quantity` or float)
+        Albedo [dimensionless].
+
+    w: :class:`~pint.Quantity` or float)
+        Wavelength [nm].
+
+    r: :class:`~pint.Quantity` or float
+        Radius [micrometer].
+
+    m: :class:`~pint.Quantity` or complex
+        Index of refraction [dimensionless].
+
+    mu: :class:`~pint.Quantity` or :class:`~numpy.ndarray`
+        Scattering angles cosine values [dimensionless].
+
+    Returns:
+    --------
+        Radiative properties :class:`~xarray.Dataset`
+    """
+    return xr.Dataset(
+        data_vars={
+            "phase": (
+                ["w", "r", "m", "mu"],
+                phase.reshape(1, 1, 1, len(mu)),
+                dict(
+                    standard_name="scattering_phase_function",
+                    long_name="scattering phase function",
+                    units="steradian^-1",
+                ),
+            ),
+            "sigma_t": (
+                ["w", "r", "m"],
+                np.array([sigma_t]).reshape(1, 1, 1),
+                dict(
+                    standard_name="extinction_cross_section",
+                    long_name="extinction cross section",
+                    units="m^2",
+                ),
+            ),
+            "albedo": (
+                ["w", "r", "m"],
+                np.array([albedo]).reshape(1, 1, 1),
+                dict(standard_name="albedo", long_name="albedo", units=""),
+            ),
+        },
+        coords={
+            "w": (
+                "w",
+                [w],
+                dict(
+                    standard_name="radiation_wavelength",
+                    long_name="radiation_wavelength",
+                    units="nm",
+                ),
+            ),
+            "r": (
+                "r",
+                [r],
+                dict(
+                    standard_name="particle_radius",
+                    long_name="particle radius",
+                    units="micrometer",
+                ),
+            ),
+            "m": (
+                "m",
+                [m],
+                dict(
+                    standard_name="refractive_index",
+                    long_name="refractive index",
+                    units="",
+                ),
+            ),
+            "mu": (
+                "mu",
+                mu,
+                dict(
+                    standard_name="scattering_angle_cosine",
+                    long_name="scattering angle cosine",
+                    units="",
+                ),
+            ),
+        },
+    )

--- a/eradiate/radprops/mie.py
+++ b/eradiate/radprops/mie.py
@@ -249,11 +249,11 @@ def make_data_set(
     return xr.Dataset(
         data_vars={
             "phase": (
-                ["w", "r", "mu"],
-                phase.reshape(1, 1, len(mu)),
+                ["w", "r", "mu", "i", "j"],
+                phase.reshape(1, 1, len(mu), 1, 1),
                 dict(
-                    standard_name="scattering_phase_function",
-                    long_name="scattering phase function",
+                    standard_name="scattering_phase_matrix",
+                    long_name="scattering phase matrix",
                     units="steradian^-1",
                 ),
             ),
@@ -307,6 +307,20 @@ def make_data_set(
                     standard_name="scattering_angle_cosine",
                     long_name="scattering angle cosine",
                     units="",
+                ),
+            ),
+            "i": (
+                "i",
+                [0],
+                dict(
+                    long_name="matrix row index",
+                ),
+            ),
+            "j": (
+                "j",
+                [0],
+                dict(
+                    long_name="matrix column index",
                 ),
             ),
         },

--- a/eradiate/radprops/tests/test_mie.py
+++ b/eradiate/radprops/tests/test_mie.py
@@ -17,7 +17,7 @@ def test_make_data_test():
     """
     ds = make_data_set(
         phase=np.random.rand((50)),
-        sigma_t=1e-2,
+        xs_t=1e-2,
         albedo=0.96,
         w=550.0,
         r=1.0,

--- a/eradiate/radprops/tests/test_mie.py
+++ b/eradiate/radprops/tests/test_mie.py
@@ -1,0 +1,104 @@
+import numpy as np
+import xarray as xr
+
+from eradiate import unit_registry as ureg
+from eradiate.radprops.mie import (
+    make_data_set,
+    compute_mono_properties_single_radius,
+    compute_mono_properties_multiple_radius,
+    compute_mono_properties,
+    compute_properties,
+)
+
+
+def test_make_data_test():
+    """
+    Returns a xarray.Dataset.
+    """
+    ds = make_data_set(
+        phase=np.random.rand((50)),
+        sigma_t=1e-2,
+        albedo=0.96,
+        w=550.0,
+        r=1.0,
+        m=1.5 - 0.01j,
+        mu=np.linspace(-1, 1),
+    )
+    assert isinstance(ds, xr.Dataset)
+
+
+def test_compute_mono_properties_single_radius():
+    """
+    Returns a xarray.Dataset.
+    """
+    ds = compute_mono_properties_single_radius(
+        w=550.0,
+        r=1.0,
+        m=1.5 - 0.1j,
+    )
+    assert isinstance(ds, xr.Dataset)
+
+
+def test_compute_mono_properties_multiple_radius():
+    """
+    Returns a xarray.Dataset.
+    """
+    ds = compute_mono_properties_multiple_radius(
+        w=550.0,
+        r=np.linspace(1.0, 2.0),
+        m=1.5 - 0.1j,
+    )
+    assert isinstance(ds, xr.Dataset)
+
+
+def lognorm(r0: float, std: float = 0.4):
+    """
+    Return a log-normal distribution
+    """
+    return lambda r: (1.0 / (np.log(10) * r * std * np.sqrt(2 * np.pi))) * np.exp(
+        -np.square(np.log10(r) - np.log10(r0)) / (2 * np.square(std))
+    )
+
+
+def make_data_array(r: np.ndarray, rw: np.ndarray) -> xr.DataArray:
+    return xr.DataArray(
+        data=rw,
+        coords=[("r", r)],
+        attrs=dict(
+            units="",
+        ),
+    )
+
+
+def test_compute_mono_properties():
+    """
+    Returns a xarray.Dataset.
+    """
+    distribution = lognorm(r0=1.0, std=0.4)
+    r = np.geomspace(0.1, 5.0)
+    rw = distribution(r=r)
+    rdist = make_data_array(r=r, rw=rw)
+
+    ds = compute_mono_properties(
+        w=550.0,
+        rdist=rdist,
+        m=1.5 - 0.1j,
+    )
+    assert isinstance(ds, xr.Dataset)
+
+
+def test_compute_properties():
+    """
+    Returns a xarray.Dataset.
+    """
+    distribution = lognorm(r0=1.0, std=0.4)
+    r = np.geomspace(0.1, 5.0)
+    rw = distribution(r=r)
+    rdist = make_data_array(r=r, rw=rw)
+
+    ds = compute_properties(
+        w=np.linspace(500, 600, 3),
+        rdist=rdist,
+        m=1.5 - 0.1j,
+    )
+    assert isinstance(ds, xr.Dataset)

--- a/eradiate/radprops/tests/test_mie.py
+++ b/eradiate/radprops/tests/test_mie.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 import xarray as xr
 
 from eradiate import unit_registry as ureg
@@ -87,7 +88,18 @@ def test_compute_mono_properties():
     assert isinstance(ds, xr.Dataset)
 
 
-def test_compute_properties():
+@pytest.fixture
+def test_refractive_index():
+    return xr.DataArray(
+        np.array([1.5 - 0.1j, 1.5 - 0.01j], dtype=complex),
+        dims="w",
+        coords={
+            "w": ("w", np.array([240.0, 2800.0]), dict(units="nm")),
+        },
+    )
+
+
+def test_compute_properties(test_refractive_index):
     """
     Returns a xarray.Dataset.
     """
@@ -99,6 +111,6 @@ def test_compute_properties():
     ds = compute_properties(
         w=np.linspace(500, 600, 3),
         rdist=rdist,
-        m=1.5 - 0.1j,
+        m=test_refractive_index,
     )
     assert isinstance(ds, xr.Dataset)


### PR DESCRIPTION
Resolves eradiate/eradiate-issues#109

# Description

Adds the possibility to compute the Mie scattering properties from micro-physical properties input (radius distribution, refractive index) at any wavelength.

# Checklist

- [ ] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [ ] The code is appropriately documented
- [x] The code is tested to prove its function
- [ ] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
