### PR TITLE
ParticleLayer: system and unit tests

### DIFF
--- a/src/eradiate/scenes/atmosphere/_particle_layer.py
+++ b/src/eradiate/scenes/atmosphere/_particle_layer.py
@@ -182,8 +182,9 @@ class ParticleLayer(AbstractHeterogeneousAtmosphere):
 
         else:
             if self.width is AUTO:
-                spectral_ctx = ctx.spectral_ctx if ctx is not None else None
-                return 10.0 / self.eval_sigma_s(spectral_ctx=spectral_ctx).min()
+                min_sigma_s = self.eval_sigma_s(spectral_ctx=ctx.spectral_ctx).min()
+                width = 10.0 / min_sigma_s if min_sigma_s != 0.0 else np.inf * ureg.m
+                return min(width, 1000 * ureg.km)
             else:
                 return self.width
 

--- a/src/eradiate/scenes/spectra/_solar_irradiance.py
+++ b/src/eradiate/scenes/spectra/_solar_irradiance.py
@@ -80,7 +80,7 @@ class SolarIrradianceSpectrum(Spectrum):
         doc="Dataset identifier. Allowed values: see "
         ":attr:`solar irradiance dataset documentation <eradiate.data.solar_irradiance_spectra>`.",
         type="str",
-        default='``"thuiller_2003"``',
+        default='"thuiller_2003"',
     )
 
     @dataset.validator

--- a/tests/_system/test_onedim_particle_layer.py
+++ b/tests/_system/test_onedim_particle_layer.py
@@ -1,0 +1,213 @@
+"""Test cases targetting the particle layer component of a 1D experiment."""
+import os
+
+import numpy as np
+import pytest
+import seaborn
+
+import eradiate
+from eradiate import unit_registry as ureg
+from eradiate.units import to_quantity
+
+from .test_onedim_phase import ensure_output_dir, make_figure, rayleigh_radprops
+
+seaborn.set_style("ticks")
+
+eradiate_dir = os.environ["ERADIATE_DIR"]
+output_dir = os.path.join(eradiate_dir, "test_report", "generated")
+
+
+def init_experiment_particle_layer(bottom, top, dataset_path, tau_550, r, w, spp):
+    eradiate.set_mode("mono_double")
+
+    return eradiate.experiments.OneDimExperiment(
+        measures=[
+            eradiate.scenes.measure.MultiDistantMeasure.from_viewing_angles(
+                spectral_cfg=eradiate.scenes.measure.MeasureSpectralConfig.new(
+                    wavelengths=w,
+                ),
+                zeniths=np.linspace(-75, 75, 11) * ureg.deg,
+                azimuths=0.0 * ureg.deg,
+                spp=spp,
+            )
+        ],
+        illumination=eradiate.scenes.illumination.DirectionalIllumination(
+            zenith=30 * ureg.deg,
+            azimuth=0.0 * ureg.deg,
+            irradiance=eradiate.scenes.spectra.SolarIrradianceSpectrum(
+                dataset="blackbody_sun"
+            ),
+        ),
+        atmosphere=eradiate.scenes.atmosphere.HeterogeneousAtmosphere(
+            molecular_atmosphere=None,
+            particle_layers=[
+                eradiate.scenes.atmosphere.ParticleLayer(
+                    bottom=bottom,
+                    top=top,
+                    dataset=dataset_path,
+                    tau_550=tau_550,
+                )
+            ],
+        ),
+        surface=eradiate.scenes.surface.LambertianSurface(reflectance=r),
+    )
+
+
+def init_experiment_homogeneous_atmosphere(
+    bottom, top, sigma_a, sigma_s, phase, r, w, spp
+):
+    eradiate.set_mode("mono_double")
+
+    return eradiate.experiments.OneDimExperiment(
+        measures=[
+            eradiate.scenes.measure.MultiDistantMeasure.from_viewing_angles(
+                spectral_cfg=eradiate.scenes.measure.MeasureSpectralConfig.new(
+                    wavelengths=w,
+                ),
+                zeniths=np.linspace(-75, 75, 11) * ureg.deg,
+                azimuths=0.0 * ureg.deg,
+                spp=spp,
+            )
+        ],
+        illumination=eradiate.scenes.illumination.DirectionalIllumination(
+            zenith=30 * ureg.deg,
+            azimuth=0.0 * ureg.deg,
+            irradiance=eradiate.scenes.spectra.SolarIrradianceSpectrum(
+                dataset="blackbody_sun"
+            ),
+        ),
+        atmosphere=eradiate.scenes.atmosphere.HomogeneousAtmosphere(
+            bottom=bottom,
+            top=top,
+            sigma_a=sigma_a,
+            sigma_s=sigma_s,
+            phase=phase,
+        ),
+        surface=eradiate.scenes.surface.LambertianSurface(reflectance=r),
+    )
+
+
+@pytest.mark.parametrize(
+    "w",
+    np.array([280.0, 400.0, 550.0, 650.0, 1000.0, 1500.0, 2400.0]) * ureg.nm,
+)
+@pytest.mark.slow
+def test(tmpdir, rayleigh_radprops, w):
+    r"""
+    Equivalency of homogeneous atmosphere and corresponding particle layer
+    ======================================================================
+
+    Assert that a homogeneous atmosphere is equivalent to uniform particle layer
+    parametrised such that the participating medium has the same radiative
+    properties as the homogeneous atmosphere.
+
+    Rationale
+    ---------
+
+    * Sensor: Distant measure covering a plane (11 angular points,
+      1000 sample per pixel) and targeting (0, 0, 0).
+    * Illumination: Directional illumination with a zenith angle
+      :math:`\theta = 30.0°` with black body irradiance spectrum.
+    * Surface: a square surface with a Lambertian BRDF with 35 % reflectance.
+    * Atmosphere:
+      * in experiment 1: a non-absorbing 5 km high homogeneous atmosphere with
+        a tabulated phase function corresponding to the Rayleigh phase function.
+        The scattering coefficient is given by
+        :meth:`eradiate.radprops.rayleigh.compute_sigma_s_air`.
+      * in experiment 2: a non-absorbing uniform 5 km thick particle layer with
+        a tabulated phase function corresponding to the Rayleigh phase function.
+        The optical thickness at 550 nm of the particle layer is set to a value
+        that match the optical thickness at 550 nm of the homogeneous
+        atmosphere in experiment 1.
+    * Integrator: volumetric path tracer.
+
+    Expected behaviour
+    ------------------
+
+    Distant bi-directional reflectance factors measured by both experiments must
+    agree within 1%, outliers excluded.
+
+    Results
+    -------
+
+    .. image:: generated/plots/test_onedim_particle_layer_280.0.png
+       :width: 95%
+    .. image:: generated/plots/test_onedim_particle_layer_400.0.png
+       :width: 95%
+    .. image:: generated/plots/test_onedim_particle_layer_550.0.png
+       :width: 95%
+    .. image:: generated/plots/test_onedim_particle_layer_650.0.png
+       :width: 95%
+    .. image:: generated/plots/test_onedim_particle_layer_1000.0.png
+       :width: 95%
+    .. image:: generated/plots/test_onedim_particle_layer_1500.0.png
+       :width: 95%
+    .. image:: generated/plots/test_onedim_particle_layer_2400.0.png
+       :width: 95%
+    """
+    spp = 1e3
+    reflectance = 0.35
+    bottom = 0.0 * ureg.km
+    top = 5.0 * ureg.km
+
+    w_units = rayleigh_radprops.w.attrs["units"]
+    sigma_t = to_quantity(rayleigh_radprops.sigma_t.interp(w=w.m_as(w_units)))
+    albedo = to_quantity(rayleigh_radprops.albedo.interp(w=w.m_as(w_units)))
+    sigma_s = sigma_t * albedo
+    sigma_a = sigma_t * (1.0 - albedo)
+    phase = eradiate.scenes.phase.TabulatedPhaseFunction(data=rayleigh_radprops.phase)
+
+    sigma_s_550 = eradiate.radprops.rayleigh.compute_sigma_s_air(
+        wavelength=550.0 * ureg.nm
+    )
+    height = top - bottom
+    tau_550 = sigma_s_550 * height
+
+    dataset_path = tmpdir / "radprops.nc"
+    rayleigh_radprops.to_netcdf(dataset_path)
+
+    experiment_1 = init_experiment_particle_layer(
+        bottom=bottom,
+        top=top,
+        dataset_path=dataset_path,
+        tau_550=tau_550,
+        r=reflectance,
+        w=w,
+        spp=spp,
+    )
+
+    experiment_2 = init_experiment_homogeneous_atmosphere(
+        bottom=bottom,
+        top=top,
+        sigma_a=sigma_a,
+        sigma_s=sigma_s,
+        phase=phase,
+        r=reflectance,
+        w=w,
+        spp=spp,
+    )
+
+    with eradiate.unit_context_kernel.override(length="km"):
+        experiment_1.run()
+        experiment_2.run()
+
+    brf_1 = experiment_1.results["measure"]["brf"]
+    brf_2 = experiment_2.results["measure"]["brf"]
+
+    # Make figure
+    filename = f"test_onedim_particle_layer_{w.magnitude}.png"
+    ensure_output_dir(os.path.join(output_dir, "plots"))
+    fname_plot = os.path.join(output_dir, "plots", filename)
+    make_figure(fname_plot=fname_plot, brf_1=brf_1, brf_2=brf_2)
+
+    # exclude outliers that are due to the batman issue
+    outliers_1 = np.isclose(brf_1.values, reflectance, rtol=1e-5)
+    outliers_2 = np.isclose(brf_2.values, reflectance, rtol=1e-5)
+    no_outliers = ~outliers_1 & ~outliers_2
+
+    assert np.allclose(
+        brf_1.where(no_outliers).values,
+        brf_2.where(no_outliers).values,
+        rtol=1e-2,
+        equal_nan=True,
+    )

--- a/tests/_system/test_onedim_phase.py
+++ b/tests/_system/test_onedim_phase.py
@@ -1,0 +1,246 @@
+"""Test cases targeting the phase function component of a 1D experiment."""
+import os
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+import seaborn
+import xarray as xr
+
+import eradiate
+from eradiate import unit_registry as ureg
+from eradiate.units import to_quantity
+
+seaborn.set_style("ticks")
+
+eradiate_dir = os.environ["ERADIATE_DIR"]
+output_dir = os.path.join(eradiate_dir, "test_report", "generated")
+
+
+@pytest.fixture
+def rayleigh_radprops():
+    """
+    Radiative properties of a Rayleigh scattering medium in [280, 2400] nm.
+    """
+    w = np.linspace(279.0, 2401.0, 10000) * ureg.nm
+
+    # Collision coefficients
+    sigma_s = eradiate.radprops.rayleigh.compute_sigma_s_air(wavelength=w)
+    albedo = np.ones_like(sigma_s) * ureg.dimensionless  # no absorption
+    sigma_t = sigma_s * albedo
+
+    # Phase function
+    # Note: rayleigh phase function does not change with wavelength
+    def rayleigh_phase_function(mu):
+        magnitude = 3.0 * (1 + np.square(mu)) / (16 * np.pi)
+        return magnitude / ureg.steradian
+
+    mu = np.linspace(-1.0, 1.0)
+    arrays = [rayleigh_phase_function(mu) for _ in w]
+    phase = np.stack(arrays, axis=0).reshape(w.size, mu.size, 1, 1)
+
+    return xr.Dataset(
+        data_vars={
+            "sigma_t": (
+                "w",
+                sigma_t.magnitude,
+                dict(
+                    standard_name="air_volume_extinction_coefficient",
+                    units=f"{sigma_t.units:~}",
+                ),
+            ),
+            "albedo": (
+                "w",
+                albedo.magnitude,
+                dict(
+                    standard_name="single_scattering_albedo", units=f"{albedo.units:~}"
+                ),
+            ),
+            "phase": (
+                ("w", "mu", "i", "j"),
+                phase.magnitude,
+                dict(standard_name="scattering_phase_matrix", units=f"{phase.units:~}"),
+            ),
+        },
+        coords={
+            "w": ("w", w.magnitude, dict(units=f"{w.units:~}")),
+            "mu": (
+                "mu",
+                mu,
+                dict(standard_name="scattering_angle_cosine", units="dimensionless"),
+            ),
+            "i": ("i", [0]),
+            "j": ("j", [0]),
+        },
+    )
+
+
+def init_experiment(bottom, top, sigma_a, sigma_s, phase, r, w, spp):
+    assert eradiate.mode().id == "mono"
+
+    return eradiate.experiments.OneDimExperiment(
+        measures=[
+            eradiate.scenes.measure.MultiDistantMeasure.from_viewing_angles(
+                spectral_cfg=eradiate.scenes.measure.MeasureSpectralConfig.new(
+                    wavelengths=w,
+                ),
+                zeniths=np.linspace(-75, 75, 11) * ureg.deg,
+                azimuths=0.0 * ureg.deg,
+                spp=spp,
+            )
+        ],
+        illumination=eradiate.scenes.illumination.DirectionalIllumination(
+            zenith=30 * ureg.deg,
+            azimuth=0.0 * ureg.deg,
+            irradiance=eradiate.scenes.spectra.SolarIrradianceSpectrum(
+                dataset="blackbody_sun"
+            ),
+        ),
+        atmosphere=eradiate.scenes.atmosphere.HomogeneousAtmosphere(
+            bottom=bottom,
+            top=top,
+            sigma_a=sigma_a,
+            sigma_s=sigma_s,
+            phase=phase,
+        ),
+        surface=eradiate.scenes.surface.LambertianSurface(reflectance=r),
+    )
+
+
+def ensure_output_dir(path):
+    if not os.path.isdir(path):
+        os.makedirs(path)
+
+
+def make_figure(fname_plot, brf_1, brf_2):
+    fig = plt.figure(figsize=(8, 5))
+    params = dict(x="vza", ls="dotted", marker=".")
+    brf_1.plot(**params)
+    brf_2.plot(**params)
+    plt.legend(["experiment 1", "experiment 2"])
+    plt.tight_layout()
+    fig.savefig(fname_plot, dpi=200)
+    plt.close()
+
+
+@pytest.mark.parametrize(
+    "w",
+    np.array([280.0, 400.0, 550.0, 650.0, 1000.0, 1500.0, 2400.0]) * ureg.nm,
+)
+@pytest.mark.slow
+def test(mode_mono, rayleigh_radprops, w):
+    r"""
+    Equivalency of plugin and tabulated versions of Rayleigh phase function
+    =======================================================================
+
+    Assert that a homogeneous atmosphere with a Rayleigh phase function is
+    equivalent to a homogeneous atmosphere with a tabulated version of the
+    Rayleigh phase function.
+
+    Rationale
+    ---------
+
+    * Sensor: Distant measure covering a plane (11 angular points,
+      1000 sample per pixel) and targeting (0, 0, 0).
+    * Illumination: Directional illumination with a zenith angle
+      :math:`\theta = 30.0°` with black body irradiance spectrum.
+    * Surface: a square surface with a Lambertian BRDF with 35 % reflectance.
+    * Atmosphere: a non-absorbing 10 km high homogeneous atmosphere. The
+      scattering phase function is defined in two ways in two experiments:
+      * in experiment 1: using
+        :class:`~eradiate.scenes.phase.RayleighPhaseFunction`
+      * in experiment 2: using
+        :class:`~eradiate.scenes.phase.TabulatedPhaseFunction` with Rayleigh
+        phase function tabulated values.
+    * Integrator: volumetric path tracer.
+
+    Expected behaviour
+    ------------------
+
+    Distant bi-directional reflectance factors measured by both experiments must
+    agree within 1%, outliers excluded.
+
+    Results
+    -------
+
+    .. image:: generated/plots/test_onedim_phase_300.0.png
+       :width: 95%
+    .. image:: generated/plots/test_onedim_phase_550.0.png
+       :width: 95%
+    .. image:: generated/plots/test_onedim_phase_650.0.png
+       :width: 95%
+    .. image:: generated/plots/test_onedim_phase_850.0.png
+       :width: 95%
+    .. image:: generated/plots/test_onedim_phase_1000.0.png
+       :width: 95%
+    .. image:: generated/plots/test_onedim_phase_1500.0.png
+       :width: 95%
+    .. image:: generated/plots/test_onedim_phase_2000.0.png
+       :width: 95%
+    .. image:: generated/plots/test_onedim_phase_2400.0.png
+       :width: 95%
+    """
+    spp = 1e3
+    reflectance = 0.35
+    bottom = 0.0 * ureg.km
+    top = 10.0 * ureg.km
+
+    sigma_a_1 = 0.0
+    sigma_s_1 = eradiate.scenes.spectra.AirScatteringCoefficientSpectrum()
+    phase_1 = eradiate.scenes.phase.RayleighPhaseFunction()
+
+    w_units = rayleigh_radprops.w.attrs["units"]
+    sigma_t = to_quantity(rayleigh_radprops.sigma_t.interp(w=w.m_as(w_units)))
+    albedo = to_quantity(rayleigh_radprops.albedo.interp(w=w.m_as(w_units)))
+    sigma_s_2 = sigma_t * albedo
+    sigma_a_2 = sigma_t * (1.0 - albedo)
+    phase_2 = eradiate.scenes.phase.TabulatedPhaseFunction(data=rayleigh_radprops.phase)
+
+    experiment_1 = init_experiment(
+        bottom=bottom,
+        top=top,
+        sigma_a=sigma_a_1,
+        sigma_s=sigma_s_1,
+        phase=phase_1,
+        r=reflectance,
+        w=w,
+        spp=spp,
+    )
+
+    with eradiate.unit_context_kernel.override(length="km"):
+        experiment_1.run()
+
+    experiment_2 = init_experiment(
+        bottom=bottom,
+        top=top,
+        sigma_a=sigma_a_2,
+        sigma_s=sigma_s_2,
+        phase=phase_2,
+        r=reflectance,
+        w=w,
+        spp=spp,
+    )
+
+    with eradiate.unit_context_kernel.override(length="km"):
+        experiment_2.run()
+
+    brf_1 = experiment_1.results["measure"]["brf"]
+    brf_2 = experiment_2.results["measure"]["brf"]
+
+    # Make figure
+    filename = f"test_onedim_phase_{w.magnitude}.png"
+    ensure_output_dir(os.path.join(output_dir, "plots"))
+    fname_plot = os.path.join(output_dir, "plots", filename)
+    make_figure(fname_plot=fname_plot, brf_1=brf_1, brf_2=brf_2)
+
+    # exclude outliers that are due to the batman issue
+    outliers_1 = np.isclose(brf_1.values, reflectance, rtol=1e-5)
+    outliers_2 = np.isclose(brf_2.values, reflectance, rtol=1e-5)
+    no_outliers = ~outliers_1 & ~outliers_2
+
+    assert np.allclose(
+        brf_1.where(no_outliers).values,
+        brf_2.where(no_outliers).values,
+        rtol=1e-2,
+        equal_nan=True,
+    )

--- a/tests/scenes/atmosphere/test_particle_layer.py
+++ b/tests/scenes/atmosphere/test_particle_layer.py
@@ -4,18 +4,207 @@ import xarray as xr
 
 from eradiate import path_resolver
 from eradiate import unit_registry as ureg
-from eradiate.contexts import KernelDictContext, SpectralContext
+from eradiate.contexts import KernelDictContext, MonoSpectralContext, SpectralContext
 from eradiate.scenes.atmosphere._particle_dist import UniformParticleDistribution
 from eradiate.scenes.atmosphere._particle_layer import ParticleLayer
-from eradiate.units import to_quantity
+from eradiate.scenes.measure._core import CKDMeasureSpectralConfig
+from eradiate.units import symbol, to_quantity
 
 
-def test_particle_layer_construct_basic(mode_mono):
+def to_dataset(albedo, sigma_t, phase, mu, w):
+    return xr.Dataset(
+        data_vars={
+            "sigma_t": (
+                "w",
+                sigma_t.magnitude,
+                dict(
+                    standard_name="air_volume_extinction_coefficient",
+                    units=symbol(sigma_t.units),
+                ),
+            ),
+            "albedo": (
+                "w",
+                albedo.magnitude,
+                dict(
+                    standard_name="single_scattering_albedo", units=symbol(albedo.units)
+                ),
+            ),
+            "phase": (
+                ("w", "mu", "i", "j"),
+                phase.magnitude,
+                dict(
+                    standard_name="scattering_phase_matrix", units=symbol(phase.units)
+                ),
+            ),
+        },
+        coords={
+            "w": ("w", w.magnitude, dict(units=symbol(w.units))),
+            "mu": (
+                "mu",
+                mu.magnitude,
+                dict(standard_name="scattering_angle_cosine", units=f"{mu.units:~}"),
+            ),
+            "i": ("i", [0]),
+            "j": ("j", [0]),
+        },
+    )
+
+
+@pytest.fixture
+def absorbing_only(tmpdir):
+    """Absorbing only particles radiative properties data set path fixture."""
+    mu = np.linspace(-1.0, 1.0) * ureg.dimensionless
+    w = np.linspace(279.0, 2401.0) * ureg.nm
+    arrays = [np.ones_like(mu) / ureg.steradian for _ in w]
+    phase = np.stack(arrays, axis=0).reshape(w.size, mu.size, 1, 1)
+    albedo = np.zeros_like(w) * ureg.dimensionless
+    sigma_t = np.ones_like(w) / ureg.km
+    radprops = to_dataset(albedo=albedo, sigma_t=sigma_t, phase=phase, mu=mu, w=w)
+    path = tmpdir / "absorbing_particles.nc"
+    radprops.to_netcdf(path)
+    return path
+
+
+@pytest.fixture
+def scattering_only(tmpdir):
+    """Scattering only particles radiative properties data set path fixture."""
+    mu = np.linspace(-1.0, 1.0) * ureg.dimensionless
+    w = np.linspace(279.0, 2401.0) * ureg.nm
+    arrays = [np.ones_like(mu) / ureg.steradian for _ in w]
+    phase = np.stack(arrays, axis=0).reshape(w.size, mu.size, 1, 1)
+    albedo = np.ones_like(w) * ureg.dimensionless
+    sigma_t = np.ones_like(w) / ureg.km
+    radprops = to_dataset(albedo=albedo, sigma_t=sigma_t, phase=phase, mu=mu, w=w)
+    path = tmpdir / "scattering_particles.nc"
+    radprops.to_netcdf(path)
+    return path
+
+
+@pytest.fixture
+def test_particles_dataset(tmpdir):
+    """Particles radiative properties data set path fixture."""
+    mu = np.linspace(-1.0, 1.0) * ureg.dimensionless
+    w = np.linspace(279.0, 2401.0) * ureg.nm
+    arrays = [np.ones_like(mu) / ureg.steradian for _ in w]
+    phase = np.stack(arrays, axis=0).reshape(w.size, mu.size, 1, 1)
+    albedo = 0.8 * np.ones_like(w) * ureg.dimensionless
+    sigma_t = np.ones_like(w) / ureg.km
+    radprops = to_dataset(albedo=albedo, sigma_t=sigma_t, phase=phase, mu=mu, w=w)
+    path = tmpdir / "test_particles_dataset.nc"
+    radprops.to_netcdf(path)
+    return path
+
+
+@pytest.mark.parametrize("wavelength", [280.0, 550.0, 1600.0, 2400.0])
+def test_particle_layer_eval_mono_absorbing_only(
+    mode_mono, tmpdir, absorbing_only, wavelength
+):
+    """eval methods return expected values for an absorbing-only layer."""
+    layer = ParticleLayer(dataset=absorbing_only)
+    spectral_ctx = MonoSpectralContext(wavelength=wavelength)
+    assert np.all(layer.eval_sigma_s(spectral_ctx).magnitude == 0.0)
+    assert np.all(layer.eval_sigma_a(spectral_ctx).magnitude > 0.0)
+    assert np.all(layer.eval_albedo(spectral_ctx).magnitude == 0.0)
+
+    ctx = KernelDictContext(spectral_ctx=spectral_ctx)
+    assert layer.eval_width(ctx).magnitude > 0.0
+
+
+@pytest.mark.parametrize("wavelength", [280.0, 550.0, 1600.0, 2400.0])
+def test_particle_layer_eval_mono_scattering_only(
+    mode_mono, tmpdir, scattering_only, wavelength
+):
+    """eval methods return expected values for a scattering-only layer."""
+    layer = ParticleLayer(dataset=scattering_only)
+    spectral_ctx = MonoSpectralContext(wavelength=wavelength)
+    assert np.all(layer.eval_sigma_s(spectral_ctx).magnitude > 0.0)
+    assert np.all(layer.eval_sigma_a(spectral_ctx).magnitude == 0.0)
+    assert np.all(layer.eval_albedo(spectral_ctx).magnitude == 1.0)
+
+    ctx = KernelDictContext(spectral_ctx=spectral_ctx)
+    assert layer.eval_width(ctx).magnitude > 0.0
+
+
+@pytest.mark.parametrize("wavelength", [280.0, 550.0, 1600.0, 2400.0])
+def test_particle_layer_eval_mono(
+    mode_mono, tmpdir, test_particles_dataset, wavelength
+):
+    """eval methods return expected values for a scattering-only layer."""
+    layer = ParticleLayer(
+        dataset=test_particles_dataset,
+        n_layers=1,
+        tau_550=1.0,
+        bottom=0.0 * ureg.km,
+        top=1.0 * ureg.km,
+    )
+    spectral_ctx = MonoSpectralContext(wavelength=wavelength)
+    assert np.isclose(layer.eval_sigma_t(spectral_ctx), 1.0 / ureg.km)
+    assert np.isclose(layer.eval_sigma_s(spectral_ctx), 0.8 / ureg.km)
+    assert np.isclose(layer.eval_sigma_a(spectral_ctx), 0.2 / ureg.km)
+    assert np.isclose(layer.eval_albedo(spectral_ctx).magnitude, 0.8)
+
+    ctx = KernelDictContext(spectral_ctx=spectral_ctx)
+    assert layer.eval_width(ctx) == 12.5 * ureg.km
+
+
+@pytest.mark.parametrize("bins", ["280", "550", "1600", "2400"])
+def test_particle_layer_eval_ckd_absorbing_only(mode_ckd, tmpdir, absorbing_only, bins):
+    """eval methods return expected values for an absorbing-only layer."""
+    layer = ParticleLayer(dataset=absorbing_only)
+    spectral_config = CKDMeasureSpectralConfig(bin_set="10nm", bins=bins)
+    spectral_ctx = spectral_config.spectral_ctxs()[0]
+    assert np.all(layer.eval_sigma_s(spectral_ctx).magnitude == 0.0)
+    assert np.all(layer.eval_sigma_a(spectral_ctx).magnitude > 0.0)
+    assert np.all(layer.eval_albedo(spectral_ctx).magnitude == 0.0)
+
+    ctx = KernelDictContext(spectral_ctx=spectral_ctx)
+    assert layer.eval_width(ctx).magnitude > 0.0
+
+
+@pytest.mark.parametrize("bins", ["280", "550", "1600", "2400"])
+def test_particle_layer_eval_ckd_scattering_only(
+    mode_ckd, tmpdir, scattering_only, bins
+):
+    """eval methods return expected values for a scattering-only layer."""
+    layer = ParticleLayer(dataset=scattering_only)
+    spectral_config = CKDMeasureSpectralConfig(bin_set="10nm", bins=bins)
+    spectral_ctx = spectral_config.spectral_ctxs()[0]
+    assert np.all(layer.eval_sigma_s(spectral_ctx).magnitude > 0.0)
+    assert np.all(layer.eval_sigma_a(spectral_ctx).magnitude == 0.0)
+    assert np.all(layer.eval_albedo(spectral_ctx).magnitude == 1.0)
+
+    ctx = KernelDictContext(spectral_ctx=spectral_ctx)
+    assert layer.eval_width(ctx).magnitude > 0.0
+
+
+@pytest.mark.parametrize("bins", ["280", "550", "1600", "2400"])
+def test_particle_layer_eval_ckd(mode_ckd, tmpdir, test_particles_dataset, bins):
+    """eval methods return expected values for a scattering-only layer."""
+    layer = ParticleLayer(
+        dataset=test_particles_dataset,
+        n_layers=1,
+        tau_550=1.0,
+        bottom=0.0 * ureg.km,
+        top=1.0 * ureg.km,
+    )
+    spectral_config = CKDMeasureSpectralConfig(bin_set="10nm", bins=bins)
+    spectral_ctx = spectral_config.spectral_ctxs()[0]
+    assert np.isclose(layer.eval_sigma_t(spectral_ctx), 1.0 / ureg.km)
+    assert np.isclose(layer.eval_sigma_s(spectral_ctx), 0.8 / ureg.km)
+    assert np.isclose(layer.eval_sigma_a(spectral_ctx), 0.2 / ureg.km)
+    assert np.isclose(layer.eval_albedo(spectral_ctx).magnitude, 0.8)
+
+    ctx = KernelDictContext(spectral_ctx=spectral_ctx)
+    assert layer.eval_width(ctx) == 12.5 * ureg.km
+
+
+def test_particle_layer_construct_basic():
     """Construction succeeds with basic parameters."""
     assert ParticleLayer(n_layers=9)
 
 
-def test_particle_layer_scale(mode_mono):
+def test_particle_layer_scale(modes_all_single):
+    """Scale parameter propagates to kernel dict and latter can be loaded."""
     ctx = KernelDictContext()
     d = ParticleLayer(scale=2.0).kernel_dict(ctx)
     assert d["medium_atmosphere"]["scale"] == 2.0
@@ -32,14 +221,14 @@ def test_particle_layer_construct_attrs():
         top=top,
         distribution=UniformParticleDistribution(),
         tau_550=tau_550,
-        n_layers=1,
+        n_layers=9,
         dataset="tests/radprops/rtmom_aeronet_desert.nc",
     )
     assert layer.bottom == bottom
     assert layer.top == top
     assert isinstance(layer.distribution, UniformParticleDistribution)
     assert layer.tau_550 == tau_550
-    assert layer.n_layers == 1
+    assert layer.n_layers == 9
     assert layer.dataset == path_resolver.resolve(
         "tests/radprops/rtmom_aeronet_desert.nc"
     )
@@ -47,48 +236,47 @@ def test_particle_layer_construct_attrs():
 
 def test_particle_layer_altitude_units():
     """Accept different units for bottom and top altitudes."""
-    assert ParticleLayer(bottom=ureg.Quantity(1, "km"), top=ureg.Quantity(2000.0, "m"))
+    assert ParticleLayer(bottom=1.0 * ureg.km, top=2000.0 * ureg.m)
 
 
 def test_particle_layer_invalid_bottom_top():
     """Raises when 'bottom' is larger that 'top'."""
     with pytest.raises(ValueError):
-        ParticleLayer(top=ureg.Quantity(1.2, "km"), bottom=ureg.Quantity(1.8, "km"))
+        ParticleLayer(top=1.2 * ureg.km, bottom=1.8 * ureg.km)
 
 
 def test_particle_layer_invalid_tau_550():
     """Raises when 'tau_550' is invalid."""
     with pytest.raises(ValueError):
         ParticleLayer(
-            bottom=ureg.Quantity(1.2, "km"), top=ureg.Quantity(1.8, "km"), tau_550=-0.1
+            bottom=1.2 * ureg.km,
+            top=1.8 * ureg.km,
+            tau_550=-0.1 * ureg.dimensionless,
         )
 
 
 def test_particle_layer_kernel_phase(modes_all_single):
+    """Dictionary key is set to appropriate value."""
     atmosphere = ParticleLayer(n_layers=9)
-
-    # Phase function kernel dictionary can be generated
     ctx = KernelDictContext()
     kernel_phase = atmosphere.kernel_phase(ctx)
-
-    # Dictionary key is set to appropriate value
     assert set(kernel_phase.data.keys()) == {f"phase_{atmosphere.id}"}
 
 
 def test_particle_layer_kernel_dict(modes_all_single):
+    """Kernel dictionary can be loaded"""
     particle_layer = ParticleLayer(n_layers=9)
-
-    # Produced kernel dictionary can be loaded
     ctx = KernelDictContext()
     assert particle_layer.kernel_dict(ctx).load()
 
 
 @pytest.fixture
 def test_dataset():
+    """Test dataset path fixture."""
     return path_resolver.resolve("tests/radprops/rtmom_aeronet_desert.nc")
 
 
-def test_particle_layer_eval_radprops(mode_mono, test_dataset):
+def test_particle_layer_eval_radprops(modes_all_single, test_dataset):
     """Method 'eval_radprops' returns dataset with expected datavars and coords."""
     layer = ParticleLayer(dataset=test_dataset)
     spectral_ctx = SpectralContext.new()


### PR DESCRIPTION
# Description

Add two fixes and a bunch of tests targeting the `ParticleLayer` scene element (including test updates).

## Fix

* `ParticleLayer.eval_width` was not handling zero scattering coefficient values. This is fixed ; `ParticleLayer.eval_width` now behaves similarly to `MolecularAtmosphere.eval_width`.
* The default value of `SolarIrradianceSpectrum`'s `dataset` attribute

## Tests added

### System tests

* a test that checks that using the **plugin** (`rayleigh`) and **tabulated** (`lut_phase`) versions of the Rayleigh phase function yield the same distant BRF measurements in a 1D experiment with a lambertian surface and a homogeneous atmosphere.
* a test that check that a 5 km high non-absorbing homogeneous atmosphere and the 'radiative-equivalent' 5 km thick 5 km thick uniform particle layer produce the same distant BRF measurement in a 1D experiment with a lambertian surface.

### Unit tests

* a test with non-absorbing particles (in mono and ckd modes) : the `eval*` methods must return an albedo of 1, a zero absorption coefficient, a non-zero scattering coefficient and a non-zero particle layer width.
* a test with non-scattering particles (in mono and ckd modes) : the `eval*` methods must return an albedo of 0, a zero scattering coefficient, a non-zero absorption coefficient and a non-zero particle layer width.
* a test with scattering and absorbing particles (in mono and ckd modes) : the `eval* `methods must compute the collision coefficients correctly

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
