### PR TITLE
Improve Solar irradiance spectrum initialisation sequence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,9 @@ when necessary—we also advise to not ignore `DeprecationWarning`s.
 * Various fixes to the `rpv` plugin, among which a missing PDF term in the 
   `sample()` method (`ghpr`{240}).
 * Fix incorrect spectral indexing of result datasets in CKD mode (`ghpr`{241}).
+* Improve the Solar irradiance spectrum initialisation sequence (`ghpr`{242}).
+* The `thuillier_2003_extrapolated` dataset is now the default Solar irradiance 
+  spectrum (`ghpr`{242}).
 
 % ### Documentation
 

--- a/tests/02_eradiate/01_unit/scenes/spectra/test_solar_irradiance.py
+++ b/tests/02_eradiate/01_unit/scenes/spectra/test_solar_irradiance.py
@@ -5,6 +5,7 @@ import eradiate
 from eradiate import unit_registry as ureg
 from eradiate.ckd import BinSet
 from eradiate.contexts import KernelDictContext, SpectralContext
+from eradiate.exceptions import DataError
 from eradiate.scenes.core import KernelDict
 from eradiate.scenes.spectra import SolarIrradianceSpectrum
 
@@ -18,7 +19,7 @@ def test_solar_irradiance(mode_mono):
     s = SolarIrradianceSpectrum()
 
     # Unsupported solar spectrum keywords raise
-    with pytest.raises(TypeError):
+    with pytest.raises(DataError):
         SolarIrradianceSpectrum(dataset="doesnt_exist")
 
     # Produced kernel dict is valid


### PR DESCRIPTION
# Description

This PR upgrades the initialisation sequence of the `SolarIrradianceSpectrum` type to the standard data lookup pattern. Changes are as follows:

* `SolarIrradianceSpectrum.dataset` now follows the standard data lookup pattern:
  1. Try and load based on an identifier
  2. Try and load a file on the hard drive
  3. Try and load a file from the data store
  4. Pass a dataset directly
* The `thuillier_2003_extrapolated` has a keyword and is now the default.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
