### PR TITLE
CLI: Add registry content display feature to eradiate data info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,12 @@ when necessary—we also advise to not ignore `DeprecationWarning`s.
   ({ghpr}`197`, {ghpr}`206`).
 * Fix incorrect volume data transform for spherical heterogeneous atmospheres ({ghpr}`199`).
 * Add default value for `CKDSpectralContext.bin_set` ({ghpr}`205`).
+* Add a `-l` option to the `eradiate data info` command-line utility now has. If 
+  this flag is set, the tool displays the list of files registered to each data 
+  store ({ghpr}`208`).
+* Add an optional `DATA_STORES` argument to the `eradiate data info` 
+  command-line utility which may be used to select the data stores for which 
+  information is requested ({ghpr}`208`).
 
 % ### Documentation
 
@@ -59,6 +65,7 @@ when necessary—we also advise to not ignore `DeprecationWarning`s.
 * Add a `deprecated()` decorator to mark a component for deprecation ({ghpr}`200`).
 * Update regression testing interface for improved robustness and ease of use 
   ({ghpr}`207`).
+* Rewrite `eradiate data info` CLI for improved maintainability ({ghpr}`208`).
 
 ---
 


### PR DESCRIPTION
# Description

This PR closes eradiate/eradiate-issues#149. Changes are as follows:

* The `eradiate data info` command-line utility now has a `-l` option which, if active, displays the list of files registered to each data store.
* The `eradiate data info` now has an optional `DATA_STORES` arguments which may be used to select the data stores for which information is requested. If it is not passed, all data stores are queried.
* The `eradiate data info` code has been rewritten for improved maintainability.

**To do**

* [x] Add change log entry

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
