### PR TITLE
Change cache directory policy to a less aggressive behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,11 @@ when necessary—we also advise to not ignore `DeprecationWarning`s.
 * Updated all tests to use `eradiate.run()` instead of the deprecated 
   `Experiment.run()` method ({ghpr}`227`).
 
-% ### Improvements and fixes
+### Improvements and fixes
+
+* Changed the cache directory policy to a less aggressive behaviour: cache dirs 
+  are now created upon file write, not upon scene element instantiation 
+  ({ghpr}`230`).
 
 % ### Documentation
 

--- a/src/eradiate/util/misc.py
+++ b/src/eradiate/util/misc.py
@@ -4,7 +4,11 @@ A collection of tools which don't really fit anywhere else.
 
 import functools
 import inspect
+import os
+import random
 import re
+import string
+import tempfile
 import typing as t
 from collections import OrderedDict
 from numbers import Number
@@ -275,3 +279,15 @@ def str_summary_numpy(x):
             array_str = ("\n" + " " * len(prefix)).join(split)
 
         return f"{prefix}{array_str})"
+
+
+def tempdir_name() -> str:
+    """
+    Return a temporary directory path. This implementation is unsafe and may
+    race competing processes.
+    """
+    # See https://stackoverflow.com/a/67231057/3645374
+    random_string = "".join(
+        random.choices(string.ascii_uppercase + string.digits, k=10)
+    )
+    return os.path.join(tempfile.gettempdir(), random_string)


### PR DESCRIPTION
# Description

This PR changes how cache directory creation is handled. Previous behaviour (cache dir creation upon scene element initialisation) would result in unused directories being created by heterogeneous atmosphere components, even though they would not write files themselves. When running many simulation, a large number of directories would be created and not cleaned up.

The new behaviour defers directory creation to the kernel dict generation step, at the very moment when files are written to disk. A drawback is that we lose a safety check previously preformed during initialisation: a protected cache directory will be detected only upon kernel dict creation. This also introduces a race condition, which requires that the user set the cache directory manually in a multiprocess environment.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
