### PR TITLE
Distant array measure bugfix

### DIFF
--- a/eradiate/scenes/measure/tests/test_measure_core.py
+++ b/eradiate/scenes/measure/tests/test_measure_core.py
@@ -123,13 +123,13 @@ def test_measure(mode_mono):
     m = MyMeasure()
 
     # This measure has a single sensor associated to it
-    assert m.sensor_infos() == [SensorInfo(id=m.id, spp=m.spp)]
+    assert m.sensor_infos() == [SensorInfo(id=f"{m.id}_ms0", spp=m.spp)]
 
     # The kernel dict is well-formed
     ctx = KernelDictContext()
     m.spp = 256
     assert m.kernel_dict(ctx).data == {
-        m.id: {
+        f"{m.id}_ms0": {
             "type": "some_sensor",
             "id": m.id,
             "film": {
@@ -164,9 +164,9 @@ def test_measure_spp_splitting(mode_mono):
     m = MyMeasure(id="my_measure", spp=256, spp_splitting_threshold=100)
     assert m._split_spp() == [100, 100, 56]
     assert m.sensor_infos() == [
-        SensorInfo(id="my_measure_spp0", spp=100),
-        SensorInfo(id="my_measure_spp1", spp=100),
-        SensorInfo(id="my_measure_spp2", spp=56),
+        SensorInfo(id="my_measure_ms0_spp0", spp=100),
+        SensorInfo(id="my_measure_ms0_spp1", spp=100),
+        SensorInfo(id="my_measure_ms0_spp2", spp=56),
     ]
 
     # fmt: off


### PR DESCRIPTION
# Description

This PR introduces a series of bugfixes for the `DistantSensorArray`.

First of all sensor id handling was updated. Sorting the sensor ids as strings produces a wrong order, since "100" comes before "2". Therefore spp aggregation is now handled by converting the sensor id's numerical part into an integer and introducing this as a temporary coordinate into the DataArrays. After spp aggregation, this temporary coordinate is used to correctly arrange the results in the Dataset, instead of the string sensor id.

The major issue I have with this approach is, that I had to alter the default `sensor_infos` method. This now adds a "ms0" suffix to the sensor ids, even if the `DistantMeasure` derivatives are used, which use only one mitsuba sensor plugin by default.

This needs to be made more robust. It crashes a lot of tests: The postprocessing tests inject raw results with sensor ids, that do not have a "msXXX" suffix.

Also the direction computation was updated. It turns out, that setting the direction to `[0, 0, 1]` will create a sensor that records the radiance leaving towards that direction, instead of creating a sensor that would point towards this direction and "look at the scene from below".

Finally I added a test case that assures the correctness of the generated directions in the `azimuthal_ring` constructor.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
