### PR TITLE
Check atmosphere feature switch combinations where relevant

### DIFF
--- a/src/eradiate/scenes/atmosphere/_heterogeneous.py
+++ b/src/eradiate/scenes/atmosphere/_heterogeneous.py
@@ -4,7 +4,6 @@ Heterogeneous atmospheres.
 from __future__ import annotations
 
 import typing as t
-import warnings
 from collections import abc as cabc
 
 import attr
@@ -139,6 +138,13 @@ class HeterogeneousAtmosphere(AbstractHeterogeneousAtmosphere):
                 "scaled individually"
             )
 
+        if self.particle_layers and (value.has_absorption and not value.has_scattering):
+            raise ValueError(
+                f"while validating {attribute.name}: a purely absorbing "
+                "molecular atmosphere cannot be mixed with particle layers; this "
+                "will be addressed in a future release"
+            )
+
     particle_layers: t.List[ParticleLayer] = documented(
         attr.ib(
             factory=list,
@@ -157,7 +163,7 @@ class HeterogeneousAtmosphere(AbstractHeterogeneousAtmosphere):
     )
 
     @particle_layers.validator
-    def _component_validator(self, attribute, value):
+    def _particle_layers_validator(self, attribute, value):
         if not all([component.width is AUTO for component in value]):
             raise ValueError(
                 f"while validating {attribute.name}: all components must have "

--- a/src/eradiate/scenes/atmosphere/_molecular_atmosphere.py
+++ b/src/eradiate/scenes/atmosphere/_molecular_atmosphere.py
@@ -64,7 +64,6 @@ class MolecularAtmosphere(AbstractHeterogeneousAtmosphere):
         attr.ib(
             default=True,
             converter=bool,
-            validator=attr.validators.instance_of(bool),
         ),
         doc="Absorption switch. If ``True``, the absorption coefficient is "
         "computed. Else, the absorption coefficient is not computed and "
@@ -77,7 +76,6 @@ class MolecularAtmosphere(AbstractHeterogeneousAtmosphere):
         attr.ib(
             default=True,
             converter=bool,
-            validator=attr.validators.instance_of(bool),
         ),
         doc="Scattering switch. If ``True``, the scattering coefficient is "
         "computed. Else, the scattering coefficient is not computed and "
@@ -85,6 +83,15 @@ class MolecularAtmosphere(AbstractHeterogeneousAtmosphere):
         type="bool",
         default="True",
     )
+
+    @has_absorption.validator
+    @has_scattering.validator
+    def _switch_validator(self, attribute, value):
+        if not self.has_absorption and not self.has_scattering:
+            raise ValueError(
+                f"while validating {attribute.name}: at least one of 'has_absorption' "
+                "and 'has_scattering' must be True"
+            )
 
     absorption_data_sets: t.Optional[t.Dict[str, str]] = documented(
         attr.ib(

--- a/tests/_system/test_onedim_atmosphere.py
+++ b/tests/_system/test_onedim_atmosphere.py
@@ -53,24 +53,22 @@ def test_heterogeneous_atmosphere_contains_particle_layer(mode_mono, bottom, tau
     assert np.all(results1 == results2)
 
 
-@pytest.mark.parametrize("has_scattering", [True, False])
-def test_heterogeneous_atmosphere_contains_molecular_atmosphere(
-    mode_mono, has_scattering
-):
+def test_heterogeneous_atmosphere_contains_molecular_atmosphere(mode_mono):
     """
     HeterogeneousAtmosphere is a good container for a MolecularAtmosphere
     =====================================================================
 
-    This testcase asserts that the HeterogeneousAtmosphere class can act as a container for
-    other atmosphere objects.
-
+    This testcase asserts that the HeterogeneousAtmosphere class can act as a
+    container for other atmosphere objects.
 
     Rationale
     ---------
 
     Run a OneDimExperiment with two different atmosphere definitions.
-    First define an atmosphere that is directly made up from a non-absorbing molecular atmosphere.
-    Second define a heterogeneous atmosphere that contains *only* a non-absorbing molecular atmosphere.
+    First define an atmosphere that is directly made up from a non-absorbing
+    molecular atmosphere.
+    Second define a heterogeneous atmosphere that contains *only* a
+    non-absorbing molecular atmosphere.
 
     Expected behaviour
     ------------------
@@ -82,11 +80,7 @@ def test_heterogeneous_atmosphere_contains_molecular_atmosphere(
     """
     # non absorbing molecular atmosphere
     exp1 = eradiate.experiments.OneDimExperiment(
-        atmosphere={
-            "type": "molecular",
-            "has_absorption": False,
-            "has_scattering": has_scattering,
-        }
+        atmosphere={"type": "molecular", "has_absorption": False}
     )
     exp1.run()
     results1 = exp1.results["measure"]["radiance"].values
@@ -95,11 +89,7 @@ def test_heterogeneous_atmosphere_contains_molecular_atmosphere(
     exp2 = eradiate.experiments.OneDimExperiment(
         atmosphere={
             "type": "heterogeneous",
-            "molecular_atmosphere": {
-                "type": "molecular",
-                "has_absorption": False,
-                "has_scattering": has_scattering,
-            },
+            "molecular_atmosphere": {"type": "molecular", "has_absorption": False},
         }
     )
     exp2.run()

--- a/tests/scenes/atmosphere/test_heterogeneous.py
+++ b/tests/scenes/atmosphere/test_heterogeneous.py
@@ -106,3 +106,22 @@ def test_heterogeneous_scale(mode_mono, path_to_ussa76_approx_data):
     ).kernel_dict(ctx)
     assert d["medium_atmosphere"]["scale"] == 2.0
     assert d.load()
+
+
+def test_heterogeneous_blend_switches(mode_mono):
+    # Rayleigh-only atmosphere + particle layer combination works
+    assert HeterogeneousAtmosphere(
+        molecular_atmosphere=MolecularAtmosphere.ussa1976(
+            has_absorption=False, has_scattering=True
+        ),
+        particle_layers=[ParticleLayer()],
+    )
+
+    # Purely absorbing atmosphere + particle layer combination is not allowed
+    with pytest.raises(ValueError):
+        HeterogeneousAtmosphere(
+            molecular_atmosphere=MolecularAtmosphere.ussa1976(
+                has_absorption=True, has_scattering=False
+            ),
+            particle_layers=[ParticleLayer()],
+        )

--- a/tests/scenes/atmosphere/test_molecular_atmosphere.py
+++ b/tests/scenes/atmosphere/test_molecular_atmosphere.py
@@ -1,5 +1,6 @@
 """Test cases of the _molecular_atmosphere module."""
 
+import numpy as np
 import pytest
 
 from eradiate import path_resolver
@@ -88,3 +89,19 @@ def test_molecular_atmosphere_ussa1976(
         absorption_data_sets=dict(us76_u86_4=ussa76_approx_test_absorption_data_set)
     )
     assert KernelDict.from_elements(atmosphere, ctx=ctx).load() is not None
+
+
+def test_molecular_atmosphere_switches(mode_mono):
+    # Absorption can be deactivated
+    atmosphere = MolecularAtmosphere(has_absorption=False)
+    ctx = KernelDictContext()
+    assert np.all(atmosphere.eval_radprops(ctx.spectral_ctx).sigma_a == 0.0)
+
+    # Scattering can be deactivated
+    atmosphere = MolecularAtmosphere(has_scattering=False)
+    ctx = KernelDictContext()
+    assert np.all(atmosphere.eval_radprops(ctx.spectral_ctx).sigma_s == 0.0)
+
+    # At least one must be active
+    with pytest.raises(ValueError):
+        MolecularAtmosphere(has_absorption=False, has_scattering=False)


### PR DESCRIPTION
# Description

This PR improves atmosphere feature switch handling. This is a very early check for eradiate/eradiate-issues#134. Changes are as follows:

- `MolecularAtmosphere` must have at least one of its two features active.
- `HeterogeneousAtmosphere` explicitly refuses to combine a purely absorbing atmosphere with particle layers.
- The `test_heterogeneous_atmosphere_contains_molecular_atmosphere` test case now skips atmosphere-free configurations.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
