### PR TITLE
Updated the _inversebeta function 

### DIFF
--- a/docs/references.bib
+++ b/docs/references.bib
@@ -305,3 +305,15 @@
 	pages={70--83},
 	year={1941}
 }
+
+@article{GoelStrebel1984,
+author = {Goel, Narendra S. and Strebel, Donald E.},
+title = {Simple Beta Distribution Representation of Leaf Orientation in Vegetation Canopies1},
+journal = {Agronomy Journal},
+volume = {76},
+number = {5},
+pages = {800-802},
+doi = {https://doi.org/10.2134/agronj1984.00021962007600050021x},
+url = {https://acsess.onlinelibrary.wiley.com/doi/abs/10.2134/agronj1984.00021962007600050021x},
+year = {1984}
+}


### PR DESCRIPTION
A factor of two pi was missing in the `_inversebeta` function and the code utilizing it, was wrongly converting the results from degree to radians, when they were actually given in radians.

# Description

With this bugfix the code will finally produce leaf orientations that are correct.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
