### PR TITLE
Re-formatted particle radiative properties data sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,9 @@ when necessary—we also advise to not ignore `DeprecationWarning`s.
   of a path), which does not change over the instance lifetime. 
   This reduces the amount of time spent on I/O ({ghpr}`212`).
 * Optionally, export extra fields useful for analysis and debugging upon calling
-  `AbstractHeterogeneousAtmosphere.eval_radprops()` ({ghpr}`206`, {ghpr}`212`).  
+  `AbstractHeterogeneousAtmosphere.eval_radprops()` ({ghpr}`206`, {ghpr}`212`).
+* Re-formated `spectra/particles/govaerts_2021-*-extrapolated.nc` data sets
+  ({ghpr}`213`).  
 
 ### Documentation
 


### PR DESCRIPTION
# Description

Resolves eradiate/eradiate-issues#159

Two particle radiative properties data sets were badly formatted (data variables had wrong names), namely `spectra/particles/govaerts_2021-continental-extrapolated.nc` and `spectra/particles/govaerts_2021-desert-extrapolated.nc`.
I've re-formated these data sets

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
- [x] I merged `159-fix` on `eradiate-data`