### PR TITLE
Make `config.progress` an `IntEnum`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,10 @@ newer version, we recommend that you to go through the list of changes.
 
 % ### Documentation
 
-% ### Internal changes
+### Internal changes
+
+* The `progress` configuration variable is now an `IntEnum`, allowing for
+  string-based setting while retaining comparison capabilities ({ghpr}`202`).
 
 ---
 

--- a/docs/rst/reference_api/config.rst
+++ b/docs/rst/reference_api/config.rst
@@ -25,6 +25,10 @@ Classes
 .. autoclass:: EradiateConfig
    :members:
 
+.. autoclass:: ProgressLevel
+   :members:
+   :member-order: bysource
+
 Attributes
 ----------
 

--- a/src/eradiate/_config.py
+++ b/src/eradiate/_config.py
@@ -5,6 +5,7 @@ variables. A single instance :data:`.config` is aliased in the top-level module
 for convenience.
 """
 
+import enum
 import os.path
 import pathlib
 import warnings
@@ -23,7 +24,7 @@ def var(
     name=None,
     validator=None,
     help=None,
-    on_setattr=True,
+    on_setattr=None,
 ):
     """
     Reimplementation of `environ-config`'s :func:`var` with `on_setattr` support.
@@ -35,7 +36,6 @@ def var(
 
     Parameters
     ----------
-
     default
         Setting this to a value makes the config attribute optional.
 
@@ -72,6 +72,18 @@ def var(
         validator=validator,
         on_setattr=on_setattr,
     )
+
+
+class ProgressLevel(enum.IntEnum):
+    """
+    An enumeration defining valid progress levels.
+
+    This is an integer enumeration, meaning that levels can be compared.
+    """
+
+    NONE = 0  #: No progress
+    SPECTRAL_LOOP = enum.auto()  #: Up to spectral loop level progress
+    KERNEL = enum.auto()  #: Up to kernel level progress
 
 
 def format_help_dicts_rst(help_dicts, display_defaults=False):
@@ -170,14 +182,18 @@ class EradiateConfig:
         help="Path to the Eradiate download directory.",
     )
 
-    #: An integer flag setting the level of progress display
-    #: [0: None; 1: Spectral loop; 2: Kernel]. Only affects tqdm-based
-    #: progress bars.
+    #: An integer flag setting the level of progress display (see
+    #: :class:`ProgressLevel`). Values are preferrably using strings
+    #: (``["NONE", "SPECTRAL_LOOP", "KERNEL"]``). Only affects tqdm-based progress
+    #: bars.
     progress = var(
-        default=2,
-        converter=int,
-        help="An integer flag setting the level of progress display "
-        "[0: None; 1: Spectral loop; 2: Kernel]. Only affects tqdm-based "
+        default="KERNEL",
+        converter=lambda x: ProgressLevel[x.upper()]
+        if isinstance(x, str)
+        else ProgressLevel(x),
+        help="An integer flag setting the level of progress display (see"
+        ":class:`.ProgressLevel`). Values are preferrably using strings "
+        '(``["NONE", "SPECTRAL_LOOP", "KERNEL"]``). Only affects tqdm-based '
         "progress bars.",
     )
 

--- a/src/eradiate/experiments/_core.py
+++ b/src/eradiate/experiments/_core.py
@@ -14,6 +14,7 @@ from tqdm.auto import tqdm
 import eradiate
 
 from .. import config, pipelines
+from .._config import ProgressLevel
 from .._mode import ModeFlags, supported_mode
 from ..attrs import documented, parse_docs
 from ..contexts import KernelDictContext
@@ -334,7 +335,8 @@ class Experiment(ABC):
                 unit_scale=1.0,
                 leave=True,
                 bar_format="{desc}{n:g}/{total:g}|{bar}| {elapsed}, ETA={remaining}",
-                disable=config.progress < 1 or len(spectral_ctxs) <= 1,
+                disable=config.progress < ProgressLevel.SPECTRAL_LOOP
+                or len(spectral_ctxs) <= 1,
             ) as pbar:
                 for kernel_dict, ctx in self.kernel_dicts(measure):
                     spectral_ctx = ctx.spectral_ctx

--- a/src/eradiate/kernel/logging.py
+++ b/src/eradiate/kernel/logging.py
@@ -8,7 +8,7 @@ import re
 import mitsuba.scalar_rgb as mi
 from tqdm.auto import tqdm
 
-from .._config import config
+from .._config import ProgressLevel, config
 
 
 def _add_logging_level(level_name, level_num, method_name=None):
@@ -139,7 +139,7 @@ def install_logging(force: bool = False) -> None:
                     unit_scale=1.0,
                     leave=True,
                     bar_format="{l_bar}{bar}| {elapsed}, ETA={remaining}",
-                    disable=config.progress < 2,
+                    disable=config.progress < ProgressLevel.KERNEL,
                 )
                 self.progress = 0.0
 

--- a/tests/02_eradiate/01_unit/test_config.py
+++ b/tests/02_eradiate/01_unit/test_config.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pytest
 from environ.exceptions import ConfigError, MissingEnvValueError
 
-from eradiate._config import EradiateConfig
+from eradiate._config import EradiateConfig, ProgressLevel
 from eradiate.exceptions import ConfigWarning
 
 
@@ -53,3 +53,23 @@ def test_config(tmpdir):
         )
 
         assert [str(x) for x in cfg.data_path] == paths
+
+
+def test_config_progress():
+    cfg = EradiateConfig.from_environ()
+
+    # We can set progress level using a level
+    cfg.progress = ProgressLevel.NONE
+    assert cfg.progress is ProgressLevel.NONE
+
+    # We can set progress level using an int
+    cfg.progress = 0
+    assert cfg.progress is ProgressLevel.NONE
+
+    # We can set progress using a string
+    cfg.progress = "NONE"
+    assert cfg.progress is ProgressLevel.NONE
+
+    # Progress levels are comparable to int
+    assert cfg.progress < 1
+    assert cfg.progress == 0


### PR DESCRIPTION
# Description

This PR closes eradiate/eradiate-issues#154. Changes are as follows:

* `environ-config`'s `var()` function is reimplemented based on Hynek's advice (see hynek/environ-config#32) to support `on_setattr`
* The `config.progress` field is now an `IntEnum`, which allows to set it using either a integer or a string.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
