### PR TITLE
Tests: Use eradiate.run()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,10 @@ when necessary—we also advise to not ignore `DeprecationWarning`s.
 
 % ### Breaking changes
 
-% ### Deprecations and removals
+### Deprecations and removals
+
+* Updated all tests to use `eradiate.run()` instead of the deprecated 
+  `Experiment.run()` method ({ghpr}`227`).
 
 % ### Improvements and fixes
 

--- a/tests/02_eradiate/01_unit/experiments/test_onedim.py
+++ b/tests/02_eradiate/01_unit/experiments/test_onedim.py
@@ -210,7 +210,7 @@ def test_onedim_experiment_run_basic(modes_all):
     exp = OneDimExperiment()
     exp.measures[0].spectral_cfg = spectral_cfg
 
-    exp.run()
+    eradiate.run(exp)
     assert isinstance(exp.results, dict)
 
 
@@ -240,11 +240,9 @@ def test_onedim_experiment_run_detailed(modes_all):
     )
 
     # Run RT simulation
-    exp.run()
+    results = eradiate.run(exp)
 
     # Check result dataset structure
-    results = exp.results["toa_hsphere"]
-
     # Post-processing creates expected variables ...
     expected = {"irradiance", "brf", "brdf", "radiance", "spp", "srf"}
     if eradiate.mode().is_ckd:

--- a/tests/02_eradiate/01_unit/experiments/test_rami.py
+++ b/tests/02_eradiate/01_unit/experiments/test_rami.py
@@ -188,9 +188,7 @@ def test_rami_experiment_run_detailed(modes_all_double):
         ]
     )
 
-    exp.run()
-
-    results = exp.results["toa_hsphere"]
+    results = eradiate.run(exp)
 
     # Post-processing creates expected variables ...
     assert set(results.data_vars) == expected_vars

--- a/tests/02_eradiate/01_unit/experiments/test_rami4atm.py
+++ b/tests/02_eradiate/01_unit/experiments/test_rami4atm.py
@@ -234,10 +234,7 @@ def test_rami4atm_experiment_run_detailed(mode_mono):
             },
         ]
     )
-
-    exp.run()
-
-    results = exp.results["toa_brf"]
+    results = eradiate.run(exp)
 
     # Post-processing creates expected variables ...
     assert set(results.data_vars) == {

--- a/tests/02_eradiate/02_system/test_albedo.py
+++ b/tests/02_eradiate/02_system/test_albedo.py
@@ -148,8 +148,7 @@ def test_albedo(mode_mono, artefact_dir):
 
     for exp_name, exp in exps.items():
         # Run simulation
-        exp.run()
-        results = exp.results["measure"]
+        results = eradiate.run(exp)
 
         # Plot results
         fig, [ax1, ax2] = plt.subplots(1, 2, figsize=(10, 5))

--- a/tests/02_eradiate/02_system/test_ckd_basic.py
+++ b/tests/02_eradiate/02_system/test_ckd_basic.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 
+import eradiate
 from eradiate import unit_registry as ureg
 from eradiate.experiments import OneDimExperiment
 from eradiate.scenes.bsdfs import LambertianBSDF
@@ -56,7 +57,7 @@ def test_ckd_basic(modes_all_ckd):
             )
         ],
     )
-    exp.run()
+    results = eradiate.run(exp)
 
     # Reflectance is uniform, equal to 1
-    assert np.allclose(exp.results["measure"].data_vars["brf"], 1.0)
+    assert np.allclose(results.data_vars["brf"], 1.0)

--- a/tests/02_eradiate/02_system/test_compare_rami4atm.py
+++ b/tests/02_eradiate/02_system/test_compare_rami4atm.py
@@ -4,6 +4,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 
+import eradiate
 import eradiate.experiments as ertxp
 import eradiate.scenes as ertsc
 from eradiate.units import symbol
@@ -107,10 +108,10 @@ def test_compare_rami4atm_onedim(
     )
 
     ert_seed_state.reset()
-    onedim.run(seed_state=ert_seed_state)
+    eradiate.run(onedim, seed_state=ert_seed_state)
 
     ert_seed_state.reset()
-    r4a.run(seed_state=ert_seed_state)
+    eradiate.run(r4a, seed_state=ert_seed_state)
 
     fig = plt.figure(figsize=(6, 3))
     ax = plt.gca()
@@ -239,10 +240,10 @@ def test_compare_rami4atm_rami(
     )
 
     ert_seed_state.reset()
-    rami.run(seed_state=ert_seed_state)
+    eradiate.run(rami, seed_state=ert_seed_state)
 
     ert_seed_state.reset()
-    r4a.run(seed_state=ert_seed_state)
+    eradiate.run(r4a, seed_state=ert_seed_state)
 
     fig = plt.figure(figsize=(6, 3))
     ax = plt.gca()

--- a/tests/02_eradiate/02_system/test_onedim_atmosphere.py
+++ b/tests/02_eradiate/02_system/test_onedim_atmosphere.py
@@ -5,6 +5,7 @@ import eradiate
 from eradiate import unit_registry as ureg
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize("bottom", [0.0, 1.0, 10.0])
 @pytest.mark.parametrize("tau_ref", [0.1, 1.0, 10.0])
 def test_heterogeneous_atmosphere_contains_particle_layer(
@@ -55,7 +56,7 @@ def test_heterogeneous_atmosphere_contains_particle_layer(
         measures=[measure],
     )
     ert_seed_state.reset()
-    exp1.run(seed_state=ert_seed_state)
+    eradiate.run(exp1, seed_state=ert_seed_state)
     results1 = exp1.results["measure"]["radiance"].values
 
     # heterogeneous atmosphere with a particle layer
@@ -64,12 +65,13 @@ def test_heterogeneous_atmosphere_contains_particle_layer(
         measures=[measure],
     )
     ert_seed_state.reset()
-    exp2.run(seed_state=ert_seed_state)
+    eradiate.run(exp2, seed_state=ert_seed_state)
     results2 = exp2.results["measure"]["radiance"].values
 
     assert np.all(results1 == results2)
 
 
+@pytest.mark.slow
 def test_heterogeneous_atmosphere_contains_molecular_atmosphere(
     mode_ckd_double, ert_seed_state
 ):
@@ -113,7 +115,7 @@ def test_heterogeneous_atmosphere_contains_molecular_atmosphere(
         measures=[measure],
     )
     ert_seed_state.reset()
-    exp1.run(seed_state=ert_seed_state)
+    eradiate.run(exp1, seed_state=ert_seed_state)
     results1 = exp1.results["measure"]["radiance"].values
 
     # heterogeneous atmopshere with a non-absorbing molecular atmosphere
@@ -125,7 +127,7 @@ def test_heterogeneous_atmosphere_contains_molecular_atmosphere(
         measures=[measure],
     )
     ert_seed_state.reset()
-    exp2.run(seed_state=ert_seed_state)
+    eradiate.run(exp2, seed_state=ert_seed_state)
     results2 = exp2.results["measure"]["radiance"].values
 
     assert np.all(results1 == results2)

--- a/tests/02_eradiate/02_system/test_onedim_ckd_vs_mono.py
+++ b/tests/02_eradiate/02_system/test_onedim_ckd_vs_mono.py
@@ -221,9 +221,7 @@ def test_550(reflectance, artefact_dir):
         reflectance=reflectance,
         zeniths=zeniths,
     )
-    with uck.override(length="km"):  # this is a temporary workaround the 'batman' issue
-        mono_exp.run()
-    mono_results = mono_exp.results["measure"]
+    mono_results = eradiate.run(mono_exp)
 
     wavelength_bin_width = (wavelengths.max() - wavelengths.min()).m_as(
         mono_results.w.attrs["units"]
@@ -238,8 +236,7 @@ def test_550(reflectance, artefact_dir):
         reflectance=reflectance,
         zeniths=zeniths,
     )
-    ckd_exp.run()
-    ckd_results = ckd_exp.results["measure"]
+    ckd_results = eradiate.run(ckd_exp)
 
     # Make figure
     make_figure(
@@ -370,9 +367,7 @@ def test_1050(reflectance, artefact_dir):
         reflectance=reflectance,
         zeniths=zeniths,
     )
-    with uck.override(length="km"):  # this is a temporary workaround the 'batman' issue
-        mono_exp.run()
-    mono_results = mono_exp.results["measure"]
+    mono_results = eradiate.run(mono_exp)
 
     wavelength_bin_width = (wavelengths.max() - wavelengths.min()).m_as(
         mono_results.w.attrs["units"]
@@ -387,8 +382,7 @@ def test_1050(reflectance, artefact_dir):
         reflectance=reflectance,
         zeniths=zeniths,
     )
-    ckd_exp.run()
-    ckd_results = ckd_exp.results["measure"]
+    ckd_results = eradiate.run(ckd_exp)
 
     # Make figure
     make_figure(

--- a/tests/02_eradiate/02_system/test_onedim_lambertian_brf.py
+++ b/tests/02_eradiate/02_system/test_onedim_lambertian_brf.py
@@ -76,7 +76,7 @@ def test_onedim_lambertian_brf(mode_mono_double, artefact_dir):
                 },
                 atmosphere=None,
             )
-            exp.run()
+            eradiate.run(exp)
 
             results[illumination_zenith][reflectance] = exp.results["toa_pplane"]
 

--- a/tests/02_eradiate/02_system/test_onedim_phase.py
+++ b/tests/02_eradiate/02_system/test_onedim_phase.py
@@ -152,10 +152,10 @@ def test(mode_mono_double, onedim_rayleigh_radprops, w, artefact_dir, ert_seed_s
     )
 
     ert_seed_state.reset()
-    experiment_1.run(seed_state=ert_seed_state)
+    eradiate.run(experiment_1, seed_state=ert_seed_state)
 
     ert_seed_state.reset()
-    experiment_2.run(seed_state=ert_seed_state)
+    eradiate.run(experiment_2, seed_state=ert_seed_state)
 
     brf_1 = experiment_1.results["measure"]["brf"]
     brf_2 = experiment_2.results["measure"]["brf"]

--- a/tests/02_eradiate/02_system/test_onedim_rpv.py
+++ b/tests/02_eradiate/02_system/test_onedim_rpv.py
@@ -139,11 +139,8 @@ def test_film_to_angular_coord_conversion_multi_distant(
         illumination_azimuth=illumination_azimuth,
     )
 
-    experiment1.run()
-    experiment2.run()
-
-    results1 = experiment1.results["measure"]
-    results2 = experiment2.results["measure"]
+    results1 = eradiate.run(experiment1)
+    results2 = eradiate.run(experiment2)
 
     def select_forward_brf(brf, illumination_azimuth, measure_azimuth):
         relative_azimuth = map_to_0_360(measure_azimuth - illumination_azimuth)
@@ -577,11 +574,8 @@ def test_film_to_angular_coord_conversion_distant_flux(
         illumination_azimuth=illumination_azimuth,
     )
 
-    experiment1.run()
-    experiment2.run()
-
-    results1 = experiment1.results["measure"]
-    results2 = experiment2.results["measure"]
+    results1 = eradiate.run(experiment1)
+    results2 = eradiate.run(experiment2)
 
     make_figure(
         results=results1,
@@ -747,11 +741,8 @@ def test_film_to_angular_coord_conversion_hemispherical_distant(
         illumination_azimuth=illumination_azimuth,
     )
 
-    experiment1.run()
-    experiment2.run()
-
-    results1 = experiment1.results["measure"]
-    results2 = experiment2.results["measure"]
+    results1 = eradiate.run(experiment1)
+    results2 = eradiate.run(experiment2)
 
     make_figure(
         results=results1,

--- a/tests/02_eradiate/02_system/test_onedim_symmetry.py
+++ b/tests/02_eradiate/02_system/test_onedim_symmetry.py
@@ -91,10 +91,9 @@ def test_symmetry_zenith(mode_mono_double, surface, atmosphere, artefact_dir):
             },
         }[atmosphere],
     )
-    exp.run()
+    results = eradiate.run(exp)
 
     # Post-process results
-    results = exp.results["toa_pplane"]
     radiance = results["radiance"].squeeze().values
     results["diff"] = (
         results["radiance"].dims,

--- a/tests/02_eradiate/02_system/test_spectral_loop.py
+++ b/tests/02_eradiate/02_system/test_spectral_loop.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 
+import eradiate
 from eradiate.experiments import OneDimExperiment, RamiExperiment
 from eradiate.scenes.bsdfs import LambertianBSDF
 from eradiate.scenes.illumination import DirectionalIllumination
@@ -71,5 +72,5 @@ def test_spectral_loop(mode_mono, cls, wavelengths, irradiance):
         **kwargs,
     )
 
-    exp.run()
-    assert np.allclose(np.squeeze(exp.results["measure"].brf.values), 1.0)
+    results = eradiate.run(exp)
+    assert np.allclose(np.squeeze(results.brf.values), 1.0)

--- a/tests/02_eradiate/02_system/test_spp_splitting.py
+++ b/tests/02_eradiate/02_system/test_spp_splitting.py
@@ -85,7 +85,7 @@ def test_spp_splitting(mode_mono_single, artefact_dir):
 
             for spp in spps:
                 exp.measures[0].spp = spp
-                exp.run()
+                eradiate.run(exp)
                 results[spp_split_label, mode][spp] = float(exp.results["measure"].brf)
 
     # Save plot for report

--- a/tests/02_eradiate/03_regression/atmospheres/test_rpv_afgl1986.py
+++ b/tests/02_eradiate/03_regression/atmospheres/test_rpv_afgl1986.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 
+import eradiate
 import eradiate.scenes as esc
 from eradiate.experiments import OneDimExperiment
 from eradiate.test_tools.regression import Chi2Test
@@ -57,8 +58,7 @@ def test_rpv_afgl1986_brfpp(mode_ckd_double, artefact_dir, session_timestamp):
         atmosphere=esc.atmosphere.MolecularAtmosphere.afgl_1986(),
     )
 
-    exp.run()
-    result = exp.results["measure"]
+    result = eradiate.run(exp)
 
     test = Chi2Test(
         name=f"{session_timestamp:%Y%m%d-%H%M%S}-rpv_afgl1986.nc",

--- a/tests/02_eradiate/03_regression/atmospheres/test_rpv_afgl1986_continental.py
+++ b/tests/02_eradiate/03_regression/atmospheres/test_rpv_afgl1986_continental.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 
+import eradiate
 import eradiate.scenes as esc
 from eradiate.data import data_store
 from eradiate.experiments import OneDimExperiment
@@ -74,8 +75,7 @@ def test_rpv_afgl1986_continental_brfpp(
         ),
     )
 
-    exp.run()
-    result = exp.results["measure"]
+    result = eradiate.run(exp)
 
     test = Chi2Test(
         name=f"{session_timestamp:%Y%m%d-%H%M%S}-rpv_afgl1986_continental.nc",

--- a/tests/02_eradiate/03_regression/rami4atm/test_rami4atm_hom00_bla_sd2s_m03_z30a000_brfpp.py
+++ b/tests/02_eradiate/03_regression/rami4atm/test_rami4atm_hom00_bla_sd2s_m03_z30a000_brfpp.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 
+import eradiate
 from eradiate.experiments import OneDimExperiment
 from eradiate.test_tools.regression import Chi2Test
 
@@ -93,8 +94,7 @@ def test_rami4atm_hom00_bla_sd2s_m03_z30a000_brfpp(
     }
 
     exp = OneDimExperiment(**config)
-    exp.run()
-    result = exp.results["measure"]
+    result = eradiate.run(exp)
 
     test = Chi2Test(
         name=f"{session_timestamp:%Y%m%d-%H%M%S}-rami4atm_hom00_bla_sd2s_m03_z30a000_brfpp",

--- a/tests/02_eradiate/03_regression/romc/test_het01.py
+++ b/tests/02_eradiate/03_regression/romc/test_het01.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 
+import eradiate
 from eradiate.data import data_store
 from eradiate.experiments import RamiExperiment
 from eradiate.test_tools.regression import Chi2Test
@@ -96,8 +97,7 @@ def test_het01_brfpp(mode_mono_double, artefact_dir, session_timestamp):
         integrator={"type": "path", "max_depth": -1},
     )
 
-    exp.run()
-    result = exp.results["measure"]
+    result = eradiate.run(exp)
 
     test = Chi2Test(
         name=f"{session_timestamp:%Y%m%d-%H%M%S}-het01.nc",

--- a/tests/02_eradiate/03_regression/romc/test_het04.py
+++ b/tests/02_eradiate/03_regression/romc/test_het04.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 
+import eradiate
 from eradiate.contexts import KernelDictContext
 from eradiate.data import data_store
 from eradiate.experiments import RamiExperiment
@@ -122,8 +123,7 @@ def test_het04a1_brfpp(mode_mono_double, artefact_dir, session_timestamp):
         integrator={"type": "path", "max_depth": -1},
     )
 
-    exp.run()
-    result = exp.results["measure"]
+    result = eradiate.run(exp)
 
     test = Chi2Test(
         name=f"{session_timestamp:%Y%m%d-%H%M%S}-het04.nc",

--- a/tests/02_eradiate/03_regression/romc/test_het06.py
+++ b/tests/02_eradiate/03_regression/romc/test_het06.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 
+import eradiate
 from eradiate.data import data_store
 from eradiate.experiments import RamiExperiment
 from eradiate.test_tools.regression import Chi2Test
@@ -108,8 +109,7 @@ def test_het06_brfpp(mode_mono_double, artefact_dir, session_timestamp):
         integrator={"type": "path", "max_depth": -1},
     )
 
-    exp.run()
-    result = exp.results["measure"]
+    result = eradiate.run(exp)
 
     test = Chi2Test(
         name=f"{session_timestamp:%Y%m%d-%H%M%S}-het06.nc",


### PR DESCRIPTION
# Description

This PR updates all tests to use `eradiate.run()` instead of the deprecated `Experiment.run()` method.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
