### PR TITLE
ParticleLayer system test: parameterised with albedo

### DIFF
--- a/tests/02_eradiate/02_system/conftest.py
+++ b/tests/02_eradiate/02_system/conftest.py
@@ -10,55 +10,88 @@ from eradiate import unit_registry as ureg
 def onedim_rayleigh_radprops():
     """
     Radiative properties of a Rayleigh scattering medium in [280, 2400] nm.
+
+    The Rayleigh scattering phase function is computed from the analytical
+    formula and tabulated on a regular scattering angle cosine grid.
+    The Rayleigh scattering phase function does not depend on wavelength.
+
+    The Rayleigh scattering coefficient is computed with
+    :meth:`~eradiate.radprops.rayleigh.compute_sigma_s_air` with default
+    the number density, i.e., standard air number density.
+
+    The single-scattering albedo can be set but it is assumed to be spectrally
+    invariant.
+
+    This fixture returns a callable that takes the single-scattering albedo as
+    argument and returns the corresponding Rayleigh radiative properties data
+    set.
     """
-    w = np.linspace(279.0, 2401.0, 10000) * ureg.nm
 
-    # Collision coefficients
-    sigma_s = eradiate.radprops.rayleigh.compute_sigma_s_air(wavelength=w)
-    albedo = np.ones_like(sigma_s) * ureg.dimensionless  # no absorption
-    sigma_t = sigma_s * albedo
+    def radprops(albedo: float = 1.0) -> xr.DataArray:
+        w = np.linspace(279.0, 2401.0, 10000) * ureg.nm
 
-    # Phase function
-    # Note: rayleigh phase function does not change with wavelength
-    def rayleigh_phase_function(mu):
-        magnitude = 3.0 * (1 + np.square(mu)) / (16 * np.pi)
-        return magnitude / ureg.steradian
+        # Collision coefficients
+        sigma_s = eradiate.radprops.rayleigh.compute_sigma_s_air(wavelength=w)
+        albedo = albedo * np.ones_like(sigma_s) * ureg.dimensionless
+        sigma_t = (
+            np.divide(
+                sigma_s.m,
+                albedo.m,
+                where=albedo.m != 0,
+                out=sigma_s.m,
+            )
+            * sigma_s.units
+        )
 
-    mu = np.linspace(-1.0, 1.0)
-    arrays = [rayleigh_phase_function(mu) for _ in w]
-    phase = np.stack(arrays, axis=0).reshape(w.size, mu.size, 1, 1)
+        # Phase function
+        # Note: rayleigh phase function does not change with wavelength
+        def rayleigh_phase_function(mu):
+            magnitude = 3.0 * (1 + np.square(mu)) / (16 * np.pi)
+            return magnitude / ureg.steradian
 
-    return xr.Dataset(
-        data_vars={
-            "sigma_t": (
-                "w",
-                sigma_t.magnitude,
-                dict(
-                    standard_name="air_volume_extinction_coefficient",
-                    units=f"{sigma_t.units:~}",
+        mu = np.linspace(-1.0, 1.0)
+        arrays = [rayleigh_phase_function(mu) for _ in w]
+        phase = np.stack(arrays, axis=0).reshape(w.size, mu.size, 1, 1)
+
+        return xr.Dataset(
+            data_vars={
+                "sigma_t": (
+                    "w",
+                    sigma_t.magnitude,
+                    dict(
+                        standard_name="air_volume_extinction_coefficient",
+                        units=f"{sigma_t.units:~}",
+                    ),
                 ),
-            ),
-            "albedo": (
-                "w",
-                albedo.magnitude,
-                dict(
-                    standard_name="single_scattering_albedo", units=f"{albedo.units:~}"
+                "albedo": (
+                    "w",
+                    albedo.magnitude,
+                    dict(
+                        standard_name="single_scattering_albedo",
+                        units=f"{albedo.units:~}",
+                    ),
                 ),
-            ),
-            "phase": (
-                ("w", "mu", "i", "j"),
-                phase.magnitude,
-                dict(standard_name="scattering_phase_matrix", units=f"{phase.units:~}"),
-            ),
-        },
-        coords={
-            "w": ("w", w.magnitude, dict(units=f"{w.units:~}")),
-            "mu": (
-                "mu",
-                mu,
-                dict(standard_name="scattering_angle_cosine", units="dimensionless"),
-            ),
-            "i": ("i", [0]),
-            "j": ("j", [0]),
-        },
-    )
+                "phase": (
+                    ("w", "mu", "i", "j"),
+                    phase.magnitude,
+                    dict(
+                        standard_name="scattering_phase_matrix",
+                        units=f"{phase.units:~}",
+                    ),
+                ),
+            },
+            coords={
+                "w": ("w", w.magnitude, dict(units=f"{w.units:~}")),
+                "mu": (
+                    "mu",
+                    mu,
+                    dict(
+                        standard_name="scattering_angle_cosine", units="dimensionless"
+                    ),
+                ),
+                "i": ("i", [0]),
+                "j": ("j", [0]),
+            },
+        )
+
+    return radprops

--- a/tests/02_eradiate/02_system/test_onedim_phase.py
+++ b/tests/02_eradiate/02_system/test_onedim_phase.py
@@ -121,14 +121,13 @@ def test(mode_mono_double, onedim_rayleigh_radprops, w, artefact_dir, ert_seed_s
     sigma_s_1 = eradiate.scenes.spectra.AirScatteringCoefficientSpectrum()
     phase_1 = eradiate.scenes.phase.RayleighPhaseFunction()
 
-    w_units = onedim_rayleigh_radprops.w.attrs["units"]
-    sigma_t = to_quantity(onedim_rayleigh_radprops.sigma_t.interp(w=w.m_as(w_units)))
-    albedo = to_quantity(onedim_rayleigh_radprops.albedo.interp(w=w.m_as(w_units)))
+    radprops = onedim_rayleigh_radprops(albedo=1.0)
+    w_units = radprops.w.attrs["units"]
+    sigma_t = to_quantity(radprops.sigma_t.interp(w=w.m_as(w_units)))
+    albedo = to_quantity(radprops.albedo.interp(w=w.m_as(w_units)))
     sigma_s_2 = sigma_t * albedo
     sigma_a_2 = sigma_t * (1.0 - albedo)
-    phase_2 = eradiate.scenes.phase.TabulatedPhaseFunction(
-        data=onedim_rayleigh_radprops.phase
-    )
+    phase_2 = eradiate.scenes.phase.TabulatedPhaseFunction(data=radprops.phase)
 
     experiment_1 = init_experiment(
         bottom=bottom,


### PR DESCRIPTION
# Description

I parametrised the system test `test_onedim_particle_layer.test()` with albedo values (0.2, 0.5, 0.8).
The test was already parametrised with wavelength (monochromatic mode).
For that purpose, I have modified `tests/02_eradiate/02_system/conftest.onedim_radprops()` and better documented it.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [ ] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
