### PR TITLE
Typo in pytest command

### DIFF
--- a/docs/rst/contributing.rst
+++ b/docs/rst/contributing.rst
@@ -395,7 +395,7 @@ pytest like this:
 
 .. code-block:: bash
 
-    pytest tests -m "regression" --artefact_dir <a directory of your choice>
+    pytest tests -m "regression" --artefact-dir <a directory of your choice>
 
 The ``artefact_dir`` parameter defines the output directory in which the results
 and plots will be placed. If the directory does not exist, it will be created.


### PR DESCRIPTION
# Description

A pytest command had a typo in the contributing documentation.

# Checklist

- [ ] ~~The code follows the relevant coding guidelines~~
- [ ] ~~The code generates no new warnings~~
- [x] The code is appropriately documented
- [ ] ~~The code is tested to prove its function~~
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
