### PR TITLE
Compute King correction factor from Bates (1984) data

### DIFF
--- a/tests/02_eradiate/01_unit/radprops/test_rayleigh_scattering.py
+++ b/tests/02_eradiate/01_unit/radprops/test_rayleigh_scattering.py
@@ -35,7 +35,7 @@ def test_sigma_s_air_wavelength_dependence():
     wavelength = ureg.Quantity(np.linspace(240.0, 2400.0), "nm")
     sigma_s = compute_sigma_s_air(wavelength)
     prod = sigma_s.magnitude * np.power(wavelength, 4)
-    assert np.allclose(prod, prod[0], rtol=0.2)
+    assert np.allclose(prod, prod[0], rtol=0.25)
 
 
 def test_sigma_s_air_optical_thickness():
@@ -50,7 +50,7 @@ def test_sigma_s_air_optical_thickness():
     n = to_quantity(profile.n)
     z = profile.z_level.values
     dz = z[1:] - z[:-1]
-    sigma_s = compute_sigma_s_air(number_density=n, depolarisation_ratio=0.031)
+    sigma_s = compute_sigma_s_air(number_density=n)
     optical_thickness = np.sum(sigma_s.to("m^-1").magnitude * dz)
 
     assert np.isclose(optical_thickness, 0.0973, rtol=1e-2)


### PR DESCRIPTION
# Description

Resolves eradiate/eradiate-issues#138 and eradiate/eradiate-issues#8

Computation of the Rayleigh scattering coefficient involves the King correction factor which depends on wavelength. So far this King correction factor was set to the constant value of 1,049 (dimensionless). This pull request suggests to compute the King correction factor by interpolating the data published by Bates (1984). Bates' data covers the range of wavelength from 200 to 1000 nanometers, therefore it is extrapolated in [1000, 2400] assuming a constant value. This assumption is rough, but since the corresponding scattering coefficient decreases at a rate proportional to the 4th power of the wavelength, it can be justified.
The figure below illustrates the old and new King correction factor spectra. The largest deviation occurs at the shortest wavelength, and is around 3%.

![king_correction_factor](https://user-images.githubusercontent.com/62285993/158228510-d2a095a3-3002-4545-842e-a13e14a8346a.png)

The figure below illustrate the corresponding scattering coefficient spectra. The difference between the two curves is barely visible. The largest deviation occurs around 280 nm and is approximately 0.8 %.

![scattering_coefficient](https://user-images.githubusercontent.com/62285993/158228523-f8eaeea6-3ef7-4c58-95cb-c8ca59cd3653.png)

## Changes

* remove obsolete function `kf`
* remove obsolete arguments `king_factor` and `depolarisation_ratio` of `compute_sigma_s_air`

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
