### PR TITLE
Spherical grid volume plugin

### DIFF
--- a/src/plugins/src/CMakeLists.txt
+++ b/src/plugins/src/CMakeLists.txt
@@ -1,3 +1,4 @@
 # Plugins
 add_subdirectory(bsdfs)
 add_subdirectory(sensors)
+add_subdirectory(volumes)

--- a/src/plugins/src/volumes/CMakeLists.txt
+++ b/src/plugins/src/volumes/CMakeLists.txt
@@ -1,3 +1,3 @@
 set(MTS_PLUGIN_PREFIX "volumes")
 
-add_plugin(grid_spherical grid_spherical.cpp)
+add_plugin(sphericalgridvolume sphericalgrid.cpp)

--- a/src/plugins/src/volumes/CMakeLists.txt
+++ b/src/plugins/src/volumes/CMakeLists.txt
@@ -1,0 +1,3 @@
+set(MTS_PLUGIN_PREFIX "volumes")
+
+add_plugin(grid_spherical grid_spherical.cpp)

--- a/src/plugins/src/volumes/grid_spherical.cpp
+++ b/src/plugins/src/volumes/grid_spherical.cpp
@@ -28,10 +28,25 @@ Grid-based volume data source in spherical coordinates(:monosp:`sphericalgridvol
    - Nested gridvolume object that holds the actual data organized in spherical coordinates
      Method calls are pre processed if necessary and then forwarded to this object.
 
- * - inner_bsphere_radius
+ * - rmin
    - |float|
-   - Specifies the relative radius of the inner bounding sphere of the spherical shell
-     that delimits this volume. This must be within [0, 1.0]. 
+   - Radius for the inner limit of the spherical shell. Note that this radius
+     is given in relative units to the [0,1] unit sphere.
+
+ * - rmax
+   - |float|
+   - Radius for the outer limit of the spherical shell. Note that this radius
+     is given in relative units to the [0,1] unit sphere.
+
+ * - fillmin
+   - |float|
+   - Fill value to return for points which lie inside the bounding sphere of
+     the volume but have a radial component smaller than `rmin`.
+
+ * - fillmax
+   - |float|
+   - Fill value to return for points which lie inside the bounding sphere of
+     the volume but have a radial component greater than `rmax`.
 
 This class implements a gridvolume in spherical coordinates. To achieve that, it holds a nested
 gridvolume object and preprocesses method calls accordingly before forwarding them to the nested

--- a/src/plugins/src/volumes/grid_spherical.cpp
+++ b/src/plugins/src/volumes/grid_spherical.cpp
@@ -16,9 +16,9 @@ enum class FilterType { Nearest, Trilinear };
 enum class WrapMode { Repeat, Mirror, Clamp };
 
 /**!
-.. _volume-gridvolume_spherical:
+.. _volume-sphericalgridvolume:
 
-Grid-based volume data source in spherical coordinates(:monosp:`gridvolume_spherical`)
+Grid-based volume data source in spherical coordinates(:monosp:`sphericalgridvolume`)
 ----------------------------------------------------------
 
 .. pluginparameters::
@@ -42,35 +42,45 @@ cover the [0,1] range.
 */
 
 template <typename Float, typename Spectrum>
-class GridVolumeSpherical final : public Volume<Float, Spectrum> {
+class SphericalGridVolume final : public Volume<Float, Spectrum> {
 public:
-    MTS_IMPORT_BASE(Volume, m_to_local, update_bbox)
+    MTS_IMPORT_BASE(Volume, m_to_local, m_bbox)
     MTS_IMPORT_TYPES(Volume, VolumeGrid)
 
-    GridVolumeSpherical(const Properties &props) : Base(props) {
+    SphericalGridVolume(const Properties &props) : Base(props) {
         m_gridvol = props.volume<Volume>("gridvolume", 1.f);
-        m_inner_bsphere_radius_relative = props.get<ScalarFloat>("inner_bsphere_radius", 0.f);
+
+        m_rmin = props.get<ScalarFloat>("rmin", 0.f);
+        m_rmax = props.get<ScalarFloat>("rmax", 1.f);
+        m_rmin_rel = m_rmin / m_rmax;
+
+        m_fillmin = props.get<ScalarFloat>("fillmin", 0.f);
+        m_fillmax = props.get<ScalarFloat>("fillmax", 0.f);
+
+        m_to_local = props.get<ScalarTransform4f>("to_world", ScalarTransform4f()).inverse();
+        update_bbox_sphere();
     }
 
     UnpolarizedSpectrum eval(const Interaction3f &it, Mask active) const override {
-        auto p = m_to_local * it.p;
-
-        // transform from the [0:1, 0:1, 0:1] cube to a  [-1:1, -1:1, -1:1] cube
-        ScalarTransform4f to_center = ScalarTransform4f::translate(ScalarPoint3f(-1, -1, -1)) * ScalarTransform4f::scale(2.f);
-        p = to_center * p;
+        Point3f p = m_to_local * it.p;
+        Float p_magnitude = ek::norm(p);
 
         Point3f p_spherical = Point3f(
-            (ek::norm(p) - m_inner_bsphere_radius_relative) / (1.f - m_inner_bsphere_radius_relative),
-            ek::acos(p.z() / ek::norm(p)) / ek::Pi<ScalarFloat>,
-            ek::atan2(p.y(), p.x()) / ek::Pi<ScalarFloat> + 1.f
+            (p_magnitude - m_rmin) / (m_rmax - m_rmin),
+            ek::acos(p.z() / p_magnitude) * ek::InvPi<ScalarFloat>,
+            ek::atan2(p.y(), p.x()) * ek::InvPi<ScalarFloat> + 1.f
         );
 
         Interaction3f it_spherical = it;
         it_spherical.p = p_spherical;
 
-        Mask within_spherical_shell = (m_inner_bsphere_radius_relative <= ek::norm(p) && ek::norm(p) <= 1.0);
-
-        return ek::select(within_spherical_shell, m_gridvol->eval(it_spherical, active), 0.f);
+        return ek::select(p_magnitude < m_rmin,
+            m_fillmin,
+            ek::select(p_magnitude > m_rmax,
+                m_fillmax,
+                m_gridvol->eval(it_spherical, active)
+            )
+        );
     }
 
     ScalarFloat max() const override { return m_gridvol->max(); }
@@ -80,11 +90,18 @@ public:
     MTS_DECLARE_CLASS()
 
 protected:
-    ScalarFloat m_inner_bsphere_radius_relative;
+    ScalarFloat m_center, m_rmin, m_rmax, m_rmin_rel, m_fillmin, m_fillmax;
     ref<Volume> m_gridvol;
+
+    void update_bbox_sphere() {
+        ScalarTransform4f to_world = m_to_local.inverse();
+        ScalarPoint3f a = to_world * ScalarPoint3f(-1.f, -1.f, -1.f);
+        ScalarPoint3f b = to_world * ScalarPoint3f(1.f, 1.f, 1.f);
+        m_bbox = ScalarBoundingBox3f(a, b);
+    }
 };
 
-MTS_IMPLEMENT_CLASS_VARIANT(GridVolumeSpherical, Volume)
-MTS_EXPORT_PLUGIN(GridVolumeSpherical, "GridVolumeSpherical texture")
+MTS_IMPLEMENT_CLASS_VARIANT(SphericalGridVolume, Volume)
+MTS_EXPORT_PLUGIN(SphericalGridVolume, "SphericalGridVolume texture")
 
 NAMESPACE_END(mitsuba)

--- a/src/plugins/src/volumes/grid_spherical.cpp
+++ b/src/plugins/src/volumes/grid_spherical.cpp
@@ -1,0 +1,90 @@
+#include <mitsuba/core/fresolver.h>
+#include <mitsuba/core/properties.h>
+#include <mitsuba/core/spectrum.h>
+#include <mitsuba/core/string.h>
+#include <mitsuba/core/transform.h>
+
+#include <mitsuba/render/srgb.h>
+#include <mitsuba/render/volume.h>
+#include <mitsuba/render/volumegrid.h>
+#include <enoki/dynamic.h>
+#include <enoki/tensor.h>
+
+NAMESPACE_BEGIN(mitsuba)
+
+enum class FilterType { Nearest, Trilinear };
+enum class WrapMode { Repeat, Mirror, Clamp };
+
+/**!
+.. _volume-gridvolume_spherical:
+
+Grid-based volume data source in spherical coordinates(:monosp:`gridvolume_spherical`)
+----------------------------------------------------------
+
+.. pluginparameters::
+
+ * - gridvolume
+   - |gridvolume|
+   - Nested gridvolume object that holds the actual data organized in spherical coordinates
+     Method calls are pre processed if necessary and then forwarded to this object.
+
+ * - inner_bsphere_radius
+   - |float|
+   - Specifies the relative radius of the inner bounding sphere of the spherical shell
+     that delimits this volume. This must be within [0, 1.0]. 
+
+This class implements a gridvolume in spherical coordinates. To achieve that, it holds a nested
+gridvolume object and preprocesses method calls accordingly before forwarding them to the nested
+object. In the :monosp:`eval()` method, the sampled point is converted to spherical coordinates,
+relative to the center of the sphere and converted such that :math:`r`, :math:`\theta` and :math:`\phi`
+cover the [0,1] range.
+
+*/
+
+template <typename Float, typename Spectrum>
+class GridVolumeSpherical final : public Volume<Float, Spectrum> {
+public:
+    MTS_IMPORT_BASE(Volume, m_to_local, update_bbox)
+    MTS_IMPORT_TYPES(Volume, VolumeGrid)
+
+    GridVolumeSpherical(const Properties &props) : Base(props) {
+        m_gridvol = props.volume<Volume>("gridvolume", 1.f);
+        m_inner_bsphere_radius_relative = props.get<ScalarFloat>("inner_bsphere_radius", 0.f);
+    }
+
+    UnpolarizedSpectrum eval(const Interaction3f &it, Mask active) const override {
+        auto p = m_to_local * it.p;
+
+        // transform from the [0:1, 0:1, 0:1] cube to a  [-1:1, -1:1, -1:1] cube
+        ScalarTransform4f to_center = ScalarTransform4f::translate(ScalarPoint3f(-1, -1, -1)) * ScalarTransform4f::scale(2.f);
+        p = to_center * p;
+
+        Point3f p_spherical = Point3f(
+            (ek::norm(p) - m_inner_bsphere_radius_relative) / (1.f - m_inner_bsphere_radius_relative),
+            ek::acos(p.z() / ek::norm(p)) / ek::Pi<ScalarFloat>,
+            ek::atan2(p.y(), p.x()) / ek::Pi<ScalarFloat> + 1.f
+        );
+
+        Interaction3f it_spherical = it;
+        it_spherical.p = p_spherical;
+
+        Mask within_spherical_shell = (m_inner_bsphere_radius_relative <= ek::norm(p) && ek::norm(p) <= 1.0);
+
+        return ek::select(within_spherical_shell, m_gridvol->eval(it_spherical, active), 0.f);
+    }
+
+    ScalarFloat max() const override { return m_gridvol->max(); }
+
+    ScalarVector3i resolution() const override { return m_gridvol->resolution(); };
+
+    MTS_DECLARE_CLASS()
+
+protected:
+    ScalarFloat m_inner_bsphere_radius_relative;
+    ref<Volume> m_gridvol;
+};
+
+MTS_IMPLEMENT_CLASS_VARIANT(GridVolumeSpherical, Volume)
+MTS_EXPORT_PLUGIN(GridVolumeSpherical, "GridVolumeSpherical texture")
+
+NAMESPACE_END(mitsuba)

--- a/src/plugins/src/volumes/grid_spherical.cpp
+++ b/src/plugins/src/volumes/grid_spherical.cpp
@@ -67,6 +67,10 @@ public:
 
         m_rmin = props.get<ScalarFloat>("rmin", 0.f);
         m_rmax = props.get<ScalarFloat>("rmax", 1.f);
+        if (m_rmin > m_rmax) {
+            Throw("rmin must be smaller than rmax!");
+        }
+
         m_rmin_rel = m_rmin / m_rmax;
 
         m_fillmin = props.get<ScalarFloat>("fillmin", 0.f);
@@ -83,9 +87,8 @@ public:
         Point3f p_spherical = Point3f(
             (p_magnitude - m_rmin) / (m_rmax - m_rmin),
             ek::acos(p.z() / p_magnitude) * ek::InvPi<ScalarFloat>,
-            ek::atan2(p.y(), p.x()) * ek::InvPi<ScalarFloat> + 1.f
+            ek::atan2(p.y(), p.x()) * ek::InvTwoPi<ScalarFloat> + 0.5
         );
-
         Interaction3f it_spherical = it;
         it_spherical.p = p_spherical;
 

--- a/src/plugins/src/volumes/sphericalgrid.cpp
+++ b/src/plugins/src/volumes/sphericalgrid.cpp
@@ -18,7 +18,7 @@ enum class WrapMode { Repeat, Mirror, Clamp };
 /**!
 .. _volume-sphericalgridvolume:
 
-Grid-based volume data source in spherical coordinates(:monosp:`sphericalgridvolume`)
+Grid-based volume data source in spherical coordinates (:monosp:`sphericalgridvolume`)
 ----------------------------------------------------------
 
 .. pluginparameters::
@@ -82,19 +82,19 @@ public:
 
     UnpolarizedSpectrum eval(const Interaction3f &it, Mask active) const override {
         Point3f p = m_to_local * it.p;
-        Float p_magnitude = ek::norm(p);
+        Float r = ek::norm(p);
 
         Point3f p_spherical = Point3f(
-            (p_magnitude - m_rmin) / (m_rmax - m_rmin),
-            ek::acos(p.z() / p_magnitude) * ek::InvPi<ScalarFloat>,
-            ek::atan2(p.y(), p.x()) * ek::InvTwoPi<ScalarFloat> + 0.5
+            (r - m_rmin) / (m_rmax - m_rmin),
+            ek::acos(p.z() / r) * ek::InvPi<ScalarFloat>,
+            ek::atan2(p.y(), p.x()) * ek::InvTwoPi<ScalarFloat> + .5f
         );
         Interaction3f it_spherical = it;
         it_spherical.p = p_spherical;
 
-        return ek::select(p_magnitude < m_rmin,
+        return ek::select(r < m_rmin,
             m_fillmin,
-            ek::select(p_magnitude > m_rmax,
+            ek::select(r > m_rmax,
                 m_fillmax,
                 m_gridvol->eval(it_spherical, active)
             )

--- a/tests/test_plugins/test_volumes/test_grid_spherical.py
+++ b/tests/test_plugins/test_volumes/test_grid_spherical.py
@@ -1,0 +1,114 @@
+import numpy as np
+import pytest
+
+from eradiate.kernel.gridvolume import write_binary_grid3d
+
+
+def gridvol_constant(basepath, data=[[[1.0]]]):
+    filename = basepath / "gridvol_const.vol"
+    data = np.array(data)
+    write_binary_grid3d(filename, data)
+    return filename
+
+
+def test_construct(variant_scalar_rgb, tmp_path):
+    from mitsuba.core import ScalarTransform4f, load_dict
+
+    # Construct without parameters
+    volume = load_dict({"type": "grid_spherical"})
+    assert volume is not None
+
+    # Construct with rmin > rmax:
+    with pytest.raises(Exception):
+        load_dict({"type": "grid_spherical", "rmin": 0.8, "rmax": 0.2})
+
+    # Construct with all parameters set to typical values
+    gridvol_filename = gridvol_constant(tmp_path)
+    volume = load_dict(
+        {
+            "type": "grid_spherical",
+            "rmin": 0.0,
+            "rmax": 1.0,
+            "fillmin": 0.0,
+            "fillmax": 0.0,
+            "gridvolume": {
+                "type": "gridvolume",
+                "filename": str(gridvol_filename)
+            }
+        }
+    )
+    assert volume is not None
+
+
+def test_eval_basic(variant_scalar_rgb, tmp_path):
+    from mitsuba.core import load_dict
+    from mitsuba.render import Interaction3f
+    gridvol_filename = gridvol_constant(tmp_path, data=[[[2.0]]])
+    volume = load_dict(
+        {
+            "type": "grid_spherical",
+            "rmin": 0.2,
+            "rmax": 0.8,
+            "fillmin": 3.0,
+            "fillmax": 1.0,
+            "gridvolume": {
+                "type": "gridvolume",
+                "filename": str(gridvol_filename)
+            }
+        }
+    )
+
+    p_outside_max = [0.9, 0.0, 0.0]
+    p_outside_min = [0.0, 0.0, 0.1]
+    p_inside = [0.0, 0.5, 0.0]
+
+    it_outside_max = Interaction3f()
+    it_outside_max.p = p_outside_max
+    it_outside_min = Interaction3f()
+    it_outside_min.p = p_outside_min
+    it_inside = Interaction3f()
+    it_inside.p = p_inside
+
+    assert volume.eval(it_outside_max) == 1.0
+    assert volume.eval(it_outside_min) == 3.0
+    assert volume.eval(it_inside) == 2.0
+
+
+def test_eval_advanced(variant_scalar_mono, tmp_path):
+    from mitsuba.core import load_dict
+    from mitsuba.render import Interaction3f
+    data = np.arange(1, 7, 1)
+    sigma_t = np.zeros((6, 2, 2))
+    sigma_t[:, 0, 0] = data
+    sigma_t[:, 0, 1] = data
+    sigma_t[:, 1, 0] = data
+    sigma_t[:, 1, 1] = data
+    gridvol_filename = gridvol_constant(tmp_path, data=sigma_t)
+    volume = load_dict(
+        {
+            "type": "grid_spherical",
+            "rmin": 0.0,
+            "rmax": 1.0,
+            "fillmin": 3.0,
+            "fillmax": 1.0,
+            "gridvolume": {
+                "type": "gridvolume",
+                "filename": str(gridvol_filename),
+                "filter_type": "nearest"
+            }
+        }
+    )
+
+    # have one point in each sector of the spherical volume
+    angles = [5, 65, 125, 185, 245, 305]
+    results = []
+    for angle in angles:
+        p = [0.5*np.cos(np.deg2rad(angle)), 0.5*np.sin(np.deg2rad(angle)), 0.0]
+        print(f"Angle: {angle}, Point: {p}")
+        it = Interaction3f()
+        it.p = p
+        results.append(volume.eval(it))
+
+    # This order looks strange, but the output of enokis atan2 function
+    # does not map the [0: 2pi] range to [0:1] but is shifted by pi
+    assert np.all(np.squeeze(results) == [4.0, 5.0, 6.0, 1.0, 2.0, 3.0])

--- a/tests/test_plugins/volumes/test_sphericalgrid.py
+++ b/tests/test_plugins/volumes/test_sphericalgrid.py
@@ -31,18 +31,24 @@ def test_construct(variant_scalar_rgb, tmp_path):
             "rmax": 1.0,
             "fillmin": 0.0,
             "fillmax": 0.0,
-            "gridvolume": {
-                "type": "gridvolume",
-                "filename": str(gridvol_filename)
-            }
+            "gridvolume": {"type": "gridvolume", "filename": str(gridvol_filename)},
         }
     )
     assert volume is not None
 
 
-def test_eval_basic(variant_scalar_rgb, tmp_path):
+@pytest.mark.parametrize(
+    "point,result",
+    [
+        ([0.9, 0.0, 0.0], 1.0),
+        ([0.0, 0.0, 0.1], 3.0),
+        ([0.0, 0.5, 0.0], 2.0),
+    ],
+)
+def test_eval_basic(variant_scalar_rgb, tmp_path, point, result):
     from mitsuba.core import load_dict
     from mitsuba.render import Interaction3f
+
     gridvol_filename = gridvol_constant(tmp_path, data=[[[2.0]]])
     volume = load_dict(
         {
@@ -51,32 +57,20 @@ def test_eval_basic(variant_scalar_rgb, tmp_path):
             "rmax": 0.8,
             "fillmin": 3.0,
             "fillmax": 1.0,
-            "gridvolume": {
-                "type": "gridvolume",
-                "filename": str(gridvol_filename)
-            }
+            "gridvolume": {"type": "gridvolume", "filename": str(gridvol_filename)},
         }
     )
 
-    p_outside_max = [0.9, 0.0, 0.0]
-    p_outside_min = [0.0, 0.0, 0.1]
-    p_inside = [0.0, 0.5, 0.0]
+    it = Interaction3f()
+    it.p = point
 
-    it_outside_max = Interaction3f()
-    it_outside_max.p = p_outside_max
-    it_outside_min = Interaction3f()
-    it_outside_min.p = p_outside_min
-    it_inside = Interaction3f()
-    it_inside.p = p_inside
-
-    assert volume.eval(it_outside_max) == 1.0
-    assert volume.eval(it_outside_min) == 3.0
-    assert volume.eval(it_inside) == 2.0
+    assert volume.eval(it) == result
 
 
 def test_eval_advanced(variant_scalar_mono, tmp_path):
     from mitsuba.core import load_dict
     from mitsuba.render import Interaction3f
+
     data = np.arange(1, 7, 1)
     sigma_t = np.zeros((6, 2, 2))
     sigma_t[:, 0, 0] = data
@@ -94,21 +88,20 @@ def test_eval_advanced(variant_scalar_mono, tmp_path):
             "gridvolume": {
                 "type": "gridvolume",
                 "filename": str(gridvol_filename),
-                "filter_type": "nearest"
-            }
+                "filter_type": "nearest",
+            },
         }
     )
 
     # have one point in each sector of the spherical volume
-    angles = [5, 65, 125, 185, 245, 305]
+    # since the atan2 method maps [-pi, pi] to [0, 1], we choose this
+    # order of inputs
+    angles = [-175, -115, -55, 5, 65, 125]
     results = []
     for angle in angles:
-        p = [0.5*np.cos(np.deg2rad(angle)), 0.5*np.sin(np.deg2rad(angle)), 0.0]
-        print(f"Angle: {angle}, Point: {p}")
+        p = [0.5 * np.cos(np.deg2rad(angle)), 0.5 * np.sin(np.deg2rad(angle)), 0.0]
         it = Interaction3f()
         it.p = p
         results.append(volume.eval(it))
 
-    # This order looks strange, but the output of enokis atan2 function
-    # does not map the [0: 2pi] range to [0:1] but is shifted by pi
-    assert np.all(np.squeeze(results) == [4.0, 5.0, 6.0, 1.0, 2.0, 3.0])
+    assert np.all(np.squeeze(results) == [1.0, 2.0, 3.0, 4.0, 5.0, 6.0])


### PR DESCRIPTION
# Description

This PR introduces a mitsuba plugin that maps the `grid` plugin to spherical coordinates. This allows for the creation of a spherical shell volume, which in turn enables the simulation of a spatially varying atmosphere around a spherical earth!

This plugin does not have tests yet. Also there is an issue, when adding a `rotation` to the volume's transformation matrix.
It is unknown whether this is actually an issue, since only rotationally symmetric atmospheres are currently planned.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
