### PR TITLE
`AbstractHeterogeneousAtmosphere`: Fix incorrect volume data transform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ newer version, we recommend that you to go through the list of changes.
 ### Improvements and fixes
 
 * Fix incorrect phase function blending in multi-component atmospheres ({ghpr}`197`).
+* Fix incorrect volume data transform for spherical heterogeneous atmospheres ({ghpr}`199`).
 
 % ### Documentation
 

--- a/src/eradiate/scenes/atmosphere/_core.py
+++ b/src/eradiate/scenes/atmosphere/_core.py
@@ -601,9 +601,7 @@ class AbstractHeterogeneousAtmosphere(Atmosphere, ABC):
 
             planet_radius = self.geometry.planet_radius.m_as(length_units)
             rmax = planet_radius + top
-            to_world = mi.ScalarTransform4f.translate(
-                [0, 0, -planet_radius + bottom]
-            ) * mi.ScalarTransform4f.scale(rmax)
+            to_world = mi.ScalarTransform4f.scale(rmax)
 
             volumes = {
                 "albedo": {


### PR DESCRIPTION
# Description

This commit fixes a bug where the coordinate transform assigned to the volume data of a spherical atmosphere was incorrect.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
