### PR TITLE
`InterpolatedSpectrum`: Load from `xarray.DataArray`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@ when necessary—we also advise to not ignore `DeprecationWarning`s.
 * Improve the Solar irradiance spectrum initialisation sequence ({ghpr}`242`).
 * The `thuillier_2003_extrapolated` dataset is now the default Solar irradiance 
   spectrum ({ghpr}`242`).
+* Added a `InterpolatedSpectrum.from_dataarray()` class method constructor 
+  ({ghpr}`243`).
 
 % ### Documentation
 

--- a/src/eradiate/scenes/spectra/_core.py
+++ b/src/eradiate/scenes/spectra/_core.py
@@ -101,6 +101,7 @@ class Spectrum(SceneElement, ABC):
         "based on ``quantity``.",
         type=":class:`.PhysicalQuantity`",
         init_type=":class:`.PhysicalQuantity` or str",
+        default="dimensionless",
     )
 
     @quantity.validator
@@ -167,7 +168,7 @@ class Spectrum(SceneElement, ABC):
         Returns
         -------
         value : quantity
-            Evaluated spectrum as an array with shape (len(bindexes),).
+            Evaluated spectrum as an array with shape ``(len(bindexes),)``.
         """
         pass
 

--- a/tests/02_eradiate/01_unit/scenes/spectra/test_interpolated.py
+++ b/tests/02_eradiate/01_unit/scenes/spectra/test_interpolated.py
@@ -192,3 +192,12 @@ def test_interpolated_kernel_dict(modes_all_mono):
     with uck.override({"radiance": "kW/m^2/sr/nm"}):
         d = s.kernel_dict(ctx)
         assert np.allclose(d["spectrum"]["value"], 5e-4)
+
+
+def test_interpolated_from_dataarray(mode_mono):
+    da = eradiate.data.load_dataset(
+        "spectra/reflectance/lambertian_soil_01.nc"
+    ).reflectance
+    spectrum = InterpolatedSpectrum.from_dataarray(dataarray=da)
+    assert np.all(spectrum.wavelengths.m_as(da.w.attrs["units"]) == da.w.values)
+    assert np.all(spectrum.values.m_as(da.attrs["units"]) == da.values)


### PR DESCRIPTION
# Description

This PR adds the possibility to load interpolated spectra from an xarray data array. Changes are as follows:

* `InterpolatedSpectrum` gets a new `from_dataarray()` class constructor (also accessible from the dictionary initialisation interface).
* The data submodule now contains a set of bare soil reflectance spectra suitable for usage with this constructor.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
