### PR TITLE
data: Fix incorrect dataset naming for AFGL1986

### DIFF
--- a/eradiate/data/ckd_absorption.py
+++ b/eradiate/data/ckd_absorption.py
@@ -42,8 +42,8 @@ Metadata:
 
 class _CKDAbsorptionGetter(DataGetter):
     PATHS = {
-        "afgl_1986-us_standard-10nm_test": "ckd/absorption/10nm_test/afgl_1986-us_standard-10nm_test.nc",
-        "afgl_1986-us_standard-10nm": "ckd/absorption/10nm/afgl_1986-us_standard-10nm.nc",
+        "afgl1986-us_standard-10nm_test": "ckd/absorption/10nm_test/afgl1986-us_standard-10nm_test.nc",
+        "afgl1986-us_standard-10nm": "ckd/absorption/10nm/afgl1986-us_standard-10nm.nc",
     }
 
     @classmethod

--- a/eradiate/radprops/rad_profile.py
+++ b/eradiate/radprops/rad_profile.py
@@ -1082,7 +1082,7 @@ class AFGL1986RadProfile(RadProfile):
 
     def eval_sigma_a_ckd(self, *bindexes: Bindex) -> pint.Quantity:
         ds = eradiate.data.open(
-            category="ckd_absorption", id="afgl_1986-us_standard-10nm"
+            category="ckd_absorption", id="afgl1986-us_standard-10nm"
         )
         # evaluate H2O and O3 concentrations
         h2o_concentration = compute_column_mass_density(

--- a/eradiate/radprops/tests/test_rad_profile.py
+++ b/eradiate/radprops/tests/test_rad_profile.py
@@ -206,7 +206,7 @@ def test_us76_approx_rad_profile_has_scattering_false(
 @pytest.fixture
 def afgl1986_test_absorption_data_sets():
     """
-    Fixture to return paths to test absorption data sets for 'afgl_1986'.
+    Fixture to return paths to test absorption data sets for 'afgl1986'.
     """
     return {
         "CH4": path_resolver.resolve(

--- a/eradiate/tests/unit/test_ckd.py
+++ b/eradiate/tests/unit/test_ckd.py
@@ -88,7 +88,7 @@ def test_ckd_bin_set_constructors(mode_ckd):
     assert bin_set.id == "10nm"
 
     # Load from node (i.e. gas absorption) dataset
-    ds = data.open("ckd_absorption", "afgl_1986-us_standard-10nm_test")
+    ds = data.open("ckd_absorption", "afgl1986-us_standard-10nm_test")
     bin_set = BinSet.from_node_dataset(ds)
     assert bin_set.id == "10nm_test"
 


### PR DESCRIPTION
# Description

This PR fixes incorrect paths and names in the data submodule. @nollety please make sure that this is in line with your naming conventions.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
