### PR TITLE
AggregateCKDQuad: Fix final dataset index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ when necessary—we also advise to not ignore `DeprecationWarning`s.
   (`ghpr`{237}).
 * Various fixes to the `rpv` plugin, among which a missing PDF term in the 
   `sample()` method (`ghpr`{240}).
+* Fix incorrect spectral indexing of result datasets in CKD mode (`ghpr`{241}).
 
 % ### Documentation
 


### PR DESCRIPTION
# Description

This commit fixes an indexing issue in the aggregated result dataset in CKD mode. The wavelength indexing was incorrect due to the fact that the list of bins returned by BinSet.select_bins() is ordered by ascending central wavelength values, while the dataset bin index values are not necessarily (they actually alphanumerically ordered, *i.e.* `"1000"` comes before `"900"`).

The updated code ensures that the various coordinate variables are generated in the same order as the bin coordinate. It then sorts the dataset in ascending wavelength order.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license