### PR TITLE
Add automated deprecation management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ scheme more similar to SemVer in the future.
 
 Updates are tracked in this change log. Every time you decide to update to a
 newer version, we recommend that you to go through the list of changes.
+We try hard to remain backward-compatible and warn in advance for deprecation
+when necessary—we also advise to not ignore `DeprecationWarning`s.
 ```
 
 % HEREAFTER IS A TEMPLATE FOR THE NEXT RELEASE
@@ -20,7 +22,7 @@ newer version, we recommend that you to go through the list of changes.
 %
 % ### Breaking changes
 %
-% ### Deprecations
+% ### Deprecations and removals
 %
 % ### Improvements and fixes
 %
@@ -32,11 +34,9 @@ newer version, we recommend that you to go through the list of changes.
 
 % ### New features
 
-### Breaking changes
+% ### Breaking changes
 
-* Internal `_util` library is now `util.misc` ({ghcommit}`5a593d37b72a1070b5a8fa909359fd8ae6498d96`).
-
-### Deprecations
+### Deprecations and removals
 
 * Deprecated function `ensure_array()` is removed ({ghcommit}`622821439cc4b66483518288e78dad0e9aa0da77`).
 
@@ -51,6 +51,9 @@ newer version, we recommend that you to go through the list of changes.
 
 * The `progress` configuration variable is now an `IntEnum`, allowing for
   string-based setting while retaining comparison capabilities ({ghpr}`202`).
+* Internal `_util` library is now `util.misc` ({ghcommit}`5a593d37b72a1070b5a8fa909359fd8ae6498d96`).
+* Add a Numpydoc docstring parsing module ({ghpr}`200`).
+* Add a `deprecated()` decorator to mark a component for deprecation ({ghpr}`200`).
 
 ---
 

--- a/docs/rst/contributing.rst
+++ b/docs/rst/contributing.rst
@@ -299,6 +299,22 @@ Initialisation from dictionaries
     * [optional] if relevant, allow for class method constructor selection using
       the ``"construct"`` parameter.
 
+
+.. _sec-contributing-codebase-deprecations_removals:
+
+Deprecations and removals
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Eradiate tries to remain backward-compatible when possible. Sometimes however,
+compatibility must be broken. Following the recommended practice in the Python
+community, removals are, whenever possible, preceded by a deprecation period
+during which a deprecated component is still available, marked as such in the
+documentation, and using it triggers a :class:`DeprecationWarning`.
+
+This workflow is facilitated by components defined in the
+:mod:`util.deprecation <eradiate.util.deprecation>` module, and in particular
+the :func:`.deprecated` decorator. Be sure to use them when relevant.
+
 .. _sec-contributing-codebase-testing:
 
 Testing

--- a/docs/rst/reference_api/util.rst
+++ b/docs/rst/reference_api/util.rst
@@ -6,3 +6,9 @@
 
 .. automodule:: eradiate.util.misc
    :members:
+
+``eradiate.util.numpydoc``
+--------------------------
+
+.. automodule:: eradiate.util.numpydoc
+   :members:

--- a/docs/rst/reference_api/util.rst
+++ b/docs/rst/reference_api/util.rst
@@ -1,6 +1,15 @@
 ``eradiate.util``
 =================
 
+.. automodule:: eradiate.util
+
+``eradiate.util.deprecation``
+-----------------------------
+
+.. automodule:: eradiate.util.deprecation
+   :members:
+   :member-order: bysource
+
 ``eradiate.util.misc``
 ----------------------
 

--- a/src/eradiate/util/deprecation.py
+++ b/src/eradiate/util/deprecation.py
@@ -1,0 +1,263 @@
+import datetime
+import functools
+import inspect
+import typing as t
+import warnings
+
+from packaging import version
+
+from .numpydoc import format_doc, parse_doc
+from .._version import _version
+
+# Note: Most of this code is taken from https://github.com/briancurtin/deprecation.
+# Class wrapping code is inspired by https://github.com/tantale/deprecated.
+
+
+def deprecated(
+    deprecated_in: t.Optional[str] = None,
+    removed_in: t.Optional[str] = None,
+    details: str = "",
+    current_version: str = None,
+):
+    r"""
+    Decorate a component to signify its deprecation
+
+    This component wraps a component (function or class) that will soon be
+    removed and does two things:
+
+    * The docstring of the method will be modified to include a notice
+      about deprecation, *e.g.* "Deprecated since 0.9.11. Use foo instead."
+    * Raises a :class:`.DeprecatedWarning` via the :mod:`warnings` module,
+      which is a subclass of the built-in :class:`DeprecationWarning`. Note that
+      built-in :class:`DeprecationWarning`\ s are ignored by default, so for users
+      to be informed of said warnings they will need to enable them---see
+      the :mod:`warnings` module documentation for more details.
+
+    Parameters
+    ----------
+    deprecated_in : str, optional, default: None
+        The version at which the decorated method is considered deprecated.
+        This will usually be the next version to be released when the decorator
+        is added. The default is ``None``, which effectively means immediate
+        deprecation. If this is not specified, then the `removed_in` and
+        `current_version` arguments are ignored.
+
+    removed_in : str, optional, default: None
+        The version or :class:`datetime.date` when the decorated method will be
+        removed. The default is ``None``, specifying that the component is not
+        currently planned to be removed.
+        Note: This parameter cannot be set to a value if `deprecated_in` is set
+        to ``None``.
+
+    details : str, optional
+        Extra details to be added to the method docstring and warning. For
+        example, the details may point users to a replacement method, such as
+        "Use the foo_bar method instead". By default there are no details.
+
+    current_version : str, optional
+        Current version. If unset, Eradiate's package version number is looked
+        up automatically.
+
+    Raises
+    ------
+    ValueError
+        If `removed_in` is not ``None`` and `deprecated_in` is not ``None``.
+
+    Examples
+    --------
+    This decorator allows for specifying the version from which the wrapped
+    component is deprecated, and when it will be retired (this latter argument
+    is optional):
+
+    >>> @deprecated(deprecated_in="0.21.1", removed_in="0.22.1")
+    ... def foo(): ...
+    >>> foo()
+
+    We can also deprecate classes:
+
+    >>> @deprecated(deprecated_in="0.21.1", removed_in="0.22.1")
+    ... class SomeClass: ...
+
+    If those components are used before v0.21.1, nothing happens. If they are
+    used between v0.21.1 (included) and v0.22.1 (excluded), a
+    :class:`.DeprecatedWarning` is emitted. If they are used from v0.22.1 on,
+    an :class:`.UnsupportedWarning` is emitted.
+    """
+    # You can't just jump to removal. It's weird, unfair, and also makes
+    # building up the docstring weird.
+    if deprecated_in is None and removed_in is not None:
+        raise ValueError(
+            "Cannot set removed_in to a value without also setting deprecated_in"
+        )
+
+    # Only warn when it's appropriate. There may be cases when it makes sense
+    # to add this decorator before a formal deprecation period begins.
+    # In CPython, PendingDeprecatedWarning gets used in that period,
+    # so perhaps mimic that at some point.
+    is_deprecated = False
+    is_unsupported = False
+
+    # StrictVersion won't take a None or a "", so make whatever goes to it
+    # is at least *something*. Compare versions only if removed_in is not
+    # of type datetime.date
+    if isinstance(removed_in, datetime.date):
+        if datetime.date.today() >= removed_in:
+            is_unsupported = True
+        else:
+            is_deprecated = True
+    else:
+        current_version = version.parse(
+            _version if current_version is None else current_version
+        )
+
+        if removed_in is not None and current_version >= version.parse(removed_in):
+            is_unsupported = True
+        elif deprecated_in and current_version >= version.parse(deprecated_in):
+            is_deprecated = True
+
+    should_warn = any([is_deprecated, is_unsupported])
+
+    def _wrapper(wrapped):
+        if should_warn:
+            # The various parts of this decorator being optional makes for
+            # a number of ways the deprecation notice could go. The following
+            # makes for a nicely constructed sentence with or without any
+            # of the parts.
+
+            # If removed_in is a date, use "removed on"
+            # If removed_in is a version, use "removed in"
+            parts = [".. deprecated::"]
+            if deprecated_in:
+                parts.append(f" {deprecated_in}")
+            if removed_in:
+                parts.append(
+                    "\n   This will be removed "
+                    f"{'on' if isinstance(removed_in, datetime.date) else 'in'} "
+                    f"{removed_in}."
+                )
+            if details:
+                parts.append(f"\n   {details}")
+
+            deprecation_note = "".join(parts)
+
+            # Parse and update wrapped object docstring
+            doc = wrapped.__doc__ or ""  # Safety in case wrapped has no docstring
+            sections = parse_doc(doc)
+            sections["_deprecation"] = deprecation_note
+            wrapped.__doc__ = "".join(format_doc(sections))
+
+            # Define the actual emitted warning
+            warning_cls = UnsupportedWarning if is_unsupported else DeprecatedWarning
+            the_warning = warning_cls(
+                wrapped.__name__, deprecated_in, removed_in, details
+            )
+
+        if inspect.isclass(
+            wrapped
+        ):  # We're wrapping a class: issue a warning upon class instantiation
+            old_new = wrapped.__new__
+
+            def wrapped_cls(cls, *args, **kwargs):
+                if should_warn:
+                    warnings.warn(
+                        the_warning, category=DeprecationWarning, stacklevel=2
+                    )
+
+                if old_new is object.__new__:
+                    return old_new(cls)
+
+                # actually, we don't know the real signature of *old_new*
+                return old_new(cls, *args, **kwargs)
+
+            wrapped.__new__ = staticmethod(wrapped_cls)
+
+            return wrapped
+
+        else:  # We assume we're wrapping a function: issue a warning upon call
+
+            @functools.wraps(wrapped)
+            def _inner(*args, **kwargs):
+                if should_warn:
+                    warnings.warn(
+                        the_warning, category=DeprecationWarning, stacklevel=2
+                    )
+
+                return wrapped(*args, **kwargs)
+
+            return _inner
+
+    return _wrapper
+
+
+class DeprecatedWarning(DeprecationWarning):
+    """
+    A warning class for deprecated methods
+
+    This is a specialization of the built-in :class:`DeprecationWarning`,
+    adding parameters that allow us to get information into the ``__str__``
+    that ends up being sent through the :mod:`warnings` system.
+    The attributes aren't able to be retrieved after the warning gets
+    raised and passed through the system as only the class--not the
+    instance--and message are what gets preserved.
+
+    Parameters
+    ----------
+    component : type or callable
+        The component being deprecated.
+
+    deprecated_in : str, optional, default: None
+        The version that `component` is deprecated in.
+
+    removed_in : str or datetime, optional, default: None
+        The version or :class:`datetime.date` specifying when `component` gets
+        removed.
+
+    details : str, optional
+        Optional details about the deprecation. Most often this will include
+        directions on what to use instead of the now deprecated code.
+    """
+
+    def __init__(self, component, deprecated_in, removed_in, details=""):
+        # NOTE: The docstring only works for this class if it appears up
+        # near the class name, not here inside __init__. I think it has
+        # to do with being an exception class.
+        self.component = component
+        self.deprecated_in = deprecated_in
+        self.removed_in = removed_in
+        self.details = details
+        super(DeprecatedWarning, self).__init__(
+            component, deprecated_in, removed_in, details
+        )
+
+    def __str__(self):
+        parts = [f"{self.component} is deprecated"]
+        if self.deprecated_in:
+            parts.append(f" as of {self.deprecated_in}")
+        if self.removed_in:
+            parts.append(
+                " and will be removed "
+                f"{'on' if isinstance(self.removed_in, datetime.date) else 'in'} "
+                f"{self.removed_in}"
+            )
+        if any([self.deprecated_in, self.removed_in, self.details]):
+            parts.append(".")
+        if self.details:
+            parts.append(f" {self.details}")
+
+        return "".join(parts)
+
+
+class UnsupportedWarning(DeprecatedWarning):
+    """
+    A warning class for methods to be removed
+
+    This is a subclass of :class:`.DeprecatedWarning` and is used to output a
+    proper message about a component being unsupported.
+    """
+
+    def __str__(self):
+        parts = [f"{self.component} is unsupported as of {self.removed_in}."]
+        if self.details:
+            parts.append(f" {self.details}")
+
+        return "".join(parts)

--- a/src/eradiate/util/numpydoc.py
+++ b/src/eradiate/util/numpydoc.py
@@ -1,0 +1,109 @@
+"""
+Numpydoc docstring tools.
+"""
+
+import re
+import typing as t
+from textwrap import dedent
+
+#: List of support docstring sections. The "Fields" section is unique to
+#: Eradiate.
+NUMPYDOC_SECTION_TITLES = [
+    "Parameters",
+    "Fields",  # Special section used for classes only
+    "Attributes",
+    "Returns",
+    "Yields",
+    "Receives",
+    "Other Parameters",
+    "Raises",
+    "Warns",
+    "Warnings",
+    "See Also",
+    "Notes",
+    "References",
+    "Examples",
+]
+
+
+def parse_doc(doc: str) -> t.Dict[str, str]:
+    """
+    Parse a docstring formatted with the Numpydoc style.
+
+    Parameters
+    ----------
+    doc : str
+        Docstring to parse.
+
+    Returns
+    -------
+    sections : dict
+        A dictionary mapping section names to their content. Special
+        ``_short_summary`` and ``_extended_summary`` keys are used for
+        summary contents.
+    """
+    doc = dedent(doc.lstrip("\n")).rstrip()
+
+    # We process only sections mentioned in the Numpy doc style
+    # Detect existing sections
+    section_pattern = {}
+
+    for section_title in NUMPYDOC_SECTION_TITLES:
+        full_section_title = f"{section_title}\n{'-' * len(section_title)}\n"
+        if re.findall(full_section_title, doc):
+            section_pattern[section_title] = full_section_title
+
+    # Collect section content
+    section_contents = (
+        re.split("|".join(section_pattern.values()), doc) if section_pattern else [doc]
+    )
+
+    sections = {}
+    if len(section_contents) == len(section_pattern) + 1:
+        summary = section_contents.pop(0).strip().split("\n\n")
+        sections["_short_summary"] = summary.pop(0)
+        if summary:
+            sections["_extended_summary"] = "\n\n".join(summary)
+
+    for title, content in zip(section_pattern.keys(), section_contents):
+        sections[title] = content.strip()
+
+    return sections
+
+
+def format_doc(sections: t.Dict[str, str]) -> str:
+    """
+    Assemble docstring sections and format them according to the Numpydoc style.
+
+    Parameters
+    ----------
+    sections : dict
+        A dictionary mapping section names to contents. Section ordering
+        follows the Nompydoc style guide.
+
+    Returns
+    -------
+    docstring : str
+        Formatted docstring.
+    """
+
+    # Generate section full text
+    section_fulltexts = []
+
+    for section_title in ["_short_summary", "_deprecation", "_extended_summary"]:
+        if section_title in sections:
+            section_fulltexts.append(sections.pop(section_title) + "\n")
+
+    for section_title in NUMPYDOC_SECTION_TITLES:
+        try:
+            section_content = sections.pop(section_title)
+        except KeyError:
+            continue
+
+        section_fulltexts.append(
+            f"{section_title}\n{'-' * len(section_title)}\n{section_content}\n"
+        )
+
+    # Assemble the final docstring
+    doc = "\n".join(section_fulltexts) + "\n"
+    return doc

--- a/tests/02_eradiate/01_unit/test_deprecation.py
+++ b/tests/02_eradiate/01_unit/test_deprecation.py
@@ -1,0 +1,44 @@
+from inspect import signature
+
+import pytest
+
+from eradiate.util.deprecation import DeprecatedWarning, UnsupportedWarning, deprecated
+
+
+@pytest.mark.parametrize("comptype", ("function", "class"))
+def test_deprecated(comptype):
+    if comptype == "function":
+
+        def component():
+            ...
+
+        wrapped = deprecated(deprecated_in="1.1")(component)
+        # Decorator wraps function but preserves signature
+        assert wrapped is not component
+        assert signature(wrapped) == signature(component)
+
+    elif comptype == "class":
+
+        class component:
+            ...
+
+        component_new = component.__new__
+        wrapped = deprecated(deprecated_in="1.1")(component)
+        # Decorator only redefines __new__
+        assert wrapped is component
+        assert wrapped.__new__ is not component_new
+
+    else:
+        raise ValueError("unhandled case")
+
+    wrapped = deprecated(deprecated_in="1.1", current_version="1.2")(component)
+    with pytest.warns(DeprecatedWarning):
+        wrapped()
+
+    wrapped = deprecated(
+        deprecated_in="1.1",
+        removed_in="1.2",
+        current_version="1.3",
+    )(component)
+    with pytest.warns(UnsupportedWarning):
+        wrapped()


### PR DESCRIPTION
# Description

This PR closes eradiate/eradiate-issues#157. Changes are as follows:

- Added a new `util.numpydoc` module featuring a Numpydoc parser and docstring formatter
- Added a new `util.deprecation` module featuring a `@deprecated` decorator

To do:

- [x] Add tests
- [x] Add API docs
- [x] Improve docstrings
- [x] Update dev docs to explain deprecation policy
- [x] Clean up Git commit history and messages
- [x] Check how to handle `DeprecationWarning`s in our test suite (see *e.g.* [this](https://docs.pytest.org/en/6.2.x/warnings.html#deprecationwarning-and-pendingdeprecationwarning))

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
