### PR TITLE
ckd datasets update

### DIFF
--- a/src/eradiate/radprops/_afgl1986.py
+++ b/src/eradiate/radprops/_afgl1986.py
@@ -22,6 +22,7 @@ from ..thermoprops import afgl_1986
 from ..thermoprops.util import (
     compute_column_mass_density,
     compute_column_number_density,
+    compute_volume_mixing_ratio_at_surface,
 )
 from ..units import to_quantity
 from ..units import unit_registry as ureg
@@ -102,11 +103,13 @@ class AFGL1986RadProfile(RadProfile):
         if not self.has_absorption:
             return ureg.Quantity(np.zeros(self.thermoprops.z_layer.size), "km^-1")
 
-        with _util_ckd.open_dataset(f"afgl_1986-us_standard-{bin_set_id}") as ds:
+        ds_id = f"{self.thermoprops.attrs['identifier']}-{bin_set_id}-v3"
+        with _util_ckd.open_dataset(ds_id) as ds:
             # This table maps species to the function used to compute
             # corresponding physical quantities used for concentration rescaling
             compute = {
                 "H2O": functools.partial(compute_column_mass_density, species="H2O"),
+                "CO2": functools.partial(compute_volume_mixing_ratio_at_surface, species="CO2"),
                 "O3": functools.partial(compute_column_number_density, species="O3"),
             }
 

--- a/src/eradiate/radprops/_util_ckd.py
+++ b/src/eradiate/radprops/_util_ckd.py
@@ -5,6 +5,10 @@ from .. import data
 PATHS = {
     "afgl_1986-us_standard-10nm": "ckd/absorption/10nm/afgl_1986-us_standard-10nm.nc",
     "afgl_1986-us_standard-1nm": "ckd/absorption/1nm/afgl_1986-us_standard-1nm.nc",
+    "afgl_1986-us_standard-10nm-v3": "ckd/absorption/10nm/afgl_1986-us_standard-10nm-v3.nc",
+    "afgl_1986-us_standard-1nm-v3": "ckd/absorption/1nm/afgl_1986-us_standard-1nm-v3.nc",
+    "afgl_1986-midlatitude_summer-10nm-v3": "ckd/absorption/10nm/afgl_1986-midlatitude_summer-10nm-v3.nc",
+    "afgl_1986-midlatitude_summer-1nm-v3": "ckd/absorption/1nm/afgl_1986-midlatitude_summer-1nm-v3.nc",
 }
 
 

--- a/src/eradiate/thermoprops/afgl_1986.py
+++ b/src/eradiate/thermoprops/afgl_1986.py
@@ -93,16 +93,18 @@ def make_profile(
        interpolated on the regular altitude mesh with an altitude step of 1 km
        from 0 to 120 km.
 
-    All six models include the following six absorbing molecular species:
+    All six models include the following 7 absorbing molecular species:
     H2O, CO2, O3, N2O, CO, CH4 and O2.
     """
     if eradiate.mode().is_ckd:
-        if model_id != "us_standard":
+        supported_models = ["us_standard", "midlatitude_summer"]
+        if model_id not in supported_models:
             raise NotImplementedError(
-                "In CKD mode, only the 'us_standard' model is supported."
+                f"In ckd mode, only {' and '.join(supported_models)} models "
+                f"are supported."
             )
         species = set(concentrations.keys()) if concentrations else set()
-        unhandled = species - {"H2O", "O3"}
+        unhandled = species - {"H2O", "CO2", "O3"}
 
         if unhandled:
             raise NotImplementedError(

--- a/src/eradiate/thermoprops/util.py
+++ b/src/eradiate/thermoprops/util.py
@@ -137,6 +137,26 @@ def compute_mass_density_at_surface(ds, species):
     return m * compute_number_density_at_surface(ds=ds, species=species)
 
 
+def compute_volume_mixing_ratio_at_surface(ds, species):
+    """Compute the volume mixing ratio at the surface of a given species in an
+    atmospheric profile.
+
+    Parameters
+    ----------
+    ds : Dataset
+        Atmosphere thermophysical properties data set.
+
+    species : str
+        Species.
+
+    Returns
+    -------
+    quantity
+        Volume mixing ratio at the surface.
+    """
+    return to_quantity(ds.mr.sel(species=species))[0]
+
+
 def compute_scaling_factors(ds, concentration):
     r"""
     Compute the scaling factors to be applied to the mixing ratio values

--- a/tests/02_eradiate/01_unit/radprops/test_afgl_1986.py
+++ b/tests/02_eradiate/01_unit/radprops/test_afgl_1986.py
@@ -13,17 +13,20 @@ def test_ckd_spectral_ctx_1650():
     bindex = eradiate.ckd.Bindex(bin=spectral_cfg.bins[0], index=3)
     return eradiate.contexts.CKDSpectralContext(bindex=bindex, bin_set="10nm")
 
+
 @pytest.fixture
 def test_ckd_spectral_ctx_550():
     spectral_cfg = eradiate.scenes.measure._core.CKDMeasureSpectralConfig(bins="550")
     bindex = eradiate.ckd.Bindex(bin=spectral_cfg.bins[0], index=3)
     return eradiate.contexts.CKDSpectralContext(bindex=bindex, bin_set="10nm")
 
-def test_afgl_1986_rad_profile_default_ckd(mode_ckd):
+
+@pytest.mark.parametrize("model_id", ["midlatitude_summer", "us_standard"])
+def test_afgl_1986_rad_profile_default_ckd(mode_ckd, model_id):
     """
     Collision coefficient evaluation methods return pint.Quantity objects.
     """
-    p = AFGL1986RadProfile()
+    p = AFGL1986RadProfile(dict(model_id=model_id))
 
     spectral_ctx = SpectralContext.new(bin_set="10nm")
     for field in ["albedo", "sigma_a", "sigma_t"]:
@@ -36,34 +39,36 @@ def test_afgl_1986_rad_profile_default_ckd(mode_ckd):
     assert isinstance(sigma_s, ureg.Quantity)
 
 
-def test_afgl_1986_rad_profile_has_absorption_default(mode_ckd, test_ckd_spectral_ctx_1650):
+@pytest.mark.parametrize("model_id", ["midlatitude_summer", "us_standard"])
+def test_afgl_1986_rad_profile_has_absorption_default(mode_ckd, test_ckd_spectral_ctx_1650, model_id):
     """
     Default value for 'has_absorption' is True, hence the absorption
     coefficient is computed and is not zero everywhere at 1650 nm.
     """
-    p = AFGL1986RadProfile()
+    p = AFGL1986RadProfile(dict(model_id=model_id))
     assert p.has_absorption
     ds = p.eval_dataset(test_ckd_spectral_ctx_1650)
     assert (ds.sigma_a.values != 0.0).any()
 
 
-def test_afgl_1986_rad_profile_has_absorption_true(mode_ckd, test_ckd_spectral_ctx_1650):
+@pytest.mark.parametrize("model_id", ["midlatitude_summer", "us_standard"])
+def test_afgl_1986_rad_profile_has_absorption_true(mode_ckd, test_ckd_spectral_ctx_1650, model_id):
     """
     When 'has_absorption' is True, the absorption coefficient is computed
     and is not zero everywhere at 1650 nm.
     """
-    p = AFGL1986RadProfile(has_absorption=True)
+    p = AFGL1986RadProfile(thermoprops=dict(model_id=model_id), has_absorption=True)
     assert p.has_absorption
     ds = p.eval_dataset(test_ckd_spectral_ctx_1650)
     assert (ds.sigma_a.values != 0.0).any()
 
-
-def test_afgl_1986_rad_profile_has_absorption_false(mode_ckd, test_ckd_spectral_ctx_1650):
+@pytest.mark.parametrize("model_id", ["midlatitude_summer", "us_standard"])
+def test_afgl_1986_rad_profile_has_absorption_false(mode_ckd, test_ckd_spectral_ctx_1650, model_id):
     """
     When 'has_absorption' is False, the absorption coefficient is not
     computed and is zero everywhere.
     """
-    p = AFGL1986RadProfile(has_absorption=False)
+    p = AFGL1986RadProfile(thermoprops=dict(model_id=model_id), has_absorption=False)
     assert not p.has_absorption
     ds = p.eval_dataset(test_ckd_spectral_ctx_1650)
     assert (ds.sigma_a.values == 0.0).all()
@@ -105,7 +110,6 @@ def test_afgl_1986_rad_profile_has_scattering_false(mode_ckd, test_ckd_spectral_
 @pytest.mark.parametrize(
     "model_id",
     [
-        "midlatitude_summer",
         "midlatitude_winter",
         "subarctic_summer",
         "subarctic_winter",
@@ -114,7 +118,8 @@ def test_afgl_1986_rad_profile_has_scattering_false(mode_ckd, test_ckd_spectral_
 )
 def test_afgl_1986_rad_profile_model_id_ckd_not_implemented(mode_ckd, model_id):
     """
-    Models other than 'us_standard' are not implemented in CKD mode.
+    Models other than 'us_standard' or 'midlatitude_summer' are not implemented
+    in ckd mode.
     """
     with pytest.raises(NotImplementedError):
         AFGL1986RadProfile(thermoprops=dict(model_id=model_id))
@@ -122,7 +127,7 @@ def test_afgl_1986_rad_profile_model_id_ckd_not_implemented(mode_ckd, model_id):
 
 @pytest.mark.parametrize(
     "molecule",
-    ["CO2", "N2O", "CO", "CH4", "O2"],
+    ["N2O", "CO", "CH4", "O2"],
 )
 def test_afgl_1986_rad_profile_concentrations_ckd_not_implemented(mode_ckd, molecule):
     """
@@ -138,11 +143,12 @@ def test_afgl_1986_rad_profile_concentrations_ckd_not_implemented(mode_ckd, mole
 @pytest.mark.parametrize(
     "bin", ["280", "550", "790", "1040", "1270", "1590", "2220", "2400"]
 )
-def test_afgl_1986_rad_profile_ckd_10nm(mode_ckd, bin):
+@pytest.mark.parametrize("model_id", ["midlatitude_summer", "us_standard"])
+def test_afgl_1986_rad_profile_ckd_10nm(mode_ckd, bin, model_id):
     """
     Can evaluate absorption coefficient.
     """
-    p = AFGL1986RadProfile()
+    p = AFGL1986RadProfile(thermoprops=dict(model_id=model_id))
     bin = eradiate.scenes.measure._core.CKDMeasureSpectralConfig(bins=bin).bins[0]
     bindex = eradiate.ckd.Bindex(bin=bin, index=3)
     spectral_ctx = eradiate.contexts.CKDSpectralContext(bindex=bindex, bin_set="10nm")


### PR DESCRIPTION
# Description

Resolves eradiate/eradiate-issues#102

# Changes

* updated ckd absorption data sets, with the following main features:
  * based on `HITRAN2020` (previously a mix between HITRAN2016 and HITRAN2020)
  * correct use of ozone photodissociation absorption data (previously incorrect, affecting the range `400-650nm` in particular)
  * new `CO2` dimension, giving the carbon dioxide volume mixing ratio at sea level (representative of the amount of carbon dioxide in the entire atmosphere)
  * absorption data correspond to the 10-molecule version of the AFGL (1986) atmospheres, namely `H2O`, `CO2`, `O3`, `N2O`, `CO`, `CH4`, `O2`, `NO`, `SO2`, `NO2` (previously 7 molecules only were included)
* you can use the AFGL (1986) `us_standard` and `midlatitude_summer` variants (previously only `us_standard`)
* you can rescale `H2O`, `CO2` and `O3` (previously only `H2O` and `O3`)

## Notes about the FTP server update

I uploaded the new ckd data sets (gzipped) on our ftp server here: https://eradiate.eu/data/store/unstable/ckd/absorption.
The total upload size is 1.2 GB.
In order to not break previously running eradiate versions, I did not overwrite the previous ckd data sets. Instead, I appended a version number to the new data set filenames.
`src/eradiate/radprops/_util_ckd.py.PATHS` was updated with the addition of these filenames.

## Notes about the data submodule update

I updated the AFGL (1986) thermophysical properties data sets to add an `identifier` attribute. This identifier attribute is aligned with how the corresponding ckd absorption data sets are named.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [ ] The feature branch is rebased on the current state of the `next` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license

:warning: we must pull eradiate/eradiate-data#6 before pulling this