### PR TITLE
Raise `ValueError` when concentration values are out of bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@ when necessary—we also advise to not ignore `DeprecationWarning`s.
   (`ghpr`{236}). 
 * Fixed a bug, where the two BSDFs in the `CentralPatchSurface` would be
   assigned in the wrong order (`ghpr`{237}).
+* Raise an exception when molecular concentrations are out of bounds
+  (`ghpr`{237}).
 
 % ### Documentation
 

--- a/src/eradiate/radprops/_afgl1986.py
+++ b/src/eradiate/radprops/_afgl1986.py
@@ -128,7 +128,14 @@ class AFGL1986RadProfile(RadProfile):
             result = ureg.Quantity(
                 [
                     ds.k.sel(bd=(bindex.bin.id, bindex.index))
-                    .interp(z=z, **concentrations, kwargs=dict(fill_value=0.0))
+                    .interp(
+                        z=z,
+                        kwargs=dict(fill_value=0.0),
+                    )  # extrapolate to 0.0 for altitude out of bounds
+                    .interp(
+                        **concentrations,
+                        kwargs=dict(bounds_error=True),  # raise when concentration are out of bounds
+                    )
                     .values
                     for bindex in bindexes
                 ],


### PR DESCRIPTION
# Description

Resolves eradiate/eradiate-issues#167

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
