### PR TITLE
`ParticleLayer`: more flexible optical thickness parameterisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@ when necessary—we also advise to not ignore `DeprecationWarning`s.
 
 * Change the default value for the `ParticleLayer.dataset` field to:
   `spectra/particles/govaerts_2021-continental.nc` ({ghpr}`212`).
+* Change the interface of `ParticleLayer`; `tau_550` is replaced by `tau_ref`
+  which sets the extinction optical thickness of the particle layer at the 
+  wavelength set by the newly added `w_ref` attribute whose default value is
+  550 nanometer ({ghpr}`221`).
 
 ### Deprecations and removals
 

--- a/tests/02_eradiate/01_unit/scenes/atmosphere/test_heterogeneous.py
+++ b/tests/02_eradiate/01_unit/scenes/atmosphere/test_heterogeneous.py
@@ -264,13 +264,13 @@ def test_heterogeneous_mix_weight(modes_all_double):
             ParticleLayer(
                 bottom=0.0 * ureg.km,
                 top=100.0 * ureg.km,
-                tau_550=1.0,
+                tau_ref=1.0,
                 distribution={"type": "uniform"},
             ),
             ParticleLayer(
                 bottom=50.0 * ureg.km,
                 top=100.0 * ureg.km,
-                tau_550=0.5,
+                tau_ref=0.5,
                 distribution={"type": "uniform"},
             ),
         ],

--- a/tests/02_eradiate/02_system/test_onedim_atmosphere.py
+++ b/tests/02_eradiate/02_system/test_onedim_atmosphere.py
@@ -6,9 +6,9 @@ from eradiate import unit_registry as ureg
 
 
 @pytest.mark.parametrize("bottom", [0.0, 1.0, 10.0])
-@pytest.mark.parametrize("tau_550", [0.1, 1.0, 10.0])
+@pytest.mark.parametrize("tau_ref", [0.1, 1.0, 10.0])
 def test_heterogeneous_atmosphere_contains_particle_layer(
-    mode_ckd_double, bottom, tau_550, ert_seed_state
+    mode_ckd_double, bottom, tau_ref, ert_seed_state
 ):
     """
     Perfect single-component HeterogeneousAtmosphere expansion (particle layer)
@@ -48,7 +48,7 @@ def test_heterogeneous_atmosphere_contains_particle_layer(
     bottom = bottom * ureg.km
     top = bottom + 1.0 * ureg.km
     layer = eradiate.scenes.atmosphere.ParticleLayer(
-        bottom=bottom, top=top, tau_550=tau_550
+        bottom=bottom, top=top, tau_ref=tau_ref
     )
     exp1 = eradiate.experiments.OneDimExperiment(
         atmosphere=layer,

--- a/tests/02_eradiate/02_system/test_onedim_particle_layer.py
+++ b/tests/02_eradiate/02_system/test_onedim_particle_layer.py
@@ -223,7 +223,9 @@ def test_homogeneous_vs_particle_layer(
        :width: 95%
     """
 
-    def init_experiment_particle_layer(bottom, top, dataset_path, tau_550, r, w, spp):
+    def init_experiment_particle_layer(
+        bottom, top, dataset_path, w_ref, tau_ref, r, w, spp
+    ):
         return eradiate.experiments.OneDimExperiment(
             measures=[
                 eradiate.scenes.measure.MultiDistantMeasure.from_viewing_angles(
@@ -249,7 +251,8 @@ def test_homogeneous_vs_particle_layer(
                         bottom=bottom,
                         top=top,
                         dataset=dataset_path,
-                        tau_550=tau_550,
+                        w_ref=w_ref,
+                        tau_ref=tau_ref,
                     )
                 ],
             ),
@@ -300,13 +303,14 @@ def test_homogeneous_vs_particle_layer(
     sigma_s = sigma_t * albedo
     sigma_a = sigma_t - sigma_s
     phase = eradiate.scenes.phase.TabulatedPhaseFunction(data=radprops.phase)
-    sigma_t_550 = to_quantity(
+    w_ref = 550 * ureg.nm
+    sigma_t_ref = to_quantity(
         radprops.sigma_t.interp(
-            w=(550 * ureg.nm).m_as(w_units),
+            w=w_ref.m_as(w_units),
         )
     )
     height = top - bottom
-    tau_550 = sigma_t_550 * height  # the layer is uniform
+    tau_ref = sigma_t_ref * height  # the layer is uniform
     dataset_path = tmpdir / "radprops.nc"
     radprops.to_netcdf(dataset_path)
 
@@ -314,7 +318,8 @@ def test_homogeneous_vs_particle_layer(
         bottom=bottom,
         top=top,
         dataset_path=dataset_path,
-        tau_550=tau_550,
+        w_ref=w_ref,
+        tau_ref=tau_ref,
         r=reflectance,
         w=w,
         spp=spp,
@@ -396,13 +401,14 @@ def test_particle_layer_energy_conservation(
     radprops = onedim_rayleigh_radprops(albedo=1.0)
 
     w_units = radprops.w.attrs["units"]
-    sigma_t_550 = to_quantity(
+    w_ref = 550 * ureg.nm
+    sigma_t_ref = to_quantity(
         radprops.sigma_t.interp(
-            w=(550 * ureg.nm).m_as(w_units),
+            w=w_ref.m_as(w_units),
         )
     )
     height = top - bottom
-    tau_550 = sigma_t_550 * height  # the layer is uniform
+    tau_ref = sigma_t_ref * height  # the layer is uniform
     dataset_path = tmpdir / "radprops.nc"
     radprops.to_netcdf(dataset_path)
 
@@ -434,7 +440,8 @@ def test_particle_layer_energy_conservation(
                     bottom=bottom,
                     top=top,
                     dataset=dataset_path,
-                    tau_550=tau_550,
+                    w_ref=w_ref,
+                    tau_ref=tau_ref,
                 )
             ],
         ),
@@ -579,7 +586,8 @@ def test_one_layer_molecular_atmosphere_vs_particle_layer(
         return ParticleLayer(
             bottom=mol_atm.bottom,
             top=mol_atm.top,
-            tau_550=mol_atm_tau,
+            w_ref=550.0 * ureg.nm,
+            tau_ref=mol_atm_tau,
             dataset=particle_radprops,
             n_layers=1,
         )

--- a/tests/02_eradiate/03_regression/atmospheres/test_rpv_afgl1986_continental.py
+++ b/tests/02_eradiate/03_regression/atmospheres/test_rpv_afgl1986_continental.py
@@ -49,7 +49,7 @@ def test_rpv_afgl1986_continental_brfpp(
         bottom=1 * ureg.km,
         top=2 * ureg.km,
         n_layers=16,
-        tau_550=0.5,
+        tau_ref=0.5,
         dataset=data_store.fetch("spectra/particles/govaerts_2021-continental.nc"),
     )
 

--- a/tests/02_eradiate/03_regression/rami4atm/test_rami4atm_hom00_bla_sd2s_m03_z30a000_brfpp.py
+++ b/tests/02_eradiate/03_regression/rami4atm/test_rami4atm_hom00_bla_sd2s_m03_z30a000_brfpp.py
@@ -64,7 +64,7 @@ def test_rami4atm_hom00_bla_sd2s_m03_z30a000_brfpp(
                     "top": 2000,
                     "top_units": "meter",
                     "distribution": {"type": "uniform"},
-                    "tau_550": 0.2,
+                    "tau_ref": 0.2,
                     "n_layers": 16,
                     "dataset": "spectra/particles/govaerts_2021-desert.nc",
                 }


### PR DESCRIPTION
# Description

Resolves eradiate/eradiate-issues#161

:warning: These changes are **breaking**. The following code for instance does not work anymore:

```python
from eradiate.scenes.atmosphere import ParticleLayer

ParticleLayer(tau_550=1.0) 
```

The same particle layer scene element is now obtained with:

```python
from eradiate import unit_registry as ureg

ParticleLayer(
    w_ref=550.0 * ureg.nm,
    tau_ref=1.0,
)
```

or simply:

```python
ParticleLayer(tau_ref=1.0)
```

since the default value for `w_ref` is 550 nanometers.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
