### PR TITLE
`TabulatedPhase`: better eval method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,11 @@ when necessary—we also advise to not ignore `DeprecationWarning`s.
   from 201 to 20001 ({ghcommit}`2eb3408f1e249da353600e315af7ce09ca2f893f`).
 * Replaced leftover calls to deprecated `eradiate.data.open` with 
   `eradiate.data.open_dataset` ({ghpr}`220`).
+* Improved interpolation of phase function along `mu` dimension in 
+  `TabulatedPhaseFunction`; if input `xarray.DataArray` object `mu` coordinate
+  is not regularly spaced, it is interpolated on a regular `mu` grid based on
+  the smallest `mu` step found in the input phase function data. Otherwise, the
+  input `xarray.DataArray` object is not interpolated ({ghpr}`226`).
 
 ### Documentation
 

--- a/docs/rst/reference_api/scenes.rst
+++ b/docs/rst/reference_api/scenes.rst
@@ -306,6 +306,7 @@
    RayleighPhaseFunction
    HenyeyGreensteinPhaseFunction
    BlendPhaseFunction
+   TabulatedPhaseFunction
 
 ``eradiate.scenes.integrators``
 -------------------------------

--- a/tests/02_eradiate/01_unit/scenes/phase/test_tabulated.py
+++ b/tests/02_eradiate/01_unit/scenes/phase/test_tabulated.py
@@ -2,23 +2,29 @@ import numpy as np
 import pytest
 import xarray as xr
 
+from eradiate import data
 from eradiate import path_resolver
 from eradiate.contexts import KernelDictContext, SpectralContext
 from eradiate.scenes.phase._tabulated import TabulatedPhaseFunction
 
 
 @pytest.fixture
-def dataset():
-    result = xr.open_dataset(
-        path_resolver.resolve("tests/radprops/rtmom_aeronet_desert.nc")
-    ).load()
-    result.close()
-    return result
+def regular_mu() -> xr.DataArray:
+    """Phase function data with a regular mu grid."""
+    result = data.load_dataset("tests/spectra/particles/random-regular_mu.nc")
+    return result.phase
 
 
-def test_tabulated_basic(modes_all, dataset):
+@pytest.fixture
+def irregular_mu() -> xr.DataArray:
+    """Phase function data with an irregular mu grid."""
+    result = data.load_dataset("tests/spectra/particles/random-irregular_mu.nc")
+    return result.phase
+
+
+def test_tabulated_basic(modes_all, regular_mu):
     # The phase function can be constructed
-    phase = TabulatedPhaseFunction(data=dataset.phase)
+    phase = TabulatedPhaseFunction(data=regular_mu)
 
     # Its kernel dict can be generated
     ctx = KernelDictContext()
@@ -63,3 +69,26 @@ def test_tabulated_order(mode_mono, tmpdir):
     phase_mu_decreasing = layer_mu_decreasing.eval(spectral_ctx)
 
     assert np.all(phase_mu_increasing == phase_mu_decreasing)
+
+
+def test_tabulated_eval_regular_mu(modes_all, regular_mu):
+    """
+    Phase function data with regular mu grid is not interpolated along mu.
+    """
+    tabphase = TabulatedPhaseFunction(data=regular_mu)
+    spectral_ctx = SpectralContext.new()
+    phase = tabphase.eval(spectral_ctx)
+    assert phase.size == regular_mu.mu.size
+
+
+def test_tabulated_eval_irregular_mu(modes_all, irregular_mu):
+    """
+    Phase function data with irregular mu grid is interpolated on a regular
+    grid that has enough points to sample the input data.
+    """
+    tabphase = TabulatedPhaseFunction(data=irregular_mu)
+    spectral_ctx = SpectralContext.new()
+    phase = tabphase.eval(spectral_ctx)
+    dmu = irregular_mu.mu.diff(dim="mu").values.min()
+    nmu = int(np.ceil(2.0 / dmu)) + 1
+    assert phase.size == nmu


### PR DESCRIPTION
# Description

Resolves eradiate/eradiate-issues#165

I improved how `TabulatedPhase.eval` maps the input phase function data to a regular grid of scattering angle cosine (`mu`) when the input data does not already map to a regular `mu` grid.

## Changes

I removed the hidden `_n_mu` class attribute and updated `eval_mono` in the following way:
* if the input phase function `data` maps to a `mu` regular grid, interpolate in wavelength and return the values
* else, compute regular `mu` grid based on the smallest `mu` step found in the input phase function data, and interpolate in wavelength (using `xarray.DataArray.interp`) and on that regular `mu` grid (using `numpy.interp` for performance) and return the values. For further details, refer to a discussion about the choice of this regular `mu` grid in the comments down below.

I added 2 unit tests for this new implementation (hence the data submodule update). 

If the user wants to control the number of points used along the `mu` axis to discretize a tabulated phase function, they would simply have to provide phase function data mapping directly to a regular `mu` grid, since in that case the input `DataArray` is left unchanged.

I added a converter for the `data` attribute, that ensures the `mu` coordinate is monotonically increasing.

I added a validator for the `data` attribute to check that the `mu` coordinate in the input data set goes from `-1.0` to `1.0`.

I added `TabulatedPhaseFunction` to the API Reference.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
