### PR TITLE
GitHub actions update and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,112 @@
+# This is a basic CI pipeline, which will build eradiate and
+# run the test suite on it.
+name: Eradiate build and test
+
+on:
+  issue_comment
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.comment.body == 'run Eradiate CI' }}
+    steps:
+      - uses: xt0rted/pull-request-comment-branch@v1
+        id: comment-branch
+      - uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+          token: ${{ secrets.ERADIATECI_PAT }}
+          ref: ${{ steps.comment-branch.outputs.head_ref }}
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          miniconda-version: latest
+          activate-environment: eradiate
+      - name: Get Mitsuba hash
+        run: |
+          cd ext/mitsuba
+          echo "MITSUBA_HASH=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+      - name: Cache Mitsuba
+        uses: actions/cache@v2
+        with:
+          path: build
+          key:
+            mitsuba-${{ env.MITSUBA_HASH }}-${{hashFiles('src/plugins/src/*/*.cpp', 'src/plugins/src/*/*.h')}}-${{ env.CACHE_NUMBER}}
+        env:
+          CACHE_NUMBER: 0
+        id: cache
+      - name: Build
+        shell: bash -l {0}
+        run: |          
+          sudo apt-get update && DEBIAN_FRONTEND=noninteractive sudo apt-get install -y   \
+          git              \
+          ninja-build      \
+          clang-11          \
+          libc++-11-dev     \
+          libc++abi-11-dev  \
+          libpng-dev       \
+          zlib1g-dev       \
+          build-essential  \
+          libjpeg-dev      \
+          ninja-build
+
+          export CUDA_VISIBLE_DEVICES=""
+          conda install mamba -n base -c conda-forge
+          make conda-init
+          conda deactivate
+          conda activate eradiate
+
+          conda install cmake=3.22
+          cmake --version
+          
+          export CC=clang-11
+          export CXX=clang++-11
+
+          cmake --preset default
+          cmake --build build
+          python -c "import drjit; import mitsuba; mitsuba.set_variant('scalar_rgb')"
+        if: steps.cache.outputs.cache-hit != 'true'
+
+  test:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.comment.body == 'run Eradiate CI' }}
+    needs: build
+    steps:
+      - uses: xt0rted/pull-request-comment-branch@v1
+        id: comment-branch
+      - uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+          token: ${{ secrets.ERADIATECI_PAT }}
+          ref: ${{ steps.comment-branch.outputs.head_ref }}
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          miniconda-version: latest
+          activate-environment: eradiate
+      - name: Get Mitsuba hash
+        run: |
+          cd ext/mitsuba
+          echo "MITSUBA_HASH=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+      - name: Cache Mitsuba
+        uses: actions/cache@v2
+        with:
+          path: build
+          key:
+            mitsuba-${{ env.MITSUBA_HASH }}-${{hashFiles('src/plugins/src/*/*.cpp', 'src/plugins/src/*/*.h')}}-${{ env.CACHE_NUMBER}}
+        env:
+          CACHE_NUMBER: 0
+      - name: run tests
+        shell: bash -l {0}
+        run: |
+          export CUDA_VISIBLE_DEVICES=""
+          conda install mamba -n base -c conda-forge
+          make conda-init
+          conda deactivate
+          conda activate eradiate
+          make test
+      - name: archive test results
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: test_results
+          path: build/test_artefacts
+          retention-days: 5

--- a/docs/rst/maintainer_guide.rst
+++ b/docs/rst/maintainer_guide.rst
@@ -300,6 +300,23 @@ need to update the lock file.
    This command skips the Setuptools and pip-compile update which could disrupt
    your Conda environment.
 
+Continuous integration
+----------------------
+
+Eradiate has a continuous integration scheme built in `Github Actions <https://docs.github.com/en/actions>`_ .
+The action is configured in the ``.github/workflows/ci.yml`` file.
+
+As per the documented installation process, Conda environment setup is handled using
+the appropriate Makefile and Mitsuba build configuration is done using the CMake preset.
+No CI-specific build setup operations are required.
+
+The CI workflow uses caching for the compiled Mitsuba binaries. The cache is identified by the commit hash of the 
+``mitsuba`` submodule and the file hashes of all .cpp and .h files in ``src/plugins/src``.
+
+Since the entire pipeline takes more than one hour to complete, it is not triggered automatically.
+Instead, issuing a PR comment containing only ``run Eradiate CI`` will trigger the pipeline on the source
+branch of the PR.
+
 .. _sec-maintainer_guide-release:
 
 Preparing a  release


### PR DESCRIPTION
# Description

Closes eradiate/eradiate-issues/issues/141

This PR introduces a github action which builds mitsuba, sets up Eradiate and runs the test suite.

I also added a short section about the CI to the maintainer guide.

Note: The action is currently set up to explicitly run on the `public` branch, to avoid having it fail every night, because the `eradiateci` user does not have access to mitsuba3 yet.

This workflow will be updated to run on `main`, once the CI user has access to mitsuba3 and I would suggest to not merge it until then.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
