### PR TITLE
Fix paths to CKD data sets in `downloads.yml`

### DIFF
--- a/resources/downloads.yml
+++ b/resources/downloads.yml
@@ -1,7 +1,7 @@
 # This file contains a list of frequently used files which you might want to
 # download.
-- ckd/absorption/1nm/afgl_1986-us_standard-1nm.nc
-- ckd/absorption/10nm/afgl_1986-us_standard-10nm.nc
+- ckd/absorption/1nm/afgl_1986-us_standard-1nm-v3.nc
+- ckd/absorption/10nm/afgl_1986-us_standard-10nm-v3.nc
 - spectra/absorption/us76_u86_4/us76_u86_4-spectra-4000_5000.nc
 - spectra/absorption/us76_u86_4/us76_u86_4-spectra-5000_6000.nc
 - spectra/absorption/us76_u86_4/us76_u86_4-spectra-6000_7000.nc


### PR DESCRIPTION
# Description

Fix the paths to the CKD data sets that are actually used by the `AFGL1986RadProfile` constructor. 

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
