### PR TITLE
rpv: Fixes and improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,10 +54,12 @@ when necessary—we also advise to not ignore `DeprecationWarning`s.
   spectrum to cover the full wavelength range of Eradiate ({ghpr}`233`).
 * Fixed a bug where converting an integer to a `Spectrum` would fail 
   (`ghpr`{236}). 
-* Fixed a bug, where the two BSDFs in the `CentralPatchSurface` would be
+* Fixed a bug where the two BSDFs in the `CentralPatchSurface` would be
   assigned in the wrong order (`ghpr`{237}).
 * Raise an exception when molecular concentrations are out of bounds
   (`ghpr`{237}).
+* Various fixes to the `rpv` plugin, among which a missing PDF term in the 
+  `sample()` method (`ghpr`{240}).
 
 % ### Documentation
 

--- a/src/eradiate/test_tools/plugin.py
+++ b/src/eradiate/test_tools/plugin.py
@@ -1,0 +1,67 @@
+"""
+Helper tools for plugin tests.
+"""
+
+import drjit as dr
+import mitsuba as mi
+
+
+def sample_eval_pdf_bsdf(
+    plugin: "mitsuba.BSDF",
+    wi: "mitsuba.ScalarVector3f",
+    sample_count: int = 100000,
+    seed: int = 0,
+):
+    """
+    Sample a BSDF and get corresponding ``eval()`` and ``pdf()`` values.
+
+    Parameters
+    ----------
+    plugin : mitsuba.BSDF
+        A BSDF plugin to be evaluated.
+
+    wi : mitsuba.ScalarVector3f
+        An incoming direction.
+
+    sample_count : int, optional, default: 100000
+        The number of samples to generate.
+
+    seed : int, optional, default: 0
+        RNG seed to be used.
+
+    Returns
+    -------
+    sample
+        The result of a call to the plugin's ``sample()`` method.
+
+    eval
+        The result of a call to the plugin's ``eval()`` method.
+
+    pdf
+        The result of a call to the plugin's ``pdf()`` method.
+    """
+
+    # Generate a table of uniform variates
+    idx = dr.arange(mi.UInt64, sample_count)
+    v0, v1 = mi.sample_tea_32(idx, seed)
+
+    # Scramble seed and stream index using TEA, a linearly increasing sequence
+    # does not produce a sufficiently statistically independent set of streams
+    rng = mi.PCG32(initstate=v0, initseq=v1)
+
+    sample = mi.Vector3f()
+    for i in range(3):
+        sample[i] = rng.next_float32() if mi.Float is mi.Float32 else rng.next_float64()
+
+    # Invoke sampling strategy
+    n = dr.width(sample)
+    ctx = mi.BSDFContext()
+    si = dr.zero(mi.SurfaceInteraction3f, n)
+    si.wi = wi
+    bs, weight = plugin.sample(ctx, si, sample[0], [sample[1], sample[2]])
+
+    # Get corresponding eval() and pdf() calls
+    eval = plugin.eval(ctx, si, bs.wo)
+    pdf = plugin.pdf(ctx, si, bs.wo)
+
+    return (bs, weight), eval, pdf


### PR DESCRIPTION
# Description

This PR fixes and upgrades the RPV BSDF plugin. Changes are as follows:

* `sample()` is fixed: The missing pdf division has been added. A corresponding unit test was added, as well as a plugin evaluation helper in a new `test_tools.plugin` module.
* A few more fixes and improvements were made (constructor, string repr, tests).
* The `RPVBSDF` test suite was overhauled (code deduplication).
* A system test checking that degenerating the RPV BRDF into a Lambertian BRDF yields the expected result.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
