### PR TITLE
Tests: Improve regression testing framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@ when necessary—we also advise to not ignore `DeprecationWarning`s.
 * Internal `_util` library is now `util.misc` ({ghcommit}`5a593d37b72a1070b5a8fa909359fd8ae6498d96`).
 * Add a Numpydoc docstring parsing module ({ghpr}`200`).
 * Add a `deprecated()` decorator to mark a component for deprecation ({ghpr}`200`).
+* Update regression testing interface for improved robustness and ease of use 
+  ({ghpr}`207`).
 
 ---
 

--- a/tests/02_eradiate/01_unit/test_tools/test_regression.py
+++ b/tests/02_eradiate/01_unit/test_tools/test_regression.py
@@ -9,43 +9,57 @@ def test_instantiate():
 
     # instantiate the test with reasonable defaults
     assert tt.RMSETest(
-        archive_filename="tests/archive.nc",
+        name="rmse",
+        archive_dir="tests/",
         value=xr.Dataset(),
         reference=xr.Dataset(),
         threshold=0.05,
     )
 
     assert tt.Chi2Test(
-        archive_filename="tests/archive.nc",
+        name="chi2",
+        archive_dir="tests/",
         value=xr.Dataset(),
         reference=xr.Dataset(),
         threshold=0.05,
     )
 
     # assert all arguments except reference are needed
-    with pytest.raises(TypeError) as e:
-        tt.Chi2Test(
+    with pytest.raises(TypeError):
+        assert tt.Chi2Test(
+            archive_dir="tests/",
             value=xr.Dataset(),
             reference=xr.Dataset(),
             threshold=0.05,
         )
 
-    with pytest.raises(TypeError) as e:
+    with pytest.raises(TypeError):
         tt.Chi2Test(
-            archive_filename="tests/archive.nc",
+            name="chi2",
+            value=xr.Dataset(),
             reference=xr.Dataset(),
             threshold=0.05,
         )
 
-    with pytest.raises(TypeError) as e:
+    with pytest.raises(TypeError):
         tt.Chi2Test(
-            archive_filename="tests/archive.nc",
+            name="chi2",
+            archive_dir="tests/",
+            reference=xr.Dataset(),
+            threshold=0.05,
+        )
+
+    with pytest.raises(TypeError):
+        tt.Chi2Test(
+            name="chi2",
+            archive_dir="tests/",
             value=xr.Dataset(),
             reference=xr.Dataset(),
         )
 
     assert tt.Chi2Test(
-        archive_filename="tests/archive.nc",
+        name="chi2",
+        archive_dir="tests/",
         value=xr.Dataset(),
         threshold=0.05,
     )
@@ -56,7 +70,8 @@ def test_reference_converter(tmp_path):
 
     # file does not exist
     test = tt.Chi2Test(
-        archive_filename="tests/archive.nc",
+        name="chi2",
+        archive_dir="tests/",
         value=xr.Dataset(),
         threshold=0.05,
         reference="./this/file/doesnot.exist",
@@ -69,8 +84,9 @@ def test_reference_converter(tmp_path):
     tempfile.write_text("test")
 
     with pytest.raises(ValueError):
-        test2 = tt.Chi2Test(
-            archive_filename="tests/archive.nc",
+        tt.Chi2Test(
+            name="chi2",
+            archive_dir="tests/",
             value=xr.Dataset(),
             threshold=0.05,
             reference=tempfile,
@@ -78,8 +94,9 @@ def test_reference_converter(tmp_path):
 
     # wrong data type
     with pytest.raises(ValueError):
-        test2 = tt.Chi2Test(
-            archive_filename="tests/archive.nc",
+        tt.Chi2Test(
+            name="chi2",
+            archive_dir="tests/",
             value=xr.Dataset(),
             threshold=0.05,
             reference=np.zeros(25),
@@ -111,9 +128,10 @@ def test_rmse_evaluate():
     rmse_ref = np.linalg.norm(result - ref) / np.sqrt(len(ref))
 
     test = tt.RMSETest(
+        name="rmse",
         value=result_ds,
         reference=ref_ds,
-        archive_filename="tests/archive.nc",
+        archive_dir="tests/",
         threshold=0.05,
     )
 
@@ -165,9 +183,10 @@ def test_chi2_evaluate(mode_mono):
     )
 
     test = tt.Chi2Test(
+        name="chi2",
         value=result_ds,
         reference=ref_ds,
-        archive_filename="tests/archive.nc",
+        archive_dir="tests/",
         threshold=0.05,
     )
 

--- a/tests/02_eradiate/03_regression/atmospheres/test_rpv_afgl1986.py
+++ b/tests/02_eradiate/03_regression/atmospheres/test_rpv_afgl1986.py
@@ -1,11 +1,7 @@
-import os
-
 import numpy as np
 import pytest
-import xarray as xr
 
 import eradiate.scenes as esc
-from eradiate.data import data_store
 from eradiate.experiments import OneDimExperiment
 from eradiate.test_tools.regression import Chi2Test
 from eradiate.units import unit_registry as ureg
@@ -64,21 +60,12 @@ def test_rpv_afgl1986_brfpp(mode_ckd_double, artefact_dir, session_timestamp):
     exp.run()
     result = exp.results["measure"]
 
-    reference_path = data_store.fetch(
-        "tests/regression_test_references/rpv_afgl1986_brfpp_ref.nc"
-    )
-
-    archive_filename = (
-        os.path.join(artefact_dir, f"{session_timestamp:%Y%m%d-%H%M%S}-rpv_afgl1986.nc")
-        if artefact_dir
-        else None
-    )
-
     test = Chi2Test(
+        name=f"{session_timestamp:%Y%m%d-%H%M%S}-rpv_afgl1986.nc",
         value=result,
-        reference=reference_path,
+        reference="tests/regression_test_references/rpv_afgl1986_brfpp_ref.nc",
         threshold=0.05,
-        archive_filename=archive_filename,
+        archive_dir=artefact_dir,
     )
 
     assert test.run()

--- a/tests/02_eradiate/03_regression/atmospheres/test_rpv_afgl1986_continental.py
+++ b/tests/02_eradiate/03_regression/atmospheres/test_rpv_afgl1986_continental.py
@@ -1,8 +1,5 @@
-import os
-
 import numpy as np
 import pytest
-import xarray as xr
 
 import eradiate.scenes as esc
 from eradiate.data import data_store
@@ -80,24 +77,12 @@ def test_rpv_afgl1986_continental_brfpp(
     exp.run()
     result = exp.results["measure"]
 
-    reference_path = data_store.fetch(
-        "tests/regression_test_references/rpv_afgl1986_continental_brfpp_ref.nc"
-    )
-
-    archive_filename = (
-        os.path.join(
-            artefact_dir,
-            f"{session_timestamp:%Y%m%d-%H%M%S}-rpv_afgl1986_continental.nc",
-        )
-        if artefact_dir
-        else None
-    )
-
     test = Chi2Test(
+        name=f"{session_timestamp:%Y%m%d-%H%M%S}-rpv_afgl1986_continental.nc",
         value=result,
-        reference=reference_path,
+        reference="tests/regression_test_references/rpv_afgl1986_continental_brfpp_ref.nc",
         threshold=0.05,
-        archive_filename=archive_filename,
+        archive_dir=artefact_dir,
     )
 
     assert test.run()

--- a/tests/02_eradiate/03_regression/romc/test_het01.py
+++ b/tests/02_eradiate/03_regression/romc/test_het01.py
@@ -1,8 +1,5 @@
-import os
-
 import numpy as np
 import pytest
-import xarray as xr
 
 from eradiate.data import data_store
 from eradiate.experiments import RamiExperiment
@@ -102,21 +99,12 @@ def test_het01_brfpp(mode_mono_double, artefact_dir, session_timestamp):
     exp.run()
     result = exp.results["measure"]
 
-    reference_path = data_store.fetch(
-        "tests/regression_test_references/het01_brfpp_ref.nc"
-    )
-
-    archive_filename = (
-        os.path.join(artefact_dir, f"{session_timestamp:%Y%m%d-%H%M%S}-het01.nc")
-        if artefact_dir
-        else None
-    )
-
     test = Chi2Test(
+        name=f"{session_timestamp:%Y%m%d-%H%M%S}-het01.nc",
         value=result,
-        reference=reference_path,
+        reference="tests/regression_test_references/het01_brfpp_ref.nc",
         threshold=0.05,
-        archive_filename=archive_filename,
+        archive_dir=artefact_dir,
     )
 
     assert test.run()

--- a/tests/02_eradiate/03_regression/romc/test_het04.py
+++ b/tests/02_eradiate/03_regression/romc/test_het04.py
@@ -1,8 +1,5 @@
-import os
-
 import numpy as np
 import pytest
-import xarray as xr
 
 from eradiate.contexts import KernelDictContext
 from eradiate.data import data_store
@@ -131,21 +128,12 @@ def test_het04a1_brfpp(mode_mono_double, artefact_dir, session_timestamp):
     exp.run()
     result = exp.results["measure"]
 
-    reference_path = data_store.fetch(
-        "tests/regression_test_references/het04_brfpp_ref.nc"
-    )
-
-    archive_filename = (
-        os.path.join(artefact_dir, f"{session_timestamp:%Y%m%d-%H%M%S}-het04.nc")
-        if artefact_dir
-        else None
-    )
-
     test = Chi2Test(
+        name=f"{session_timestamp:%Y%m%d-%H%M%S}-het04.nc",
         value=result,
-        reference=reference_path,
+        reference="tests/regression_test_references/het04_brfpp_ref.nc",
         threshold=0.05,
-        archive_filename=archive_filename,
+        archive_dir=artefact_dir,
     )
 
     assert test.run()

--- a/tests/02_eradiate/03_regression/romc/test_het06.py
+++ b/tests/02_eradiate/03_regression/romc/test_het06.py
@@ -1,8 +1,5 @@
-import os
-
 import numpy as np
 import pytest
-import xarray as xr
 
 from eradiate.data import data_store
 from eradiate.experiments import RamiExperiment
@@ -114,21 +111,12 @@ def test_het06_brfpp(mode_mono_double, artefact_dir, session_timestamp):
     exp.run()
     result = exp.results["measure"]
 
-    reference_path = data_store.fetch(
-        "tests/regression_test_references/het06_brfpp_ref.nc"
-    )
-
-    archive_filename = (
-        os.path.join(artefact_dir, f"{session_timestamp:%Y%m%d-%H%M%S}-het06.nc")
-        if artefact_dir
-        else None
-    )
-
     test = Chi2Test(
+        name=f"{session_timestamp:%Y%m%d-%H%M%S}-het06.nc",
         value=result,
-        reference=reference_path,
+        reference="tests/regression_test_references/het06_brfpp_ref.nc",
         threshold=0.05,
-        archive_filename=archive_filename,
+        archive_dir=artefact_dir,
     )
 
     assert test.run()


### PR DESCRIPTION
# Description

This commit improves the regression testing framework with the following changes:

* Artefact names are now assembled from a test name and an archive directory, both set in the test code.
* The reference data can now be passed as a data store path.
* Spectral results (*e.g.* with more than a single CKD bin) are now handled.
* Various type hint and docstring fixes.

This overall simplifies the test code and improves its robustness by handling cases where the reference is expected to be retrieved from the data store but is still missing (relevant when adding a new regression test case).

**To do**

- [x] Update testing framework tests
- [x] Update change log

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
