### PR TITLE
Performance: reduce time spent on I/O and interpolation for scenes with particle layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@ when necessary—we also advise to not ignore `DeprecationWarning`s.
   evaluation; instead, its dataset field now holds an xarray dataset (instead 
   of a path), which does not change over the instance lifetime. 
   This reduces the amount of time spent on I/O ({ghpr}`212`).
+* Optionally, export extra fields useful for analysis and debugging upon calling
+  `AbstractHeterogeneousAtmosphere.eval_radprops()` ({ghpr}`206`, {ghpr}`212`).  
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,10 @@ when necessary—we also advise to not ignore `DeprecationWarning`s.
 
 % ### New features
 
-% ### Breaking changes
+### Breaking changes
+
+* Change the default value for the `ParticleLayer.dataset` field to:
+  `spectra/particles/govaerts_2021-continental.nc` ({ghpr}`212`).
 
 ### Deprecations and removals
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,10 +53,17 @@ when necessary—we also advise to not ignore `DeprecationWarning`s.
 * Add an optional `DATA_STORES` argument to the `eradiate data info` 
   command-line utility which may be used to select the data stores for which 
   information is requested ({ghpr}`208`).
+* Add a new `load_dataset()` converter. It allows to set fields expecting an x
+  array dataset using a path to a file or a data store resource ({ghpr}`212`).
+* The `ParticleLayer` class no longer opens a dataset upon collision coefficient 
+  evaluation; instead, its dataset field now holds an xarray dataset (instead 
+  of a path), which does not change over the instance lifetime. 
+  This reduces the amount of time spent on I/O ({ghpr}`212`).
 
 ### Documentation
 
 * Add tutorials on homogeneous and molecular atmospheres ({ghpr}`194`).
+
 ### Internal changes
 
 * The `progress` configuration variable is now an `IntEnum`, allowing for

--- a/src/eradiate/converters.py
+++ b/src/eradiate/converters.py
@@ -1,8 +1,17 @@
+import os
 import typing as t
 
 import pint
+import xarray as xr
 
+from . import data
 from .attrs import AUTO
+
+__all__ = [
+    "auto_or",
+    "load_dataset",
+    "on_quantity",
+]
 
 
 def on_quantity(
@@ -54,3 +63,31 @@ def auto_or(
         return wrapped_converter(value)
 
     return f
+
+
+def load_dataset(value: t.Any) -> t.Any:
+    """
+    Try to load an xarray dataset from the passed value:
+
+    * if `value` is a string or path-like object, it attempts to load
+      a dataset from that location;
+    * if the previous step fails, it tries to serve it from the data store;
+    * if `value` is an xarray dataset, it is returned directly;
+    * otherwise, a :class:`ValueError` is raised.
+    """
+    if isinstance(value, (str, os.PathLike, bytes)):
+        # Try to open a file if it is directly referenced
+        if os.path.isfile(value):
+            return xr.load_dataset(value)
+
+        # Try to serve the file from the data store
+        return data.load_dataset(value)
+
+    elif isinstance(value, xr.Dataset):
+        return value
+
+    else:
+        raise ValueError(
+            "Reference must be provided as a Dataset or a file path. "
+            f"Got {type(value).__name__}"
+        )

--- a/src/eradiate/scenes/atmosphere/_core.py
+++ b/src/eradiate/scenes/atmosphere/_core.py
@@ -520,7 +520,9 @@ class AbstractHeterogeneousAtmosphere(Atmosphere, ABC):
     # --------------------------------------------------------------------------
 
     @abstractmethod
-    def eval_radprops(self, spectral_ctx: SpectralContext) -> xr.Dataset:
+    def eval_radprops(
+        self, spectral_ctx: SpectralContext, optional_fields: bool = False
+    ) -> xr.Dataset:
         """
         Return a dataset that holds the radiative properties profile of this
         atmospheric model.
@@ -531,6 +533,10 @@ class AbstractHeterogeneousAtmosphere(Atmosphere, ABC):
             A spectral context data structure containing relevant spectral
             parameters (*e.g.* wavelength in monochromatic mode, bin and
             quadrature point index in CKD mode).
+
+        optional_fields : bool, optional, default: False
+            If ``True``, export optional fields, not required for scene
+            construction but useful for analysis and debugging.
 
         Returns
         -------

--- a/src/eradiate/scenes/atmosphere/_molecular_atmosphere.py
+++ b/src/eradiate/scenes/atmosphere/_molecular_atmosphere.py
@@ -170,7 +170,11 @@ class MolecularAtmosphere(AbstractHeterogeneousAtmosphere):
         else:
             raise NotImplementedError("Unsupported thermophysical properties data set.")
 
-    def eval_radprops(self, spectral_ctx: SpectralContext) -> xr.Dataset:
+    def eval_radprops(
+        self, spectral_ctx: SpectralContext, optional_fields: bool = False
+    ) -> xr.Dataset:
+        # Inherit docstrings
+        # All fields are already exported: `optional_fields` has no effect
         return self.radprops_profile.eval_dataset(spectral_ctx=spectral_ctx)
 
     # --------------------------------------------------------------------------

--- a/src/eradiate/scenes/atmosphere/_particle_layer.py
+++ b/src/eradiate/scenes/atmosphere/_particle_layer.py
@@ -155,7 +155,7 @@ class ParticleLayer(AbstractHeterogeneousAtmosphere):
 
     dataset: xr.Dataset = documented(
         attr.ib(
-            default="tests/radprops/rtmom_aeronet_desert.nc",
+            default="spectra/particles/govaerts_2021-continental.nc",
             converter=converters.load_dataset,
             validator=attr.validators.instance_of(xr.Dataset),
         ),
@@ -164,7 +164,7 @@ class ParticleLayer(AbstractHeterogeneousAtmosphere):
         "this fails, it tries to load a resource from the data store.",
         type="Dataset",
         init_type="Dataset or path-like, optional",
-        default="tests/radprops/rtmom_aeronet_desert.nc",
+        default="spectra/particles/govaerts_2021-continental.nc",
     )
 
     _phase: t.Optional[TabulatedPhaseFunction] = attr.ib(default=None, init=False)

--- a/src/eradiate/test_tools/regression.py
+++ b/src/eradiate/test_tools/regression.py
@@ -9,7 +9,7 @@ import mitsuba as mi
 import numpy as np
 import xarray as xr
 
-from .. import data
+from .. import converters, data
 from ..attrs import documented, parse_docs
 from ..exceptions import DataError
 from ..typing import PathLike
@@ -78,25 +78,14 @@ def reference_converter(value):
     * if ``value`` is an xarray dataset or ``None``, it is returned directly;
     * otherwise, a ValueError is raised.
     """
-    if isinstance(value, (str, os.PathLike, bytes)):
-        # Try to open a file if it is directly referenced
-        if os.path.isfile(value):
-            return xr.load_dataset(value)
-
-        # Try to serve the file from the data store
-        try:
-            return data.load_dataset(value)
-        except DataError:
-            return None
-
-    elif isinstance(value, xr.Dataset) or value is None:
+    if value is None:
         return value
 
-    else:
-        raise ValueError(
-            "Reference must be provided as a Dataset or a file path. "
-            f"Got {type(value).__name__}"
-        )
+    try:
+        return converters.load_dataset(value)
+
+    except DataError:
+        return None
 
 
 @parse_docs

--- a/tests/02_eradiate/01_unit/scenes/atmosphere/test_heterogeneous.py
+++ b/tests/02_eradiate/01_unit/scenes/atmosphere/test_heterogeneous.py
@@ -151,7 +151,7 @@ def test_heterogeneous_mix_collision_coefficients(modes_all_double, field):
     ctx = KernelDictContext()
 
     radprofiles = {
-        component: atmosphere.eval_radprops(ctx.spectral_ctx)
+        component: atmosphere.eval_radprops(ctx.spectral_ctx, optional_fields=True)
         for component, atmosphere in [
             ("component_1", component_1),
             ("component_2", component_2),


### PR DESCRIPTION
# Description

This PR optimises the performance of scene construction when multiple components are used. Changes are as follows:

* A new `load_dataset()` converter is added. It allows to set fields expecting an xarray dataset using a path to a file or a data store resource.
* The `ParticleLayer` class no longer opens a dataset upon collision coefficient evaluation; instead, its `dataset` field now holds an xarray dataset (instead of a path), which does not change over the instance lifetime. This reduces the amount of time spent on I/O.
* The extra fields introduced by #206 are now optional. This reduces the amount of time spent on interpolation tasks.
* The `ParticleLayer.dataset` field default is changed to a more useful `spectra/particles/govaerts_2021-continental.nc`.

I used the following test case to estimate performance gains (sample count is low, therefore run time is dominated by scene construction):

```python
import numpy as np

import eradiate
import eradiate.scenes as esc

eradiate.set_mode("ckd")


def test_ertprofile():
    exp = eradiate.experiments.OneDimExperiment(
        atmosphere=esc.atmosphere.HeterogeneousAtmosphere(
            molecular_atmosphere=esc.atmosphere.MolecularAtmosphere.afgl_1986(),
            particle_layers=[esc.atmosphere.ParticleLayer()],
        ),
        illumination=esc.illumination.DirectionalIllumination(zenith=30.0),
        measures=esc.measure.MultiDistantMeasure.from_viewing_angles(
            zeniths=np.linspace(-75, 76, 2),
            azimuths=0.0,
            spp=100,
            spectral_cfg={"srf": "sentinel_2a-msi-3"},
        ),
    )
    exp.run()
```

A very quick benchmark shows noticeable improvements:

Commit | Run time
:----------:|:------------:
b6155be97ef8552a7eabb92bf2b4287a15158149 | 23 s
1e8092a15d1eb640d81ce458dd742b4f43a63a17 | 15 s
4f11eabc303fd3bb8cc4cb7b03317ed4384d4292 | 13 s

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
