### PR TITLE
Using abspath to fix the issue of os.makedirs being passed an empty s…

### DIFF
--- a/src/eradiate/test_tools/regression.py
+++ b/src/eradiate/test_tools/regression.py
@@ -207,7 +207,9 @@ class RegressionTest(ABC):
         reference_only : bool
             Create only a simple visualisation of the computation data
         """
-        filename = "".join([os.path.splitext(self.archive_filename)[0], ".png"])
+        filename = "".join(
+            [os.path.splitext(os.path.abspath(self.archive_filename))[0], ".png"]
+        )
         os.makedirs(os.path.dirname(filename), exist_ok=True)
         print(f"Saving plot in {filename}")
         if reference_only:


### PR DESCRIPTION
…tring as directory name.

# Description
Closes eradiate/eradiate-issues/issues/156

The issue was that the `RegressionTest` classes store the artefact path as a `pathlib.Path` object which strips off the leading `./`. Later we call `os.path.dirname` on the stripped Path object, which returns an empty path. This is why the call to `os.makedirs` failed.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
