### PR TITLE
Add SRF feature to Measures

### DIFF
--- a/src/eradiate/scenes/spectra/_air_scattering_coefficient.py
+++ b/src/eradiate/scenes/spectra/_air_scattering_coefficient.py
@@ -110,3 +110,6 @@ class AirScatteringCoefficientSpectrum(Spectrum):
 
         else:
             raise UnsupportedModeError(supported=("monochromatic", "ckd"))
+
+    def integral(self, wmin: pint.Quantity, wmax: pint.Quantity) -> pint.Quantity:
+        raise NotImplementedError

--- a/src/eradiate/scenes/spectra/_core.py
+++ b/src/eradiate/scenes/spectra/_core.py
@@ -165,3 +165,23 @@ class Spectrum(SceneElement, ABC):
             Evaluated spectrum as an array with shape (len(bindexes),).
         """
         pass
+
+    @abstractmethod
+    def integral(self, wmin: pint.Quantity, wmax: pint.Quantity) -> pint.Quantity:
+        """
+        Compute the integral of the spectrum on a given interval.
+
+        Parameters
+        ----------
+        wmin : quantity
+            Integration interval's lower bound.
+
+        wmax : quantity
+            Integration interval's upper bound.
+
+        Returns
+        -------
+        quantity
+            Computed integral value.
+        """
+        pass

--- a/src/eradiate/scenes/spectra/_solar_irradiance.py
+++ b/src/eradiate/scenes/spectra/_solar_irradiance.py
@@ -164,3 +164,6 @@ class SolarIrradianceSpectrum(Spectrum):
                 }
             }
         )
+
+    def integral(self, wmin: pint.Quantity, wmax: pint.Quantity) -> pint.Quantity:
+        raise NotImplementedError

--- a/src/eradiate/scenes/spectra/_uniform.py
+++ b/src/eradiate/scenes/spectra/_uniform.py
@@ -71,6 +71,11 @@ class UniformSpectrum(Spectrum):
         else:
             return np.full((len(bindexes),), self.value) * ureg.dimensionless
 
+    def integral(self, wmin: pint.Quantity, wmax: pint.Quantity) -> pint.Quantity:
+        wmin = pinttr.util.ensure_units(wmin, ucc.get("wavelength"))
+        wmax = pinttr.util.ensure_units(wmax, ucc.get("wavelength"))
+        return self.value * (wmax - wmin)
+
     def kernel_dict(self, ctx: KernelDictContext) -> KernelDict:
         kernel_units = uck.get(self.quantity)
         spectral_ctx = ctx.spectral_ctx

--- a/tests/scenes/spectra/test_interpolated.py
+++ b/tests/scenes/spectra/test_interpolated.py
@@ -63,6 +63,58 @@ def test_interpolated_construct(modes_all):
     )
 
 
+def test_interpolated_integral(mode_mono):
+    s = InterpolatedSpectrum(
+        wavelengths=[500.0, 525.0, 550.0, 575.0, 600.0],
+        values=[0.0, 0.25, 0.5, 0.75, 1.0],
+    )
+
+    # Easy case: integrate over full interval
+    assert np.isclose(
+        50.0 * ureg.nm, s.integral(500.0 * ureg.nm, 600.0 * ureg.nm), rtol=1e-10
+    )
+
+    # Min or max falls in-between two coordinate values
+    assert np.isclose(
+        42.0 * ureg.nm, s.integral(540.0 * ureg.nm, 600.0 * ureg.nm), rtol=1e-10
+    )
+    assert np.isclose(
+        28.0 * ureg.nm, s.integral(550.0 * ureg.nm, 590.0 * ureg.nm), rtol=1e-10
+    )
+    assert np.isclose(
+        32.5 * ureg.nm, s.integral(540.0 * ureg.nm, 590.0 * ureg.nm), rtol=1e-10
+    )
+    assert np.isclose(
+        3.5 * ureg.nm, s.integral(530.0 * ureg.nm, 540.0 * ureg.nm), rtol=1e-10
+    )
+
+    # Integrating on an interval not intersecting the support yields 0
+    assert np.isclose(
+        0.0 * ureg.nm, s.integral(400.0 * ureg.nm, 450.0 * ureg.nm), atol=1e-10
+    )
+    assert np.isclose(
+        0.0 * ureg.nm, s.integral(400.0 * ureg.nm, 500.0 * ureg.nm), atol=1e-10
+    )
+    assert np.isclose(
+        0.0 * ureg.nm, s.integral(650.0 * ureg.nm, 700.0 * ureg.nm), atol=1e-10
+    )
+    assert np.isclose(
+        0.0 * ureg.nm, s.integral(600.0 * ureg.nm, 700.0 * ureg.nm), atol=1e-10
+    )
+
+    # Integrating on an interval covering the whole support yields correct
+    # integral values
+    assert np.isclose(
+        50.0 * ureg.nm, s.integral(450.0 * ureg.nm, 650.0 * ureg.nm), rtol=1e-10
+    )
+    assert np.isclose(
+        50.0 * ureg.nm, s.integral(500.0 * ureg.nm, 650.0 * ureg.nm), rtol=1e-10
+    )
+    assert np.isclose(
+        50.0 * ureg.nm, s.integral(450.0 * ureg.nm, 600.0 * ureg.nm), rtol=1e-10
+    )
+
+
 def test_interpolated_eval(modes_all):
     if eradiate.mode().has_flags(ModeFlags.ANY_MONO):
         spectral_ctx = SpectralContext.new(wavelength=550.0)

--- a/tests/scenes/spectra/test_uniform.py
+++ b/tests/scenes/spectra/test_uniform.py
@@ -54,3 +54,11 @@ def test_uniform(modes_all):
         ctx = KernelDictContext()
         d = s.kernel_dict(ctx)
         assert np.allclose(d["spectrum"]["value"], 1e-3)
+
+
+def test_integral(mode_mono):
+    s = UniformSpectrum(value=0.5)
+    assert s.integral(300.0, 400.0) == 50.0 * ureg.nm
+
+    s = UniformSpectrum(quantity="collision_coefficient", value=0.5)
+    assert s.integral(300.0, 400.0) == 50.0 * ureg("nm / m")


### PR DESCRIPTION
# Description

This PR closes eradiate/eradiate-issues#98. It adds a spectral response function setting to the `Measure` class. Changes are as follows:

- The `Spectrum` class is extended with an `integral()` method which computes the integral of the function over  a specified interval. Only `UniformSpectrum` and `InterpolatedSpectrum` provide implementations. For now, this method is only used to determine whether a SRF has nonzero values in a given spectral interval.
- The `MeasureSpectralConfig` class is extended with a `srf` field, on type `Spectrum` (differs from the initial plan in eradiate/eradiate-issues#98).
- `MeasureSpectralConfig` subclasses can use their SRF to check whether a wavelength or spectral bin is active. In CKD modes, automatic bin selection is now driven by the SRF.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
