### PR TITLE
experiments: Add run() function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,10 @@ when necessary—we also advise to not ignore `DeprecationWarning`s.
 
 ## v0.22.3 (unreleased)
 
-% ### New features
+### New features
+
+* Add entry point `eradiate.run()`, which executes a full experiment pipeline 
+  and returns results as an xarray dataset ({ghpr}`210`).
 
 ### Breaking changes
 
@@ -44,6 +47,7 @@ when necessary—we also advise to not ignore `DeprecationWarning`s.
 ### Deprecations and removals
 
 * Deprecated function `ensure_array()` is removed ({ghcommit}`622821439cc4b66483518288e78dad0e9aa0da77`).
+* Deprecating instance method `Experiment.run()` ({ghpr}`210`).
 
 ### Improvements and fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ when necessary—we also advise to not ignore `DeprecationWarning`s.
 
 * Change the default value for the `ParticleLayer.dataset` field to:
   `spectra/particles/govaerts_2021-continental.nc` ({ghpr}`212`).
+* Change the default value for the `SpectralMeasureConfig.srf` field to
+  `"sentinel_2a-msi-2"`, in CKD mode ({ghpr}`214`).
 
 ### Deprecations and removals
 

--- a/docs/rst/reference_api/eradiate_core.rst
+++ b/docs/rst/reference_api/eradiate_core.rst
@@ -55,3 +55,9 @@ Metadata
 
 .. autodata:: __version__
    :annotation:
+
+Convenience aliases
+-------------------
+
+.. autodata:: run
+   :annotation:

--- a/docs/rst/reference_api/experiments.rst
+++ b/docs/rst/reference_api/experiments.rst
@@ -31,3 +31,4 @@ Functions
    :toctree: generated/autosummary/
 
    mitsuba_run
+   run

--- a/src/eradiate/__init__.py
+++ b/src/eradiate/__init__.py
@@ -79,6 +79,13 @@ Mode = _mode.Mode
 #: Alias to :class:`eradiate._mode.ModeFlags`.
 ModeFlags = _mode.ModeFlags
 
+# -- Convenience entry points --------------------------------------------------
+
+from . import experiments  # isort: skip
+
+#: Alias to :class:`eradiate.experiments.run`.
+run = experiments.run
+
 
 # -- Import submodules ---------------------------------------------------------
 
@@ -87,7 +94,6 @@ from . import (
     contexts,
     converters,
     data,
-    experiments,
     kernel,
     notebook,
     pipelines,
@@ -114,6 +120,7 @@ __all__ = [
     "pipelines",
     "plot",
     "rng",
+    "run",
     "scenes",
     "set_mode",
     "supported_mode",

--- a/src/eradiate/experiments/__init__.py
+++ b/src/eradiate/experiments/__init__.py
@@ -1,10 +1,11 @@
-from ._core import EarthObservationExperiment, Experiment, mitsuba_run
+from ._core import EarthObservationExperiment, Experiment, mitsuba_run, run
 from ._onedim import OneDimExperiment
 from ._rami import RamiExperiment
 from ._rami4atm import Rami4ATMExperiment
 
 __all__ = [
     "mitsuba_run",
+    "run",
     "EarthObservationExperiment",
     "Experiment",
     "OneDimExperiment",

--- a/src/eradiate/experiments/_core.py
+++ b/src/eradiate/experiments/_core.py
@@ -35,6 +35,7 @@ from ..scenes.measure import (
     MultiDistantMeasure,
     measure_factory,
 )
+from ..util.deprecation import deprecated
 
 logger = logging.getLogger(__name__)
 
@@ -152,6 +153,47 @@ def mitsuba_run(
 
 
 # ------------------------------------------------------------------------------
+#                              Experiment runner
+# ------------------------------------------------------------------------------
+
+
+def run(
+    exp: Experiment,
+    measure: t.Union[Measure, int] = 0,
+    seed_state: t.Optional[SeedState] = None,
+) -> xr.Dataset:
+    """
+    Run an Eradiate experiment, including the Monte Carlo simulation and data
+    post-processing.
+
+    Parameters
+    ----------
+    exp : .Experiment
+        The experiment to be run.
+
+    measure : .Measure or int, optional
+        The measure to be simulated.
+
+    seed_state : .SeedState, optional
+        A RNG seed state used to generate the seeds used by Mitsuba's random
+        number generator. By default, Eradiate's :data:`.root_seed_state` is
+        used.
+
+    Returns
+    -------
+    result : Dataset
+        Experiment result data.
+    """
+
+    if isinstance(measure, int):
+        measure = exp.measures[measure]
+
+    exp.process(measure, seed_state=seed_state)
+    exp.postprocess(measure)
+    return exp.results[measure.id]
+
+
+# ------------------------------------------------------------------------------
 #                                 Base classes
 # ------------------------------------------------------------------------------
 
@@ -256,6 +298,7 @@ class Experiment(ABC):
     #                              Processing
     # --------------------------------------------------------------------------
 
+    @deprecated(deprecated_in="0.22.3", removed_in="0.22.5")
     def run(
         self,
         *measures: t.Union[Measure, int],
@@ -273,8 +316,9 @@ class Experiment(ABC):
             If no value is passed, all measures are processed.
 
         seed_state : .SeedState, optional
-            A RNG seed state used generate the seeds used by Mitsuba's RNG
-            generator. By default, Eradiate's :data:`.root_seed_state` is used.
+            A RNG seed state used to generate the seeds used by Mitsuba's random
+            number generator. By default, Eradiate's :data:`.root_seed_state` is
+            used.
 
         See Also
         --------
@@ -300,8 +344,9 @@ class Experiment(ABC):
             If no value is passed, all measures are processed.
 
         seed_state : .SeedState, optional
-            A RNG seed state used generate the seeds used by Mitsuba's RNG
-            generator. By default, Eradiate's :data:`.root_seed_state` is used.
+            A RNG seed state used to generate the seeds used by Mitsuba's random
+            number generator. By default, Eradiate's :data:`.root_seed_state` is
+            used.
 
         See Also
         --------

--- a/src/eradiate/scenes/measure/_core.py
+++ b/src/eradiate/scenes/measure/_core.py
@@ -33,6 +33,16 @@ measure_factory = Factory()
 # ------------------------------------------------------------------------------
 
 
+def _measure_spectral_config_srf_factory():
+    from eradiate import mode
+
+    if mode().is_mono:
+        return UniformSpectrum(value=1.0)
+
+    else:
+        return "sentinel_2a-msi-2"
+
+
 def _measure_spectral_config_srf_converter(value: t.Any) -> Spectrum:
     if isinstance(value, str):
         with data.open_dataset(f"spectra/srf/{value}.nc") as ds:
@@ -62,7 +72,7 @@ class MeasureSpectralConfig(ABC):
 
     srf: Spectrum = documented(
         attr.ib(
-            factory=lambda: UniformSpectrum(value=1.0),
+            factory=_measure_spectral_config_srf_factory,
             converter=_measure_spectral_config_srf_converter,
             validator=validators.has_quantity(PhysicalQuantity.DIMENSIONLESS),
         ),
@@ -71,7 +81,8 @@ class MeasureSpectralConfig(ABC):
         "database. Other types will be converted by :data:`.spectrum_factory`.",
         type=".Spectrum",
         init_type="str or .Spectrum or dict or float",
-        default=":class:`UniformSpectrum(value=1.0) <.UniformSpectrum>`",
+        default=":class:`UniformSpectrum(value=1.0) <.UniformSpectrum>` in mono "
+        'mode, "sentinel_2a-msi-2" otherwise',
     )
 
     # --------------------------------------------------------------------------

--- a/tests/02_eradiate/01_unit/experiments/test_core.py
+++ b/tests/02_eradiate/01_unit/experiments/test_core.py
@@ -1,7 +1,9 @@
 import pytest
+import xarray as xr
 
+import eradiate
 from eradiate.exceptions import KernelVariantError
-from eradiate.experiments import mitsuba_run
+from eradiate.experiments import OneDimExperiment, mitsuba_run
 from eradiate.scenes.core import KernelDict
 
 
@@ -62,3 +64,9 @@ def test_mitsuba_run_fail():
     mitsuba.set_variant("scalar_rgb")
     with pytest.raises(KernelVariantError):
         mitsuba_run(kernel_dict)
+
+
+def test_run_function(modes_all_double):
+    exp = OneDimExperiment(atmosphere=None)
+    result = eradiate.run(exp)
+    assert isinstance(result, xr.Dataset)


### PR DESCRIPTION
# Description

This PR introduces a convenience `eradiate.run()` function, *à la Mitsuba*. This function directly returns measure results, making it unnecessary to manually access results stored in the `Experiment` instance. It is bound to replacing the `Experiment.run()` in the medium term.

**To do**

- [x] Add tests
- [x] Propagate changes where relevant in the code

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
