### PR TITLE
Added a check to KernelDict.__setitem__(): The method will now issue …

### DIFF
--- a/eradiate/scenes/core.py
+++ b/eradiate/scenes/core.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import typing as t
+import warnings
 from abc import ABC, abstractmethod
 from collections import abc as collections_abc
 
@@ -79,6 +80,13 @@ class KernelDict(collections_abc.MutableMapping):
         return self.data.__iter__()
 
     def __setitem__(self, k, v):
+        try:
+            self.data.__getitem__(k)
+            warnings.warn(
+                f"Duplicate key '{k}' will be overwritten. Are you trying to add scene elements with duplicate IDs to this KernelDict?"
+            )
+        except KeyError:
+            pass
         return self.data.__setitem__(k, v)
 
     def check(self) -> None:

--- a/eradiate/scenes/tests/test_core.py
+++ b/eradiate/scenes/tests/test_core.py
@@ -88,3 +88,40 @@ def test_kernel_dict_post_load(mode_mono):
     params = traverse(obj)
     assert params["irradiance.wavelengths"] == np.array([400.0, 500.0, 600.0])
     assert params["irradiance.values"] == np.array([0.0, 1.0, 2.0])
+
+
+def test_kernel_dict_duplicate_id():
+    from eradiate.contexts import KernelDictContext
+    from eradiate.scenes.illumination import illumination_factory
+
+    # Upon trying to add a scene element, whose ID is already present
+    # in the KernelDict, a Warning must be issued.
+    with pytest.warns(Warning):
+        kd = KernelDict(
+            {
+                "testmeasure": {
+                    "type": "directional",
+                    "id": "testmeasure",
+                    "irradiance": {
+                        "type": "interpolated",
+                        "wavelengths": [400, 500],
+                        "values": [1, 1],
+                    },
+                }
+            }
+        )
+
+        kd.add(
+            illumination_factory.convert(
+                {
+                    "type": "directional",
+                    "id": "testmeasure",
+                    "irradiance": {
+                        "type": "interpolated",
+                        "wavelengths": [400, 500],
+                        "values": [2, 2],
+                    },
+                }
+            ),
+            ctx=KernelDictContext(),
+        )


### PR DESCRIPTION
…a warning if a scene element ID appears more than once in a KernelDict.

closes eradiate/eradiate-issues#89

# Description
A generic warning is raised, mentioning the id in question and stating that scene elements will be overwritten.

Writing the tests I found, that this anyways applies only if you use `KernelDict.add()`. If you create one large dictionary with all your scene elements manually, their IDs will be different, because the are the keys in this manually created dict.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
