### PR TITLE
Fix incorrect phase function blending in multi-component atmospheres

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 
 * Account for spectral dependency of the King correction factor ({ghpr}`187`).
 * Fix wrong atmosphere shape size in plane parallel geometry with no scattering ({ghpr}`195`).
+* Fix incorrect phase function blending in multi-component atmospheres ({ghpr}`197`)
 
 ### Documentation
 


### PR DESCRIPTION
# Description

Closes eradiate/eradiate-issues#155

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
- [x] :warning: update regression test: `tests/02_eradiate/03_regression/atmospheres/test_rpv_afgl1986_continental.py::test_rpv_afgl1986_continental_brfpp`
