### PR TITLE
PM3

### DIFF
--- a/eradiate/tests/system/test_onedim_atmosphere.py
+++ b/eradiate/tests/system/test_onedim_atmosphere.py
@@ -1,0 +1,82 @@
+"""
+Test cases for the one-dimensional solver with a heterogeneous atmosphere.
+"""
+import numpy as np
+import pytest
+
+import eradiate
+from eradiate import unit_registry as ureg
+
+
+@pytest.mark.parametrize("bottom", [0.0, 1.0, 10.0])
+@pytest.mark.parametrize("tau_550", [0.1, 1.0, 10.0])
+def test_heterogeneous_atmosphere_contains_particle_layer(mode_mono, bottom, tau_550):
+    """
+    HeterogeneousAtmosphere is a good container for a ParticleLayer.
+
+    Same results are produced for a scene consisting of
+    * a particle layer
+    * a heterogeneous atmosphere that (only) contains that particle layer.
+    """
+    # particle layer
+    bottom = bottom * ureg.km
+    top = bottom + 1.0 * ureg.km
+    layer = eradiate.scenes.atmosphere.ParticleLayer(
+        bottom=bottom, top=top, tau_550=tau_550
+    )
+    config1 = {"atmosphere": layer}
+    app1 = eradiate.solvers.onedim.OneDimSolverApp(config1)
+    app1.run()
+    results1 = app1.results["measure"].lo.values
+
+    # heterogeneous atmosphere with a particle layer
+    config2 = {
+        "atmosphere": {"type": "heterogeneous", "particle_layers": [layer]},
+    }
+    app2 = eradiate.solvers.onedim.OneDimSolverApp(config2)
+    app2.run()
+    results2 = app2.results["measure"].lo.values
+
+    assert np.all(results1 == results2)
+
+
+@pytest.mark.parametrize("has_scattering", [True, False])
+def test_heterogeneous_atmosphere_contains_molecular_atmosphere(
+    mode_mono, has_scattering
+):
+    """
+    HeterogeneouAtmosphere is a good container for a MolecularAtmosphere.
+
+    Same results are produced for a scene consisting of:
+       * a non-absorbing molecular atmosphere
+       * a heterogeneous atmosphere that (only) contains that non-absorbing
+       molecular atmosphere
+    """
+    # non absorbing molecular atmosphere
+    config1 = {
+        "atmosphere": {
+            "type": "molecular",
+            "has_absorption": False,
+            "has_scattering": has_scattering,
+        }
+    }
+    app1 = eradiate.solvers.onedim.OneDimSolverApp(config1)
+    app1.run()
+    results1 = app1.results["measure"].lo.values
+
+    # heterogeneous atmopshere with a non-absorbing molecular atmosphere
+    config2 = {
+        "atmosphere": {
+            "type": "heterogeneous",
+            "molecular_atmosphere": {
+                "type": "molecular",
+                "has_absorption": False,
+                "has_scattering": has_scattering,
+            },
+        }
+    }
+    app2 = eradiate.solvers.onedim.OneDimSolverApp(config2)
+    app2.run()
+    results2 = app2.results["measure"].lo.values
+
+    assert np.all(results1 == results2)

--- a/eradiate/thermoprops/us76.py
+++ b/eradiate/thermoprops/us76.py
@@ -76,6 +76,9 @@ def make_profile(levels=ureg.Quantity(np.linspace(0.0, 1e5, 51), "m")):
         .rename_dims({"z": "z_layer"})
         .reset_coords("z", drop=True)
     )
+    thermoprops_ds.data_vars["mr"].attrs.update(
+        dict(standard_name="mixing_ratio", long_name="mixing ratio", units="")
+    )
     thermoprops_ds.coords["z_layer"] = (
         "z_layer",
         z_layer,


### PR DESCRIPTION
Resolves eradiate/eradiate-issues#113

# Description

Applies a bunch of changes required to run a set of simulations with heterogeneous atmospheres with a molecular atmosphere and a particle layer embedded.

## Changes

* changed `HeterogeneousAtmosphere` to blend the radiative properties of the molecular atmosphere with those of the particle layer and write its own collection of plugin dictionaries (phase, media and shapes)
* changed the behaviour of `MolecularAtmosphere.eval_width()` when `width=AUTO`.
* Refactored `atmosphere/tests/test_heterogeneous.py`
* Fixed `ParticleLayer.eval_phase()` and added related test
* Fixed `eradiate.thermoprops.us76.make_profile()`

### Notes

This branch was rebased on `upstream/atmosphere_fixes` to include the new `HeterogeneousAtmosphereAbstract` interface.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
