### PR TITLE
Stop raising exception when purely absorbing `MolecularAtmosphere` is mixed with `ParticleLayer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,8 @@ when necessary—we also advise to not ignore `DeprecationWarning`s.
 * Some dependencies are now optional, although recommended ({ghpr}`266`).
 * Added new sahara and continental particle radiative properties including the
   full scattering phase matrix ({ghpr}`259`).
+* Allow mixing a purely absorbing `MolecularAtmosphere` with a `ParticleLayer` 
+  ({ghpr}`239`).
 
 ### Documentation
 

--- a/src/eradiate/scenes/atmosphere/_heterogeneous.py
+++ b/src/eradiate/scenes/atmosphere/_heterogeneous.py
@@ -138,13 +138,6 @@ class HeterogeneousAtmosphere(AbstractHeterogeneousAtmosphere):
                 "scaled individually"
             )
 
-        if self.particle_layers and (value.has_absorption and not value.has_scattering):
-            raise ValueError(
-                f"while validating {attribute.name}: a purely absorbing "
-                "molecular atmosphere cannot be mixed with particle layers; this "
-                "will be addressed in a future release"
-            )
-
     particle_layers: t.List[ParticleLayer] = documented(
         attrs.field(
             factory=list,


### PR DESCRIPTION
# Description

Resolves eradiate/eradiate-issues#153

I simply removed the lines that raised the exception.
I am not really sure why this exception was raised in the first place ? @leroyvn 

If the molecular atmosphere is not scattering, its scattering coefficient is zero. The values of the weighting factors for the phase functions blending then depend on the values of the scattering coefficient of the particle layers ; where the latter are non zero, the weight is 1, else the weight is 0 (although, in this case, it does not really matter since no scattering event will never occur).

I made a few quick tests and the results make sense.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
