### PR TITLE
Sensors in the atmosphere

### DIFF
--- a/src/eradiate/contexts.py
+++ b/src/eradiate/contexts.py
@@ -305,6 +305,14 @@ class KernelDictContext(Context):
         default="True",
     )
 
+    atmosphere_medium_id: t.Optional[str] = documented(
+        attr.ib(default=None, converter=attr.converters.optional(str)),
+        doc="If relevant, a kernel medium ID to reference by other kernel components.",
+        type="str or None",
+        init_type="str, optional",
+        default="None",
+    )
+
     override_scene_width: t.Optional[pint.Quantity] = documented(
         pinttr.ib(
             default=None,

--- a/src/eradiate/experiments/_onedim.py
+++ b/src/eradiate/experiments/_onedim.py
@@ -26,7 +26,7 @@ def measure_inside_atmosphere(atmosphere, measure, ctx):
     bbox = atmosphere.eval_bbox(ctx)
 
     if isinstance(measure, MultiRadiancemeterMeasure):
-        inside = [bbox.contains(origin) for origin in measure.origins]
+        inside = bbox.contains(measure.origins)
         if all(inside):
             return True
         elif not any(inside):

--- a/src/eradiate/experiments/_onedim.py
+++ b/src/eradiate/experiments/_onedim.py
@@ -33,8 +33,9 @@ def measure_inside_atmosphere(atmosphere, measure, ctx):
             return False
         else:
             raise ValueError(
-                "Inconsistent placement of Multiradiancemeter origins. "
-                "Origins must lie either all inside or all outside of the atmosphere."
+                "Inconsistent placement of MultiRadiancemeterMeasure origins. "
+                "Origins must lie either all inside or all outside of the "
+                "atmosphere."
             )
     elif measure.flags & MeasureFlags.DISTANT:
         return False
@@ -52,17 +53,17 @@ class OneDimExperiment(EarthObservationExperiment):
 
     Notes
     -----
-    A post-initialisation step will constrain the measure setup if a
-    distant measure is used and no target is defined:
+    * A post-initialisation step will constrain the measure setup if a
+      distant measure is used and no target is defined:
 
-    * if an atmosphere is defined, the target will be set to [0, 0, TOA];
-    * if no atmosphere is defined, the target will be set to [0, 0, 0].
+      * if an atmosphere is defined, the target will be set to [0, 0, TOA];
+      * if no atmosphere is defined, the target will be set to [0, 0, 0].
 
-    This experiment supports arbitrary measure positioning, except for
-    :class:`.MultiRadiancemeterMeasure`, for which subsensors are required to
-    be either all inside or all outside of the atmosphere. If an unsuitable
-    configuration is detected, a :class:`ValueError` will be raised during
-    initialisation..
+    * This experiment supports arbitrary measure positioning, except for
+      :class:`.MultiRadiancemeterMeasure`, for which subsensor origins are
+      required to be either all inside or all outside of the atmosphere. If an
+      unsuitable configuration is detected, a :class:`ValueError` will be raised
+      during initialisation.
     """
 
     atmosphere: t.Optional[Atmosphere] = documented(

--- a/src/eradiate/experiments/_rami.py
+++ b/src/eradiate/experiments/_rami.py
@@ -28,7 +28,7 @@ class RamiExperiment(EarthObservationExperiment):
     Notes
     -----
     A post-initialisation step will constrain the measure setup if a
-    :class:`.DistantMeasure` is used and no target is defined:
+    distant measure is used and no target is defined:
 
     * if a canopy is defined, the target will be set to the top of the canopy unit cell
       (*i.e.* without its padding);

--- a/src/eradiate/experiments/_rami4atm.py
+++ b/src/eradiate/experiments/_rami4atm.py
@@ -35,22 +35,21 @@ class Rami4ATMExperiment(EarthObservationExperiment):
 
     Notes
     -----
-    A post-initialisation step will constrain the measure setup if a
-    :class:`.DistantMeasure` is used and no target is defined:
+    * A post-initialisation step will constrain the measure setup if a
+      distant measure is used and no target is defined:
 
-    * if a canopy is defined, the target will be set to the top of the canopy unit cell
-      (*i.e.* without its padding);
-    * if no canopy is defined, the target will be set according to the atmosphere
-      (*i.e.* to [0, 0, `toa`] where `toa` is the top-of-atmosphere altitude);
-    * if neither atmosphere nor canopy are defined, the target is set to
-      [0, 0, 0].
+      * if a canopy is defined, the target will be set to the top of the canopy unit cell
+        (*i.e.* without its padding);
+      * if no canopy is defined, the target will be set according to the atmosphere
+        (*i.e.* to [0, 0, `toa`] where `toa` is the top-of-atmosphere altitude);
+      * if neither atmosphere nor canopy are defined, the target is set to
+        [0, 0, 0].
 
-    This experiment supports arbitrary measure positioning, except for
-    :class:`.MultiRadiancemeterMeasure`, for which subsensors are required to
-    be either all inside or all outside of the atmosphere. If an unsuitable
-    configuration is detected, a :class:`ValueError` will be raised during
-    initialisation.
-
+    * This experiment supports arbitrary measure positioning, except for
+      :class:`.MultiRadiancemeterMeasure`, for which subsensor origins are
+      required to be either all inside or all outside of the atmosphere. If an
+      unsuitable configuration is detected, a :class:`ValueError` will be raised
+      during initialisation.
     """
 
     atmosphere: t.Optional[Atmosphere] = documented(

--- a/src/eradiate/scenes/atmosphere/_core.py
+++ b/src/eradiate/scenes/atmosphere/_core.py
@@ -113,20 +113,31 @@ class Atmosphere(SceneElement, ABC):
 
         Parameters
         ----------
-        ctx : :class:`.KernelDictContext`
+        ctx : .KernelDictContext
             A context data structure containing parameters relevant for kernel
             dictionary generation.
 
         Returns
         -------
-        quantity
+        width : quantity
             Atmosphere width.
         """
         pass
 
-    def eval_bbox(self, ctx):
+    def eval_bbox(self, ctx: KernelDictContext) -> BoundingBox:
         """
-        Evaluate and return the bounding box enclosing the atmosphere's volume.
+        Evaluate the bounding box enclosing the atmosphere's volume.
+
+        Parameters
+        ----------
+        ctx : .KernelDictContext
+            A context data structure containing parameters relevant for kernel
+            dictionary generation.
+
+        Returns
+        -------
+        bbox : .BoundingBox
+            Calculated bounding box.
         """
         length_units = ucc.get("length")
 
@@ -171,13 +182,13 @@ class Atmosphere(SceneElement, ABC):
 
         Parameters
         ----------
-        ctx : :class:`.KernelDictContext`
+        ctx : .KernelDictContext
             A context data structure containing parameters relevant for kernel
             dictionary generation.
 
         Returns
         -------
-        :class:`.KernelDict`
+        kernel_dict : .KernelDict
             A kernel dictionary containing all the phase functions attached to
             the atmosphere.
         """
@@ -190,13 +201,13 @@ class Atmosphere(SceneElement, ABC):
 
         Parameters
         ----------
-        ctx : :class:`.KernelDictContext`
+        ctx : .KernelDictContext
             A context data structure containing parameters relevant for kernel
             dictionary generation.
 
         Returns
         -------
-        :class:`.KernelDict`
+        kernel_dict : .KernelDict
             A kernel dictionary containing all the media attached to the
             atmosphere.
         """
@@ -209,13 +220,13 @@ class Atmosphere(SceneElement, ABC):
 
         Parameters
         ----------
-        ctx : :class:`.KernelDictContext`
+        ctx : .KernelDictContext
             A context data structure containing parameters relevant for kernel
             dictionary generation.
 
         Returns
         -------
-        :class:`.KernelDict`
+        kernel_dict : .KernelDict
             A kernel dictionary containing all the shapes attached to the
             atmosphere.
         """
@@ -227,13 +238,13 @@ class Atmosphere(SceneElement, ABC):
 
         Parameters
         ----------
-        ctx : :class:`.KernelDictContext`
+        ctx : .KernelDictContext
             A context data structure containing parameters relevant for kernel
             dictionary generation.
 
         Returns
         -------
-        quantity
+        height : quantity
             Height of the kernel object delimiting the atmosphere
         """
         return self.height + self.kernel_offset(ctx=ctx)
@@ -246,13 +257,13 @@ class Atmosphere(SceneElement, ABC):
 
         Parameters
         ----------
-        ctx : :class:`.KernelDictContext`
+        ctx : .KernelDictContext
             A context data structure containing parameters relevant for kernel
             dictionary generation.
 
         Returns
         -------
-        quantity
+        offset : quantity
             Vertical offset of cuboid shape.
 
         Notes
@@ -268,13 +279,13 @@ class Atmosphere(SceneElement, ABC):
 
         Parameters
         ----------
-        ctx : :class:`.KernelDictContext`
+        ctx : .KernelDictContext
             A context data structure containing parameters relevant for kernel
             dictionary generation.
 
         Returns
         -------
-        quantity
+        width : quantity
             Width of the kernel object delimiting the atmosphere.
         """
         return self.eval_width(ctx=ctx)
@@ -417,7 +428,7 @@ class AbstractHeterogeneousAtmosphere(Atmosphere, ABC):
 
         Parameters
         ----------
-        spectral_ctx : :class:`.SpectralContext`
+        spectral_ctx : .SpectralContext
             A spectral context data structure containing relevant spectral
             parameters (*e.g.* wavelength in monochromatic mode, bin and
             quadrature point index in CKD mode).

--- a/src/eradiate/scenes/atmosphere/_core.py
+++ b/src/eradiate/scenes/atmosphere/_core.py
@@ -11,7 +11,7 @@ import pint
 import pinttr
 import xarray as xr
 
-from ..core import KernelDict, SceneElement
+from ..core import BoundingBox, KernelDict, SceneElement
 from ... import converters
 from ... import unit_context_kernel as uck
 from ... import validators
@@ -123,6 +123,21 @@ class Atmosphere(SceneElement, ABC):
             Atmosphere width.
         """
         pass
+
+    def eval_bbox(self, ctx):
+        """
+        Evaluate and return the bounding box enclosing the atmosphere's volume.
+        """
+        length_units = ucc.get("length")
+
+        k_width = self.eval_width(ctx).m_as(length_units)
+        k_bottom = (self.bottom - self.kernel_offset(ctx)).m_as(length_units)
+        k_top = self.top.m_as(length_units)
+
+        return BoundingBox(
+            [-k_width / 2.0, -k_width / 2.0, k_bottom] * length_units,
+            [k_width / 2.0, k_width / 2.0, k_top] * length_units,
+        )
 
     # --------------------------------------------------------------------------
     #                       Kernel dictionary generation

--- a/src/eradiate/scenes/measure/_multi_radiancemeter.py
+++ b/src/eradiate/scenes/measure/_multi_radiancemeter.py
@@ -116,7 +116,15 @@ class MultiRadiancemeterMeasure(Measure):
         result = KernelDict()
 
         for spp, sensor_id in zip(sensor_spps, sensor_ids):
-            result.data[sensor_id] = self._kernel_dict(sensor_id, spp)
+            if ctx.atmosphere_medium_id is not None:
+                result_dict = self._kernel_dict(sensor_id, spp)
+                result_dict["medium"] = {
+                    "type": "ref",
+                    "id": ctx.atmosphere_medium_id,
+                }
+                result.data[sensor_id] = result_dict
+            else:
+                result.data[sensor_id] = self._kernel_dict(sensor_id, spp)
 
         return result
 

--- a/src/eradiate/scenes/measure/_perspective.py
+++ b/src/eradiate/scenes/measure/_perspective.py
@@ -182,7 +182,15 @@ class PerspectiveCameraMeasure(Measure):
         result = KernelDict()
 
         for spp, sensor_id in zip(sensor_spps, sensor_ids):
-            result.data[sensor_id] = self._kernel_dict(sensor_id, spp)
+            if ctx.atmosphere_medium_id is not None:
+                result_dict = self._kernel_dict(sensor_id, spp)
+                result_dict["medium"] = {
+                    "type": "ref",
+                    "id": ctx.atmosphere_medium_id,
+                }
+                result.data[sensor_id] = result_dict
+            else:
+                result.data[sensor_id] = self._kernel_dict(sensor_id, spp)
 
         return result
 

--- a/src/eradiate/scenes/measure/_radiancemeter.py
+++ b/src/eradiate/scenes/measure/_radiancemeter.py
@@ -112,7 +112,15 @@ class RadiancemeterMeasure(Measure):
         result = KernelDict()
 
         for spp, sensor_id in zip(sensor_spps, sensor_ids):
-            result.data[sensor_id] = self._kernel_dict(sensor_id, spp)
+            if ctx.atmosphere_medium_id is not None:
+                result_dict = self._kernel_dict(sensor_id, spp)
+                result_dict["medium"] = {
+                    "type": "ref",
+                    "id": ctx.atmosphere_medium_id,
+                }
+                result.data[sensor_id] = result_dict
+            else:
+                result.data[sensor_id] = self._kernel_dict(sensor_id, spp)
 
         return result
 

--- a/tests/scenes/measure/test_multi_radiancemeter.py
+++ b/tests/scenes/measure/test_multi_radiancemeter.py
@@ -21,3 +21,20 @@ def test_multi_radiancemeter_args(mode_mono):
     # The kernel dict can be instantiated
     ctx = KernelDictContext()
     assert KernelDict.from_elements(s, ctx=ctx).load()
+
+
+def test_multi_radiancemeter_external_medium(mode_mono):
+    # create a series of multiradiancemeter measures and a kernel dict context
+    # which places some of them inside and outside the atmospheric volume
+    # assert that the external medium is set correctly in the cameras' kernel dicts
+
+    d1 = MultiRadiancemeterMeasure()
+
+    ctx1 = KernelDictContext(atmosphere_medium_id="test_atmosphere")
+    ctx2 = KernelDictContext()
+
+    kd1 = d1.kernel_dict(ctx=ctx1)
+    kd2 = d1.kernel_dict(ctx=ctx2)
+
+    assert kd1["measure"]["medium"] == {"type": "ref", "id": "test_atmosphere"}
+    assert "medium" not in kd2["measure"].keys()

--- a/tests/scenes/measure/test_perspective.py
+++ b/tests/scenes/measure/test_perspective.py
@@ -19,3 +19,20 @@ def test_perspective(mode_mono):
     # Up must differ from the camera's viewing direction
     with pytest.raises(ValueError):
         PerspectiveCameraMeasure(origin=[0, 1, 0], target=[1, 0, 0], up=[1, -1, 0])
+
+
+def test_perspective_external_medium(mode_mono):
+    # create a series of perspective camera measures and a kernel dict context
+    # which places some of them inside and outside the atmospheric volume
+    # assert that the external medium is set correctly in the cameras' kernel dicts
+
+    s1 = PerspectiveCameraMeasure()
+
+    ctx1 = KernelDictContext(atmosphere_medium_id="test_atmosphere")
+    ctx2 = KernelDictContext()
+
+    kd1 = s1.kernel_dict(ctx=ctx1)
+    kd2 = s1.kernel_dict(ctx=ctx2)
+
+    assert kd1["measure"]["medium"] == {"type": "ref", "id": "test_atmosphere"}
+    assert "medium" not in kd2["measure"].keys()

--- a/tests/scenes/measure/test_radiancemeter.py
+++ b/tests/scenes/measure/test_radiancemeter.py
@@ -10,3 +10,20 @@ def test_radiancemeter(mode_mono):
     # The kernel dict can be instantiated
     ctx = KernelDictContext()
     assert KernelDict.from_elements(s, ctx=ctx).load()
+
+
+def test_radiancemeter_external_medium(mode_mono):
+    # create a series of radiancemeter measures and a kernel dict context
+    # which places some of them inside and outside the atmospheric volume
+    # assert that the external medium is set correctly in the cameras' kernel dicts
+
+    s1 = RadiancemeterMeasure()
+
+    ctx1 = KernelDictContext(atmosphere_medium_id="test_atmosphere")
+    ctx2 = KernelDictContext()
+
+    kd1 = s1.kernel_dict(ctx=ctx1)
+    kd2 = s1.kernel_dict(ctx=ctx2)
+
+    assert kd1["measure"]["medium"] == {"type": "ref", "id": "test_atmosphere"}
+    assert "medium" not in kd2["measure"].keys()


### PR DESCRIPTION
# Description

This PR adds functionality which lets Experiment classes that support atmospheres add an external medium to the sensors, which are placed inside the atmosphere's volume.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
