### PR TITLE
`AFGL1986RadProfile`: Refactor concentration rescaling

### DIFF
--- a/src/eradiate/thermoprops/util.py
+++ b/src/eradiate/thermoprops/util.py
@@ -75,7 +75,7 @@ def compute_column_mass_density(ds, species):
     Parameters
     ----------
     ds : Dataset
-        Atmosphere thermophysical properties data set.
+        Atmosphere thermophysical property data set.
 
     species : str
         Species.
@@ -85,7 +85,7 @@ def compute_column_mass_density(ds, species):
     quantity
         Column mass density.
     """
-    with data.open_dataset(f"chemistry/molecular_masses.nc") as molecular_mass:
+    with data.open_dataset("chemistry/molecular_masses.nc") as molecular_mass:
         m = molecular_mass.m.sel(s=species).values * ATOMIC_MASS_CONSTANT
 
     return m * compute_column_number_density(ds=ds, species=species)


### PR DESCRIPTION
# Description

This PR refactors the concentration rescaling code to simplify the addition of new species. Supporting a new species now simply requires adding a new entry to the *species → quantity computation method* mapping.

I tried to improve code readability with [partials](https://docs.python.org/3/library/functools.html#functools.partial) and by reducing the unit conversion boilerplate. I hope this helps!

I'm not a super fan of the rescaled species detection a.t.m, but fixing that requires more refactoring (the underlying `compute_*()` functions should then be modified).

@nollety if this looks good to you, I think checking out if additional testing is required would be good. I think we already have unit tests, but I might have overlooked something.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
