### PR TITLE
Data guide update

### DIFF
--- a/docs/rst/user_guide/data/absorption.rst
+++ b/docs/rst/user_guide/data/absorption.rst
@@ -3,8 +3,6 @@
 Absorption cross section
 ========================
 
-.. warning:: This content is outdated.
-
 Absorption cross section data sets provide the monochromatic absorption cross
 section spectrum of a given absorbing species at specific pressure and
 temperature conditions.
@@ -13,8 +11,8 @@ Data sets access
 ----------------
 Due to their extremely large size (almost 1TB), most data sets are not
 distributed.
-Distributed data sets are hosted at
-`https://eradiate.eu/data <https://eradiate.eu/data>`_.
+Distributed data sets are managed by Eradiate's global data store.
+Refer to the :ref:`sec-user_guide-data-intro` page for further details.
 
 Identifiers format
 ^^^^^^^^^^^^^^^^^^

--- a/docs/rst/user_guide/data/ckd.rst
+++ b/docs/rst/user_guide/data/ckd.rst
@@ -3,8 +3,6 @@
 Correlated-k distribution (CKD)
 ===============================
 
-.. warning:: This content is outdated.
-
 Eradiate supports simulation using the correlated-k distribution method. To that
 end, various data are used and shipped as part of the software package.
 

--- a/docs/rst/user_guide/data/index.rst
+++ b/docs/rst/user_guide/data/index.rst
@@ -11,7 +11,7 @@ Data guide
    intro
    absorption
    radprops
-   solar_irradiance_spectrum_data_sets
+   solar_irradiance_spectra
    spectra-us76_u86_4
    srf
    thermoprops

--- a/docs/rst/user_guide/data/intro.rst
+++ b/docs/rst/user_guide/data/intro.rst
@@ -3,8 +3,6 @@
 Introduction
 ============
 
-.. warning:: This content is outdated.
-
 Eradiate ships, processes and produces data. This guide presents:
 
 * the rationale underlying data models used in Eradiate;
@@ -23,37 +21,42 @@ data.
 Accessing shipped data
 ----------------------
 
-Eradiate ships with a series of data sets located in its ``resources/data``
-directory. Some of the larger data sets consist of aggregates of many NetCDF
-files, while others are stand-alone NetCDF files. In order to provide a simple
-and unified interface, Eradiate references data sets in a registry which can be
-queried using the :mod:`~eradiate.data` module.
+Eradiate ships with a series of data sets managed its global data store.
 
-Data sets are grouped by category, *e.g.* solar irradiance spectrum, absorption
-spectrum, etc. The complete list of registered categories can be found in the
-reference documentation for the :mod:`~eradiate.data` module. Each data set is
-then referenced by an identifier unique in its category. The pair
-(category, identifier) therefore identifies a data set completely.
+.. code-block:: python
 
-To open a specific data set, the :func:`eradiate.data.open` function should be
-used:
+   from eradiate.data import data_store
+
+This global data store aggregates multiple subordinated data stores based on
+the size and maturity level of data files they manage.
+List a data store' registered data sets by reading its ``registry`` property,
+*i.e.*:
+
+.. code-block:: python
+
+   list(data_store.stores["small_files"].registry)
+
+for small data files and:
+
+.. code-block:: python
+
+   list(data_store.stores["large_files_stable"].registry)
+
+for large data files.
+
+To open a specific data set, use :func:`eradiate.data.open_dataset`:
 
 .. code-block:: python
 
    import eradiate
-   ds = eradiate.data.open("solar_irradiance_spectrum", "thuillier_2003")
+   ds = eradiate.data.open_dataset("spectra/solar_irradiance/thuillier_2003.nc")
 
-The :func:`~eradiate.data.open` function can also be used to load user-defined
-data at a known location:
+To load a data set into memory, use :func:`eradiate.data.load_dataset`:
 
 .. code-block:: python
 
-   ds = eradiate.data.open("path/to/my/data.nc")
+   ds = eradiate.data.load_dataset("spectra/solar_irradiance/thuillier_2003.nc")
 
-.. note::
-
-   :func:`~eradiate.data.open` resolves paths using Eradiate's
-   :class:`.PathResolver`.
 
 .. _sec-user_guide-data_guide-working_angular_data:
 
@@ -135,7 +138,4 @@ computer graphics technology and measure results are usually mapped against
 *film coordinates* :math:`(x, y) \in [0, 1]^2`. When those data represent
 hemispherical quantities, a mapping transformation associate angles to film
 coordinates. For convenience, Eradiate ships helpers to convert data from film
-coordinates to angular coordinates. See
-:ref:`sphx_glr_examples_generated_tutorials_data_01_polar_plot.py` for a
-concrete introduction to those features, as well as angular data visualisation
-in polar coordinates.
+coordinates to angular coordinates.

--- a/docs/rst/user_guide/data/radprops.rst
+++ b/docs/rst/user_guide/data/radprops.rst
@@ -3,8 +3,6 @@
 Atmosphere radiative properties
 ===============================
 
-.. warning:: This content is outdated.
-
 An atmosphere radiative properties data set provide the collision (absorption,
 extinction, scattering) coefficient and albedo values within the atmosphere.
 
@@ -12,8 +10,7 @@ Data sets access
 ----------------
 
 Atmosphere radiative properties data sets are created by
-:class:`~eradiate.radprops.rad_profile.RadProfile` objects'
-:meth:`~eradiate.radprops.rad_profile.RadProfile.to_dataset` method.
+:meth:`.RadProfile.eval_dataset` method.
 
 Structure
 ---------
@@ -37,9 +34,3 @@ and one
 * the level altitude (``z_level``).
 
 All data variables are tabulated with respect to ``w`` and ``z_layer``.
-
-Visualise the data
-------------------
-Refer to
-:ref:`this tutorial <sphx_glr_examples_generated_tutorials_atmosphere_02_heterogeneous.py>`
-for an example of use.

--- a/docs/rst/user_guide/data/solar_irradiance_spectra.rst
+++ b/docs/rst/user_guide/data/solar_irradiance_spectra.rst
@@ -1,7 +1,7 @@
 .. _sec-user_guide-data-solar_irradiance_spectrum_data_sets:
 
-Solar irradiance spectrum
-=========================
+Solar irradiance spectra
+========================
 
 A solar irradiance spectrum data set provide the Sun's spectral irradiance
 spectrum at a Sun-Earth distance of 1 astronomical unit.
@@ -12,8 +12,9 @@ blackbody model.
 Data sets access
 ----------------
 
-All required solar irradiance spectrum data sets are available Eradiate using
-the :mod:`eradiate.data` module.
+All required solar irradiance spectrum data sets are are managed by
+Eradiate's global data store.
+Refer to the :ref:`sec-user_guide-data-intro` page for further details.
 
 Identifiers format
 ^^^^^^^^^^^^^^^^^^
@@ -108,7 +109,7 @@ irradiance spectra from 1978-11-7 to 2014-12-31. Wavelength range: [0.5,
 1991.5] nm. Resolution: variable, between 1 and 16 nm. Reference:
 :cite:`Haberreiter2017ObservationalSolarIrradiance`. See also
 `the Cal/Val Portal of the Committee on Earth Observation Satellites
-<http://calvalportal.ceos.org/solar-irradiance-spectrum>`_
+<http://calvalportal.ceos.org/solar-irradiance-spectrum>`_.
 
 ``solid_2017_mean``
 ^^^^^^^^^^^^^^^^^^^
@@ -150,8 +151,3 @@ three time periods (numbered 1, 2, 3 here):
 
 ``whi_2008`` is an alias to the quiet sun spectrum ``whi_2008_3``.
 Reference: :cite:`Woods2008SolarIrradianceReference`.
-
-Visualise the data
-------------------
-Refer to the
-:ref:`dedicated tutorial <sphx_glr_examples_generated_tutorials_data_05_solar_irradiance_spectrum_data_set.py>`.

--- a/docs/rst/user_guide/data/spectra-us76_u86_4.rst
+++ b/docs/rst/user_guide/data/spectra-us76_u86_4.rst
@@ -3,8 +3,6 @@
 ``us76_u86_4-spectra``
 ======================
 
-.. warning:: This content is outdated.
-
 The ``us76_u86_4-spectra`` data set is an absorption cross section data set
 for the the ``us76_u86_4`` absorbing gas mixture and computed using the
 `SPECTRA <https://spectra.iao.ru>`_ Information System.

--- a/docs/rst/user_guide/data/srf.rst
+++ b/docs/rst/user_guide/data/srf.rst
@@ -3,16 +3,15 @@
 Spectral response function
 ==========================
 
-.. warning:: This content is outdated.
-
 A spectral response function data set provide the spectral response of a
 given instrument on a specific platform and in a specific spectral band.
 
 Data sets access
 ----------------
 
-All spectral response function data sets required by Eradiate are available
-within Eradiate using :meth:`eradiate.data.open`.
+All spectral response function data sets required by Eradiate are 
+managed by Eradiate's global data store.
+Refer to the :ref:`sec-user_guide-data-intro` page for further details.
 
 .. _sec-user_guide-data-srf-naming_convention:
 
@@ -52,9 +51,3 @@ The following additional data set attributes are provided:
 * ``platform``: platform identifier (e.g. ``sentinel_3b``)
 * ``instrument``: instrument identifier (e.g. ``slstr``)
 * ``band``: spectral band number (e.g. ``5``)
-
-Visualise the data
-------------------
-
-Refer to the
-:ref:`dedicated tutorial <sphx_glr_examples_generated_tutorials_data_03_visualise_srf_data_set.py>`.

--- a/docs/rst/user_guide/data/thermoprops.rst
+++ b/docs/rst/user_guide/data/thermoprops.rst
@@ -3,17 +3,16 @@
 Atmosphere thermophysical properties
 ====================================
 
-.. warning:: This content is outdated.
-
 An atmosphere thermophysical properties data set provide the spatial variation
 of air pressure, air temperature, air number density and individual species
-mixing ratios.
+volume mixing ratios.
 
 Data sets access
 ----------------
 
 All atmosphere thermophysical properties data sets required by Eradiate are
-available within Eradiate using :meth:`eradiate.data.open`.
+are managed by Eradiate's global data store.
+Refer to the :ref:`sec-user_guide-data-intro` page for further details.
 
 Identifiers format
 ^^^^^^^^^^^^^^^^^^
@@ -33,7 +32,7 @@ Atmosphere thermophysical properties data sets include four data variables:
 * air pressure (``p``)
 * air temperature (``t``)
 * air number density (``n``)
-* individual species mixing ratios (``mr``)
+* individual species volume mixing ratios (``mr``)
 
 two
 `dimension coordinates <http://xarray.pydata.org/en/stable/data-structures.html#coordinates>`_:
@@ -48,9 +47,3 @@ and one
 
 Data variables ``p``, ``t`` and ``n`` are tabulated with respect to ``z_layer``.
 Data variable ``mr`` is tabulated with respect to ``species`` and ``z_layer``.
-
-Visualise the data
-------------------
-
-Refer to the
-:ref:`dedicated tutorial <sphx_glr_examples_generated_tutorials_data_04_visualise_thermoprops_data_set.py>`.


### PR DESCRIPTION
# Description

Updates the data guide.

Most of the updating relates to #168 and affects the introduction page in particular.
All the other pages were updated by removing the outdated content warnings and the "Visualise the data" sections due to missing tutorials, and by referring to the introduction page about how to access the specific datasets.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
