### PR TITLE
HeterogeneousAtmosphere: Pass the cache_dir parameter to the BlendPha…

### DIFF
--- a/src/eradiate/scenes/atmosphere/_heterogeneous.py
+++ b/src/eradiate/scenes/atmosphere/_heterogeneous.py
@@ -397,6 +397,7 @@ class HeterogeneousAtmosphere(AbstractHeterogeneousAtmosphere):
 
             # Construct a blended phase function based on those weighting values
             phase = BlendPhaseFunction(
+                cache_dir=self.cache_dir,
                 components=[component.phase for component in components],
                 weights=sigma_ss,
             )


### PR DESCRIPTION
# Description

close #166

Add the cache_dir parameter to the BlendPhaseFunction in the HeterogeneousAtmosphere class.
The constructor was creating a new tmp folder at each call to `kernel_phase`, thus filling the `/tmp` directory.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [ ] The feature branch is rebased on the current state of the `main` branch
- [ ] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
