### PR TITLE
Upgrade Docker build process to work with mitsuba2-next on a local dev env

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,11 +6,7 @@ name: Docker build
 on:
   # Triggers the workflow on push or pull request events but only for the main branch
   push:
-    tags: [ v*.*.* ]
-
-  # Trigger every day at 23:42
-  schedule:
-    - cron: '42 23 * * *'
+    tags: [ 'v*.*.*', 'build_*' ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/docker-build.yml
+++ b/docker-build.yml
@@ -24,6 +24,7 @@ services:
         BASE_IMAGE: ${REGISTRY:-rayference}/eradiate-base
         BASE_IMAGE_VERSION: ${VERSION:-dirty}
         ERADIATE_KERNEL_VERSION: ${VERSION:-dirty}
+        NUM_CORES: ${NUM_CORES:-8}
   
   # Contains a properly configured Eradiate kernel
   eradiate-kernel:

--- a/docker-build.yml
+++ b/docker-build.yml
@@ -24,7 +24,7 @@ services:
         BASE_IMAGE: ${REGISTRY:-rayference}/eradiate-base
         BASE_IMAGE_VERSION: ${VERSION:-dirty}
         ERADIATE_KERNEL_VERSION: ${VERSION:-dirty}
-        NUM_CORES: ${NUM_CORES:-8}
+        NUM_CORES: ${NUM_CORES:-4}
   
   # Contains a properly configured Eradiate kernel
   eradiate-kernel:

--- a/docker/eradiate-kernel-builder/Dockerfile
+++ b/docker/eradiate-kernel-builder/Dockerfile
@@ -22,10 +22,8 @@ ENV CXX=clang++-9
 COPY . /sources/eradiate
 WORKDIR /sources/eradiate
 RUN make conda-init
-RUN git submodule update --init --recursive
 
-RUN mkdir -p /build/eradiate-kernel                                                                                       \
-    && cd /build/eradiate-kernel                                                                                          \
-    && cmake -GNinja -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)") /sources/eradiate/ext/mitsuba2 \
-    && ninja                                                                                                              \
-    && tar -cvf eradiate-kernel-dist_${ERADIATE_KERNEL_VERSION}.tar ./dist
+WORKDIR /build/eradiate-kernel
+RUN cmake -GNinja -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)") /sources/eradiate/ext/mitsuba2
+RUN ninja
+

--- a/docker/eradiate-kernel-builder/Dockerfile
+++ b/docker/eradiate-kernel-builder/Dockerfile
@@ -7,7 +7,6 @@ ARG ERADIATE_KERNEL_VERSION
 ARG NUM_CORES=4
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y   \
-    cmake                                           \
     git                                             \
     ninja-build                                     \
     clang-9                                         \
@@ -15,7 +14,10 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y   \
     libc++abi-9-dev                                 \
     libpng-dev                                      \
     zlib1g-dev                                      \
+    build-essential                                 \
     libjpeg-dev
+
+RUN conda install -y cmake
 
 ENV CC=clang-9
 ENV CXX=clang++-9
@@ -25,6 +27,6 @@ WORKDIR /sources/eradiate
 RUN make conda-init
 
 WORKDIR /build/eradiate-kernel
-RUN cmake --preset default /sources/eradiate/ext/mitsuba2 -GNinja
+RUN cmake --preset default -S /sources/eradiate -B .
 RUN cmake --build . -j${NUM_CORES}
 

--- a/docker/eradiate-kernel-builder/Dockerfile
+++ b/docker/eradiate-kernel-builder/Dockerfile
@@ -4,6 +4,7 @@ ARG BASE_IMAGE_VERSION
 FROM ${BASE_IMAGE}:${BASE_IMAGE_VERSION}
 
 ARG ERADIATE_KERNEL_VERSION
+ARG NUM_CORES=8
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y   \
     cmake                                           \
@@ -24,6 +25,6 @@ WORKDIR /sources/eradiate
 RUN make conda-init
 
 WORKDIR /build/eradiate-kernel
-RUN cmake -GNinja -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)") /sources/eradiate/ext/mitsuba2
-RUN ninja
+RUN cmake --preset default /sources/eradiate/ext/mitsuba2 -GNinja
+RUN cmake --build . -j${NUM_CORES}
 

--- a/docker/eradiate-kernel-builder/Dockerfile
+++ b/docker/eradiate-kernel-builder/Dockerfile
@@ -4,7 +4,7 @@ ARG BASE_IMAGE_VERSION
 FROM ${BASE_IMAGE}:${BASE_IMAGE_VERSION}
 
 ARG ERADIATE_KERNEL_VERSION
-ARG NUM_CORES=8
+ARG NUM_CORES=4
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y   \
     cmake                                           \

--- a/docker/eradiate-kernel/Dockerfile
+++ b/docker/eradiate-kernel/Dockerfile
@@ -9,18 +9,14 @@ FROM ${BASE_IMAGE}:${BASE_IMAGE_VERSION}
 
 ARG ERADIATE_KERNEL_VERSION
 
-COPY --from=build /build/eradiate-kernel/eradiate-kernel-dist_${ERADIATE_KERNEL_VERSION}.tar /build/mitsuba/
+COPY --from=build /build/eradiate-kernel /mitsuba
 
 RUN apt-get update && DEBIAN_FRONTEND="noninteractive" apt-get install -y ninja-build cmake libc++-9-dev libz-dev libpng-dev libjpeg-dev libxrandr-dev libxinerama-dev libxcursor-dev
-
-RUN mkdir -p /build/mistuba /mitsuba && cd /build/mitsuba && tar -xf eradiate-kernel-dist_${ERADIATE_KERNEL_VERSION}.tar  \
-    && mv dist /mitsuba/dist \
-    && cd / && rm -rf /build
 
 ENV MITSUBA_DIR=/mitsuba
 WORKDIR /app
 
-ENV PYTHONPATH="$MITSUBA_DIR/dist/python"
-ENV PATH="$MITSUBA_DIR/dist:$PATH"
+ENV PYTHONPATH="$MITSUBA_DIR/python"
+ENV PATH="$MITSUBA_DIR:$PATH"
 
 CMD mitsuba --help

--- a/docker/eradiate-kernel/Dockerfile
+++ b/docker/eradiate-kernel/Dockerfile
@@ -11,9 +11,9 @@ ARG ERADIATE_KERNEL_VERSION
 
 COPY --from=build /build/eradiate-kernel /mitsuba
 
-RUN apt-get update && DEBIAN_FRONTEND="noninteractive" apt-get install -y ninja-build cmake libc++-9-dev libz-dev libpng-dev libjpeg-dev libxrandr-dev libxinerama-dev libxcursor-dev
+RUN apt-get update && DEBIAN_FRONTEND="noninteractive" apt-get install -y ninja-build cmake libc++-9-dev libz-dev libpng-dev libjpeg-dev libxrandr-dev libxinerama-dev libxcursor-dev llvm-9
 
-ENV MITSUBA_DIR=/mitsuba
+ENV MITSUBA_DIR=/mitsuba/ext/mitsuba2
 WORKDIR /app
 
 ENV PYTHONPATH="$MITSUBA_DIR/python"

--- a/docker/eradiate/Dockerfile
+++ b/docker/eradiate/Dockerfile
@@ -13,13 +13,13 @@ COPY --from=build /sources/eradiate /sources/eradiate
 
 WORKDIR /sources/eradiate
 
-RUN wget https://eradiate.eu/data/solid_2017.zip \
-    && wget https://eradiate.eu/data/us76_u86_4-spectra.zip \
-    && cd resources/data && (unzip ../../solid_2017.zip || true) \
-    && (unzip ../../spectra-us76_u86_4.zip || true)
+SHELL ["conda", "run", "-n", "docker", "/bin/bash", "-c"]
 
+ENV LD_LIBRARY_PATH=/mitsuba
 ENV ERADIATE_DIR=/sources/eradiate
 
 RUN make conda-init
+
+RUN ertdownload
 
 WORKDIR /app

--- a/docker/eradiate/Dockerfile
+++ b/docker/eradiate/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /sources/eradiate
 
 SHELL ["conda", "run", "-n", "docker", "/bin/bash", "-c"]
 
-ENV LD_LIBRARY_PATH=/mitsuba
+ENV LD_LIBRARY_PATH=/mitsuba/ext/mitsuba2
 ENV ERADIATE_DIR=/sources/eradiate
 
 RUN make conda-init

--- a/docs/rst/getting_started/docker.rst
+++ b/docs/rst/getting_started/docker.rst
@@ -207,5 +207,5 @@ A ``docker-compose`` config file named ``docker-build.yml`` is provided at the r
 
 .. code:: bash
 
-    # Build all docker images specifying a custom version
-    VERSION=myLocalVersion docker-compose -f docker-build.yml build
+    # Build all docker images specifying a custom version, using 16 cores
+    VERSION=myLocalVersion NUM_CORES=16 docker-compose -f docker-build.yml build


### PR DESCRIPTION
# Description

This PR Allows the Docker build to be performed on a local machine with the private mitsuba kernel for eradiate:next

## Limitations
Due to the current private status of the Eradiate kernel on the next branch, these changes do not allow to build the images in github actions or to distribute them through docker Hub. This is intended.

## Github actions changes
The docker github actions now triggers only when there is a tag in the form v*.*.* or build_*. Eradiate developers with sufficient permissions may also trigger the build manually on github.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [ ] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
