### PR TITLE
Improve and fix SRF defaults in CKD mode

### DIFF
--- a/src/eradiate/ckd.py
+++ b/src/eradiate/ckd.py
@@ -260,6 +260,23 @@ def bin_filter(type: str, filter_kwargs: t.Dict[str, t.Any]):
         raise ValueError(f"unknown bin filter type {type}")
 
 
+def bin_filter_converter(filter_spec):
+    if isinstance(filter_spec, str):
+        return bin_filter_ids(ids=(filter_spec,))
+
+    elif isinstance(filter_spec, t.Sequence):
+        return bin_filter(*filter_spec)
+
+    elif isinstance(filter_spec, abc.Mapping):
+        return bin_filter(**filter_spec)
+
+    elif callable(filter_spec):
+        return filter_spec
+
+    else:
+        raise ValueError(f"unhandled CKD bin selector {filter_spec}")
+
+
 # ------------------------------------------------------------------------------
 #                              Bin set definitions
 # ------------------------------------------------------------------------------
@@ -397,20 +414,7 @@ class BinSet:
         filters = []
 
         for filter_spec in filter_specs:
-            if isinstance(filter_spec, str):
-                filters.append(bin_filter_ids(ids=(filter_spec,)))
-
-            elif isinstance(filter_spec, t.Sequence):
-                filters.append(bin_filter(*filter_spec))
-
-            elif isinstance(filter_spec, abc.Mapping):
-                filters.append(bin_filter(**filter_spec))
-
-            elif callable(filter_spec):
-                filters.append(filter_spec)
-
-            else:
-                raise ValueError(f"unhandled CKD bin selector {filter_spec}")
+            filters.append(bin_filter_converter(filter_spec))
 
         return self.filter_bins(*filters)
 

--- a/tests/02_eradiate/01_unit/experiments/test_onedim.py
+++ b/tests/02_eradiate/01_unit/experiments/test_onedim.py
@@ -210,7 +210,7 @@ def test_onedim_experiment_run_basic(modes_all):
     exp = OneDimExperiment()
     exp.measures[0].spectral_cfg = spectral_cfg
 
-    exp.run()
+    eradiate.run(exp)
     assert isinstance(exp.results, dict)
 
 
@@ -240,7 +240,7 @@ def test_onedim_experiment_run_detailed(modes_all):
     )
 
     # Run RT simulation
-    exp.run()
+    eradiate.run(exp)
 
     # Check result dataset structure
     results = exp.results["toa_hsphere"]

--- a/tests/02_eradiate/01_unit/scenes/measure/test_core.py
+++ b/tests/02_eradiate/01_unit/scenes/measure/test_core.py
@@ -90,9 +90,9 @@ def test_mono_spectral_config(modes_all_mono):
     assert len(cfg.spectral_ctxs()) == 2  # The 640 nm point is filtered out
 
 
-def test_ckd_spectral_config(modes_all_ckd):
+def test_ckd_spectral_config(mode_ckd):
     """
-    Unit tests for :class:`.MeasureSpectralConfig` and child classes.
+    Unit tests for :class:`.CKDMeasureSpectralConfig`.
     """
     # The new() class method constructor selects an appropriate config class
     # depending on the active mode
@@ -100,7 +100,9 @@ def test_ckd_spectral_config(modes_all_ckd):
     assert isinstance(cfg, CKDMeasureSpectralConfig)
 
     # Generated spectral contexts are of the appropriate type and in correct numbers
+    assert False, "FIX THIS"
     ctxs = cfg.spectral_ctxs()
+    print("Hello")
     assert len(ctxs) == 32
     assert all(isinstance(ctx, CKDSpectralContext) for ctx in ctxs)
 
@@ -121,6 +123,20 @@ def test_ckd_spectral_config(modes_all_ckd):
     # Using the S2A-MSI-B4 SRF results in 4 * 16 = 64 contexts being generated
     cfg = MeasureSpectralConfig.new(bin_set="10nm", srf="sentinel_2a-msi-4")
     assert len(cfg.spectral_ctxs()) == 64
+
+
+def test_ckd_spectral_config_advanced(mode_ckd):
+    """
+    Selecting bins disjoint from the SRF leads to no bin being selected.
+    """
+    cfg = MeasureSpectralConfig.new(
+        bin_set="10nm", bins=["550"], srf="sentinel_2a-msi-6"
+    )
+
+    with pytest.warns(UserWarning):
+        bins = cfg.bins
+
+    assert len(bins) == 0
 
 
 def test_measure_flags(mode_mono):


### PR DESCRIPTION
# Description

This PR is a follow-up and fix to work started and merged hastily in #214. It provides nicer defaults for measure SRF in CKD mode.

# Checklist

- [ ] The code follows the relevant coding guidelines
- [ ] The code generates no new warnings
- [ ] The code is appropriately documented
- [ ] The code is tested to prove its function
- [ ] The feature branch is rebased on the current state of the `main` branch
- [ ] I updated the change log if relevant
- [ ] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
