### PR TITLE
Enable bin set selection when evaluating gaseous absorption in CKD mode

### DIFF
--- a/src/eradiate/contexts.py
+++ b/src/eradiate/contexts.py
@@ -224,6 +224,19 @@ class CKDSpectralContext(SpectralContext):
         doc="The bindex value corresponding to this spectral context. "
         "The default value is a simple placeholder used for testing purposes.",
         type=":class:`.Bindex`",
+        init_type=":class:`.Bindex` or tuple or dict, optional",
+    )
+
+    bin_set: t.Optional[BinSet] = documented(
+        attr.ib(
+            default=None,
+            converter=attr.converters.optional(BinSet.convert),
+            validator=attr.validators.optional(attr.validators.instance_of(BinSet)),
+        ),
+        doc="If relevant, the bin set from which ``bindex`` originates.",
+        type=":class:`.BinSet` or None",
+        init_type=":class:`.BinSet` or str, optional",
+        default="None",
     )
 
     @property

--- a/src/eradiate/scenes/measure/_core.py
+++ b/src/eradiate/scenes/measure/_core.py
@@ -406,10 +406,11 @@ class CKDMeasureSpectralConfig(MeasureSpectralConfig):
 
     def spectral_ctxs(self) -> t.List[CKDSpectralContext]:
         ctxs = []
+        bin_set = self.bin_set
 
         for bin in self.bins:
             for bindex in bin.bindexes:
-                ctxs.append(CKDSpectralContext(bindex))
+                ctxs.append(CKDSpectralContext(bindex, bin_set))
 
         return ctxs
 

--- a/tests/_system/test_onedim_ckd_vs_mono.py
+++ b/tests/_system/test_onedim_ckd_vs_mono.py
@@ -155,7 +155,7 @@ def test_550(reflectance):
     ------------------
 
     The [545, 555] nm - integrated BRF results obtained with the `mono_double`
-    and `ckd_double` modes should agree within 10%.
+    and `ckd_double` modes should agree within 5 %.
 
     The `mono_double` BRF results are spectrally averaged according to the
     following formula:
@@ -246,10 +246,10 @@ def test_550(reflectance):
         reflectance=reflectance,
     )
 
-    # Assert averaged mono results are consistent with ckd results within 10 %
+    # Assert averaged mono results are consistent with ckd results within 5 %
     mono_brf = mono_results_integrated.brf.squeeze().values
     ckd_brf = ckd_results.brf.squeeze().values
-    assert np.allclose(mono_brf, ckd_brf, rtol=0.1)
+    assert np.allclose(mono_brf, ckd_brf, rtol=0.05)
 
 
 @pytest.mark.parametrize("reflectance", [0.0, 0.5, 1.0])
@@ -292,7 +292,7 @@ def test_1050(reflectance):
     ------------------
 
     The [1049.5, 1050.5] nm - integrated BRF results obtained with the
-    `mono_double` and `ckd_double` modes should agree within 10%.
+    `mono_double` and `ckd_double` modes should agree within 5 %.
 
     The `mono_double` BRF results are spectrally averaged according to the
     following formula:
@@ -383,7 +383,7 @@ def test_1050(reflectance):
         reflectance=reflectance,
     )
 
-    # Assert averaged mono results are consistent with ckd results within 10 %
+    # Assert averaged mono results are consistent with ckd results within 5 %
     mono_brf = mono_results_averaged.brf.squeeze().values
     ckd_brf = ckd_results.brf.squeeze().values
-    assert np.allclose(mono_brf, ckd_brf, rtol=0.1)
+    assert np.allclose(mono_brf, ckd_brf, rtol=0.05)

--- a/tests/experiments/test_onedim.py
+++ b/tests/experiments/test_onedim.py
@@ -4,7 +4,7 @@ import pytest
 import eradiate
 from eradiate import unit_registry as ureg
 from eradiate._mode import ModeFlags
-from eradiate.contexts import KernelDictContext
+from eradiate.contexts import CKDSpectralContext, KernelDictContext
 from eradiate.exceptions import ModeError, UnsupportedModeError
 from eradiate.experiments._onedim import OneDimExperiment
 from eradiate.scenes.atmosphere import (
@@ -48,11 +48,12 @@ def test_onedim_experiment_construct_normalize_measures(mode_mono):
     )
 
 
-def test_onedim_experiment_ckd(mode_ckd):
+@pytest.mark.parametrize("bin_set", ["1nm", "10nm"])
+def test_onedim_experiment_ckd(mode_ckd, bin_set):
     """
     OneDimExperiment with heterogeneous atmosphere in CKD mode can be created.
     """
-    ctx = KernelDictContext()
+    ctx = KernelDictContext(spectral_ctx=CKDSpectralContext(bin_set=bin_set))
     exp = OneDimExperiment(
         atmosphere=HeterogeneousAtmosphere(
             molecular_atmosphere=MolecularAtmosphere.afgl_1986()

--- a/tests/radprops/test_rad_profile.py
+++ b/tests/radprops/test_rad_profile.py
@@ -249,10 +249,15 @@ def test_afgl_1986_rad_profile_default_ckd(mode_ckd):
     """
     p = AFGL1986RadProfile()
 
-    spectral_ctx = SpectralContext.new()
-    for field in ["sigma_a", "sigma_s", "sigma_t", "albedo"]:
-        x = getattr(p, f"eval_{field}_ckd")(spectral_ctx.bindex)
+    spectral_ctx = SpectralContext.new(bin_set="10nm")
+    for field in ["albedo", "sigma_a", "sigma_t"]:
+        x = getattr(p, f"eval_{field}_ckd")(
+            spectral_ctx.bindex, bin_set_id=spectral_ctx.bin_set.id
+        )
         assert isinstance(x, ureg.Quantity)
+
+    sigma_s = p.eval_sigma_s_ckd(spectral_ctx.bindex)
+    assert isinstance(sigma_s, ureg.Quantity)
 
 
 def test_afgl_1986_rad_profile_levels(mode_mono, afgl_1986_test_absorption_data_sets):
@@ -438,7 +443,7 @@ def test_afgl_1986_rad_profile_ckd_10nm(mode_ckd, bin):
     p = AFGL1986RadProfile()
     bin = eradiate.scenes.measure._core.CKDMeasureSpectralConfig(bins=bin).bins[0]
     bindex = eradiate.ckd.Bindex(bin=bin, index=3)
-    spectral_ctx = eradiate.contexts.CKDSpectralContext(bindex=bindex)
+    spectral_ctx = eradiate.contexts.CKDSpectralContext(bindex=bindex, bin_set="10nm")
     assert isinstance(p.eval_sigma_a(spectral_ctx), pint.Quantity)
 
 
@@ -452,7 +457,7 @@ def test_afgl_1986_rad_profile_ckd_10nm_invalid(mode_ckd, bin):
     p = AFGL1986RadProfile()
     bin = eradiate.scenes.measure._core.CKDMeasureSpectralConfig(bins=bin).bins[0]
     bindex = eradiate.ckd.Bindex(bin=bin, index=3)
-    spectral_ctx = eradiate.contexts.CKDSpectralContext(bindex=bindex)
+    spectral_ctx = eradiate.contexts.CKDSpectralContext(bindex=bindex, bin_set="10nm")
 
     with pytest.raises(KeyError):
         p.eval_sigma_a(spectral_ctx)

--- a/tests/scenes/atmosphere/test_heterogeneous.py
+++ b/tests/scenes/atmosphere/test_heterogeneous.py
@@ -3,7 +3,7 @@ import pytest
 import eradiate
 from eradiate import path_resolver
 from eradiate._mode import ModeFlags
-from eradiate.contexts import KernelDictContext
+from eradiate.contexts import CKDSpectralContext, KernelDictContext
 from eradiate.scenes.atmosphere import (
     HeterogeneousAtmosphere,
     MolecularAtmosphere,
@@ -34,7 +34,10 @@ def test_heterogeneous_empty(modes_all_single):
 
 
 @pytest.mark.parametrize("components", ("molecular", "particle"))
-def test_heterogeneous_single(modes_all_single, components, path_to_ussa76_approx_data):
+@pytest.mark.parametrize("bin_set", ["1nm", "10nm"])
+def test_heterogeneous_single(
+    modes_all_single, components, bin_set, path_to_ussa76_approx_data
+):
     """
     Unit tests for a HeterogeneousAtmosphere with a single component.
     """
@@ -55,11 +58,12 @@ def test_heterogeneous_single(modes_all_single, components, path_to_ussa76_appro
         atmosphere = HeterogeneousAtmosphere(particle_layers=[component])
 
     # Produced kernel dict can be loaded
-    ctx = KernelDictContext()
+    ctx = KernelDictContext(spectral_ctx=CKDSpectralContext(bin_set=bin_set))
     assert atmosphere.kernel_dict(ctx).load()
 
 
-def test_heterogeneous_multi(modes_all_single, path_to_ussa76_approx_data):
+@pytest.mark.parametrize("bin_set", ["1nm", "10nm"])
+def test_heterogeneous_multi(modes_all_single, bin_set, path_to_ussa76_approx_data):
     """
     Unit tests for a HeterogeneousAtmosphere with multiple (2+) components.
     """
@@ -79,7 +83,7 @@ def test_heterogeneous_multi(modes_all_single, path_to_ussa76_approx_data):
     )
 
     # Radiative property metadata are correct
-    ctx = KernelDictContext()
+    ctx = KernelDictContext(spectral_ctx=CKDSpectralContext(bin_set=bin_set))
 
     # Kernel dict production succeeds
     assert atmosphere.kernel_phase(ctx)

--- a/tests/scenes/atmosphere/test_heterogeneous_legacy.py
+++ b/tests/scenes/atmosphere/test_heterogeneous_legacy.py
@@ -7,7 +7,7 @@ import pytest
 
 from eradiate import path_resolver, unit_context_config
 from eradiate import unit_registry as ureg
-from eradiate.contexts import KernelDictContext
+from eradiate.contexts import CKDSpectralContext, KernelDictContext
 from eradiate.kernel.gridvolume import read_binary_grid3d, write_binary_grid3d
 from eradiate.radprops import US76ApproxRadProfile
 from eradiate.radprops.rad_profile import AFGL1986RadProfile, ArrayRadProfile
@@ -49,12 +49,13 @@ def test_heterogeneous_write_volume_data_files(mode_mono, tmpdir):
     assert KernelDict.from_elements(atmosphere, ctx=ctx).load() is not None
 
 
-def test_heterogeneous_ckd(mode_ckd, tmpdir):
+@pytest.mark.parametrize("bin_set", ["1nm", "10nm"])
+def test_heterogeneous_ckd(mode_ckd, bin_set, tmpdir):
     """
     Writes the volume data files and produces a kernel dictionary that can be
     loaded by the kernel.
     """
-    ctx = KernelDictContext()
+    ctx = KernelDictContext(spectral_ctx=CKDSpectralContext(bin_set=bin_set))
     with unit_context_config.override({"length": "km"}):
         atmosphere = HeterogeneousAtmosphereLegacy(
             width=100.0,


### PR DESCRIPTION
# Description

This PR enables the automatic selection of CKD absorption data based on the active bin set. Changes are as follows:

- [x] `CKDSpectralContext` has a new optional `bin_set` field, which can be set by the `MeasureSpectralConfig` which emits it.
- [x] The following methods are added a `bin_set` parameter used to select a relevant CKD dataset.
  - `RadProfile.eval_sigma_a_ckd()`
  - `RadProfile.eval_dataset_ckd()`
  - `US76ApproxRadProfile.eval_sigma_t_ckd()`
  - `US76ApproxRadProfile.eval_albedo_ckd()`
  - `AFGL1986RadProfile.eval_sigma_t_ckd()`
  - `AFGL1986RadProfile.eval_albedo_ckd()`
- [x] `RadProfile.eval_sigma_a()` and `RadProfile.eval_dataset()` use the `bin_set` field of its `spectral_ctx` parameter to call `RadProfile.eval_sigma_a_ckd()` and `RadProfile.eval_dataset_ckd()` appropriately, respectively.
- [x] Changed back the tolerance of `test_onedim_vkd_vs_mono` from 10 % to 5 % ; the original tolerance was 5 %, it was changed to 10 % when the "10nm" bin set was replaced by the "1nm" bin set but this setting had no action hence the existence of this PR.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
