### PR TITLE
Added a bounding box for proper scaling of the blend phasefunction

### DIFF
--- a/src/eradiate/scenes/phase/_blend.py
+++ b/src/eradiate/scenes/phase/_blend.py
@@ -189,6 +189,7 @@ class BlendPhaseFunction(PhaseFunction):
                     components=self.components[1:],
                     weights=marginal_weights,
                     cache_dir=self.cache_dir,
+                    bbox=self.bbox
                 )
                 .kernel_dict(ctx)
                 .data

--- a/tests/02_eradiate/01_unit/scenes/phase/test_blend.py
+++ b/tests/02_eradiate/01_unit/scenes/phase/test_blend.py
@@ -73,6 +73,18 @@ def test_blend_bbox(mode_mono):
         np.array(phase._gridvolume_transform().matrix),
     )
 
+    # Nested BlendPhaseFunction objects must have the same bbox
+    for comp in phase.components:
+        if isinstance(comp, BlendPhaseFunction):
+            assert np.allclose(
+                [
+                    [1, 0, 0, -0.5],
+                    [0, 1, 0, -0.5],
+                    [0, 0, 1, 0],
+                    [0, 0, 0, 1],
+                ],
+                np.array(comp._gridvolume_transform().matrix),
+            )
 
 def test_blend_kernel_dict(mode_mono):
     ctx = KernelDictContext()


### PR DESCRIPTION
# Description

This PR fixes the "seam bug", by ensuring the bounding box for blend phase function objects is set to match the underlying atmosphere.

Please check if the bbox I define for the spherical shell geometry case is correct. I was not completely certain about this.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
