### PR TITLE
SRF postprocessing

### DIFF
--- a/docs/rst/reference/pipelines.rst
+++ b/docs/rst/reference/pipelines.rst
@@ -36,6 +36,7 @@ Assemble steps
 
    AddViewingAngles
    AddIllumination
+   AddSpectralResponseFunction
 
 Compute steps
 -------------

--- a/docs/rst/reference/pipelines.rst
+++ b/docs/rst/reference/pipelines.rst
@@ -45,3 +45,4 @@ Compute steps
 
    ComputeReflectance
    ComputeAlbedo
+   ApplySpectralResponseFunction

--- a/src/eradiate/experiments/_core.py
+++ b/src/eradiate/experiments/_core.py
@@ -561,14 +561,6 @@ class EarthObservationExperiment(Experiment, ABC):
             # Compute
             if isinstance(measure, (MultiDistantMeasure, HemisphericalDistantMeasure)):
                 pipeline.add(
-                    "apply_srf",
-                    pipelines.ApplySpectralResponseFunction(
-                        measure=measure,
-                        vars=["radiance", "irradiance"],
-                    ),
-                )
-
-                pipeline.add(
                     "compute_reflectance",
                     pipelines.ComputeReflectance(
                         radiance_var="radiance",
@@ -578,25 +570,26 @@ class EarthObservationExperiment(Experiment, ABC):
                     ),
                 )
 
-                pipeline.add(
-                    "compute_reflectance_srf",
-                    pipelines.ComputeReflectance(
-                        radiance_var="radiance_srf",
-                        irradiance_var="irradiance_srf",
-                        brdf_var="brdf_srf",
-                        brf_var="brf_srf",
-                    ),
-                )
+                if eradiate.mode().has_flags(ModeFlags.ANY_CKD):
+                    pipeline.add(
+                        "apply_srf",
+                        pipelines.ApplySpectralResponseFunction(
+                            measure=measure,
+                            vars=["radiance", "irradiance"],
+                        ),
+                    )
+
+                    pipeline.add(
+                        "compute_reflectance_srf",
+                        pipelines.ComputeReflectance(
+                            radiance_var="radiance_srf",
+                            irradiance_var="irradiance_srf",
+                            brdf_var="brdf_srf",
+                            brf_var="brf_srf",
+                        ),
+                    )
 
             elif isinstance(measure, (DistantFluxMeasure,)):
-                pipeline.add(
-                    "apply_srf",
-                    pipelines.ApplySpectralResponseFunction(
-                        measure=measure,
-                        vars=["radiosity", "irradiance"],
-                    ),
-                )
-
                 pipeline.add(
                     "compute_albedo",
                     pipelines.ComputeAlbedo(
@@ -606,14 +599,23 @@ class EarthObservationExperiment(Experiment, ABC):
                     ),
                 )
 
-                pipeline.add(
-                    "compute_albedo_srf",
-                    pipelines.ComputeAlbedo(
-                        radiosity_var="radiosity_srf",
-                        irradiance_var="irradiance_srf",
-                        albedo_var="albedo_srf",
-                    ),
-                )
+                if eradiate.mode().has_flags(ModeFlags.ANY_CKD):
+                    pipeline.add(
+                        "apply_srf",
+                        pipelines.ApplySpectralResponseFunction(
+                            measure=measure,
+                            vars=["radiosity", "irradiance"],
+                        ),
+                    )
+
+                    pipeline.add(
+                        "compute_albedo_srf",
+                        pipelines.ComputeAlbedo(
+                            radiosity_var="radiosity_srf",
+                            irradiance_var="irradiance_srf",
+                            albedo_var="albedo_srf",
+                        ),
+                    )
 
             result.append(pipeline)
 

--- a/src/eradiate/experiments/_core.py
+++ b/src/eradiate/experiments/_core.py
@@ -561,6 +561,14 @@ class EarthObservationExperiment(Experiment, ABC):
             # Compute
             if isinstance(measure, (MultiDistantMeasure, HemisphericalDistantMeasure)):
                 pipeline.add(
+                    "apply_srf",
+                    pipelines.ApplySpectralResponseFunction(
+                        measure=measure,
+                        vars=["radiance", "irradiance"],
+                    ),
+                )
+
+                pipeline.add(
                     "compute_reflectance",
                     pipelines.ComputeReflectance(
                         radiance_var="radiance",
@@ -570,13 +578,40 @@ class EarthObservationExperiment(Experiment, ABC):
                     ),
                 )
 
+                pipeline.add(
+                    "compute_reflectance_srf",
+                    pipelines.ComputeReflectance(
+                        radiance_var="radiance_srf",
+                        irradiance_var="irradiance_srf",
+                        brdf_var="brdf_srf",
+                        brf_var="brf_srf",
+                    ),
+                )
+
             elif isinstance(measure, (DistantFluxMeasure,)):
+                pipeline.add(
+                    "apply_srf",
+                    pipelines.ApplySpectralResponseFunction(
+                        measure=measure,
+                        vars=["radiosity", "irradiance"],
+                    ),
+                )
+
                 pipeline.add(
                     "compute_albedo",
                     pipelines.ComputeAlbedo(
                         radiosity_var="radiosity",
                         irradiance_var="irradiance",
                         albedo_var="albedo",
+                    ),
+                )
+
+                pipeline.add(
+                    "compute_albedo_srf",
+                    pipelines.ComputeAlbedo(
+                        radiosity_var="radiosity_srf",
+                        irradiance_var="irradiance_srf",
+                        albedo_var="albedo_srf",
                     ),
                 )
 

--- a/src/eradiate/experiments/_core.py
+++ b/src/eradiate/experiments/_core.py
@@ -554,6 +554,10 @@ class EarthObservationExperiment(Experiment, ABC):
                     "add_viewing_angles", pipelines.AddViewingAngles(measure=measure)
                 )
 
+            pipeline.add(
+                "add_srf", pipelines.AddSpectralResponseFunction(measure=measure)
+            )
+
             # Compute
             if isinstance(measure, (MultiDistantMeasure, HemisphericalDistantMeasure)):
                 pipeline.add(

--- a/src/eradiate/pipelines/__init__.py
+++ b/src/eradiate/pipelines/__init__.py
@@ -12,11 +12,11 @@ __all__ = [
     "Gather",
     # Aggregate steps
     "AggregateCKDQuad",
-    "AggregateSampleCount",
     "AggregateRadiosity",
+    "AggregateSampleCount",
     # Assemble steps
-    "AddViewingAngles",
     "AddIllumination",
+    "AddViewingAngles",
     # Compute steps
     "ComputeReflectance",
     "ComputeAlbedo",

--- a/src/eradiate/pipelines/__init__.py
+++ b/src/eradiate/pipelines/__init__.py
@@ -1,6 +1,6 @@
 from ._aggregate import AggregateCKDQuad, AggregateRadiosity, AggregateSampleCount
-from ._assemble import AddIllumination, AddViewingAngles
-from ._compute import ComputeAlbedo, ComputeReflectance
+from ._assemble import AddIllumination, AddSpectralResponseFunction, AddViewingAngles
+from ._compute import ApplySpectralResponseFunction, ComputeAlbedo, ComputeReflectance
 from ._core import Pipeline, PipelineStep
 from ._gather import Gather
 
@@ -16,8 +16,10 @@ __all__ = [
     "AggregateSampleCount",
     # Assemble steps
     "AddIllumination",
+    "AddSpectralResponseFunction",
     "AddViewingAngles",
     # Compute steps
+    "ApplySpectralResponseFunction",
     "ComputeReflectance",
     "ComputeAlbedo",
 ]

--- a/src/eradiate/pipelines/_aggregate.py
+++ b/src/eradiate/pipelines/_aggregate.py
@@ -160,7 +160,7 @@ class AggregateCKDQuad(PipelineStep):
                     wavelengths,
                     {
                         "standard_name": "wavelength",
-                        "long_description": "wavelength",
+                        "long_name": "wavelength",
                         "units": symbol(wavelength_units),
                     },
                 ),
@@ -169,7 +169,7 @@ class AggregateCKDQuad(PipelineStep):
                     bin_wmins,
                     {
                         "standard_name": "bin_wmin",
-                        "long_description": "spectral bin lower bound",
+                        "long_name": "spectral bin lower bound",
                         "units": symbol(wavelength_units),
                     },
                 ),
@@ -178,7 +178,7 @@ class AggregateCKDQuad(PipelineStep):
                     bin_wmaxs,
                     {
                         "standard_name": "bin_wmax",
-                        "long_description": "spectral bin upper bound",
+                        "long_name": "spectral bin upper bound",
                         "units": symbol(wavelength_units),
                     },
                 ),

--- a/src/eradiate/pipelines/_assemble.py
+++ b/src/eradiate/pipelines/_assemble.py
@@ -312,7 +312,7 @@ class AddSpectralResponseFunction(PipelineStep):
         result = x.copy(deep=False)
 
         # Evaluate SRF
-        w = ureg.Quantity(result.w.values, result.w.attrs["units"])
+        w = to_quantity(result.w)
         srf = self.measure.spectral_cfg.srf.eval_mono(w)
 
         # Add SRF variable to dataset

--- a/src/eradiate/pipelines/_compute.py
+++ b/src/eradiate/pipelines/_compute.py
@@ -2,10 +2,100 @@ import typing as t
 
 import attr
 import numpy as np
+import pint
+import xarray as xr
+from pinttr.util import always_iterable
 
 from ._core import PipelineStep
 from ..attrs import documented, parse_docs
-from ..units import symbol
+from ..scenes.measure import Measure
+from ..scenes.spectra import InterpolatedSpectrum
+from ..units import symbol, to_quantity
+from ..units import unit_registry as ureg
+
+
+@parse_docs
+@attr.s
+class ApplySpectralResponseFunction(PipelineStep):
+    """
+    Apply spectral response function to specified variables.
+
+    This post-processing pipeline step applies the spectral response function
+    to specified variables. It creates new corresponding data variables with no
+    dependency against the wavelength dimension.
+
+    Notes
+    -----
+    The processed dataset is expected to have a ``bin`` coordinate, associated
+    with bounds ``wmin`` and ``wmax``. If not, it becomes a no-op. In practice,
+    this means that nothing will happen in monochromatic modes.
+    """
+
+    measure: Measure = documented(
+        attr.ib(
+            validator=attr.validators.instance_of(Measure),
+            repr=lambda self: f"{self.__class__.__name__}(id='{self.id}', ...)",
+        ),
+        doc="A :class:`.Measure` instance from which the processed data originates.",
+        type=":class:`.Measure`",
+    )
+
+    vars: t.List[str] = documented(
+        attr.ib(
+            factory=list,
+            converter=lambda x: list(always_iterable(x)),
+            validator=attr.validators.deep_iterable(
+                member_validator=attr.validators.instance_of(str)
+            ),
+        ),
+        doc="List of variables to which the spectral response function is to be "
+        "applied.",
+        type="list of str",
+        init_type="str or list of str",
+        default="[]",
+    )
+
+    def transform(self, x: t.Any) -> t.Any:
+        with xr.set_options(keep_attrs=True):
+            result = x.copy(deep=False)
+        measure = self.measure
+
+        # Evaluate integral of spectral response function within selected interval
+        wmin = to_quantity(result.bin_wmin).min()
+        wmax = to_quantity(result.bin_wmax).max()
+        srf = measure.spectral_cfg.srf
+        srf_int = srf.integral(wmin, wmax)
+
+        for var in self.vars:
+            # Evaluate integral of product of variable and SRF within selected interval
+            # Note: Spectral grid is the finest between data and SRF grids
+            data_w = to_quantity(result.w)
+            srf_w = srf.wavelengths
+            w_units = data_w.units
+
+            w_m = np.array(sorted(set(data_w.m_as(w_units)) | set(srf_w.m_as(w_units))))
+            var_values = result[var].interp(
+                w=w_m, method="nearest", kwargs={"fill_value": "extrapolate"}
+            )
+
+            srf_values = srf.eval_mono(w_m * w_units).reshape(
+                [-1 if dim == "w" else 1 for dim in var_values.dims]
+            )
+            var_srf_int = (var_values * srf_values).integrate("w")
+
+            # Apply SRF to variable and store result
+            dims = list(result[var].dims)
+            dims.remove("w")
+            result[f"{var}_srf"] = (dims, var_srf_int.values / srf_int.m_as(w_units))
+            attrs = result[var].attrs.copy()
+
+            if "standard_name" in attrs:
+                attrs["standard_name"] += "_srf"
+            if "long_name" in attrs:
+                attrs["long_name"] += " (SRF applied)"
+            result[f"{var}_srf"].attrs = attrs
+
+        return result
 
 
 @parse_docs

--- a/src/eradiate/scenes/measure/_distant_flux.py
+++ b/src/eradiate/scenes/measure/_distant_flux.py
@@ -194,6 +194,6 @@ class DistantFluxMeasure(Measure):
     def var(self) -> t.Tuple[str, t.Dict]:
         return "sector_radiosity", {
             "standard_name": "sector_radiosity",
-            "long_description": "sector radiosity",
+            "long_name": "sector radiosity",
             "units": symbol(uck.get("irradiance")),
         }

--- a/src/eradiate/scenes/measure/_hemispherical_distant.py
+++ b/src/eradiate/scenes/measure/_hemispherical_distant.py
@@ -220,6 +220,6 @@ class HemisphericalDistantMeasure(Measure):
     def var(self) -> t.Tuple[str, t.Dict]:
         return "radiance", {
             "standard_name": "radiance",
-            "long_description": "radiance",
+            "long_name": "radiance",
             "units": symbol(uck.get("radiance")),
         }

--- a/src/eradiate/scenes/measure/_multi_distant.py
+++ b/src/eradiate/scenes/measure/_multi_distant.py
@@ -260,6 +260,6 @@ class MultiDistantMeasure(Measure):
     def var(self) -> t.Tuple[str, t.Dict]:
         return "radiance", {
             "standard_name": "radiance",
-            "long_description": "radiance",
+            "long_name": "radiance",
             "units": symbol(uck.get("radiance")),
         }

--- a/src/eradiate/scenes/measure/_multi_radiancemeter.py
+++ b/src/eradiate/scenes/measure/_multi_radiancemeter.py
@@ -128,6 +128,6 @@ class MultiRadiancemeterMeasure(Measure):
     def var(self) -> t.Tuple[str, t.Dict]:
         return "radiance", {
             "standard_name": "radiance",
-            "long_description": "radiance",
+            "long_name": "radiance",
             "units": symbol(uck.get("radiance")),
         }

--- a/src/eradiate/scenes/measure/_radiancemeter.py
+++ b/src/eradiate/scenes/measure/_radiancemeter.py
@@ -124,6 +124,6 @@ class RadiancemeterMeasure(Measure):
     def var(self) -> t.Tuple[str, t.Dict]:
         return "radiance", {
             "standard_name": "radiance",
-            "long_description": "radiance",
+            "long_name": "radiance",
             "units": symbol(uck.get("radiance")),
         }

--- a/src/eradiate/units.py
+++ b/src/eradiate/units.py
@@ -4,6 +4,7 @@ __all__ = [
     "unit_context_config",
     "unit_context_kernel",
     "unit_registry",
+    "PhysicalQuantity",
 ]
 
 

--- a/tests/experiments/test_onedim.py
+++ b/tests/experiments/test_onedim.py
@@ -170,7 +170,9 @@ def test_onedim_experiment_run_detailed(modes_all):
     results = exp.results["toa_hsphere"]
 
     # Post-processing creates expected variables ...
-    expected = {"irradiance", "brf", "brdf", "radiance", "spp"}
+    expected = {"irradiance", "brf", "brdf", "radiance", "spp", "srf"}
+    if eradiate.mode().has_flags(ModeFlags.ANY_CKD):
+        expected |= {"irradiance_srf", "brf_srf", "brdf_srf", "radiance_srf"}
     assert set(results.data_vars) == expected
 
     # ... dimensions
@@ -180,12 +182,12 @@ def test_onedim_experiment_run_detailed(modes_all):
     # ... and other coordinates
     expected_coords = {"sza", "saa", "vza", "vaa", "x", "y", "x_index", "y_index", "w"}
     if eradiate.mode().has_flags(ModeFlags.ANY_CKD):
-        expected_coords.add("bin")
+        expected_coords |= {"bin", "bin_wmin", "bin_wmax"}
     assert set(results["radiance"].coords) == expected_coords
 
     expected_coords = {"sza", "saa", "w"}
     if eradiate.mode().has_flags(ModeFlags.ANY_CKD):
-        expected_coords.add("bin")
+        expected_coords |= {"bin", "bin_wmin", "bin_wmax"}
     assert set(results["irradiance"].coords) == expected_coords
 
     # We just check that we record something as expected

--- a/tests/experiments/test_rami.py
+++ b/tests/experiments/test_rami.py
@@ -123,7 +123,14 @@ def test_rami_experiment_run_detailed(mode_mono):
     results = exp.results["toa_hsphere"]
 
     # Post-processing creates expected variables ...
-    assert set(results.data_vars) == {"irradiance", "brf", "brdf", "radiance", "spp"}
+    assert set(results.data_vars) == {
+        "irradiance",
+        "brf",
+        "brdf",
+        "radiance",
+        "spp",
+        "srf",
+    }
 
     # ... dimensions
     assert set(results["radiance"].dims) == {"sza", "saa", "x_index", "y_index", "w"}

--- a/tests/experiments/test_rami4atm.py
+++ b/tests/experiments/test_rami4atm.py
@@ -213,7 +213,14 @@ def test_ramiatm_experiment_run_detailed(mode_mono):
     results = exp.results["toa_brf"]
 
     # Post-processing creates expected variables ...
-    assert set(results.data_vars) == {"irradiance", "brf", "brdf", "radiance", "spp"}
+    assert set(results.data_vars) == {
+        "irradiance",
+        "brf",
+        "brdf",
+        "radiance",
+        "spp",
+        "srf",
+    }
 
     # ... dimensions
     assert set(results["radiance"].dims) == {"sza", "saa", "x_index", "y_index", "w"}

--- a/tests/pipelines/test_aggregate.py
+++ b/tests/pipelines/test_aggregate.py
@@ -50,8 +50,12 @@ def test_aggregate_ckd(results_ckd):
     assert "w" in result.dims
     assert "bin" not in result.dims
     assert "bin" in result.coords
+    assert "bin_wmin" in result.coords
+    assert "bin_wmax" in result.coords
     assert "spp" in result.data_vars
     assert result.bin.dims == ("w",)
+    assert result.bin_wmin.dims == ("w",)
+    assert result.bin_wmax.dims == ("w",)
 
     # In the present case, the quadrature evaluates to 2/π
     assert np.allclose(2.0 / np.pi, result["radiance"].values)

--- a/tests/pipelines/test_assemble.py
+++ b/tests/pipelines/test_assemble.py
@@ -5,17 +5,16 @@ import eradiate
 from eradiate import unit_registry as ureg
 from eradiate._mode import ModeFlags
 from eradiate.experiments import OneDimExperiment
-from eradiate.pipelines._aggregate import AggregateCKDQuad
-from eradiate.pipelines._assemble import (
+from eradiate.pipelines import (
     AddIllumination,
     AddSpectralResponseFunction,
     AddViewingAngles,
-    _remap_viewing_angles_plane,
+    AggregateCKDQuad,
+    Gather,
+    Pipeline,
 )
-from eradiate.pipelines._core import Pipeline
-from eradiate.pipelines._gather import Gather
-from eradiate.scenes.measure import MultiDistantMeasure
-from eradiate.scenes.measure._hemispherical_distant import HemisphericalDistantMeasure
+from eradiate.pipelines._assemble import _remap_viewing_angles_plane
+from eradiate.scenes.measure import HemisphericalDistantMeasure, MultiDistantMeasure
 
 
 @pytest.mark.parametrize(
@@ -188,4 +187,4 @@ def test_add_srf(modes_all_single):
     # The spectral response function is added to the dataset as a data variable
     assert "srf" in result.data_vars
     # Its only dimension is wavelength
-    assert set(result.srf.dims) == {"w"}
+    assert set(result.srf.dims) == {"srf_w"}

--- a/tests/pipelines/test_compute.py
+++ b/tests/pipelines/test_compute.py
@@ -1,0 +1,59 @@
+import numpy as np
+import pytest
+
+import eradiate
+from eradiate._mode import ModeFlags
+from eradiate.experiments import OneDimExperiment
+from eradiate.pipelines import ApplySpectralResponseFunction
+from eradiate.scenes.measure import MultiDistantMeasure
+
+
+@pytest.mark.parametrize(
+    "mode_id, spectral_cfg",
+    (
+        ("mono", {"wavelengths": 550.0}),
+        ("ckd", {"bin_set": "10nm", "bins": ["550"]}),
+        ("ckd", {"bin_set": "10nm", "bins": ["550", "560"]}),
+    ),
+    ids=("mono", "ckd_single_bin", "ckd_multiple_bins"),
+)
+def test_apply_spectral_response_function_transform(mode_id, spectral_cfg):
+    """
+    Unit tests for ApplySpectralResponseFunction.transform().
+    """
+    # Prepare basic data
+    eradiate.set_mode(mode_id)
+
+    exp = OneDimExperiment(
+        atmosphere=None,
+        measures=MultiDistantMeasure.from_viewing_angles(
+            id="measure",
+            zeniths=[-60, -45, 0, 45, 60],
+            azimuths=0.0,
+            spp=1,
+            spectral_cfg=spectral_cfg,
+        ),
+    )
+    measure = exp.measures[0]
+    exp.process(measure)
+
+    # Apply first steps of post-processing
+    pipeline = exp.pipeline(measure)
+    values = pipeline.transform(measure.results, stop_after="add_viewing_angles")
+
+    # Apply tested pipeline step
+    step = ApplySpectralResponseFunction(measure=measure, vars=["radiance"])
+
+    if eradiate.mode().has_flags(ModeFlags.ANY_MONO):
+        # In mono modes, the dataset produced by previous steps is missing
+        # bin data required for the step to run successfully
+        with pytest.raises(ValueError):
+            step.transform(values)
+        return
+
+    # In binned modes, computation goes through
+    result = step.transform(values)
+
+    # The step adds a SRF-weighted variable
+    assert "radiance_srf" in result.data_vars
+    assert np.all(result.radiance_srf > 0.0)


### PR DESCRIPTION
# Description

This PR adds spectral response function post-processing capabilities. Changes are as follows:

- Two new post-processing pipeline steps `AddSpectralResponseFunction` and `ApplySpectralResponseFunction` are added.
- The `AggregateCKDQuad` step is extended and now adds bin information as coordinates (indexed by the spectral dimension).
- Various metadata fixes come along this PR.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
