### PR TITLE
Get rid of temporary volume files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,12 @@ when necessary—we also advise to not ignore `DeprecationWarning`s.
 
 % ### New features
 
-% ### Breaking changes
+### Breaking changes
+
+* Removed temporary volume files used by the `AbstractHeterogeneousAtmosphere`
+  line and the `BlendPhaseFunction` class (replaced by in-memory buffers). 
+  Corresponding file name and cache directory control parameters were removed as 
+  well ({ghpr}`231`).
 
 ### Deprecations and removals
 

--- a/src/eradiate/scenes/atmosphere/_heterogeneous.py
+++ b/src/eradiate/scenes/atmosphere/_heterogeneous.py
@@ -189,10 +189,9 @@ class HeterogeneousAtmosphere(AbstractHeterogeneousAtmosphere):
 
         super().update()
 
-        # Force IDs and cache directories
+        # Force IDs
         for i, component in enumerate(self.components):
             component.id = f"{self.id}_component_{i}"
-            component.cache_dir = self.cache_dir
 
     # --------------------------------------------------------------------------
     #              Spatial extension and thermophysical properties
@@ -419,7 +418,6 @@ class HeterogeneousAtmosphere(AbstractHeterogeneousAtmosphere):
                 )
 
             phase = BlendPhaseFunction(
-                cache_dir=self.cache_dir,
                 components=[component.phase for component in components],
                 weights=sigma_ss,
                 bbox=BoundingBox(min=shape_min, max=shape_max),


### PR DESCRIPTION
# Description

This PR closes and supersedes #230. It removes temporary volume files used by the `BlendPhaseFunction` class and the `AbstractHeterogeneousAtmosphere` line. This consequently allows for dropping the cumbersome cache directory system on which this mechanism relied. Tests are also refactored and now use Mitsuba's traverse mechanism to query for internal data.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
