### PR TITLE
Particle distribution rewrite

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -152,6 +152,7 @@ intersphinx_mapping = {
     "pinttrs": ("https://pinttrs.readthedocs.io/en/latest/", None),
     "python": ("https://docs.python.org/3/", None),
     "rich": ("https://rich.readthedocs.io/en/latest/", None),
+    "scipy": ("https://docs.scipy.org/doc/scipy/", None),
     "xarray": ("http://xarray.pydata.org/en/stable/", None),
 }
 

--- a/docs/rst/reference/scenes.rst
+++ b/docs/rst/reference/scenes.rst
@@ -31,6 +31,7 @@
 
    Atmosphere
    AbstractHeterogeneousAtmosphere
+   ParticleDistribution
 
 **Factories**
 
@@ -47,12 +48,16 @@
    MolecularAtmosphere
    ParticleLayer
 
-**Particle distribution**
+**Particle distributions**
 
 .. autosummary::
    :toctree: generated/autosummary
 
-   ParticleDistribution
+   ArrayParticleDistribution
+   ExponentialParticleDistribution
+   InterpolatorParticleDistribution
+   GaussianParticleDistribution
+   UniformParticleDistribution
 
 ``eradiate.scenes.biosphere``
 -----------------------------

--- a/src/eradiate/scenes/atmosphere/__init__.py
+++ b/src/eradiate/scenes/atmosphere/__init__.py
@@ -2,17 +2,30 @@ from ._core import AbstractHeterogeneousAtmosphere, Atmosphere, atmosphere_facto
 from ._heterogeneous import HeterogeneousAtmosphere
 from ._homogeneous import HomogeneousAtmosphere
 from ._molecular_atmosphere import MolecularAtmosphere
-from ._particle_dist import ParticleDistribution, particle_distribution_factory
+from ._particle_dist import (
+    ArrayParticleDistribution,
+    ExponentialParticleDistribution,
+    GaussianParticleDistribution,
+    InterpolatorParticleDistribution,
+    ParticleDistribution,
+    UniformParticleDistribution,
+    particle_distribution_factory,
+)
 from ._particle_layer import ParticleLayer
 
 __all__ = [
+    "atmosphere_factory",
+    "particle_distribution_factory",
     "Atmosphere",
     "AbstractHeterogeneousAtmosphere",
     "HeterogeneousAtmosphere",
     "HomogeneousAtmosphere",
     "MolecularAtmosphere",
-    "ParticleDistribution",
     "ParticleLayer",
-    "atmosphere_factory",
-    "particle_distribution_factory",
+    "ParticleDistribution",
+    "ArrayParticleDistribution",
+    "ExponentialParticleDistribution",
+    "InterpolatorParticleDistribution",
+    "GaussianParticleDistribution",
+    "UniformParticleDistribution",
 ]

--- a/src/eradiate/scenes/atmosphere/_particle_layer.py
+++ b/src/eradiate/scenes/atmosphere/_particle_layer.py
@@ -34,6 +34,18 @@ from ...units import unit_registry as ureg
 from ...validators import is_positive
 
 
+def _particle_layer_distribution_converter(value):
+    if isinstance(value, str):
+        if value == "uniform":
+            return particle_distribution_factory.convert({"type": "uniform"})
+        elif value == "gaussian":
+            return particle_distribution_factory.convert({"type": "gaussian"})
+        elif value == "exponential":
+            return particle_distribution_factory.convert({"type": "exponential"})
+
+    return particle_distribution_factory.convert(value)
+
+
 @atmosphere_factory.register(type_id="particle_layer")
 @parse_docs
 @attr.s
@@ -103,14 +115,19 @@ class ParticleLayer(AbstractHeterogeneousAtmosphere):
 
     distribution: ParticleDistribution = documented(
         attr.ib(
-            factory=UniformParticleDistribution,
-            converter=particle_distribution_factory.convert,
+            default="uniform",
+            converter=_particle_layer_distribution_converter,
             validator=attr.validators.instance_of(ParticleDistribution),
         ),
-        doc="Particle distribution.",
-        init_type=":class:`.ParticleDistribution` or dict, optional",
+        doc="Particle distribution. Simple defaults can be set using a string: "
+        '``"uniform"`` (resp. ``"gaussian"``, ``"exponential"``) is converted to '
+        ":class:`UniformParticleDistribution() <.UniformParticleDistribution>` "
+        "(resp. :class:`GaussianParticleDistribution() <.GaussianParticleDistribution>`, "
+        ":class:`ExponentialParticleDistribution() <.ExponentialParticleDistribution>`).",
+        init_type=":class:`.ParticleDistribution` or dict or "
+        '{"uniform", "gaussian", "exponential"}, optional',
         type=":class:`.ParticleDistribution`",
-        default=":class:`.UniformParticleDistribution() <.UniformParticleDistribution>`",
+        default='"uniform"',
     )
 
     tau_550: pint.Quantity = documented(

--- a/src/eradiate/scenes/atmosphere/_particle_layer.py
+++ b/src/eradiate/scenes/atmosphere/_particle_layer.py
@@ -110,7 +110,7 @@ class ParticleLayer(AbstractHeterogeneousAtmosphere):
         doc="Particle distribution.",
         init_type=":class:`.ParticleDistribution` or dict, optional",
         type=":class:`.ParticleDistribution`",
-        default=":class:`UniformParticleDistribution() <.UniformParticleDistribution>`",
+        default=":class:`.UniformParticleDistribution() <.UniformParticleDistribution>`",
     )
 
     tau_550: pint.Quantity = documented(
@@ -226,9 +226,12 @@ class ParticleLayer(AbstractHeterogeneousAtmosphere):
         Returns
         -------
         ndarray
-            Particles fractions.
+            Particle fractions.
         """
-        return self.distribution.eval_fraction(self.z_layer)
+        x = (self.z_layer - self.bottom) / (self.top - self.bottom)
+        fractions = self.distribution(x.magnitude)
+        fractions /= np.sum(fractions)
+        return fractions
 
     # --------------------------------------------------------------------------
     #                       Radiative properties

--- a/tests/scenes/atmosphere/test_particle_dist.py
+++ b/tests/scenes/atmosphere/test_particle_dist.py
@@ -1,8 +1,6 @@
 import numpy as np
 import pytest
-import xarray as xr
 
-from eradiate import unit_registry as ureg
 from eradiate.scenes.atmosphere._particle_dist import (
     ArrayParticleDistribution,
     ExponentialParticleDistribution,
@@ -10,133 +8,116 @@ from eradiate.scenes.atmosphere._particle_dist import (
     UniformParticleDistribution,
 )
 
-# ------------------------------------------------------------------------------
-#                   Uniform vertical distribution
-# ------------------------------------------------------------------------------
 
+def test_particle_dist_uniform_construct():
+    # Constructing without argument is possible
+    UniformParticleDistribution()
 
-@pytest.fixture
-def test_altitudes():
-    bottom = ureg.Quantity(0000.0, "m")
-    top = ureg.Quantity(2000.0, "m")
-    return np.linspace(bottom, top)
-
-
-def test_uniform():
-    """Constructor returns 'Uniform' object."""
-    dist = UniformParticleDistribution()
-    assert isinstance(dist, UniformParticleDistribution)
-
-
-def test_uniform_fractions_all_equal(test_altitudes):
-    """Particle fraction values are all equal."""
-    dist = UniformParticleDistribution()
-    fractions = dist.eval_fraction(test_altitudes)
-    assert (fractions == fractions[0]).all()
-
-
-def test_uniform_fractions_values_sum_to_one(test_altitudes):
-    """Particle fraction values sum to one."""
-    dist = UniformParticleDistribution()
-    fractions = dist.eval_fraction(test_altitudes)
-    assert np.isclose(np.sum(fractions), 1.0, rtol=1e-6)
-
-
-# ------------------------------------------------------------------------------
-#                   Gaussian vertical distribution
-# ------------------------------------------------------------------------------
-
-
-def test_gaussian():
-    "Assign 'mean' and 'std' attributes."
-    mean = ureg.Quantity(1000.0, "m")
-    std = ureg.Quantity(200.0, "m")
-    dist = GaussianParticleDistribution(mean=mean, std=std)
-    assert dist.mean == mean
-    assert dist.std == std
-
-
-def test_gaussian_fractions_sum_to_one(test_altitudes):
-    """Particle fractions sum to one."""
-    mean = ureg.Quantity(1000.0, "m")
-    std = ureg.Quantity(200.0, "m")
-    dist = GaussianParticleDistribution(mean=mean, std=std)
-    f = dist.eval_fraction(test_altitudes)
-    assert np.isclose(np.sum(f), 1.0, rtol=1e-6)
-
-
-# ------------------------------------------------------------------------------
-#                   Exponential vertical distribution
-# ------------------------------------------------------------------------------
-
-
-def test_exponential():
-    """Bottom and top altitudes are assigned."""
-    rate = ureg.Quantity(1.0, "km^-1")
-    dist = ExponentialParticleDistribution(rate=rate)
-    assert dist.rate == rate
-
-
-def test_exponential_fractions_sum_to_one(test_altitudes):
-    """Particle fractions sum to one."""
-    rate = ureg.Quantity(1.0, "km^-1")
-    dist = ExponentialParticleDistribution(rate=rate)
-    f = dist.eval_fraction(test_altitudes)
-    assert np.isclose(np.sum(f), 1.0, rtol=1e-6)
-
-
-# ------------------------------------------------------------------------------
-#                   Array vertical distribution
-# ------------------------------------------------------------------------------
-
-
-def test_array():
-    """Bottom and top altitudes are assigned."""
-    values = np.array([1.0, 2.0, 3.0, 2.0, 1.0])
-    dist = ArrayParticleDistribution(values=values)
-    assert np.allclose(dist.values, values)
-
-
-def test_array_fractions_sum_to_one(test_altitudes):
-    """Particle fractions sum to one."""
-    values = np.array([1.0, 2.0, 3.0, 2.0, 1.0])
-    dist = ArrayParticleDistribution(values=values)
-    f = dist.eval_fraction(test_altitudes)
-    assert np.isclose(np.sum(f), 1.0, rtol=1e-6)
-
-
-def test_array_fill_value_is_zero():
-    """Missing values in 'data_array' are replaced by zero."""
-    bottom = ureg.Quantity(200.0, "m")
-    top = ureg.Quantity(800.0, "m")
-    z_values = np.linspace(bottom.magnitude + 100, top.magnitude)
-    da = xr.DataArray(
-        data=np.random.random(len(z_values)),
-        coords={
-            "z": ("z", z_values, {"units": "m"}),
-        },
-        dims=["z"],
-    )
-    dist = ArrayParticleDistribution(data_array=da)
-    f = dist.eval_fraction(np.linspace(bottom, top))
-    assert np.isclose(f[0], 0.0, rtol=1e-6)
-
-
-def test_array_invalid_values():
-    """Raises when negative values are passed."""
-    values = np.array([1.0, -2.0, 3.0, 2.0, -1.0])
+    # 'bounds' must be sorted
     with pytest.raises(ValueError):
-        ArrayParticleDistribution(values=values)
+        UniformParticleDistribution([1.0, 0.0])
 
-
-def test_array_invalid_data_array():
-    """Raises when negative values are passed to 'data_array'."""
-    da = xr.DataArray(
-        data=np.array([1.0, -2.0, 3.0, 2.0, -0.01, 0.0, 5.0]),
-        coords={
-            "z": ("z", np.linspace(200, 800, 7), {"units": "m"}),
-        },
-        dims=["z"],
-    )
+    # 'bounds' must be a 2-array
     with pytest.raises(ValueError):
-        ArrayParticleDistribution(data_array=da)
+        UniformParticleDistribution([0.0, 0.5, 1.0])
+
+
+def test_particle_dist_uniform():
+    dist = UniformParticleDistribution(bounds=[0.0, 0.5])
+    x = np.linspace(-0.5, 1.0, 7)
+    expected = np.array([0, 0, 2, 2, 2, 0, 0])
+    assert np.allclose(expected, dist(x))
+
+
+def test_particle_dist_exponential():
+    dist = ExponentialParticleDistribution(scale=1.0)
+    x = np.linspace(0, 1, 11)
+    expected = np.exp(-x)
+    assert np.allclose(expected, dist(x))
+
+
+def test_particle_dist_gaussian():
+    dist = GaussianParticleDistribution(mean=0.0, std=1.0)
+    x = np.linspace(0, 1, 11)
+    expected = np.exp(-0.5 * np.square(x)) / np.sqrt(2.0 * np.pi)
+    assert np.allclose(expected, dist(x))
+
+
+def test_particle_dist_array_construct():
+    # 'values' field is required
+    with pytest.raises(TypeError):
+        ArrayParticleDistribution()
+
+    # Omitting the 'coords' field sets a default, regularly spaced grid
+    dist = ArrayParticleDistribution(values=[0.1, 0.2, 0.3, 0.2, 0.1])
+    assert np.allclose([0.1, 0.3, 0.5, 0.7, 0.9], dist.coords)
+
+    # Specifying the 'coords' field requires both 'values' and 'coords' to be
+    # of the same length
+    with pytest.raises(ValueError):
+        ArrayParticleDistribution(
+            values=[0.1, 0.2, 0.3, 0.2, 0.1], coords=np.linspace(0, 1, 6)
+        )
+
+
+@pytest.mark.parametrize(
+    "method, expected",
+    [
+        ("nearest", [0.1, 0.1, 0.1, 0.2, 0.2, 0.3, 0.3, 0.2, 0.2, 0.1, 0.1]),
+        ("nearest-up", [0.1, 0.1, 0.2, 0.2, 0.2, 0.3, 0.2, 0.2, 0.1, 0.1, 0.1]),
+        ("linear", [0.1, 0.1, 0.15, 0.2, 0.25, 0.3, 0.25, 0.2, 0.15, 0.1, 0.1]),
+        ("zero", [0.1, 0.1, 0.1, 0.2, 0.2, 0.2, 0.3, 0.2, 0.2, 0.2, 0.1]),
+        ("slinear", [0.1, 0.1, 0.15, 0.2, 0.25, 0.3, 0.25, 0.2, 0.15, 0.1, 0.1]),
+        ("quadratic", [0.1, 0.1, 0.145, 0.2, 0.265, 0.3, 0.265, 0.2, 0.145, 0.1, 0.1]),
+        (
+            "cubic",
+            [0.1, 0.1, 0.13125, 0.2, 0.26875, 0.3, 0.26875, 0.2, 0.13125, 0.1, 0.1],
+        ),
+        ("previous", [0.1, 0.1, 0.1, 0.2, 0.2, 0.2, 0.3, 0.2, 0.2, 0.2, 0.1]),
+        ("next", [0.1, 0.1, 0.2, 0.2, 0.3, 0.3, 0.2, 0.2, 0.1, 0.1, 0.1]),
+    ],
+    ids=[
+        "nearest",
+        "nearest-up",
+        "linear",
+        "zero",
+        "slinear",
+        "quadratic",
+        "cubic",
+        "previous",
+        "next",
+    ],
+)
+def test_particle_dist_array_call(method, expected):
+    dist = ArrayParticleDistribution(
+        values=[0.1, 0.2, 0.3, 0.2, 0.1],
+        method=method,
+        extrapolate="nearest",
+    )
+    x = np.linspace(0, 1, 11)
+    result = dist(x)
+    assert np.allclose(expected, result)
+
+
+@pytest.mark.parametrize(
+    "extrapolate, expected",
+    [
+        ("zero", [0, 0]),
+        ("nearest", [0.1, 0.1]),
+        ("method", [0.05, 0.05]),
+        ("nan", None),
+    ],
+    ids=["zero", "nearest", "method", "nan"],
+)
+def test_particle_dist_array_extrapolate(extrapolate, expected):
+    dist = ArrayParticleDistribution(
+        values=[0.1, 0.2, 0.3, 0.2, 0.1],
+        method="linear",
+        extrapolate=extrapolate,
+    )
+    result = dist([0.0, 1.0])
+
+    if extrapolate != "nan":
+        assert np.allclose(expected, result)
+    else:
+        assert np.isnan(result).all()


### PR DESCRIPTION
# Description

Closes eradiate/eradiate-issues#139; closes eradiate/eradiate-issues#118.

This PR refactors particle distribution code to remove any relation to the particle layer itself and only describe the particle density in a dimensionless fashion. It also simplifies the API and introduces a `InterpolatorParticleDistribution` for maximum flexibility. Changes are as follows:

- `ParticleDistribution` subclasses no longer normalise their output: this responsiblity is transferred to `ParticleLayer`.
- `ParticleDistribution.eval()` is replaced by `ParticleDistribution()`, which makes it behave just like a `scipy.interpolate.interp1d` instance.
- The parametrisation and implementation of subclasses is simpler.
- `ArrayParticleDistribution` has received a thorough refactoring so as to make it more comprehensive and flexible.
- Docstrings and tests were checked and updated.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
