### PR TITLE
CKD 1nm

### DIFF
--- a/src/eradiate/contexts.py
+++ b/src/eradiate/contexts.py
@@ -100,7 +100,7 @@ class SpectralContext(ABC, Context):
             **Monochromatic modes** [:class:`.MonoSpectralContext`].
             Wavelength. Unit-enabled field (default: ucc[wavelength]).
 
-        bindex : :class:`.Bindex`, default: test value (1st quadrature point for the "550" bin of the "10nm_test" bin set)
+        bindex : :class:`.Bindex`, default: test value (1st quadrature point for the "550" bin of the "10nm" bin set)
             **CKD modes** [:class:`.CKDSpectralContext`].
             CKD bindex.
 
@@ -215,7 +215,7 @@ class CKDSpectralContext(SpectralContext):
     bindex: Bindex = documented(
         attr.ib(
             factory=lambda: Bindex(
-                BinSet.from_db("10nm_test").select_bins("550")[0],
+                BinSet.from_db("10nm").select_bins("550")[0],
                 0,
             ),
             converter=Bindex.convert,

--- a/src/eradiate/data/ckd_absorption.py
+++ b/src/eradiate/data/ckd_absorption.py
@@ -42,8 +42,8 @@ Metadata:
 
 class _CKDAbsorptionGetter(DataGetter):
     PATHS = {
-        "afgl_1986-us_standard-10nm_test": "ckd/absorption/10nm_test/afgl_1986-us_standard-10nm_test.nc",
         "afgl_1986-us_standard-10nm": "ckd/absorption/10nm/afgl_1986-us_standard-10nm.nc",
+        "afgl_1986-us_standard-1nm": "ckd/absorption/1nm/afgl_1986-us_standard-1nm.nc",
     }
 
     @classmethod

--- a/src/eradiate/data/ckd_bin_sets.py
+++ b/src/eradiate/data/ckd_bin_sets.py
@@ -31,8 +31,8 @@ Metadata:
 
 class _CKDBinSetGetter(DataGetter):
     PATHS = {
+        "1nm": "ckd/bin_sets/1nm.nc",
         "10nm": "ckd/bin_sets/10nm.nc",
-        "10nm_test": "ckd/bin_sets/10nm_test.nc",
     }
 
     @classmethod

--- a/tests/_integration/test_ckd_basic.py
+++ b/tests/_integration/test_ckd_basic.py
@@ -27,7 +27,7 @@ def test_ckd_basic(modes_all_ckd):
                 zeniths=np.arange(-60, 61, 5) * ureg.deg,
                 azimuths=0.0 * ureg.deg,
                 spectral_cfg={
-                    "bin_set": "10nm_test",
+                    "bin_set": "10nm",
                     "bins": [
                         "550",
                         "560",

--- a/tests/_system/test_onedim_ckd_vs_mono.py
+++ b/tests/_system/test_onedim_ckd_vs_mono.py
@@ -135,7 +135,7 @@ def test_550(reflectance):
     ================================================================
 
     This test checks the results consistency between mono_double and ckd_double
-    modes in the [545, 555] nm wavelength bin.
+    modes in the [549.5, 550.5] nm wavelength bin.
 
     Rationale
     ---------
@@ -155,7 +155,7 @@ def test_550(reflectance):
     ------------------
 
     The [545, 555] nm - integrated BRF results obtained with the `mono_double`
-    and `ckd_double` modes should agree within 5%.
+    and `ckd_double` modes should agree within 10%.
 
     The `mono_double` BRF results are spectrally averaged according to the
     following formula:
@@ -200,8 +200,11 @@ def test_550(reflectance):
     # Settings
     zeniths = np.linspace(-75, 75, 11)
     spp = 1e4
-    wavelengths = np.linspace(545.0, 555.0, 1001) * ureg.nm  # mono mode setting
-    bin_set = "10nm"  # ckd mode setting
+    wavelength_min = 549.5 * ureg.nm
+    wavelength_max = 550.5 * ureg.nm
+    wavenumbers = np.linspace(1 / wavelength_max, 1 / wavelength_min, 1001)
+    wavelengths = 1 / wavenumbers  # mono mode setting
+    bin_set = "1nm"  # ckd mode setting
     bins = "550"  # ckd mode setting
 
     # Monochromatic experiment
@@ -215,7 +218,9 @@ def test_550(reflectance):
         mono_exp.run()
     mono_results = mono_exp.results["measure"]
 
-    wavelength_bin_width = (wavelengths[-1] - wavelengths[0]).m_as(mono_results.w.units)
+    wavelength_bin_width = (wavelengths.max() - wavelengths.min()).m_as(
+        mono_results.w.attrs["units"]
+    )
     mono_results_integrated = mono_results.integrate(coord="w") / wavelength_bin_width
 
     # CKD experiment
@@ -237,14 +242,14 @@ def test_550(reflectance):
         ckd_results=ckd_results,
         mono_results_averaged=mono_results_integrated,
         fname_plot=fname_plot,
-        wavelength_bin="[545, 555] nm",
+        wavelength_bin="[549.5, 550.5] nm",
         reflectance=reflectance,
     )
 
-    # Assert averaged mono results are consistent with ckd results
+    # Assert averaged mono results are consistent with ckd results within 10 %
     mono_brf = mono_results_integrated.brf.squeeze().values
     ckd_brf = ckd_results.brf.squeeze().values
-    assert np.allclose(mono_brf, ckd_brf, rtol=5e-2)
+    assert np.allclose(mono_brf, ckd_brf, rtol=0.1)
 
 
 @pytest.mark.parametrize("reflectance", [0.0, 0.5, 1.0])
@@ -267,7 +272,7 @@ def test_1050(reflectance):
     ================================================================
 
     This test checks the results consistency between mono_double and ckd_double
-    modes in the [1045, 1055] nm wavelength bin.
+    modes in the [1049.5, 1050.5] nm wavelength bin.
 
     Rationale
     ---------
@@ -286,8 +291,8 @@ def test_1050(reflectance):
     Expected behaviour
     ------------------
 
-    The [1045, 1055] nm - integrated BRF results obtained with the `mono_double`
-    and `ckd_double` modes should agree within 5%.
+    The [1049.5, 1050.5] nm - integrated BRF results obtained with the
+    `mono_double` and `ckd_double` modes should agree within 10%.
 
     The `mono_double` BRF results are spectrally averaged according to the
     following formula:
@@ -332,8 +337,11 @@ def test_1050(reflectance):
     # Settings
     zeniths = np.linspace(-75, 75, 11)
     spp = 1e4
-    wavelengths = np.linspace(1045.0, 1055.0, 1001) * ureg.nm  # mono mode setting
-    bin_set = "10nm"  # ckd mode setting
+    wavelength_min = 1049.5 * ureg.nm
+    wavelength_max = 1050.5 * ureg.nm
+    wavenumbers = np.linspace(1 / wavelength_max, 1 / wavelength_min, 1001)
+    wavelengths = 1 / wavenumbers  # mono mode setting
+    bin_set = "1nm"  # ckd mode setting
     bins = "1050"  # ckd mode setting
 
     # Monochromatic experiment
@@ -347,7 +355,9 @@ def test_1050(reflectance):
         mono_exp.run()
     mono_results = mono_exp.results["measure"]
 
-    wavelength_bin_width = (wavelengths[-1] - wavelengths[0]).m_as(mono_results.w.units)
+    wavelength_bin_width = (wavelengths.max() - wavelengths.min()).m_as(
+        mono_results.w.attrs["units"]
+    )
     mono_results_averaged = mono_results.integrate(coord="w") / wavelength_bin_width
 
     # CKD experiment
@@ -369,11 +379,11 @@ def test_1050(reflectance):
         ckd_results=ckd_results,
         mono_results_averaged=mono_results_averaged,
         fname_plot=fname_plot,
-        wavelength_bin="[1045, 1055] nm",
+        wavelength_bin="[1049.5, 1050.5] nm",
         reflectance=reflectance,
     )
 
-    # Assert averaged mono results are consistent with ckd results
+    # Assert averaged mono results are consistent with ckd results within 10 %
     mono_brf = mono_results_averaged.brf.squeeze().values
     ckd_brf = ckd_results.brf.squeeze().values
-    assert np.allclose(mono_brf, ckd_brf, rtol=5e-2)
+    assert np.allclose(mono_brf, ckd_brf, rtol=0.1)

--- a/tests/experiments/test_onedim.py
+++ b/tests/experiments/test_onedim.py
@@ -127,7 +127,7 @@ def test_onedim_experiment_run_basic(modes_all):
     if eradiate.mode().has_flags(ModeFlags.ANY_MONO):
         spectral_cfg = MeasureSpectralConfig.new(wavelengths=550.0 * ureg.nm)
     elif eradiate.mode().has_flags(ModeFlags.ANY_CKD):
-        spectral_cfg = MeasureSpectralConfig.new(bin_set="10nm_test", bins="550")
+        spectral_cfg = MeasureSpectralConfig.new(bin_set="10nm", bins="550")
     else:
         pytest.skip(f"Please add test for '{eradiate.mode().id}' mode")
 

--- a/tests/scenes/measure/test_core.py
+++ b/tests/scenes/measure/test_core.py
@@ -96,7 +96,7 @@ def test_ckd_spectral_config(modes_all_ckd):
     """
     # The new() class method constructor selects an appropriate config class
     # depending on the active mode
-    cfg = MeasureSpectralConfig.new(bin_set="10nm_test", bins=["540", "550"])
+    cfg = MeasureSpectralConfig.new(bin_set="10nm", bins=["540", "550"])
     assert isinstance(cfg, CKDMeasureSpectralConfig)
 
     # Generated spectral contexts are of the appropriate type and in correct numbers
@@ -106,7 +106,7 @@ def test_ckd_spectral_config(modes_all_ckd):
 
     # In CKD mode, we can also select bins with an interval specification
     cfg = MeasureSpectralConfig.new(
-        bin_set="10nm_test",
+        bin_set="10nm",
         bins=[
             ("interval", {"wmin": 500.0, "wmax": 520.0}),
             {"type": "interval", "filter_kwargs": {"wmin": 530.0, "wmax": 550.0}},

--- a/tests/scenes/spectra/test_interpolated.py
+++ b/tests/scenes/spectra/test_interpolated.py
@@ -149,7 +149,7 @@ def test_interpolated_eval(modes_all):
         expected = 0.5
 
     elif eradiate.mode().has_flags(ModeFlags.ANY_CKD):
-        bin = BinSet.from_db("10nm_test").select_bins("550")[0]
+        bin = BinSet.from_db("10nm").select_bins("550")[0]
         spectral_ctx = SpectralContext.new(bindex=bin.bindexes[0])
         expected = 0.5
 

--- a/tests/scenes/spectra/test_solar_irradiance.py
+++ b/tests/scenes/spectra/test_solar_irradiance.py
@@ -52,7 +52,7 @@ def test_solar_irradiance_eval(modes_all):
         assert np.allclose(s.eval(spectral_ctx), ureg.Quantity(1.87938, "W/m^2/nm"))
 
     elif eradiate.mode().has_flags(ModeFlags.ANY_CKD):
-        bin_set = BinSet.from_db("10nm_test")
+        bin_set = BinSet.from_db("10nm")
         bin = bin_set.select_bins("550")[0]
         bindex = bin.bindexes[0]
         spectral_ctx = SpectralContext.new(bindex=bindex)

--- a/tests/test_ckd.py
+++ b/tests/test_ckd.py
@@ -88,19 +88,19 @@ def test_ckd_bin_set_constructors(mode_ckd):
     assert bin_set.id == "10nm"
 
     # Load from node (i.e. gas absorption) dataset
-    ds = data.open("ckd_absorption", "afgl_1986-us_standard-10nm_test")
+    ds = data.open("ckd_absorption", "afgl_1986-us_standard-10nm")
     ds.load()
     ds.close()
 
     bin_set = BinSet.from_node_dataset(ds)
-    assert bin_set.id == "10nm_test"
+    assert bin_set.id == "10nm"
 
 
 def test_ckd_bin_set_filter(mode_ckd):
     """
     Unit tests for :meth:`eradiate.ckd.BinSet.filter_bins`.
     """
-    bin_set = BinSet.from_db("10nm_test")
+    bin_set = BinSet.from_db("10nm")
 
     # We get a single bin using wmin == wmax
     filter = bin_filter_interval(wmin=550 * ureg.nm, wmax=550 * ureg.nm, endpoints=True)
@@ -163,7 +163,7 @@ def test_ckd_bin_set_select(mode_ckd):
     Unit tests for :meth:`eradiate.ckd.BinSet.select_bins`.
     """
 
-    bin_set = BinSet.from_db("10nm_test")
+    bin_set = BinSet.from_db("10nm")
 
     # Select with an explicit filter
     filter = bin_filter_interval(wmin=550 * ureg.nm, wmax=560 * ureg.nm)


### PR DESCRIPTION
# Description

This add the data sets required to operate the `ckd` mode within wavelength bins with a width of 1 nm.

⚠️  Only available for the atmosphere thermophysical properties profile ``afgl_1986-us_standard``.

## Changes:
* switch from "10nm_test" to "10nm" ckd binset dataset
* removed references to `"10nm_test"` ckd binset dataset
* updated system test `test_onedim_ckd_vs_mono` to use the `"1nm"` ckd datasets and work at the native spectral resolution of the monochromatic absorption data set
  * updated the tolerance of that test from 5% to 10% 

⚠️ Run `ertdownload` for these changes to take effect.

## Note
The changes to `eradiate-data` were added on a `"ckd_1nm"` branch.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
