### PR TITLE
BSDF plugins in CentralPatchSurface were in the wrong order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ when necessary—we also advise to not ignore `DeprecationWarning`s.
   spectrum to cover the full wavelength range of Eradiate ({ghpr}`233`).
 * Fixed a bug where converting an integer to a `Spectrum` would fail 
   (`ghpr`{236}). 
+* Fixed a bug, where the two BSDFs in the `CentralPatchSurface` would be
+  assigned in the wrong order (`ghpr`{237}).
 
 % ### Documentation
 

--- a/src/eradiate/scenes/surface/_central_patch.py
+++ b/src/eradiate/scenes/surface/_central_patch.py
@@ -172,8 +172,8 @@ class CentralPatchSurface(Surface):
             {
                 self.bsdf_id: {
                     "type": "blendbsdf",
-                    "bsdf_background": onedict_value(self.bsdf.kernel_dict(ctx=ctx)),
-                    "bsdf_patch": onedict_value(self.patch_bsdf.kernel_dict(ctx=ctx)),
+                    "bsdf_0": onedict_value(self.patch_bsdf.kernel_dict(ctx=ctx)),
+                    "bsdf_1": onedict_value(self.bsdf.kernel_dict(ctx=ctx)),
                     "weight": {
                         "type": "bitmap",
                         "filename": str(


### PR DESCRIPTION
# Description

The blendbsdf plugin in mitsuba sorts the nested BSDFs alphanumerically by their identifier. That means, that the previous names for the two BSDFs in the CentralPatchSurface would put them in the wrong order. The updated naming solves that issue.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
