### PR TITLE
Change `$ERADIATE_DIR` to `$ERADIATE_SOURCE_DIR`

### DIFF
--- a/docker/eradiate-jupyterlab/Dockerfile
+++ b/docker/eradiate-jupyterlab/Dockerfile
@@ -4,7 +4,7 @@ ARG BASE_IMAGE_VERSION
 FROM ${BASE_IMAGE}:${BASE_IMAGE_VERSION}
 
 ENV PORT=8888
-ENV ERADIATE_DIR=/sources/eradiate
+ENV ERADIATE_SOURCE_DIR=/sources/eradiate
 
 CMD jupyter lab --no-browser --allow-root --port=$PORT --ip='0.0.0.0' --allow_origin='*'
 EXPOSE 8888

--- a/docker/eradiate/Dockerfile
+++ b/docker/eradiate/Dockerfile
@@ -16,7 +16,7 @@ WORKDIR /sources/eradiate
 SHELL ["conda", "run", "-n", "docker", "/bin/bash", "-c"]
 
 ENV LD_LIBRARY_PATH=/mitsuba/ext/mitsuba2
-ENV ERADIATE_DIR=/sources/eradiate
+ENV ERADIATE_SOURCE_DIR=/sources/eradiate
 
 RUN make conda-init
 

--- a/docs/examples/tutorials/README.txt
+++ b/docs/examples/tutorials/README.txt
@@ -7,5 +7,5 @@ advise users to run our examples themselves, either by copying code blocks
 found in the tutorials, or by downloading them as Jupyter notebooks.*
 
 The examples presented hereafter are located (alongside their supplementary
-files) in the ``$ERADIATE_DIR/docs/examples/tutorials`` directory
+files) in the ``$ERADIATE_SOURCE_DIR/docs/examples/tutorials`` directory
 [`GitHub link <https://github.com/eradiate/eradiate/tree/main/docs/examples/tutorials>`_].

--- a/docs/examples/tutorials/biosphere/01_discrete_canopy.py
+++ b/docs/examples/tutorials/biosphere/01_discrete_canopy.py
@@ -162,7 +162,7 @@ eradiate.scenes.biosphere.biosphere_factory.convert(
 # frame origin:
 
 # We use the path resolver to get the absolute path to the data file
-# located in the $ERADIATE_DIR/resources/data/tests/canopies directory
+# located in the $ERADIATE_SOURCE_DIR/resources/data/tests/canopies directory
 leaf_cloud_filename = eradiate.path_resolver.resolve(
     "tests/canopies/HET01_UNI_scene.def"
 )
@@ -178,7 +178,7 @@ leaf_cloud
 # directory:
 
 # We use the path resolver to get the absolute path to the data file
-# located in the $ERADIATE_DIR/resources/data/tests/canopies directory
+# located in the $ERADIATE_SOURCE_DIR/resources/data/tests/canopies directory
 instance_filename = eradiate.path_resolver.resolve(
     "tests/canopies/HET01_UNI_instances.def"
 )

--- a/docs/examples/tutorials/data/02_custom_solar_irradiance.py
+++ b/docs/examples/tutorials/data/02_custom_solar_irradiance.py
@@ -45,8 +45,10 @@ df = pd.read_csv("02_custom_solar_irradiance_data.csv", header=1, names=["w", "s
 # for the meaning of these attributes.
 
 import datetime
+
 import numpy as np
 import xarray as xr
+
 from eradiate.units import symbol
 
 ds = xr.Dataset(
@@ -186,13 +188,13 @@ ds
 # To register your dataset in the list of available datasets of Eradiate, you
 # must first save the dataset to a NetCDF file.
 # It is recommended to save the dataset in
-# ``$ERADIATE_DIR/resources/data/spectra/solar_irradiance``:
+# ``$ERADIATE_SOURCE_DIR/resources/data/spectra/solar_irradiance``:
 
 import os
 
 ds.to_netcdf(
     os.path.join(
-        os.environ["ERADIATE_DIR"],
+        os.environ["ERADIATE_SOURCE_DIR"],
         "resources/data/spectra/solar_irradiance",
         "my_awesome_dataset.nc",
     )
@@ -203,7 +205,9 @@ ds.to_netcdf(
 # file next to the Eradiate's predefined solar irradiance spectrum datasets:
 
 os.listdir(
-    os.path.join(os.environ["ERADIATE_DIR"], "resources/data/spectra/solar_irradiance")
+    os.path.join(
+        os.environ["ERADIATE_SOURCE_DIR"], "resources/data/spectra/solar_irradiance"
+    )
 )
 
 # %%

--- a/docs/rst/developer_guide/documentation.rst
+++ b/docs/rst/developer_guide/documentation.rst
@@ -19,11 +19,11 @@ commands:
 
 .. code-block:: bash
 
-    cd $ERADIATE_DIR
+    cd $ERADIATE_SOURCE_DIR
     make docs
 
 After the build is completed, the html document is located in
-:code:`$ERADIATE_DIR/docs/_build/html`.
+:code:`$ERADIATE_SOURCE_DIR/docs/_build/html`.
 
 .. admonition:: Notes
    :class: note
@@ -46,10 +46,10 @@ Run the follwing commands:
 
 .. code-block:: bash
 
-    cd $ERADIATE_DIR/build
+    cd $ERADIATE_SOURCE_DIR/build
     ninja mkdoc
 
-The compiled html documentation will then be located in :code:`$ERADIATE_DIR/build/html`.
+The compiled html documentation will then be located in :code:`$ERADIATE_SOURCE_DIR/build/html`.
 
 Editing the API documentation
 -----------------------------
@@ -213,7 +213,7 @@ is recommended. They can be generated using the ``rst-api`` make target:
 
 .. code-block:: bash
 
-    cd $ERADIATE_DIR
+    cd $ERADIATE_SOURCE_DIR
     make docs-rst-api
     make docs
 
@@ -222,7 +222,7 @@ Editing tutorials
 
 Eradiates uses the `sphinx-gallery <https://sphinx-gallery.github.io/>`_
 extension to provide runnable and commented tutorials. Tutorials are located
-in the ``$ERADIATE_DIR/docs/examples/tutorials`` directory.
+in the ``$ERADIATE_SOURCE_DIR/docs/examples/tutorials`` directory.
 
 .. warning:: It is strongly recommended to read carefully the sphinx-gallery
    user guide before proceeding.
@@ -268,8 +268,8 @@ Referencing examples
 You can reference an example using its label, defined following
 `sphinx-gallery's naming convention <https://sphinx-gallery.github.io/stable/advanced.html#know-your-gallery-files>`_.
 For instance, an example located at
-``$ERADIATE_DIR/docs/examples/tutorials/my_example.py`` will have the label
-``sphx_glr_examples_generated_tutorials_my_example.py``.
+``$ERADIATE_SOURCE_DIR/docs/examples/tutorials/my_example.py`` will have the
+label ``sphx_glr_examples_generated_tutorials_my_example.py``.
 
 .. warning:: Changing filenames will break references! Do not forget to
    rebuild the docs and fix references if you move or rename an example.

--- a/docs/rst/developer_guide/testing.rst
+++ b/docs/rst/developer_guide/testing.rst
@@ -29,7 +29,8 @@ Eradiate can generate an HTML based test report, collecting information about th
 
    python test_report/generate_report.py
 
-The resulting report will be located in ``$ERADIATE_DIR/build/html_test-report``.
+The resulting report will be located in
+``$ERADIATE_SOURCE_DIR/build/html_test-report``.
 
 Testing guidelines
 ------------------

--- a/docs/rst/getting_started/install.rst
+++ b/docs/rst/getting_started/install.rst
@@ -198,7 +198,7 @@ execute a GNU Make target which will initialise our empty environment properly:
      activation, following
      `the approach recommended by the Conda user guide <https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#saving-environment-variables>`_.
    * Once the Conda environment is active, the Eradiate root directory can
-     be reached from everywhere through the ``$ERADIATE_DIR`` environment
+     be reached from everywhere through the ``$ERADIATE_SOURCE_DIR`` environment
      variable.
 
 Once your Conda environment is configured, you should reactivate it:

--- a/docs/rst/getting_started/update.rst
+++ b/docs/rst/getting_started/update.rst
@@ -14,7 +14,7 @@ In the cloned source directory, pull the latest update from GitHub:
 
 .. code:: bash
 
-   cd $ERADIATE_DIR
+   cd $ERADIATE_SOURCE_DIR
    git pull
 
 Unfortunately, pulling from the main repository won't automatically keep the
@@ -55,7 +55,7 @@ After updating, it's always better to rebuild the kernel:
 
 .. code:: bash
 
-   cd $ERADIATE_DIR
+   cd $ERADIATE_SOURCE_DIR
    cmake --build build
 
 Updating your Conda environment
@@ -66,7 +66,7 @@ necessary. In that case, the ``conda-init`` target can be used:
 
 .. code:: bash
 
-   cd $ERADIATE_DIR
+   cd $ERADIATE_SOURCE_DIR
    make conda-init
 
 If something goes wrong during that process, an environment reset should solve

--- a/requirements/copy_envvars.py
+++ b/requirements/copy_envvars.py
@@ -36,12 +36,12 @@ def main():
     # fmt: on
 
 
-def activate_script(eradiate_dir):
+def activate_script(eradiate_source_dir):
     # fmt: off
     return dedent(f"""
         #!/bin/sh
-        ERADIATE_DIR="{eradiate_dir}"
-        source ${{ERADIATE_DIR}}/setpath.sh
+        ERADIATE_SOURCE_DIR="{eradiate_source_dir}"
+        source ${{ERADIATE_SOURCE_DIR}}/setpath.sh
     """).lstrip()
     # fmt: on
 
@@ -51,13 +51,13 @@ def deactivate_script():
     return dedent(f"""
         #!/bin/sh
         # Clean up PATH
-        match="${{ERADIATE_DIR}}/build/ext/mitsuba2:"
+        match="${{ERADIATE_SOURCE_DIR}}/build/ext/mitsuba2:"
         export PATH=${{PATH//$match/}}
         # Clean up PYTHONPATH
-        match="${{ERADIATE_DIR}}/build/ext/mitsuba2/python:"
+        match="${{ERADIATE_SOURCE_DIR}}/build/ext/mitsuba2/python:"
         export PYTHONPATH="${{PYTHONPATH//$match/}}"
         # Remove other environment variables
-        unset ERADIATE_DIR
+        unset ERADIATE_SOURCE_DIR
     """).lstrip()
     # fmt: on
 

--- a/setpath.sh
+++ b/setpath.sh
@@ -7,11 +7,11 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
 fi
 
 if [ "$BASH_VERSION" ]; then
-    ERADIATE_DIR=$(dirname "$BASH_SOURCE")
-    export ERADIATE_DIR=$(builtin cd "$ERADIATE_DIR"; builtin pwd)
+    ERADIATE_SOURCE_DIR=$(dirname "$BASH_SOURCE")
+    export ERADIATE_SOURCE_DIR=$(builtin cd "$ERADIATE_SOURCE_DIR"; builtin pwd)
 elif [ "$ZSH_VERSION" ]; then
-    export ERADIATE_DIR=$(dirname "$0:A")
+    export ERADIATE_SOURCE_DIR=$(dirname "$0:A")
 fi
 
-export PYTHONPATH="${ERADIATE_DIR}/${BUILD_DIR}/ext/mitsuba2/python:${PYTHONPATH}"
-export PATH="${ERADIATE_DIR}/${BUILD_DIR}/ext/mitsuba2:${PATH}"
+export PYTHONPATH="${ERADIATE_SOURCE_DIR}/${BUILD_DIR}/ext/mitsuba2/python:${PYTHONPATH}"
+export PATH="${ERADIATE_SOURCE_DIR}/${BUILD_DIR}/ext/mitsuba2:${PATH}"

--- a/src/eradiate/_config.py
+++ b/src/eradiate/_config.py
@@ -52,19 +52,19 @@ class EradiateConfig:
     """
 
     #: Path to the Eradiate source directory.
-    dir = environ.var(
+    source_dir = environ.var(
         converter=lambda x: pathlib.Path(x).absolute(),
         help="Path to the Eradiate source directory.",
     )
 
-    @dir.validator
+    @source_dir.validator
     def _dir_validator(self, var, dir):
         eradiate_init = dir / "src" / "eradiate" / "__init__.py"
 
         if not eradiate_init.is_file():
             raise ConfigError(
                 f"While configuring Eradiate: could not find {eradiate_init} file. "
-                "Please make sure the 'ERADIATE_DIR' environment variable is "
+                "Please make sure the 'ERADIATE_SOURCE_DIR' environment variable is "
                 "correctly set to the Eradiate installation directory. If you are "
                 "using Eradiate directly from the sources, you can alternatively "
                 "source the provided setpath.sh script."
@@ -106,7 +106,7 @@ class EradiateConfig:
 
     #: Path to the Eradiate download directory.
     download_dir = environ.var(
-        default="$ERADIATE_DIR/resources/downloads",
+        default="$ERADIATE_SOURCE_DIR/resources/downloads",
         converter=lambda x: pathlib.Path(os.path.expandvars(x)).absolute(),
         help="Path to the Eradiate download directory.",
     )
@@ -129,7 +129,7 @@ try:
     config = EradiateConfig.from_environ()
 
 except environ.exceptions.MissingEnvValueError as e:
-    if "ERADIATE_DIR" in e.args:
+    if "ERADIATE_SOURCE_DIR" in e.args:
         raise ConfigError(
             f"While configuring Eradiate: environment variable '{e}' is missing. "
             "Please set this variable to the absolute path to the Eradiate "

--- a/src/eradiate/_presolver.py
+++ b/src/eradiate/_presolver.py
@@ -51,7 +51,7 @@ class PathResolver(metaclass=Singleton):
     def reset(self):
         """
         Reset path list to default value:
-        ``[$PWD, $ERADIATE_DATA_PATH, $ERADIATE_DIR/resources/data]``.
+        ``[$PWD, $ERADIATE_DATA_PATH, $ERADIATE_SOURCE_DIR/resources/data]``.
 
         See Also
         --------
@@ -64,7 +64,7 @@ class PathResolver(metaclass=Singleton):
         if config.data_path:
             self.append(*config.data_path)  # Path list
 
-        self.append(config.dir / "resources" / "data")  # Eradiate data directory
+        self.append(config.source_dir / "resources" / "data")  # Eradiate data directory
 
     def clear(self):
         """Clear the list of search paths."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,11 +12,11 @@ eradiate.plot.set_style()
 
 
 def pytest_addoption(parser):
-    eradiate_dir = os.environ.get("ERADIATE_DIR", ".")
+    eradiate_source_dir = os.environ.get("ERADIATE_SOURCE_DIR", ".")
     parser.addoption(
         "--artefact-dir",
         action="store",
-        default=os.path.join(eradiate_dir, "build/test_artefacts/"),
+        default=os.path.join(eradiate_source_dir, "build/test_artefacts/"),
     )
 
 

--- a/tests/test_eradiate/_unit/test_config.py
+++ b/tests/test_eradiate/_unit/test_config.py
@@ -13,17 +13,19 @@ def test_config(tmpdir):
     (tmpdir_path / "eradiate/src/eradiate").mkdir(parents=True)
     (tmpdir_path / "eradiate/src/eradiate/__init__.py").touch()
 
-    # Raises if ERADIATE_DIR is missing
+    # Raises if ERADIATE_SOURCE_DIR is missing
     with pytest.raises(MissingEnvValueError):
         EradiateConfig.from_environ({})
 
-    # When ERADIATE_DIR points to a correct path (i.e. contains eradiate.__init__.py),
-    # config init succeeds
-    assert EradiateConfig.from_environ({"ERADIATE_DIR": tmpdir_path / "eradiate"})
+    # When ERADIATE_SOURCE_DIR points to a correct path
+    # (i.e. contains eradiate.__init__.py), config init succeeds
+    assert EradiateConfig.from_environ(
+        {"ERADIATE_SOURCE_DIR": tmpdir_path / "eradiate"}
+    )
 
     # Otherwise it raises
     with pytest.raises(ConfigError):
-        EradiateConfig.from_environ({"ERADIATE_DIR": tmpdir_path})
+        EradiateConfig.from_environ({"ERADIATE_SOURCE_DIR": tmpdir_path})
 
     # Warns if nonexisting paths are passed
     with pytest.warns(ConfigWarning):
@@ -35,7 +37,7 @@ def test_config(tmpdir):
         # Colon-separated paths are processed correctly
         cfg = EradiateConfig.from_environ(
             {
-                "ERADIATE_DIR": tmpdir_path / "eradiate",
+                "ERADIATE_SOURCE_DIR": tmpdir_path / "eradiate",
                 "ERADIATE_DATA_PATH": ":".join(paths),
             }
         )
@@ -45,7 +47,7 @@ def test_config(tmpdir):
         # Empty paths are omitted
         cfg = EradiateConfig.from_environ(
             {
-                "ERADIATE_DIR": tmpdir_path / "eradiate",
+                "ERADIATE_SOURCE_DIR": tmpdir_path / "eradiate",
                 "ERADIATE_DATA_PATH": ":::" + "::".join(paths) + ":",
             }
         )

--- a/tests/test_eradiate/_unit/test_presolver.py
+++ b/tests/test_eradiate/_unit/test_presolver.py
@@ -64,7 +64,7 @@ def test_resolve(presolver):
     presolver.clear()
 
     # We add a path
-    base = os.getenv("ERADIATE_DIR")
+    base = os.getenv("ERADIATE_SOURCE_DIR")
     presolver.append(base)
 
     # We expect the test script to find its own location


### PR DESCRIPTION
# Description

This commit changes a configuration variable from `$ERADIATE_DIR` to `$ERADIATE_SOURCE_DIR`. Purposes are to:

* make it clear that this variable is supposed to point to the root of the source file tree;
* lay ground for making this variable optional (useful to detect whether a development or production setup is used).

I think I've been thorough and didn't miss anything.

@nollety @schunkes @wint3ria please review this PR, it will have a significant impact on your setup.

## Note: Why is this happening?

In a (hopefully) not so distant future, we'll ship Eradiate through PyPI. This means that people won't necessarily clone the repo to use it. Consequently, relying on the fact that we use a dev setup is not a viable option in the long term, in particular for the distribution of data contained in the `resources/data` submodule: without the full submodule, the `DirectoryDataStore` I wrote (see #168) doesn't work.

Fortunately, there is an alternative: if the data submodule is not available, we can just replace the `DirectoryDataStore` with an `OnlineDataStore` (or something very similar) pointing to data files on GitHub. Pooch actually has features to address this specific use case. But still, in order to do so, we need to be able to tell whether we are using a dev setup. Achieving this with an environment-controlled config variable is easy: if `$ERADIATE_DIR` is set, it means we are in dev mode; otherwise, we are in production mode. And just to make it clear that the purpose of this variable is to indicate that we are in dev mode, let's actually name it `$ERADIATE_SOURCE_DIR`!

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `next` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
