### PR TITLE
Add irregularly gridded tabulated phase function support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ when necessary—we also advise to not ignore `DeprecationWarning`s.
 * Transitioned dependency management to `pyproject.toml` following
   [PEP 621](https://peps.python.org/pep-0621/) ({ghpr}`203`).
 * Updated Mitsuba submodule ({ghpr}`228`).
+* Removed the angular regridding feature in `TabulatedPhaseFunction` and 
+  replaced with plugin selection ({ghpr}`229`).
 
 ## v0.22.3 (22 May 2022)
 

--- a/src/eradiate/scenes/phase/_tabulated.py
+++ b/src/eradiate/scenes/phase/_tabulated.py
@@ -61,26 +61,12 @@ class TabulatedPhaseFunction(PhaseFunction):
 
     Notes
     -----
-    The :math:`\mu` coordinate must cover the :math:`[-1, 1]` interval but
-    there is no constraint on value ordering or spacing. In particular,
-    irregular :math:`\mu` grids are supported.
+    * The :math:`\mu` coordinate must cover the :math:`[-1, 1]` interval but
+      there is no constraint on value ordering or spacing. In particular,
+      irregular :math:`\mu` grids are supported.
 
-    Since the underlying ``tabphase`` plugin expects phase function values on
-    a regular :math:`\mu` grid, this class will resample irregularly gridded
-    phase function data on a regular grid. The step of the resampling grid is
-    equal to the smallest :math:`\mu` step found in the input `data` field.
-
-    The resampling grid step selection policy ensures that the precision of
-    the input data is preserved, but the resampled data may be large (several
-    hundred MB) if no care is taken in the preparation of the input data.
-
-    To control the :math:`\mu` grid, you can simply provide a
-    :class:`~xarray.DataArray` object with a regularly gridded
-    :math:`\mu` coordinate ; in that case, the phase function data is not
-    resampled on the :math:`\mu` dimension.
-
-    For optimal performance, providing phase function data on a regular,
-    sorted :math:`\mu` grid is recommended.
+    * For optimal performance, providing phase function data on a regular,
+      sorted :math:`\mu` grid is recommended.
     """
 
     data: xr.DataArray = documented(
@@ -140,43 +126,14 @@ class TabulatedPhaseFunction(PhaseFunction):
         """
         w_units = self.data.w.attrs["units"]
 
-        # data already maps to regular grid of scattering angle cosines
-        dmu = self.data.mu.values[1:] - self.data.mu.values[:-1]
-        if np.allclose(dmu, dmu[0], rtol=1e-8):
-            return (
-                self.data.sel(i=0, j=0)
-                .interp(
-                    w=w.m_as(w_units),
-                    kwargs=dict(bounds_error=True),
-                )
-                .data
-            )
-
-        # data does not map to regular grid of scattering angle cosines
-        else:
-            # compute the regular grid from the smallest mu step found in the
-            # input data
-            dmu_min = np.abs(self.data.mu.diff(dim="mu")).values.min()
-            nmu = int(np.ceil(2.0 / dmu_min)) + 1
-            mu = np.linspace(-1.0, 1.0, nmu)
-
-            # interpolate first on wavelength
-            _w = _ensure_magnitude_array(w)
-            data_w_interpolated = self.data.sel(i=0, j=0).interp(
-                w=_w.m_as(w_units),
+        return (
+            self.data.isel(i=0, j=0)
+            .interp(
+                w=w.m_as(w_units),
                 kwargs=dict(bounds_error=True),
             )
-
-            # for performance, interpolation on mu dimension is performed with
-            # numpy.interp, which is found to be more than twice faster than
-            # xarray.DataArray.interp
-            phase = np.full(shape=(_w.size, nmu), fill_value=np.nan)
-            mup = self.data.mu.values
-            for iw in range(_w.size):
-                fp = data_w_interpolated.isel(w=iw).values
-                phase[iw, :] = np.interp(x=mu, xp=mup, fp=fp)
-
-            return phase.squeeze()
+            .data
+        )
 
     def eval_ckd(self, *bindexes: Bindex) -> np.ndarray:
         """
@@ -199,11 +156,31 @@ class TabulatedPhaseFunction(PhaseFunction):
         return self.eval_mono(w)
 
     def kernel_dict(self, ctx: KernelDictContext) -> KernelDict:
-        return KernelDict(
-            {
-                self.id: {
-                    "type": "tabphase",
-                    "values": ",".join(map(str, self.eval(ctx.spectral_ctx))),
+        # Evaluate phase function
+        phase_values = self.eval(ctx.spectral_ctx)
+
+        # Retrieve mu grid
+        mu = self.data.mu.values
+        dmu = mu[1:] - mu[:-1]
+
+        # Create kernel dict
+        if np.allclose(dmu, dmu[0]):  # mu grid is regular
+            return KernelDict(
+                {
+                    self.id: {
+                        "type": "tabphase",
+                        "values": ",".join(map(str, phase_values)),
+                    }
                 }
-            }
-        )
+            )
+
+        else:  # mu grid is irregular
+            return KernelDict(
+                {
+                    self.id: {
+                        "type": "tabphase_irregular",
+                        "values": ",".join(map(str, phase_values)),
+                        "nodes": ",".join(map(str, mu)),
+                    }
+                }
+            )

--- a/src/plugins/src/CMakeLists.txt
+++ b/src/plugins/src/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Plugins
 add_subdirectory(bsdfs)
+add_subdirectory(phase)
 add_subdirectory(sensors)
 add_subdirectory(volumes)

--- a/src/plugins/src/phase/CMakeLists.txt
+++ b/src/plugins/src/phase/CMakeLists.txt
@@ -1,0 +1,3 @@
+set(MI_PLUGIN_PREFIX "phasefunctions")
+
+add_plugin(tabphase_irregular tabphase_irregular.cpp)

--- a/src/plugins/src/phase/tabphase_irregular.cpp
+++ b/src/plugins/src/phase/tabphase_irregular.cpp
@@ -1,0 +1,159 @@
+#include <mitsuba/core/distr_1d.h>
+#include <mitsuba/core/properties.h>
+#include <mitsuba/core/warp.h>
+#include <mitsuba/render/phase.h>
+
+NAMESPACE_BEGIN(mitsuba)
+
+/**!
+
+.. _phase-tabphase_irregular:
+
+Tabulated phase function (irregular angular grid) (:monosp:`tabphase_irregular`)
+--------------------------------------------------------------------------------
+
+.. pluginparameters::
+
+ * - values
+   - |string|
+   - A comma-separated list of phase function values parameterized by the
+     cosine of the scattering angle. Must have the same length as `nodes`.
+   - |exposed|, |differentiable|, |discontinuous|
+
+ * - nodes
+   - |string|
+   - A comma-separated list of :math:`\cos \theta` specifying the grid on which
+     `values` are defined. Bounds must be [-1, 1] and values must be strictly
+     increasing. Must have the same length as `values`.
+   - |exposed|, |differentiable|, |discontinuous|
+
+This plugin implements a generic phase function model for isotropic media
+parametrized by a lookup table giving values of the phase function as a
+function of the cosine of the scattering angle.
+
+This plugin is a variant of the ``tabphase`` plugin and behaves similarly but
+uses an irregular distribution internally. Consequently, ``tabphase`` performs
+better for evaluation and sampling.
+*/
+
+template <typename Float, typename Spectrum>
+class IrregularTabulatedPhaseFunction final
+    : public PhaseFunction<Float, Spectrum> {
+public:
+    MI_IMPORT_BASE(PhaseFunction, m_flags, m_components)
+    MI_IMPORT_TYPES(PhaseFunctionContext)
+
+    IrregularTabulatedPhaseFunction(const Properties &props) : Base(props) {
+        std::vector<ScalarFloat> values;
+        std::vector<ScalarFloat> nodes;
+
+        if (props.type("values") == Properties::Type::String) {
+            std::vector<std::string> values_str =
+                string::tokenize(props.string("values"), " ,");
+            values.reserve(values_str.size());
+
+            for (const auto &s : values_str) {
+                try {
+                    values.push_back((ScalarFloat) std::stod(s));
+                } catch (...) {
+                    Throw("Could not parse floating point value '%s'", s);
+                }
+            }
+        } else {
+            Throw("'values' must be a string");
+        }
+
+        if (props.type("nodes") == Properties::Type::String) {
+            std::vector<std::string> nodes_str =
+                string::tokenize(props.string("nodes"), " ,");
+            nodes.reserve(nodes_str.size());
+
+            for (const auto &s : nodes_str) {
+                try {
+                    nodes.push_back((ScalarFloat) std::stod(s));
+                } catch (...) {
+                    Throw("Could not parse floating point value '%s'", s);
+                }
+            }
+        } else {
+            Throw("'nodes' must be a string");
+        }
+
+        // Check that values and nodes have the same size
+        if (values.size() != nodes.size()) {
+            Throw("'nodes' and 'values' must have the same length");
+        }
+
+        // Check that nodes cover the [-1, 1] segment
+        if (nodes[0] != -1.f || nodes[nodes.size() - 1] != 1.f) {
+            Throw("'nodes' bounds must be [-1, 1], got [%s, %s]", nodes[0],
+                  nodes[nodes.size() - 1]);
+        }
+
+        m_distr = IrregularContinuousDistribution<Float>(
+            nodes.data(), values.data(), values.size());
+
+        m_flags = +PhaseFunctionFlags::Anisotropic;
+        dr::set_attr(this, "flags", m_flags);
+        m_components.push_back(m_flags);
+    }
+
+    void traverse(TraversalCallback *callback) override {
+        callback->put_parameter("values", m_distr.pdf(),
+                                ParamFlags::Differentiable |
+                                    ParamFlags::Discontinuous);
+        callback->put_parameter("nodes", m_distr.nodes(),
+                                ParamFlags::Differentiable |
+                                    ParamFlags::Discontinuous);
+    }
+
+    void
+    parameters_changed(const std::vector<std::string> & /*keys*/) override {
+        m_distr.update();
+    }
+
+    std::pair<Vector3f, Float> sample(const PhaseFunctionContext & /* ctx */,
+                                      const MediumInteraction3f &mi,
+                                      Float /* sample1 */,
+                                      const Point2f &sample2,
+                                      Mask active) const override {
+        MI_MASKED_FUNCTION(ProfilerPhase::PhaseFunctionSample, active);
+
+        Float cos_theta = m_distr.sample(sample2.x());
+        Float sin_theta = dr::safe_sqrt(1.f - cos_theta * cos_theta);
+        auto [sin_phi, cos_phi] =
+            dr::sincos(2.f * dr::Pi<ScalarFloat> * sample2.y());
+        Vector3f wo{ sin_theta * cos_phi, sin_theta * sin_phi, cos_theta };
+        wo = -mi.to_world(wo);
+        Float pdf = m_distr.eval_pdf_normalized(-cos_theta, active) *
+                    dr::InvTwoPi<ScalarFloat>;
+
+        return { wo, pdf };
+    }
+
+    Float eval(const PhaseFunctionContext & /* ctx */,
+               const MediumInteraction3f &mi, const Vector3f &wo,
+               Mask active) const override {
+        MI_MASKED_FUNCTION(ProfilerPhase::PhaseFunctionEvaluate, active);
+
+        Float cos_theta = dot(wo, mi.wi);
+        return m_distr.eval_pdf_normalized(-cos_theta, active) *
+               dr::InvTwoPi<ScalarFloat>;
+    }
+
+    std::string to_string() const override {
+        std::ostringstream oss;
+        oss << "IrregularTabulatedPhaseFunction[" << std::endl
+            << "  distr = " << string::indent(m_distr) << std::endl
+            << "]";
+        return oss.str();
+    }
+
+    MI_DECLARE_CLASS()
+private:
+    IrregularContinuousDistribution<Float> m_distr;
+};
+
+MI_IMPLEMENT_CLASS_VARIANT(IrregularTabulatedPhaseFunction, PhaseFunction)
+MI_EXPORT_PLUGIN(IrregularTabulatedPhaseFunction, "Tabulated phase function")
+NAMESPACE_END(mitsuba)

--- a/tests/01_plugins/phase/test_tabphase_irregular.py
+++ b/tests/01_plugins/phase/test_tabphase_irregular.py
@@ -1,0 +1,126 @@
+from itertools import product
+
+import drjit as dr
+import mitsuba as mi
+
+
+def test_create(variant_scalar_rgb):
+    p = mi.load_dict(
+        {
+            "type": "tabphase_irregular",
+            "values": "0.5,1.0,1.5",
+            "nodes": "-1.0,0.0,1.0",
+        }
+    )
+    assert p is not None
+
+
+def test_eval(variant_scalar_rgb):
+    """
+    Compare eval() output with a reference implementation written in Python.
+    We make sure that the values we use to initialize the plugin are such that
+    the phase function has an asymmetric lobe.
+    """
+    import numpy as np
+
+    # Phase function table definition
+    ref_y = np.array([0.5, 1.0, 1.5])
+    ref_x = np.linspace(-1, 1, len(ref_y))
+    ref_integral = np.trapz(ref_y, ref_x)
+
+    def eval(wi, wo):
+        # Python implementation used as a reference
+        wi = wi.reshape((-1, 3))
+        wo = wo.reshape((-1, 3))
+
+        if wi.shape[0] == 1:
+            wi = np.broadcast_to(wi, wo.shape)
+        if wo.shape[0] == 1:
+            wo = np.broadcast_to(wo, wi.shape)
+
+        cos_theta = np.array([np.dot(a, b) for a, b in zip(wi, wo)])
+        return 0.5 / np.pi * np.interp(-cos_theta, ref_x, ref_y) / ref_integral
+
+    wi = np.array([[0, 0, -1]])
+    thetas = np.linspace(0, np.pi / 2, 16)
+    phis = np.linspace(0, np.pi, 16)
+    wos = np.array(
+        [
+            (
+                dr.sin(theta) * np.cos(phi),
+                np.sin(theta) * np.sin(phi),
+                np.cos(theta),
+            )
+            for theta, phi in product(thetas, phis)
+        ]
+    )
+    ref_eval = eval(wi, wos)
+
+    # Evaluate Mitsuba implementation
+    tab = mi.load_dict(
+        {
+            "type": "tabphase_irregular",
+            "values": ",".join(map(str, ref_y)),
+            "nodes": ",".join(map(str, ref_x)),
+        }
+    )
+    ctx = mi.PhaseFunctionContext(None)
+    mei = mi.MediumInteraction3f()
+    mei.wi = wi
+    tab_eval = np.zeros_like(ref_eval)
+    for i, wo in enumerate(wos):
+        tab_eval[i] = tab.eval(ctx, mei, wo)
+
+    # Compare reference and plugin outputs
+    assert np.allclose(ref_eval, tab_eval)
+
+
+def test_chi2(variants_vec_backends_once_rgb):
+    sample_func, pdf_func = mi.chi2.PhaseFunctionAdapter(
+        "tabphase_irregular",
+        (
+            "<string name='values' value='0.5,1.0,1.5'/>"
+            "<string name='nodes' value='-1.0,0.0,1.0'/>"
+        ),
+    )
+
+    chi2 = mi.chi2.ChiSquareTest(
+        domain=mi.chi2.SphericalDomain(),
+        sample_func=sample_func,
+        pdf_func=pdf_func,
+        sample_dim=3,
+    )
+
+    result = chi2.run(0.1)
+    chi2._dump_tables()
+    assert result
+
+
+def test_traverse(variant_scalar_rgb):
+    # Phase function table definition
+    import numpy as np
+
+    ref_y = np.array([0.5, 1.0, 1.5])
+    ref_x = np.array([-1, 0.5, 1])
+    ref_integral = np.trapz(ref_y, ref_x)
+
+    # Initialise as isotropic and update with parameters
+    phase = mi.load_dict(
+        {"type": "tabphase_irregular", "values": "1,1,1", "nodes": "-1,0,1"}
+    )
+    params = mi.traverse(phase)
+    params["values"] = [0.5, 1.0, 1.5]
+    params["nodes"] = [-1.0, 0.5, 1.0]
+    params.update()
+
+    # Distribution parameters are updated
+    params = mi.traverse(phase)
+    assert dr.allclose(params["values"], [0.5, 1.0, 1.5])
+    assert dr.allclose(params["nodes"], [-1.0, 0.5, 1.0])
+
+    # The plugin itself evaluates consistently
+    ctx = mi.PhaseFunctionContext(None)
+    mei = mi.MediumInteraction3f()
+    mei.wi = np.array([0, 0, -1])
+    wo = [0, 0, 1]
+    assert dr.allclose(phase.eval(ctx, mei, wo), dr.InvTwoPi * 1.5 / ref_integral)


### PR DESCRIPTION
# Description

This PR adds support for irregularly gridded phase functions. Angular regridding, required to reach appropriate accuracy with aerosol phase functions and implemented as part of #226, resulted in an important drop in performance due to the extra interpolation overhead. 

The `TabulatedPhaseFunction` kernel dictionary generation no longer triggers angular regridding. Instead, it checks whether the angular grid is regular or irregular and creates a different kernel dictionary for each case. See below for the complete list of changes:

- Added `tabphase_irregular` plugin.
- Modified `TabulatedPhaseFunction.eval_mono()` and `TabulatedPhaseFunction.kernel_dict()` to replace angular regridding with plugin selection.
- Minor refactoring of `TabulatedPhaseFunction` unit tests.

**Performance considerations**

[before]: https://user-images.githubusercontent.com/34740232/171014209-a8ee3fd0-02e5-4a68-ac6e-da59cc12804c.png "Before" 
[after]: https://user-images.githubusercontent.com/34740232/171014232-13ec1567-1acc-4f2f-8dca-9edee27c3fd6.png "After"

|   | Run time |
|---|---|
| Before (regridding) | ![][before] |
| After (no regridding) | ![][after] |

**Mini-benchmark**

Hereafter is a small script which compares performance with and without regridding. The following parameters were used:

* `n_samples = 1000000`, `n_runs = 1`, `n_reps = 1`: this compares the performance of both plugins with almost no pre-processing overhead. Little difference is observed.
* `n_samples = 0`, `n_runs = 1000`, `n_reps = 10`: this compares the performance of the two pre-processing steps. The regridding strategy performs significantly slower. It should be noted that regridding cost increases with the sharpness of the scattering lobe and the selected example is rather easy compared to what the aerosol phase function data looks like.

<details>
<summary>Click to expand</summary>

```python
import timeit
import numpy as np

import drjit as dr
import mitsuba as mi

mi.set_variant("scalar_mono_double")


def benchmark(func, n_runs=10000, n_reps=10):
    durations = timeit.Timer(func).repeat(repeat=n_reps, number=n_runs)
    results = {
        "durations": durations,
        "mean": np.mean(durations),
        "std": np.std(durations),
    }
    return results


def test_sample(plugin, n_samples):
    if not n_samples:
        return

    ctx = mi.PhaseFunctionContext(None)
    wi = [0, 0, 1]

    mei = dr.zero(mi.MediumInteraction3f, n_samples)
    mei.wi = wi
    mei.sh_frame = mi.Frame3f(mei.wi)
    mei.p = mi.Point3f(0, 0, 0)

    for sample in np.random.random((n_samples, 3)):
        plugin.sample(ctx, mei, sample[0], [sample[1], sample[2]])


def test_irregular(cos_thetas, values, n_samples=10000):
    p = mi.load_dict(
        {
            "type": "tabphase_irregular",
            "values": ",".join(map(str, values)),
            "nodes": ",".join(map(str, cos_thetas)),
        }
    )
    test_sample(p, n_samples)


def test_regular(cos_thetas, values, n_samples=10000):
    steps = cos_thetas[1:] - cos_thetas[:-1]
    cos_thetas_regular = np.linspace(-1.0, 1.0, int(np.ceil(2.0 / steps.min())))
    values_regular = np.interp(cos_thetas_regular, cos_thetas, values)
    p = mi.load_dict(
        {
            "type": "tabphase",
            "values": ",".join(map(str, values_regular)),
        }
    )
    test_sample(p, n_samples)


cos_thetas_irregular = np.array([-1.0, 0.999, 1.0])
values_irregular = np.array([0.5, 1.0, 1.5])
n_samples = 0
n_runs = 1000
n_reps = 10


for title, task in [
    ("Regular", test_regular),
    ("Irregular", test_irregular),
]:
    results = benchmark(
        lambda: task(cos_thetas_irregular, values_irregular, n_samples),
        n_runs=n_runs,
        n_reps=n_reps,
    )
    print(
        f"{title:10s}: {results['mean']:.3g} s ± {results['std']:.3g} ({n_reps} reps)"
    )
```
</details>

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
