### PR TITLE
MeasureSpectralConfig: use Sentinel-2A/B2 SRF by default in CKD mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ when necessary—we also advise to not ignore `DeprecationWarning`s.
 
 * Change the default value for the `ParticleLayer.dataset` field to:
   `spectra/particles/govaerts_2021-continental.nc` ({ghpr}`212`).
+* Change the default value for the `SpectralMeasureConfig.srf` field to
+  `"sentinel_2a-msi-2"`, in CKD mode ({ghpr}`214`).
 
 ### Deprecations and removals
 

--- a/src/eradiate/scenes/measure/_core.py
+++ b/src/eradiate/scenes/measure/_core.py
@@ -33,6 +33,16 @@ measure_factory = Factory()
 # ------------------------------------------------------------------------------
 
 
+def _measure_spectral_config_srf_factory():
+    from eradiate import mode
+
+    if mode().is_mono:
+        return UniformSpectrum(value=1.0)
+
+    else:
+        return "sentinel_2a-msi-2"
+
+
 def _measure_spectral_config_srf_converter(value: t.Any) -> Spectrum:
     if isinstance(value, str):
         with data.open_dataset(f"spectra/srf/{value}.nc") as ds:
@@ -62,7 +72,7 @@ class MeasureSpectralConfig(ABC):
 
     srf: Spectrum = documented(
         attr.ib(
-            factory=lambda: UniformSpectrum(value=1.0),
+            factory=_measure_spectral_config_srf_factory,
             converter=_measure_spectral_config_srf_converter,
             validator=validators.has_quantity(PhysicalQuantity.DIMENSIONLESS),
         ),
@@ -71,7 +81,8 @@ class MeasureSpectralConfig(ABC):
         "database. Other types will be converted by :data:`.spectrum_factory`.",
         type=".Spectrum",
         init_type="str or .Spectrum or dict or float",
-        default=":class:`UniformSpectrum(value=1.0) <.UniformSpectrum>`",
+        default=":class:`UniformSpectrum(value=1.0) <.UniformSpectrum>` in mono "
+        'mode, "sentinel_2a-msi-2" otherwise',
     )
 
     # --------------------------------------------------------------------------


### PR DESCRIPTION
# Description

This PR sets band 2 of Sentinel-2A as the default SRF in CKD mode. In mono mode, the default is left unchanged.

The previous default was such that a simulation with defaults in CKD mode would cover the entire spectrum, leading to very long computational times. Since such defaults are usually relevant only for testing purposes, situations in which we prefer computational time to be short, I'm changing the default to a SRF covering a more reasonable part of the visible spectral region.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
