### PR TITLE
Fixed: eval_sigma_a_ckd ignores has_absorption

### DIFF
--- a/src/eradiate/radprops/_afgl1986.py
+++ b/src/eradiate/radprops/_afgl1986.py
@@ -259,6 +259,9 @@ class AFGL1986RadProfile(RadProfile):
         if bin_set_id is None:
             raise ValueError("argument 'bin_set_id' is required")
 
+        if not self.has_absorption:
+            return ureg.Quantity(np.zeros(self.thermoprops.z_layer.size), "km^-1")
+
         with _util_ckd.open_dataset(f"afgl_1986-us_standard-{bin_set_id}") as ds:
             # This table maps species to the function used to compute
             # corresponding physical quantities used for concentration rescaling


### PR DESCRIPTION
# Description

`AFGL1986RadProfile.eval_sigma_a_ckd()` was ignoring the value of `has_absorption`.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
