### PR TITLE
Digital elevation model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ when necessary—we also advise to not ignore `DeprecationWarning`s.
 
 * Added support for various azimuth definition conventions ({ghpr}`247`).
 * Added an offline mode which disables all data file downloads ({ghpr}`249`).
+* Added support for Digital Elevation Models (DEM) ({ghpr}`246`).
 
 % ### Breaking changes
 

--- a/docs/rst/user_guide/onedim_experiment.rst
+++ b/docs/rst/user_guide/onedim_experiment.rst
@@ -162,6 +162,39 @@ Black surface [:class:`.BlackBSDF`, ``black``]
     The black surface absorbs all incoming radiation, irrespective of
     incident angle or wavelength.
 
+Digital elevation model [``dem``]
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Eradiate extends the standard functionalities of one-dimensional simulations with
+digital elevation models (DEM). A three-dimensional surface can be defined with the ``dem``
+parameter. The DEM can be defined in several ways and it can be used with any BSDF type
+mentioned in the surface section above. Since a DEM surface model always has a finite
+horizontal extent, Eradiate adds horizontal elements to the edge of the DEM surface
+to prevent rays from escaping under it. The remaining surface area outside of the DEM is
+covered with the surface specified in the ``surface`` section.
+
+Note that Eradiate does not adjust the horizontal level of the flat surface automatically.
+If the DEM contains elevation values below the flat surface level (0m per default), the 3D
+surface will intersect the flat surface and the areas below the flat surface's level will
+be obscured by it.
+
+There are three ways to define a DEM geometry:
+
+An xarray DataArray [:meth:`.DEMSurface.from_dataarray`]
+    A DataArray defining a digital elevation model needs to have two coordinates named
+    `lat` for the latitude and `lon` for the longitude, specified in degrees and the
+    elevation data specified in kernel units of length.
+
+Triangulated meshes [:class:`.FileMesh`, ``file_mesh``]
+    To define the DEM using a triangulated mesh users can supply either a .obj file
+    or a .ply file. The mesh file will be interpreted as kernel units of length.
+    In this case no constructor method is used. Instead the `shape` member of the
+    `dem` class is directly defined with this mesh shape.
+
+Analytical functions [:meth:`.DEMSurface.from_analytical`]
+    Digital elevation models can be defined using functions, which take an x and
+    y position and return the corresponding elevation value.
+
 Result output
 -------------
 

--- a/src/eradiate/scenes/shapes/__init__.py
+++ b/src/eradiate/scenes/shapes/__init__.py
@@ -7,6 +7,9 @@ __getattr__, __dir__, __all__ = lazy_loader.attach(
         "_cuboid": ["CuboidShape"],
         "_rectangle": ["RectangleShape"],
         "_sphere": ["SphereShape"],
+        "_dtm": ["DTMShape"],
+        "_filemesh": ["FileMeshShape"],
+        "_buffermesh": ["BufferMeshShape"],
     },
 )
 

--- a/src/eradiate/scenes/shapes/_buffermesh.py
+++ b/src/eradiate/scenes/shapes/_buffermesh.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import attr
+import mitsuba as mi
+import numpy as np
+import pint
+import pinttr
+
+from ._core import Shape, shape_factory
+from ..core import KernelDict
+from ...attrs import documented, parse_docs
+from ...contexts import KernelDictContext
+from ...units import unit_context_config as ucc
+from ...units import unit_context_kernel as uck
+
+
+@parse_docs
+@attr.s
+class BufferMeshShape(Shape):
+    """
+    Buffer mesh shape [``buffer_mesh``].
+
+    This shape represents a triangulated mesh directly defined by lists of vertex
+    positions and faces.
+    """
+
+    vertices: pint.Quantity = documented(
+        pinttr.ib(
+            validator=pinttr.validators.has_compatible_units,
+            units=ucc.deferred("length"),
+            kw_only=True,
+        ),
+        doc="List of vertex positions. The passed list must contain a (n, 3) list"
+        "of three dimensional points.",
+        type="quantity",
+        init_type="array-like",
+    )
+
+    faces: np.ndarray = documented(
+        attr.ib(
+            kw_only=True,
+            converter=np.array,
+        ),
+        doc="List of face definitions. The passed list must contain a (n, 3) list"
+        "of three vertex indices defining triangles.",
+        type="ndarray",
+        init_type="array-like",
+    )
+
+    @vertices.validator
+    @faces.validator
+    def _vertex_face_validator(self, attribute, value):
+        if value.ndim != 2 or value.shape[0] == 0 or value.shape[1] != 3:
+            raise ValueError(
+                f"while validating {attribute.name}, must be an array of shape "
+                f"(n, 3), got {value.shape}"
+            )
+
+    def kernel_dict(self, ctx: KernelDictContext) -> KernelDict:
+        if self.bsdf is not None:
+            bsdf = self.bsdf.kernel_dict(ctx).load()
+        else:
+            bsdf = None
+
+        props = mi.Properties()
+        props["mesh_bsdf"] = bsdf
+
+        mesh = mi.Mesh(
+            name=self.id,
+            face_count=self.faces.shape[0],
+            vertex_count=self.vertices.shape[0],
+            has_vertex_normals=False,
+            has_vertex_texcoords=False,
+            props=props,
+        )
+
+        vertices = self.vertices.m_as(uck.get("length"))
+        mesh_params = mi.traverse(mesh)
+        mesh_params["vertex_positions"] = vertices.ravel()
+        mesh_params["faces"] = self.faces.ravel()
+        mesh_params.update()
+
+        result = KernelDict({self.id: mesh})
+
+        return result

--- a/src/eradiate/scenes/shapes/_core.py
+++ b/src/eradiate/scenes/shapes/_core.py
@@ -16,6 +16,8 @@ shape_factory.register_lazy_batch(
         ("_cuboid.CuboidShape", "cuboid", {}),
         ("_rectangle.RectangleShape", "rectangle", {}),
         ("_sphere.SphereShape", "sphere", {}),
+        ("_filemesh.FileMeshShape", "file_mesh", {}),
+        ("_buffermesh.BufferMeshShape", "buffer_mesh", {})
     ],
     cls_prefix="eradiate.scenes.shapes",
 )

--- a/src/eradiate/scenes/shapes/_filemesh.py
+++ b/src/eradiate/scenes/shapes/_filemesh.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import attr
+
+from ._core import Shape, shape_factory
+from ..core import KernelDict
+from ...attrs import documented, parse_docs
+from ...contexts import KernelDictContext
+from ...util.misc import onedict_value
+
+
+@parse_docs
+@attr.s
+class FileMeshShape(Shape):
+    """
+    File based mesh shape [``file_mesh``].
+
+    This shape represents a triangulated mesh defined in a file
+    in either the PLY or OBJ format.
+    The vertex positions are assumed to be defined in kernel units.
+    """
+
+    filename: Path = documented(
+        attr.ib(converter=Path, kw_only=True),
+        type="Path",
+        init_type="path-like",
+        doc="Path to the mesh file.",
+    )
+
+    @filename.validator
+    def _filename_validator(self, attribute, value):
+        if value.suffix not in [".obj", ".ply"]:
+            raise ValueError(
+                f"while validating {attribute.name}:"
+                f"Eradiate supports mesh files only in PLY or OBJ format."
+            )
+
+    def kernel_dict(self, ctx: KernelDictContext) -> KernelDict:
+        if self.filename.suffix == ".obj":
+            type = "obj"
+        elif self.filename.suffix == ".ply":
+            type = "ply"
+        else:
+            raise ValueError(f"unknown mesh file type '{self.filename.suffix}'")
+
+        meshdict = {
+            "type": type,
+            "filename": str(self.filename),
+            "face_normals": True,
+        }
+
+        if self.bsdf:
+            meshdict["bsdf"] = onedict_value(self.bsdf.kernel_dict(ctx=ctx))
+
+        result = KernelDict({self.id: meshdict})
+
+        return result

--- a/src/eradiate/scenes/surface/__init__.py
+++ b/src/eradiate/scenes/surface/__init__.py
@@ -6,6 +6,7 @@ __getattr__, __dir__, __all__ = lazy_loader.attach(
         "_core": ["Surface", "surface_factory"],
         "_basic": ["BasicSurface"],
         "_central_patch": ["CentralPatchSurface"],
+        "_dem": ["DEMSurface"],
     },
 )
 

--- a/src/eradiate/scenes/surface/_core.py
+++ b/src/eradiate/scenes/surface/_core.py
@@ -16,6 +16,7 @@ surface_factory.register_lazy_batch(
     [
         ("_basic.BasicSurface", "basic", {}),
         ("_central_patch.CentralPatchSurface", "central_patch", {}),
+        ("_dem.DEMSurface", "dem", {})
     ],
     cls_prefix="eradiate.scenes.surface",
 )

--- a/src/eradiate/scenes/surface/_dem.py
+++ b/src/eradiate/scenes/surface/_dem.py
@@ -1,0 +1,272 @@
+from __future__ import annotations
+
+import typing as t
+
+import attr
+import numpy as np
+import pint
+import xarray as xr
+
+from ._core import Surface, surface_factory
+from ..bsdfs import BSDF, LambertianBSDF, bsdf_factory
+from ..core import KernelDict
+from ..shapes import BufferMeshShape, FileMeshShape, Shape, shape_factory
+from ...attrs import documented, get_doc, parse_docs
+from ...contexts import KernelDictContext
+from ...units import to_quantity
+from ...units import unit_context_config as ucc
+from ...units import unit_registry as ureg
+from ...util.misc import onedict_value
+
+
+@parse_docs
+@attr.s
+class DEMSurface(Surface):
+    """
+    DEM surface [``dem``]
+
+    A surface description for digital elevation models. This object holds only the Shape.
+    The associated BSDF is defined within the Shape plugin.
+
+    This surface supports instantiation based on preprocessed geotiff files,
+    triangulated meshes in the PLY and OBJ formats and analytical surfaces based on functions
+    which map x and y coordinates to an elevation value.
+
+    .. admonition:: Class method constructors
+
+        .. autosummary::
+
+            from_dataarray
+            from_analytical
+
+    Note: The DEMSurface overwrites :meth:`.Surface.kernel_dict`, because of the way, kernel dict
+    creation is handled in :class:`BufferMeshShape`. That class returns a mitsuba Mesh object, instead
+    of a kernel dict and so it cannot be updated to hold a reference to the BSDF specified here. Instead we
+    overwrite the bsdf member of the underlying shape class directly before kernel dict creation.
+    """
+
+    id: t.Optional[str] = documented(
+        attr.ib(
+            default="terrain",
+            validator=attr.validators.optional(attr.validators.instance_of(str)),
+        ),
+        doc=get_doc(Surface, "id", "doc"),
+        type=get_doc(Surface, "id", "type"),
+        init_type=get_doc(Surface, "id", "init_type"),
+        default='"surface"',
+    )
+
+    shape: Shape = documented(
+        attr.ib(
+            converter=attr.converters.optional(shape_factory.convert),
+            validator=attr.validators.optional(
+                attr.validators.instance_of((BufferMeshShape, FileMeshShape))
+            ),
+            kw_only=True,
+        ),
+        doc="Shape describing the surface.",
+        type=".BufferMeshShape or .OBJMeshShape or .PLYMeshShape",
+        init_type=".BufferMeshShape or .OBJMeshShape or .PLYMeshShape or dict",
+    )
+
+    bsdf: BSDF = documented(
+        attr.ib(
+            factory=LambertianBSDF,
+            converter=bsdf_factory.convert,
+            validator=attr.validators.instance_of(BSDF),
+        ),
+        doc="The reflection model attached to the surface.",
+        type=".BSDF",
+        init_type=".BSDF or dict, optional",
+        default=":class:`LambertianBSDF() <.LambertianBSDF>`",
+    )
+
+    @staticmethod
+    def _vertex_index(x, y, len_y):
+        return x * len_y + y
+
+    @staticmethod
+    def _generate_face_indices(len_x, len_y):
+        face_indices = []
+        for x in range(len_x + 1):
+            for y in range(len_y + 1):
+                vertex_sw = DEMSurface._vertex_index(x, y, len_y + 2)
+                vertex_ne = DEMSurface._vertex_index(x + 1, y + 1, len_y + 2)
+                vertex_nw = DEMSurface._vertex_index(x, y + 1, len_y + 2)
+                vertex_se = DEMSurface._vertex_index(x + 1, y, len_y + 2)
+                # In mitsuba, triangles are defined clockwise
+                face_indices.append((vertex_sw, vertex_ne, vertex_nw))
+                face_indices.append((vertex_sw, vertex_se, vertex_ne))
+
+        return face_indices
+
+    @classmethod
+    def from_dataarray(
+        cls, data: xr.DataArray, bsdf: BSDF, planet_radius=6371 * ureg.km
+    ) -> DEMSurface:
+        """
+        This classmethod enables the instantiation of a DEM from an xarray data array holding elevation data.
+        The dataarray must use latitude and longitude as its dimensional coordinates.
+
+        Parameters
+        ----------
+        data : DataArray
+            Dataarray holding the elevation data. Dimensional coordinates must be latitude `lat`
+            and longitude `lon`. Data will be interpreted to be given in kernel units.
+
+        bsdf : .BSDF
+            BSDF to be attached to the mesh shape.
+
+        planet_radius : quantity
+            Planet radius used to convert latitude and longitude into distance units.
+            Defaults to Earth's radius.
+
+        Returns
+        -------
+        :class:`.DEMSurface`
+            Created :class:`DEMSurface`.
+        """
+        radius = planet_radius.m_as(ucc.get("length"))
+
+        len_lat = len(data.lat)  # x
+        len_lon = len(data.lon)  # y
+
+        # I convert the degrees to local distances based on the planet radius
+        # This will be handled differently when I include the AtmosphereGeometry.
+        lon_rad = to_quantity(data.lon).m_as(ureg.rad)
+        lat_rad = to_quantity(data.lat).m_as(ureg.rad)
+        mean_lon = lon_rad.mean()
+        lon_range = lon_rad.max() - lon_rad.min()
+        lat_range = lat_rad.max() - lat_rad.min()
+        lon_length = (lon_range * radius)
+        lat_length = (lat_range * radius * np.cos(mean_lon))
+
+        lat_range = list(np.linspace(-lat_length / 2.0, lat_length / 2.0, len_lat))
+        # Duplicate the first and last entry for the extra vertices, which form the
+        # vertical walls
+        lat_range.insert(0, lat_range[0])
+        lat_range.append(lat_range[-1])
+
+        lon_range = list(np.linspace(-lon_length / 2.0, lon_length / 2.0, len_lon))
+
+        vertex_positions = np.zeros(((len_lat + 2) * (len_lon + 2), 3))
+        values = np.array(data.data).transpose()[:, ::-1]
+        for i, x in enumerate(lat_range):
+            if i in [0, len_lat + 1]:
+                # For the rows of vertices which are only the lower points of the wall
+                # set the z coordinate to -1
+                z_list = np.full(len_lon + 2, -1.0)
+            else:
+                z_list = values[i - 1]
+                # Add z=-1 on both ends for the points that make up the vertical wall
+                z_list = np.insert(z_list, 0, -1.0)
+                z_list = np.append(z_list, -1.0)
+            for j, z in enumerate(z_list):
+                # Duplicate the first and last entry for the extra vertices, which form the
+                # vertical walls
+                if j == 0:
+                    y = lon_range[0]
+                elif j == len_lon + 1:
+                    y = lon_range[-1]
+                else:
+                    y = lon_range[j - 1]
+                vertex_positions[i * len_lon + j, :] = [x, y, z]
+
+        # For each row and each column, except the last ones, define two
+        # triangles, extending one index in each dimension.
+        face_indices = cls._generate_face_indices(len_lat, len_lon)
+
+        return cls(
+            shape=BufferMeshShape(
+                vertices=vertex_positions, faces=face_indices, bsdf=bsdf
+            )
+        )
+
+    @classmethod
+    def from_analytical(
+        cls,
+        elevation_function: t.Callable,
+        x_length: pint.Quantity,
+        x_steps: int,
+        y_length: pint.Quantity,
+        y_steps: int,
+        bsdf: BSDF,
+    ) -> DEMSurface:
+        """
+        This classmethod allows the creation of a DEM surface based on a function, which
+        maps x,y points to an elevation.
+
+        Parameters
+        ----------
+        elevation_function : callable
+            Function that takes x, y points as inputs and returns the corresponding elevation
+            value. Elevation values are interpreted in kernel units.
+
+        x_length : pint.Quantity
+            Extent of the mapped area along the x-axis.
+
+        x_steps : int
+            Number of data points to generate along the x-axis.
+
+        y_length : pint.Quantity
+            Extent of the mapped area along the y-axis.
+
+        y_steps : int
+            Number of data points to generate along the y-axis.
+
+        bsdf : .BSDF
+            BSDF to be attached to the mesh shape.
+        """
+        x_length_m = x_length.m_as(ucc.get("length"))
+        y_length_m = y_length.m_as(ucc.get("length"))
+
+        # duplicate the first and last entries in x and y, for the vertices
+        # that form the vertical walls
+        x_range = np.empty((x_steps + 2,))
+        x_range[1:-1] = np.linspace(-x_length_m / 2.0, x_length_m / 2.0, x_steps)
+        x_range[0] = x_range[1]
+        x_range[-1] = x_range[-2]
+
+        y_range = np.empty((y_steps + 2,))
+        y_range[1:-1] = np.linspace(-y_length_m / 2.0, y_length_m / 2.0, y_steps)
+        y_range[0] = y_range[1]
+        y_range[-1] = y_range[-2]
+
+        face_indices = cls._generate_face_indices(x_steps, y_steps)
+
+        vertex_positions = []
+        for i, x in enumerate(x_range):
+            for j, y in enumerate(y_range):
+                if i in [0, x_steps + 1] or j in [0, y_steps + 1]:
+                    z = -1.0
+                else:
+                    z = elevation_function(x, y)
+                vertex_positions.append([x, y, z])
+
+        return cls(
+            shape=BufferMeshShape(
+                vertices=vertex_positions, faces=face_indices, bsdf=bsdf
+            )
+        )
+
+    def kernel_bsdfs(self, ctx: KernelDictContext) -> KernelDict:
+        # Inherit docstring
+        return self.bsdf.kernel_dict(ctx)
+
+    def kernel_shapes(self, ctx: KernelDictContext) -> KernelDict:
+        # Inherit docstring
+        return self.shape.kernel_dict(ctx)
+
+    def kernel_dict(self, ctx: KernelDictContext) -> KernelDict:
+        # Inherit docstring
+
+        # This will overwrite any set BSDF
+        self.shape.bsdf = self.bsdf
+
+        # This is handled differently, because BufferMeshShape instantiates
+        # a mitsuba object instead of returning a dict
+        kernel_dict = {
+            self.shape_id: onedict_value(self.kernel_shapes(ctx)),
+        }
+
+        return KernelDict(kernel_dict)

--- a/tests/02_eradiate/01_unit/experiments/test_atmosphere.py
+++ b/tests/02_eradiate/01_unit/experiments/test_atmosphere.py
@@ -12,7 +12,9 @@ from eradiate.scenes.atmosphere import (
     HomogeneousAtmosphere,
     MolecularAtmosphere,
 )
+from eradiate.scenes.bsdfs import LambertianBSDF
 from eradiate.scenes.measure import MeasureSpectralConfig, MultiDistantMeasure
+from eradiate.scenes.surface import DEMSurface
 
 
 def test_onedim_experiment_construct_default(modes_all_double):
@@ -266,3 +268,25 @@ def test_onedim_experiment_run_detailed(modes_all):
 
     # We just check that we record something as expected
     assert np.all(results["radiance"].data > 0.0)
+
+
+def test_atmosphere_experiment_warn_targeting_dem(modes_all):
+    """
+    Test that Eradiate raises a warning, when the measure target is a point and a DEM is defined in the scene.
+    """
+
+    with pytest.warns(UserWarning):
+        exp = AtmosphereExperiment(
+            dem=DEMSurface.from_analytical(
+                elevation_function=lambda x, y: 1,
+                x_length=1 * ureg.m,
+                x_steps=10,
+                y_length=1 * ureg.m,
+                y_steps=10,
+                bsdf=LambertianBSDF(),
+            ),
+            measures=[
+                {"type": "distant", "id": "distant_measure"},
+            ],
+        )
+        kd = exp.kernel_dict(ctx=KernelDictContext())

--- a/tests/02_eradiate/01_unit/scenes/shapes/test_buffermesh.py
+++ b/tests/02_eradiate/01_unit/scenes/shapes/test_buffermesh.py
@@ -1,0 +1,22 @@
+import pytest
+
+from eradiate.contexts import KernelDictContext
+from eradiate.scenes.shapes import BufferMeshShape
+
+
+def test_construct(modes_all_double):
+    ctx = KernelDictContext()
+    mesh = BufferMeshShape(
+        vertices=[[1, 0, 0], [0, 1, 0], [0, 0, 1]], faces=[[1, 2, 3]]
+    )
+    assert mesh.kernel_dict(ctx=ctx)
+
+    # flat list of vertex pos fails
+    with pytest.raises(ValueError):
+        mesh = BufferMeshShape(vertices=[1, 0, 0, 0, 1, 0, 0, 0, 1], faces=[[1, 2, 3]])
+
+    # flat list of face indices fails
+    with pytest.raises(ValueError):
+        mesh = BufferMeshShape(
+            vertices=[[1, 0, 0], [0, 1, 0], [0, 0, 1]], faces=[1, 2, 3]
+        )

--- a/tests/02_eradiate/01_unit/scenes/shapes/test_filemesh.py
+++ b/tests/02_eradiate/01_unit/scenes/shapes/test_filemesh.py
@@ -1,0 +1,67 @@
+import os
+import tempfile
+
+import pytest
+
+from eradiate.contexts import KernelDictContext
+from eradiate.scenes.shapes import FileMeshShape
+
+
+@pytest.fixture(scope="module")
+def tempfile_ply():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        filename = os.path.join(tmpdir, "tempfile_mesh.ply")
+        with open(filename, "w") as tf:
+            tf.write("ply\n")
+            tf.write("format ascii 1.0\n")
+            tf.write("element vertex 3\n")
+            tf.write("property float x\n")
+            tf.write("property float y\n")
+            tf.write("property float z\n")
+            tf.write("element face 1\n")
+            tf.write("property list uchar int vertex_index\n")
+            tf.write("end_header\n")
+            tf.write("1 0 0\n")
+            tf.write("0 1 0\n")
+            tf.write("0 0 1\n")
+            tf.write("3 1 2 3\n")
+        yield filename
+
+
+@pytest.fixture(scope="module")
+def tempfile_obj():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        filename = os.path.join(tmpdir, "tempfile_mesh.obj")
+        with open(filename, "w") as tf:
+            tf.write("v 1 0 0\n")
+            tf.write("v 0 1 0\n")
+            tf.write("v 0 0 1\n")
+            tf.write("f 1 2 3\n")
+        yield filename
+
+
+def test_construct_file_ply(modes_all_double, tempfile_ply):
+
+    ctx = KernelDictContext()
+    mesh = FileMeshShape(filename=tempfile_ply)
+    assert mesh.kernel_dict(ctx=ctx)
+    kd = mesh.kernel_dict(ctx=ctx)
+    assert kd[mesh.id]["type"] == "ply"
+    assert kd.load(strip=False)
+
+
+def test_construct_file_obj(modes_all_double, tempfile_obj):
+
+    ctx = KernelDictContext()
+    mesh = FileMeshShape(filename=tempfile_obj)
+    assert mesh.kernel_dict(ctx=ctx)
+    kd = mesh.kernel_dict(ctx=ctx)
+    assert kd[mesh.id]["type"] == "obj"
+    assert kd.load(strip=False)
+
+
+def test_construct_file_illegal(modes_all_double):
+
+    with pytest.raises(ValueError):
+        ctx = KernelDictContext()
+        mesh = FileMeshShape(filename="path/to/file.wrong")

--- a/tests/02_eradiate/01_unit/scenes/surface/test_dem.py
+++ b/tests/02_eradiate/01_unit/scenes/surface/test_dem.py
@@ -1,0 +1,75 @@
+import os
+import tempfile
+
+import drjit as dr
+import mitsuba as mi
+import numpy as np
+import pytest
+import xarray as xr
+
+from eradiate.contexts import KernelDictContext
+from eradiate.scenes.bsdfs import LambertianBSDF
+from eradiate.scenes.shapes import FileMeshShape
+from eradiate.scenes.surface import DEMSurface
+from eradiate.units import unit_registry as ureg
+
+
+@pytest.fixture(scope="module")
+def tempfile_obj():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        filename = os.path.join(tmpdir, "tempfile_mesh.obj")
+        with open(filename, "w") as tf:
+            tf.write("v 1 0 0\n")
+            tf.write("v 0 1 0\n")
+            tf.write("v 0 0 1\n")
+            tf.write("f 1 2 3\n")
+        yield filename
+
+
+def test_dem_construct_default(modes_all_double, tempfile_obj):
+
+    ctx = KernelDictContext()
+
+    dem = DEMSurface(
+        id="dem", shape=FileMeshShape(filename=tempfile_obj, bsdf=LambertianBSDF())
+    )
+
+    assert dem.kernel_dict(ctx=ctx).load(strip=False)
+
+
+def test_dem_construct_dataarray(modes_all_double, tempfile_obj):
+
+    ctx = KernelDictContext()
+
+    da = xr.DataArray(
+        data=np.zeros((10, 10)),
+        dims=["x", "y"],
+        coords=dict(
+            lat=(["x"], np.linspace(-5, 5.1, 10)),
+            lon=(["y"], np.linspace(-6, 6, 10)),
+        ),
+    )
+    da.lat.attrs["units"] = "degree"
+    da.lon.attrs["units"] = "degree"
+
+    dem = DEMSurface.from_dataarray(data=da, bsdf=LambertianBSDF())
+    assert dem.kernel_dict(ctx=ctx).load(strip=False)
+
+
+def test_dem_construct_analytical(modes_all_double, tempfile_obj):
+
+    # Default constructor
+    ctx = KernelDictContext()
+
+    def elevation(x, y):
+        return 10.0
+
+    dem = DEMSurface.from_analytical(
+        elevation,
+        x_length=10 * ureg.m,
+        y_length=10 * ureg.m,
+        x_steps=100,
+        y_steps=100,
+        bsdf=LambertianBSDF(),
+    )
+    assert dem.kernel_dict(ctx=ctx).load(strip=False)


### PR DESCRIPTION
# Description

This PR introduces the capability to represent surface elevation based on digital terrain models.

It adds a new member to the OneDimExperiment class.

It will be possible to specify the DTM by different means:
- NetCDF files holding the elevation data
- .ply meshes
- .obj meshes
- Functions which return the elevation depending on the local x and y coordinate.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
