### PR TITLE
KernelDictContext: Add dynamic data

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -414,6 +414,7 @@ def custom_step(app):
     generate_rst_plugins.generate()
     generate_rst_api.generate_env_vars_docs()
     generate_rst_api.generate_factory_docs()
+    generate_rst_api.generate_context_docs()
 
 
 def setup(app):

--- a/docs/generate_rst_api.py
+++ b/docs/generate_rst_api.py
@@ -2,6 +2,7 @@ from importlib import import_module
 from pathlib import Path
 from textwrap import dedent, indent
 
+import eradiate
 from eradiate._config import EradiateConfig, format_help_dicts_rst
 
 # Auto-generation disclaimer text
@@ -121,6 +122,56 @@ def generate_factory_docs():
         write_if_modified(outdir / f"{modname}.{varname}.rst", content)
 
 
+def generate_context_docs():
+    outdir = (
+        Path(__file__).parent.absolute() / "rst/reference_api/generated/context_fields"
+    )
+    print(f"Generating dynamic context field docs in '{outdir}'")
+
+    body = []
+
+    for field in sorted(eradiate.contexts.KernelDictContext.DYNAMIC_FIELDS.data.keys()):
+        methods = eradiate.contexts.KernelDictContext.DYNAMIC_FIELDS.data[field]
+
+        body.append(f"{field}")
+        body.append(
+            indent(
+                ",\n".join(
+                    sorted(
+                        f":meth:`.{'.'.join(method.split('.')[-2:])}`"
+                        for method in methods
+                    )
+                ),
+                "    ",
+            )
+        )
+        body.append("")
+
+    content = "\n".join(
+        [
+            HEADER,
+            "",
+            dedent(
+                """
+                .. _sec-contexts-context_fields:
+
+                ``KernelDictContext``: List of registered dynamic context fields
+                ----------------------------------------------------------------
+                
+                The dynamic field table held by 
+                :attr:`.KernelDictContext.DYNAMIC_FIELDS` contains the following 
+                entries:
+                """
+            ),
+            "\n".join(body),
+            "",
+        ]
+    )
+
+    write_if_modified(outdir / "context_fields.rst", content)
+
+
 if __name__ == "__main__":
     generate_factory_docs()
     generate_env_vars_docs()
+    generate_context_docs()

--- a/docs/rst/reference_api/contexts.rst
+++ b/docs/rst/reference_api/contexts.rst
@@ -1,6 +1,20 @@
 ``eradiate.contexts``
 =====================
 
+.. toctree::
+   :hidden:
+
+   generated/context_fields/context_fields.rst
+
+.. button-ref:: generated/context_fields/context_fields
+   :color: primary
+   :expand:
+
+   ``KernelDictContext``: list of registered dynamic fields
+
+Classes
+-------
+
 .. automodule:: eradiate.contexts
 
 .. py:currentmodule:: eradiate.contexts

--- a/src/eradiate/_config.py
+++ b/src/eradiate/_config.py
@@ -92,10 +92,9 @@ class EradiateConfig:
 
         if do_not_exist:
             warnings.warn(
-                ConfigWarning(
-                    "While configuring Eradiate: 'ERADIATE_DATA_PATH' contains "
-                    f"paths to nonexisting directories {[str(x) for x in do_not_exist]}"
-                )
+                "While configuring Eradiate: 'ERADIATE_DATA_PATH' contains "
+                f"paths to nonexisting directories {[str(x) for x in do_not_exist]}",
+                ConfigWarning,
             )
 
     #: URL where large data files are located.

--- a/src/eradiate/_util.py
+++ b/src/eradiate/_util.py
@@ -1,3 +1,5 @@
+import functools
+import inspect
 import re
 import typing as t
 import warnings
@@ -237,3 +239,47 @@ class LoggingContext(object):
         if self.handler and self.close:
             self.handler.close()
         # implicit return of None => don't swallow exceptions
+
+
+def get_class_that_defined_method(meth: t.Any) -> t.Type:
+    """
+    Get the class which defined a method, if relevant. Otherwise, return
+    ``None``.
+    """
+    # See https://stackoverflow.com/questions/3589311/get-defining-class-of-unbound-method-object-in-python-3/25959545#25959545
+    if isinstance(meth, functools.partial):
+        return get_class_that_defined_method(meth.func)
+
+    if inspect.ismethod(meth) or (
+        inspect.isbuiltin(meth)
+        and getattr(meth, "__self__", None) is not None
+        and getattr(meth.__self__, "__class__", None)
+    ):
+        for cls in inspect.getmro(meth.__self__.__class__):
+            if meth.__name__ in cls.__dict__:
+                return cls
+        meth = getattr(meth, "__func__", meth)  # fallback to __qualname__ parsing
+
+    if inspect.isfunction(meth):
+        cls = getattr(
+            inspect.getmodule(meth),
+            meth.__qualname__.split(".<locals>", 1)[0].rsplit(".", 1)[0],
+            None,
+        )
+        if isinstance(cls, type):
+            return cls
+
+    return getattr(meth, "__objclass__", None)  # handle special descriptor objects
+
+
+def fullname(obj: t.Any) -> str:
+    """
+    Get the fully qualified name of `obj`. Aliases will be dereferenced.
+    """
+    cls = get_class_that_defined_method(obj)
+
+    if cls is None:
+        return f"{obj.__module__}.{obj.__qualname__}"
+
+    # else: # (it's a method)
+    return f"{cls.__module__}.{obj.__qualname__}"

--- a/src/eradiate/data/_blind.py
+++ b/src/eradiate/data/_blind.py
@@ -112,7 +112,6 @@ class BlindDataStore(DataStore):
 
                 # If no gzip-compressed file is available, try the actual file
                 try:
-                    print(os.path.join(self.base_url, fname))
                     return Path(
                         pooch.retrieve(
                             os.path.join(self.base_url, fname),

--- a/src/eradiate/experiments/_onedim.py
+++ b/src/eradiate/experiments/_onedim.py
@@ -99,10 +99,8 @@ class OneDimExperiment(EarthObservationExperiment):
     def _surface_validator(self, attribute, value):
         if self.atmosphere and value.width is not AUTO:
             warnings.warn(
-                OverriddenValueWarning(
-                    "user-defined surface width will be overridden by "
-                    "atmosphere width"
-                )
+                "user-defined surface width will be overridden by atmosphere width",
+                OverriddenValueWarning,
             )
 
     _integrator: Integrator = documented(

--- a/src/eradiate/scenes/atmosphere/_molecular_atmosphere.py
+++ b/src/eradiate/scenes/atmosphere/_molecular_atmosphere.py
@@ -130,6 +130,7 @@ class MolecularAtmosphere(AbstractHeterogeneousAtmosphere):
     def thermoprops(self) -> xr.Dataset:
         return self._thermoprops
 
+    @KernelDictContext.DYNAMIC_FIELDS.register("override_scene_width")
     def eval_width(self, ctx: KernelDictContext) -> pint.Quantity:
         try:
             return ctx.override_scene_width

--- a/src/eradiate/scenes/atmosphere/_molecular_atmosphere.py
+++ b/src/eradiate/scenes/atmosphere/_molecular_atmosphere.py
@@ -131,9 +131,9 @@ class MolecularAtmosphere(AbstractHeterogeneousAtmosphere):
         return self._thermoprops
 
     def eval_width(self, ctx: KernelDictContext) -> pint.Quantity:
-        if ctx is not None and ctx.override_scene_width is not None:
+        try:
             return ctx.override_scene_width
-        else:
+        except AttributeError:
             if self.width is AUTO:
                 min_sigma_s = self.radprops_profile.eval_sigma_s(ctx.spectral_ctx).min()
                 width = np.divide(

--- a/src/eradiate/scenes/atmosphere/_particle_layer.py
+++ b/src/eradiate/scenes/atmosphere/_particle_layer.py
@@ -187,6 +187,7 @@ class ParticleLayer(AbstractHeterogeneousAtmosphere):
     def bottom(self) -> pint.Quantity:
         return self._bottom
 
+    @KernelDictContext.DYNAMIC_FIELDS.register("override_scene_width")
     def eval_width(self, ctx: KernelDictContext) -> pint.Quantity:
         try:
             return ctx.override_scene_width

--- a/src/eradiate/scenes/atmosphere/_particle_layer.py
+++ b/src/eradiate/scenes/atmosphere/_particle_layer.py
@@ -188,10 +188,10 @@ class ParticleLayer(AbstractHeterogeneousAtmosphere):
         return self._bottom
 
     def eval_width(self, ctx: KernelDictContext) -> pint.Quantity:
-        if ctx.override_scene_width is not None:
+        try:
             return ctx.override_scene_width
 
-        else:
+        except AttributeError:
             if self.width is AUTO:
                 min_sigma_s = self.eval_sigma_s(spectral_ctx=ctx.spectral_ctx).min()
                 width = 10.0 / min_sigma_s if min_sigma_s != 0.0 else np.inf * ureg.m

--- a/src/eradiate/scenes/measure/_multi_radiancemeter.py
+++ b/src/eradiate/scenes/measure/_multi_radiancemeter.py
@@ -116,15 +116,16 @@ class MultiRadiancemeterMeasure(Measure):
         result = KernelDict()
 
         for spp, sensor_id in zip(sensor_spps, sensor_ids):
-            if ctx.atmosphere_medium_id is not None:
-                result_dict = self._kernel_dict(sensor_id, spp)
+            result_dict = self._kernel_dict(sensor_id, spp)
+            try:
                 result_dict["medium"] = {
                     "type": "ref",
                     "id": ctx.atmosphere_medium_id,
                 }
-                result.data[sensor_id] = result_dict
-            else:
-                result.data[sensor_id] = self._kernel_dict(sensor_id, spp)
+            except AttributeError:
+                pass
+
+            result.data[sensor_id] = result_dict
 
         return result
 

--- a/src/eradiate/scenes/measure/_perspective.py
+++ b/src/eradiate/scenes/measure/_perspective.py
@@ -182,15 +182,17 @@ class PerspectiveCameraMeasure(Measure):
         result = KernelDict()
 
         for spp, sensor_id in zip(sensor_spps, sensor_ids):
-            if ctx.atmosphere_medium_id is not None:
-                result_dict = self._kernel_dict(sensor_id, spp)
+            result_dict = self._kernel_dict(sensor_id, spp)
+
+            try:
                 result_dict["medium"] = {
                     "type": "ref",
                     "id": ctx.atmosphere_medium_id,
                 }
-                result.data[sensor_id] = result_dict
-            else:
-                result.data[sensor_id] = self._kernel_dict(sensor_id, spp)
+            except AttributeError:
+                pass
+
+            result.data[sensor_id] = result_dict
 
         return result
 

--- a/src/eradiate/scenes/measure/_perspective.py
+++ b/src/eradiate/scenes/measure/_perspective.py
@@ -176,6 +176,7 @@ class PerspectiveCameraMeasure(Measure):
 
         return result
 
+    @KernelDictContext.DYNAMIC_FIELDS.register("atmosphere_medium_id")
     def kernel_dict(self, ctx: KernelDictContext) -> KernelDict:
         sensor_ids = self._sensor_ids()
         sensor_spps = self._sensor_spps()

--- a/src/eradiate/scenes/measure/_radiancemeter.py
+++ b/src/eradiate/scenes/measure/_radiancemeter.py
@@ -106,6 +106,7 @@ class RadiancemeterMeasure(Measure):
 
         return result
 
+    @KernelDictContext.DYNAMIC_FIELDS.register("atmosphere_medium_id")
     def kernel_dict(self, ctx: KernelDictContext) -> KernelDict:
         sensor_ids = self._sensor_ids()
         sensor_spps = self._sensor_spps()

--- a/src/eradiate/scenes/measure/_radiancemeter.py
+++ b/src/eradiate/scenes/measure/_radiancemeter.py
@@ -112,15 +112,17 @@ class RadiancemeterMeasure(Measure):
         result = KernelDict()
 
         for spp, sensor_id in zip(sensor_spps, sensor_ids):
-            if ctx.atmosphere_medium_id is not None:
-                result_dict = self._kernel_dict(sensor_id, spp)
+            result_dict = self._kernel_dict(sensor_id, spp)
+
+            try:
                 result_dict["medium"] = {
                     "type": "ref",
                     "id": ctx.atmosphere_medium_id,
                 }
-                result.data[sensor_id] = result_dict
-            else:
-                result.data[sensor_id] = self._kernel_dict(sensor_id, spp)
+            except AttributeError:
+                pass
+
+            result.data[sensor_id] = result_dict
 
         return result
 

--- a/src/eradiate/scenes/surface/_centralpatch.py
+++ b/src/eradiate/scenes/surface/_centralpatch.py
@@ -76,13 +76,16 @@ class CentralPatchSurface(Surface):
         """
         Compute the scaling parameter for the bitmap texture in the blendbsdf.
         """
-        if self.central_patch.width is AUTO and not ctx.override_canopy_width:
+        override_scene_width = getattr(ctx, "override_scene_width", None)
+        override_canopy_width = getattr(ctx, "override_canopy_width", None)
+
+        if self.central_patch.width is AUTO and not override_canopy_width:
             return 1.0
         else:
-            width = ctx.override_scene_width if ctx.override_scene_width else self.width
+            width = override_scene_width if override_scene_width else self.width
             patch_width = (
-                ctx.override_canopy_width
-                if ctx.override_canopy_width
+                override_canopy_width
+                if override_canopy_width
                 else self.central_patch.width
             )
             # the size of the central patch is one third of the overall size of the texture

--- a/src/eradiate/scenes/surface/_centralpatch.py
+++ b/src/eradiate/scenes/surface/_centralpatch.py
@@ -72,6 +72,9 @@ class CentralPatchSurface(Surface):
                 f"got: {value.width}"
             )
 
+    @KernelDictContext.DYNAMIC_FIELDS.register(
+        "override_scene_width", "override_canopy_width"
+    )
     def _compute_scale_parameter(self, ctx: KernelDictContext) -> float:
         """
         Compute the scaling parameter for the bitmap texture in the blendbsdf.

--- a/src/eradiate/scenes/surface/_core.py
+++ b/src/eradiate/scenes/surface/_core.py
@@ -182,7 +182,7 @@ class Surface(SceneElement, ABC):
         """
         if self.width is AUTO:
             warnings.warn(
-                ConfigWarning("Surface width set to 'auto', cannot be scaled")
+                "Surface width set to 'auto', cannot be scaled", ConfigWarning
             )
             new_width = self.width
         else:

--- a/src/eradiate/scenes/surface/_core.py
+++ b/src/eradiate/scenes/surface/_core.py
@@ -131,6 +131,7 @@ class Surface(SceneElement, ABC):
             }
         )
 
+    @KernelDictContext.DYNAMIC_FIELDS.register("override_scene_width")
     def kernel_width(self, ctx: KernelDictContext) -> pint.Quantity:
         """
         Return width of kernel object, possibly overridden by

--- a/src/eradiate/scenes/surface/_core.py
+++ b/src/eradiate/scenes/surface/_core.py
@@ -147,9 +147,9 @@ class Surface(SceneElement, ABC):
         quantity
             Kernel object width.
         """
-        if ctx.override_scene_width is not None:
+        try:
             return ctx.override_scene_width
-        else:
+        except AttributeError:  # No scene width override is requested
             if self.width is not AUTO:
                 return self.width
             else:

--- a/tests/test_eradiate/_unit/test_contexts.py
+++ b/tests/test_eradiate/_unit/test_contexts.py
@@ -2,7 +2,12 @@ import eradiate
 from eradiate import unit_registry as ureg
 from eradiate._mode import ModeFlags
 from eradiate.ckd import Bin
-from eradiate.contexts import CKDSpectralContext, MonoSpectralContext, SpectralContext
+from eradiate.contexts import (
+    CKDSpectralContext,
+    KernelDictContext,
+    MonoSpectralContext,
+    SpectralContext,
+)
 from eradiate.quad import Quad
 
 
@@ -55,3 +60,18 @@ def test_ckd_spectral_context(mode_ckd):
 
     # Index string repr is a compact "{bin_id}:{quad_point_index}" string
     assert ctx.spectral_index_formatted == "510:8"
+
+
+def test_kernel_dict_context_construct(modes_all_double):
+    # A default context can be instantiated without argument
+    ctx_1 = KernelDictContext()
+    print(ctx_1)
+
+
+def test_kernel_dict_context_evolve(mode_mono_double):
+    ctx_1 = KernelDictContext()
+
+    # Evolving the context adds additional data to its dynamic component
+    ctx_2 = ctx_1.evolve(foo="bar")
+    assert ctx_2.foo == "bar"
+    assert ctx_1 is not ctx_2

--- a/tests/test_eradiate/_unit/test_util.py
+++ b/tests/test_eradiate/_unit/test_util.py
@@ -46,5 +46,5 @@ def test_deduplicate():
     # Note: this latter test may not be reproducible, we might have to change it
 
 
-def test_pipeline_camel_to_snake():
+def test_camel_to_snake():
     assert camel_to_snake("SomeKindOfThing") == "some_kind_of_thing"

--- a/tests/test_eradiate/_unit/test_util.py
+++ b/tests/test_eradiate/_unit/test_util.py
@@ -1,8 +1,20 @@
+import os
+from pathlib import Path
+
 import numpy as np
 import pytest
 
+import eradiate
 from eradiate import unit_registry as ureg
-from eradiate._util import Singleton, camel_to_snake, deduplicate, is_vector3, natsorted
+from eradiate._util import (
+    Singleton,
+    camel_to_snake,
+    deduplicate,
+    fullname,
+    get_class_that_defined_method,
+    is_vector3,
+    natsorted,
+)
 
 
 def test_singleton():
@@ -48,3 +60,39 @@ def test_deduplicate():
 
 def test_camel_to_snake():
     assert camel_to_snake("SomeKindOfThing") == "some_kind_of_thing"
+
+
+def test_fullname(mode_mono):
+    # Functions
+    assert fullname(os.path.join) == "posixpath.join"
+    assert (
+        fullname(eradiate.kernel.gridvolume.write_binary_grid3d)
+        == "eradiate.kernel.gridvolume.write_binary_grid3d"
+    )
+    assert (
+        fullname(eradiate.kernel.bitmap_to_dataset)
+        == "eradiate.kernel._bitmap.bitmap_to_dataset"
+    )
+
+    # Methods
+    # -- Instance method from class definition
+    assert fullname(Path.is_file) == "pathlib.Path.is_file"
+    # -- Instance method from instance
+    path = Path()
+    assert fullname(path.is_file) == "pathlib.Path.is_file"
+    # -- Class method from class definition
+    assert (
+        fullname(eradiate.contexts.SpectralContext.new)
+        == "eradiate.contexts.SpectralContext.new"
+    )
+    assert (
+        fullname(eradiate.contexts.SpectralContext.new().new)
+        == "eradiate.contexts.SpectralContext.new"
+    )
+
+    # Classes
+    assert fullname(Path) == "pathlib.Path"
+    assert (
+        fullname(eradiate.scenes.spectra.Spectrum)
+        == "eradiate.scenes.spectra._core.Spectrum"
+    )


### PR DESCRIPTION
# Description

This commit generalises `KernelDictContext` and adds the option of storing any data in it. This greatly increases the range of data which can be  transported through the context, without cluttering the class definition with data irrelevant to most `Experiment`s or other components.

* Only the `spectral_ctx` and `ref` fields are kept static.
* Other fields are removed.
* A new `dynamic` field, consisting of a dictionary, stores arbitrary data. Its content can be set manually or through constructor keyword arguments; they can be accessed as instance attributes.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
