### PR TITLE
CKD dataset update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ newer version, we recommend that you to go through the list of changes.
 
 ### Improvements and fixes
 
+* Add support for all missing AFGL 1986 reference atmospheres in CKD mode ({ghpr}`185`).
 * Fix incorrect phase function blending in multi-component atmospheres ({ghpr}`197`).
 * Fix incorrect volume data transform for spherical heterogeneous atmospheres ({ghpr}`199`).
 

--- a/src/eradiate/radprops/_afgl1986.py
+++ b/src/eradiate/radprops/_afgl1986.py
@@ -20,9 +20,9 @@ from ..attrs import documented, parse_docs
 from ..ckd import Bindex
 from ..thermoprops import afgl_1986
 from ..thermoprops.util import (
-    compute_column_mass_density,
-    compute_column_number_density,
-    compute_volume_mixing_ratio_at_surface,
+    column_mass_density,
+    column_number_density,
+    volume_mixing_ratio_at_surface,
 )
 from ..units import to_quantity
 from ..units import unit_registry as ureg
@@ -108,11 +108,9 @@ class AFGL1986RadProfile(RadProfile):
             # This table maps species to the function used to compute
             # corresponding physical quantities used for concentration rescaling
             compute = {
-                "H2O": functools.partial(compute_column_mass_density, species="H2O"),
-                "CO2": functools.partial(
-                    compute_volume_mixing_ratio_at_surface, species="CO2"
-                ),
-                "O3": functools.partial(compute_column_number_density, species="O3"),
+                "H2O": functools.partial(column_mass_density, species="H2O"),
+                "CO2": functools.partial(volume_mixing_ratio_at_surface, species="CO2"),
+                "O3": functools.partial(column_number_density, species="O3"),
             }
 
             # Evaluate species concentrations

--- a/src/eradiate/radprops/_util_ckd.py
+++ b/src/eradiate/radprops/_util_ckd.py
@@ -9,6 +9,14 @@ PATHS = {
     "afgl_1986-us_standard-1nm-v3": "ckd/absorption/1nm/afgl_1986-us_standard-1nm-v3.nc",
     "afgl_1986-midlatitude_summer-10nm-v3": "ckd/absorption/10nm/afgl_1986-midlatitude_summer-10nm-v3.nc",
     "afgl_1986-midlatitude_summer-1nm-v3": "ckd/absorption/1nm/afgl_1986-midlatitude_summer-1nm-v3.nc",
+    "afgl_1986-midlatitude_winter-10nm-v3": "ckd/absorption/10nm/afgl_1986-midlatitude_winter-10nm-v3.nc",
+    "afgl_1986-midlatitude_winter-1nm-v3": "ckd/absorption/1nm/afgl_1986-midlatitude_winter-1nm-v3.nc",
+    "afgl_1986-subarctic_summer-10nm-v3": "ckd/absorption/10nm/afgl_1986-subarctic_summer-10nm-v3.nc",
+    "afgl_1986-subarctic_summer-1nm-v3": "ckd/absorption/1nm/afgl_1986-subarctic_summer-1nm-v3.nc",
+    "afgl_1986-subarctic_winter-10nm-v3": "ckd/absorption/10nm/afgl_1986-subarctic_winter-10nm-v3.nc",
+    "afgl_1986-subarctic_winter-1nm-v3": "ckd/absorption/1nm/afgl_1986-subarctic_winter-1nm-v3.nc",
+    "afgl_1986-tropical-10nm-v3": "ckd/absorption/10nm/afgl_1986-tropical-10nm-v3.nc",
+    "afgl_1986-tropical-1nm-v3": "ckd/absorption/1nm/afgl_1986-tropical-1nm-v3.nc",
 }
 
 

--- a/src/eradiate/thermoprops/util.py
+++ b/src/eradiate/thermoprops/util.py
@@ -4,9 +4,11 @@ sets.
 """
 
 from datetime import datetime
+import typing as t
 
 import iapws
 import numpy as np
+import pint
 import scipy.constants
 import xarray as xr
 
@@ -20,7 +22,7 @@ ATOMIC_MASS_CONSTANT = ureg.Quantity(
 )
 
 
-def compute_column_number_density(ds, species):
+def column_number_density(ds: xr.Dataset, species: str) -> pint.Quantity:
     """
     Computes the column number density of a given species in an atmospheric
     profile.
@@ -57,7 +59,7 @@ def compute_column_number_density(ds, species):
     return (n_species * dz).sum()
 
 
-def compute_column_mass_density(ds, species):
+def column_mass_density(ds: xr.Dataset, species: str) -> pint.Quantity:
     """
     Computes the column (mass) density of a given species in an atmospheric
     profile.
@@ -88,10 +90,10 @@ def compute_column_mass_density(ds, species):
     with data.open_dataset("chemistry/molecular_masses.nc") as molecular_mass:
         m = molecular_mass.m.sel(s=species).values * ATOMIC_MASS_CONSTANT
 
-    return m * compute_column_number_density(ds=ds, species=species)
+    return m * column_number_density(ds=ds, species=species)
 
 
-def compute_number_density_at_surface(ds, species):
+def number_density_at_surface(ds: xr.Dataset, species: str) -> pint.Quantity:
     """
     Compute the number density at the surface of a given species in an
     atmospheric profile.
@@ -114,7 +116,7 @@ def compute_number_density_at_surface(ds, species):
     return surface_mr * surface_n
 
 
-def compute_mass_density_at_surface(ds, species):
+def mass_density_at_surface(ds: xr.Dataset, species: str) -> pint.Quantity:
     """Compute the mass density at the surface of a given species in an
     atmospheric profile.
 
@@ -134,10 +136,10 @@ def compute_mass_density_at_surface(ds, species):
     with data.open(category="chemistry", id="molecular_masses") as molecular_mass:
         m = to_quantity(molecular_mass.m.sel(s=species)) * ATOMIC_MASS_CONSTANT
 
-    return m * compute_number_density_at_surface(ds=ds, species=species)
+    return m * number_density_at_surface(ds=ds, species=species)
 
 
-def compute_volume_mixing_ratio_at_surface(ds, species):
+def volume_mixing_ratio_at_surface(ds: xr.Dataset, species: str) -> pint.Quantity:
     """Compute the volume mixing ratio at the surface of a given species in an
     atmospheric profile.
 
@@ -157,7 +159,9 @@ def compute_volume_mixing_ratio_at_surface(ds, species):
     return to_quantity(ds.mr.sel(species=species))[0]
 
 
-def compute_scaling_factors(ds, concentration):
+def compute_scaling_factors(
+    ds: xr.Dataset, concentration: t.Dict[str, pint.Quantity]
+) -> t.Dict[str, float]:
     r"""
     Compute the scaling factors to be applied to the mixing ratio values
     of each species in an atmosphere thermophysical properties data set, so
@@ -237,16 +241,16 @@ def compute_scaling_factors(ds, concentration):
     for species in concentration:
         amount = concentration[species]
         if amount.check("[length]^-2"):  # column number density
-            initial_amount = compute_column_number_density(ds=ds, species=species)
+            initial_amount = column_number_density(ds=ds, species=species)
             factor = amount.to("m^-2") / initial_amount.to("m^-2")
         elif amount.check("[mass] * [length]^-2"):
-            initial_amount = compute_column_mass_density(ds=ds, species=species)
+            initial_amount = column_mass_density(ds=ds, species=species)
             factor = amount.to("kg/m^2") / initial_amount.to("kg/m^2")
         elif amount.check("[length]^-3"):  # number density at the surface
-            initial_amount = compute_number_density_at_surface(ds=ds, species=species)
+            initial_amount = number_density_at_surface(ds=ds, species=species)
             factor = amount.to("m^-3") / initial_amount.to("m^-3")
         elif amount.check("[mass] * [length]^-2"):
-            initial_amount = compute_mass_density_at_surface(ds=ds, species=species)
+            initial_amount = mass_density_at_surface(ds=ds, species=species)
             factor = amount.to("km/m^3") / initial_amount.to("kg/m^3")
         elif amount.check(""):  # mixing ratio at the surface
             surface_mr_species = amount
@@ -261,7 +265,7 @@ def compute_scaling_factors(ds, concentration):
     return factors
 
 
-def human_readable(items):
+def human_readable(items: t.List[str]) -> str:
     """
     Transforms a list into readable human text.
 
@@ -285,7 +289,9 @@ def human_readable(items):
     return x
 
 
-def rescale_concentration(ds, factors, inplace=False):
+def rescale_concentration(
+    ds: xr.Dataset, factors: t.Dict[str, float], inplace: bool = False
+) -> t.Optional[xr.Dataset]:
     """
     Rescale mixing ratios in an atmosphere thermophysical properties data
     set by given factors for each species.
@@ -337,7 +343,12 @@ def rescale_concentration(ds, factors, inplace=False):
 
 
 @ureg.wraps(ret=None, args=(None, "km", None, None), strict=False)
-def interpolate(ds, z_level, method="linear", conserve_columns=False):
+def interpolate(
+    ds: xr.Dataset,
+    z_level: t.Union[np.ndarray, pint.Quantity],
+    method: str = "linear",
+    conserve_columns: bool = False,
+) -> xr.Dataset:
     """
     Interpolates an atmosphere thermophysical properties data set onto a
     new level altitude mesh.
@@ -386,9 +397,7 @@ def interpolate(ds, z_level, method="linear", conserve_columns=False):
     )
 
     if conserve_columns:
-        initial_amounts = {
-            s: compute_column_number_density(ds, s) for s in ds.species.values
-        }
+        initial_amounts = {s: column_number_density(ds, s) for s in ds.species.values}
         factors = compute_scaling_factors(
             ds=interpolated, concentration=initial_amounts
         )
@@ -400,7 +409,7 @@ def interpolate(ds, z_level, method="linear", conserve_columns=False):
 
 
 @ureg.wraps(ret="Pa", args="K", strict=False)
-def water_vapor_saturation_pressure(t):
+def water_vapor_saturation_pressure(t: float) -> pint.Quantity:
     """
     Computes the water vapor saturation pressure over liquid water or ice, at
     the given temperature.
@@ -427,7 +436,7 @@ def water_vapor_saturation_pressure(t):
 
 
 @ureg.wraps(ret=ureg.dimensionless, args=("Pa", "K"), strict=False)
-def equilibrium_water_vapor_fraction(p, t):
+def equilibrium_water_vapor_fraction(p: float, t: float) -> pint.Quantity:
     """
     Computes the water vapor volume fraction at equilibrium, i.e., when the
     rate of condensation of water vapor equals the rate of evaporation of
@@ -481,7 +490,7 @@ def equilibrium_water_vapor_fraction(p, t):
         )
 
 
-def make_profile_regular(profile, atol):
+def make_profile_regular(profile: xr.Dataset, atol: float) -> xr.Dataset:
     """
     Converts the atmosphere thermophysical properties data set with an
     irregular altitude mesh to a profile defined over a regular altitude mesh.
@@ -561,7 +570,7 @@ def make_profile_regular(profile, atol):
     return dataset
 
 
-def _to_regular(mesh, atol):
+def _to_regular(mesh: np.ndarray, atol: float) -> np.ndarray:
     """
     Converts an irregular altitude mesh into a regular altitude mesh.
 
@@ -595,7 +604,9 @@ def _to_regular(mesh, atol):
     return np.linspace(start=mesh[0], stop=mesh[-1], num=n)
 
 
-def _find_regular_params_gcd(mesh, unit_number=1.0):
+def _find_regular_params_gcd(
+    mesh: np.ndarray, unit_number: float = 1.0
+) -> t.Tuple[int, float]:
     """
     Finds the parameters (number of cells, constant cell width) of the
     regular mesh that approximates the irregular input mesh.

--- a/tests/02_eradiate/01_unit/radprops/test_afgl_1986.py
+++ b/tests/02_eradiate/01_unit/radprops/test_afgl_1986.py
@@ -121,19 +121,19 @@ def test_afgl_1986_rad_profile_has_scattering_false(
 @pytest.mark.parametrize(
     "model_id",
     [
+        "tropical",
+        "midlatitude_summer",
         "midlatitude_winter",
         "subarctic_summer",
         "subarctic_winter",
-        "tropical",
+        "us_standard",
     ],
 )
-def test_afgl_1986_rad_profile_model_id_ckd_not_implemented(mode_ckd, model_id):
+def test_afgl_1986_rad_profile_model_id(mode_ckd, model_id):
     """
-    Models other than 'us_standard' or 'midlatitude_summer' are not implemented
-    in ckd mode.
+    All models are supported in ckd mode.
     """
-    with pytest.raises(NotImplementedError):
-        AFGL1986RadProfile(thermoprops=dict(model_id=model_id))
+    AFGL1986RadProfile(thermoprops=dict(model_id=model_id))
 
 
 @pytest.mark.parametrize(
@@ -147,7 +147,7 @@ def test_afgl_1986_rad_profile_concentrations_ckd_not_implemented(mode_ckd, mole
     """
     with pytest.raises(NotImplementedError):
         AFGL1986RadProfile(
-            thermoprops=dict(concentrations={molecule: 1.0 * ureg.kg / ureg.m**2})
+            thermoprops=dict(concentrations={molecule: 0.0 * ureg.dimensionless})
         )
 
 

--- a/tests/02_eradiate/01_unit/thermoprops/test_afgl1986.py
+++ b/tests/02_eradiate/01_unit/thermoprops/test_afgl1986.py
@@ -4,8 +4,8 @@ import xarray as xr
 
 from eradiate.thermoprops.afgl_1986 import make_profile
 from eradiate.thermoprops.util import (
-    compute_column_number_density,
-    compute_number_density_at_surface,
+    column_number_density,
+    number_density_at_surface,
 )
 from eradiate.units import unit_registry as ureg
 
@@ -83,20 +83,17 @@ def test_make_profile_concentrations(mode_mono, model_id, levels):
     concentrations = {
         "H2O": ureg.Quantity(5e23, "m^-2"),
         "O3": ureg.Quantity(0.5, "dobson_unit"),
-        "CH4": ureg.Quantity(4e19, "m^-3"),
         "CO2": ureg.Quantity(400e-6, ""),
     }
     ds = make_profile(model_id=model_id, levels=levels, concentrations=concentrations)
 
-    column_amount_H2O = compute_column_number_density(ds=ds, species="H2O")
-    column_amount_O3 = compute_column_number_density(ds=ds, species="O3")
-    surface_amount_CH4 = compute_number_density_at_surface(ds=ds, species="CH4")
+    column_amount_H2O = column_number_density(ds=ds, species="H2O")
+    column_amount_O3 = column_number_density(ds=ds, species="O3")
     surface_amount_CO2 = ds.mr.sel(species="CO2").values[0]
 
     assert np.isclose(column_amount_H2O, concentrations["H2O"], rtol=1e-9)
     assert np.isclose(column_amount_O3, concentrations["O3"], rtol=1e-9)
     assert np.isclose(surface_amount_CO2, concentrations["CO2"], rtol=1e-9)
-    assert np.isclose(surface_amount_CH4, concentrations["CH4"], rtol=1e-9)
 
 
 @pytest.mark.parametrize(

--- a/tests/02_eradiate/01_unit/thermoprops/test_util.py
+++ b/tests/02_eradiate/01_unit/thermoprops/test_util.py
@@ -7,8 +7,8 @@ from eradiate.thermoprops.us76 import make_profile
 from eradiate.thermoprops.util import (
     _find_regular_params_gcd,
     _to_regular,
-    compute_column_number_density,
-    compute_number_density_at_surface,
+    column_number_density,
+    number_density_at_surface,
     compute_scaling_factors,
     equilibrium_water_vapor_fraction,
     human_readable,
@@ -33,7 +33,7 @@ def test_compute_column_number_density():
             "species": ("species", ["H2O"], {}),
         },
     )
-    assert compute_column_number_density(ds, "H2O") == ureg.Quantity(6, "m^-2")
+    assert column_number_density(ds, "H2O") == ureg.Quantity(6, "m^-2")
 
     # compute correctly (irregular altitude mesh)
     ds = xr.Dataset(
@@ -47,7 +47,7 @@ def test_compute_column_number_density():
             "species": ("species", ["H2O"], {}),
         },
     )
-    assert compute_column_number_density(ds, "H2O") == ureg.Quantity(26, "m^-2")
+    assert column_number_density(ds, "H2O") == ureg.Quantity(26, "m^-2")
 
     # compute correctly (mutiple species)
     ds = xr.Dataset(
@@ -61,8 +61,8 @@ def test_compute_column_number_density():
             "species": ("species", ["H2O", "O3"], {}),
         },
     )
-    assert compute_column_number_density(ds, "H2O") == ureg.Quantity(13, "m^-2")
-    assert compute_column_number_density(ds, "O3") == ureg.Quantity(13, "m^-2")
+    assert column_number_density(ds, "H2O") == ureg.Quantity(13, "m^-2")
+    assert column_number_density(ds, "O3") == ureg.Quantity(13, "m^-2")
 
 
 def test_compute_number_density_at_surface():
@@ -78,7 +78,7 @@ def test_compute_number_density_at_surface():
             "species": ("species", ["H2O"], {}),
         },
     )
-    value = compute_number_density_at_surface(ds, "H2O")
+    value = number_density_at_surface(ds, "H2O")
     assert value == ureg.Quantity(0.6, "m^-3")
 
 
@@ -138,12 +138,12 @@ def test_rescale_concentration():
             history="",
         ),
     )
-    initial_ozone_amount = compute_column_number_density(ds=ds, species="O3")
+    initial_ozone_amount = column_number_density(ds=ds, species="O3")
     new_ozone_amount = ureg.Quantity(1, "dobson_units")
     factors = compute_scaling_factors(ds=ds, concentration={"O3": new_ozone_amount})
     rescaled_ds = rescale_concentration(ds=ds, factors=factors, inplace=False)
-    ds_ozone_amount = compute_column_number_density(ds=ds, species="O3")
-    ozone_amount = compute_column_number_density(ds=rescaled_ds, species="O3")
+    ds_ozone_amount = column_number_density(ds=ds, species="O3")
+    ozone_amount = column_number_density(ds=rescaled_ds, species="O3")
     assert ds_ozone_amount == initial_ozone_amount
     assert ozone_amount.to("dobson_unit") == new_ozone_amount
 
@@ -171,13 +171,13 @@ def test_interpolate():
         ),
     )
     initial_amounts = {
-        s: compute_column_number_density(ds, s) for s in ds.species.values
+        s: column_number_density(ds, s) for s in ds.species.values
     }
     interpolated = interpolate(
         ds=ds, method="linear", z_level=np.linspace(0, 8, 9), conserve_columns=True
     )
     amounts = {
-        s: compute_column_number_density(interpolated, s)
+        s: column_number_density(interpolated, s)
         for s in interpolated.species.values
     }
     for s in ds.species.values:


### PR DESCRIPTION
# Description

Resolves eradiate/eradiate-issues#102.

Because of missing ckd data sets, only the following AFGL 1986 atmospheres are supported in `ckd` mode:
* U.S. Standard
* Midlatitude summer

These ckd data sets are no longer missing and this PR adds support for the remaining AFGL (1986) atmospheres, namely:
* Midlatitude winter
* Subarctic Summer
* Subarctic Winter
* Tropical

All ckd data sets come into two spectral resolutions:
* low: 10 nm
* high: 1 nm.

and allow rescaling of the following molecules:

* H20: from 0 to 60 kg/m2 (column mass density).
* CO2: from 0 to 600 ppmv (sea-level volume mixing ratio).
* O3: from 0 to 600 dobson units (column number density).

The following modules were also modified (minor refactoring):
* `eradiate/radprops/_afgl1986.py`
* `eradiate/thermoprops/afgl_1986.py`

Corresponding tests were updated.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
