### PR TITLE
Bug fix

### DIFF
--- a/src/eradiate/scenes/atmosphere/_core.py
+++ b/src/eradiate/scenes/atmosphere/_core.py
@@ -315,11 +315,14 @@ class Atmosphere(SceneElement, ABC):
                 f"(currently using a '{type(self.geometry).__name__}')"
             )
 
-        return (
-            10.0 * self.eval_mfp(ctx)
-            if self.geometry.width is AUTO
-            else self.geometry.width
-        )
+        if self.geometry.width is AUTO:
+            mfp = self.eval_mfp(ctx)
+            if mfp.magnitude == np.inf:
+                return 1e7 * ureg.m  # default atmosphere width value
+            else:
+                return 10.0 * mfp
+        else:
+            return self.geometry.width
 
     @abstractmethod
     def kernel_phase(self, ctx: KernelDictContext) -> KernelDict:

--- a/tests/02_eradiate/01_unit/scenes/atmosphere/test_core.py
+++ b/tests/02_eradiate/01_unit/scenes/atmosphere/test_core.py
@@ -1,0 +1,46 @@
+import attr
+import numpy as np
+import pytest
+
+from eradiate import unit_registry as ureg
+from eradiate.contexts import KernelDictContext
+from eradiate.scenes.atmosphere import MolecularAtmosphere, PlaneParallelGeometry
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {
+            "has_absorption": True,
+            "has_scattering": True,
+        },
+        {
+            "has_absorption": True,
+            "has_scattering": False,
+        },
+        {
+            "has_absorption": False,
+            "has_scattering": True,
+        },
+    ],
+)
+def test_kernel_width_plane_parallel(mode_ckd, kwargs):
+    """Atmosphere has valid/correct width value in plane parallel geometry."""
+    # width is AUTO
+    atmosphere = MolecularAtmosphere.afgl_1986(**kwargs)
+    atmosphere = attr.evolve(
+        atmosphere,
+        geometry=PlaneParallelGeometry(),
+    )
+    width = atmosphere.kernel_width_plane_parallel(ctx=KernelDictContext())
+    assert width.magnitude > 0.0 and width.magnitude < np.inf  # width value is valid
+
+    # width is set
+    width_preset = 1e3 * ureg.km
+    atmosphere = MolecularAtmosphere.afgl_1986(**kwargs)
+    atmosphere = attr.evolve(
+        atmosphere,
+        geometry=PlaneParallelGeometry(width=width_preset),
+    )
+    width = atmosphere.kernel_width_plane_parallel(ctx=KernelDictContext())
+    assert width == width_preset  # width value is correct


### PR DESCRIPTION
# Description

Resolves eradiate/eradiate-issues#151

I have update `Atmosphere.kernel_width_plane_parallel` so that it returns 1e7 m when magnitude of `Atmosphere.eval_mfp` is `np.inf`.
I have added a unit test for valid atmosphere width value in plane parallel geometry.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
