### PR TITLE
Offline mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,8 @@ when necessary—we also advise to not ignore `DeprecationWarning`s.
 %
 % ## vXX.YY.ZZ (unreleased)
 %
-### New features
-
-* Added support for various azimuth definition conventions ({ghpr}`247`).
-
+% ### New features
+%
 % ### Breaking changes
 %
 % ### Deprecations and removals
@@ -34,8 +32,11 @@ when necessary—we also advise to not ignore `DeprecationWarning`s.
 
 ## v0.22.5 (unreleased)
 
-% ### New features
-%
+### New features
+
+* Added support for various azimuth definition conventions ({ghpr}`247`).
+* Added an offline mode which disables all data file downloads ({ghpr}`249`).
+
 % ### Breaking changes
 %
 % ### Deprecations and removals

--- a/docs/rst/reference_api/data.rst
+++ b/docs/rst/reference_api/data.rst
@@ -11,6 +11,7 @@ Functions
 .. autosummary::
    :toctree: generated/autosummary/
 
+   init_data_store
    open_dataset
    load_dataset
 
@@ -29,5 +30,7 @@ Classes
 Attributes
 ----------
 
-.. autodata:: data_store
-   :annotation:
+.. data:: data_store
+
+   Global data store. Alias to :data:`eradiate.data._store.data_store`.
+   See also: :class:`eradiate.data.MultiDataStore`.

--- a/docs/rst/reference_api/data.rst
+++ b/docs/rst/reference_api/data.rst
@@ -22,6 +22,7 @@ Classes
    :toctree: generated/autosummary/
 
    DataStore
+   BlindDirectoryDataStore
    BlindOnlineDataStore
    SafeDirectoryDataStore
    SafeOnlineDataStore

--- a/docs/rst/reference_api/data.rst
+++ b/docs/rst/reference_api/data.rst
@@ -22,9 +22,9 @@ Classes
    :toctree: generated/autosummary/
 
    DataStore
-   DirectoryDataStore
-   OnlineDataStore
-   BlindDataStore
+   BlindOnlineDataStore
+   SafeDirectoryDataStore
+   SafeOnlineDataStore
    MultiDataStore
 
 Attributes

--- a/src/eradiate/_config.py
+++ b/src/eradiate/_config.py
@@ -183,6 +183,14 @@ class EradiateConfig:
         help="Path to the Eradiate download directory.",
     )
 
+    #: If ``True``, activate the offline mode. All online data stores
+    #: will be disconnected.
+    offline = environ.bool_var(
+        default=False,
+        help="If ``True``, activate the offline mode. All online data stores "
+        "will be disconnected.",
+    )
+
     #: An integer flag setting the level of progress display (see
     #: :class:`ProgressLevel`). Values are preferably set using strings
     #: (``["NONE", "SPECTRAL_LOOP", "KERNEL"]``). Only affects tqdm-based progress

--- a/src/eradiate/cli.py
+++ b/src/eradiate/cli.py
@@ -135,7 +135,7 @@ def update_registries():
     """
     # Update data store registries
     for data_store_id, data_store in eradiate.data.data_store.stores.items():
-        if isinstance(data_store, eradiate.data.OnlineDataStore):
+        if isinstance(data_store, eradiate.data.SafeOnlineDataStore):
             console.print(
                 f"[bold cyan]{data_store_id}[/] [{data_store.__class__.__name__}]"
             )
@@ -196,11 +196,11 @@ def purge_cache(keep):
             f"[bold cyan]{data_store_id}[/] [{data_store.__class__.__name__}]"
         )
 
-        if isinstance(data_store, eradiate.data.DirectoryDataStore):
+        if isinstance(data_store, eradiate.data.SafeDirectoryDataStore):
             console.print(f"  Skipping")
             continue
 
-        if isinstance(data_store, eradiate.data.OnlineDataStore):
+        if isinstance(data_store, eradiate.data.SafeOnlineDataStore):
             console.print(f"  Purging '{data_store.path}'")
             if keep:
                 data_store.purge(keep="registered")
@@ -208,7 +208,7 @@ def purge_cache(keep):
                 data_store.purge()
             continue
 
-        if isinstance(data_store, eradiate.data.BlindDataStore):
+        if isinstance(data_store, eradiate.data.BlindOnlineDataStore):
             console.print(f"  Purging '{data_store.path}'")
             data_store.purge()
             continue

--- a/src/eradiate/data/__init__.py
+++ b/src/eradiate/data/__init__.py
@@ -4,13 +4,17 @@ Manage Eradiate's data files.
 
 __all__ = [
     "data_store",
+    "init_data_store",
     "open_dataset",
     "load_dataset",
+    "BlindDataStore",
     "DataStore",
     "DirectoryDataStore",
     "OnlineDataStore",
     "MultiDataStore",
 ]
+
+import sys
 
 import xarray as xr
 
@@ -19,16 +23,20 @@ from ._core import DataStore
 from ._directory import DirectoryDataStore
 from ._multi import MultiDataStore
 from ._online import OnlineDataStore
+from ._store import init_data_store
 from ..typing import PathLike
 
 # -- Data store ----------------------------------------------------------------
 
-from . import _store  # isort: skip
 
-#: Global data store.
-#: Alias to :data:`eradiate.data._store.data_store`.
-#: See also: :class:`eradiate.data.MultiDataStore`.
-data_store = _store.data_store
+def __getattr__(name):
+    if name == "data_store":
+        from ._store import data_store
+
+        return data_store
+
+    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
+
 
 # -- Access functions ----------------------------------------------------------
 
@@ -54,6 +62,7 @@ def open_dataset(filename: PathLike, **kwargs) -> xr.Dataset:
     --------
     xarray.open_dataset
     """
+    data_store = getattr(sys.modules[__name__], "data_store")
     filename = data_store.fetch(filename)
     return xr.open_dataset(filename, **kwargs)
 

--- a/src/eradiate/data/__init__.py
+++ b/src/eradiate/data/__init__.py
@@ -8,6 +8,7 @@ __all__ = [
     "open_dataset",
     "load_dataset",
     "DataStore",
+    "BlindDirectoryDataStore",
     "BlindOnlineDataStore",
     "MultiDataStore",
     "SafeDirectoryDataStore",
@@ -18,6 +19,7 @@ import sys
 
 import xarray as xr
 
+from ._blind_directory import BlindDirectoryDataStore
 from ._blind_online import BlindOnlineDataStore
 from ._core import DataStore
 from ._multi import MultiDataStore

--- a/src/eradiate/data/__init__.py
+++ b/src/eradiate/data/__init__.py
@@ -7,22 +7,22 @@ __all__ = [
     "init_data_store",
     "open_dataset",
     "load_dataset",
-    "BlindDataStore",
     "DataStore",
-    "DirectoryDataStore",
-    "OnlineDataStore",
+    "BlindOnlineDataStore",
     "MultiDataStore",
+    "SafeDirectoryDataStore",
+    "SafeOnlineDataStore",
 ]
 
 import sys
 
 import xarray as xr
 
-from ._blind import BlindDataStore
+from ._blind_online import BlindOnlineDataStore
 from ._core import DataStore
-from ._directory import DirectoryDataStore
 from ._multi import MultiDataStore
-from ._online import OnlineDataStore
+from ._safe_directory import SafeDirectoryDataStore
+from ._safe_online import SafeOnlineDataStore
 from ._store import init_data_store
 from ..typing import PathLike
 

--- a/src/eradiate/data/_blind_directory.py
+++ b/src/eradiate/data/_blind_directory.py
@@ -1,0 +1,63 @@
+import typing as t
+from pathlib import Path
+
+import attr
+
+from ._core import DataStore
+from ..attrs import documented, parse_docs
+from ..exceptions import DataError
+from ..typing import PathLike
+
+
+@parse_docs
+@attr.s
+class BlindDirectoryDataStore(DataStore):
+    """
+    Serve files stored in a directory.
+    """
+
+    path: Path = documented(
+        attr.ib(converter=lambda x: Path(x).absolute()),
+        type="Path",
+        init_type="path-like",
+        doc="Path to the root of the directory referenced by this data store.",
+    )
+
+    @property
+    def base_url(self) -> str:
+        """
+        Raises :class:`NotImplementedError` (this data store has not target
+        location).
+        """
+        raise NotImplementedError
+
+    @property
+    def registry(self) -> t.Dict:
+        """
+        Raises :class:`NotImplementedError` (this data store has no registry).
+        """
+        raise NotImplementedError
+
+    def registry_files(
+        self, filter: t.Optional[t.Callable[[t.Any], bool]] = None
+    ) -> t.List[str]:
+        """
+        Returns an empty list (this data store has no registry).
+        """
+        return []
+
+    def fetch(
+        self,
+        filename: PathLike,
+        **kwargs,
+    ) -> Path:
+        # No kwargs are actually accepted
+        if kwargs:
+            keyword = next(iter(kwargs.keys()))
+            raise TypeError(f"fetch() got an unexpected keyword argument '{keyword}'")
+
+        fname = self.path / filename
+        if fname.is_file():
+            return fname
+        else:
+            raise DataError(f"file '{str(filename)}' is not in '{str(self.path)}'")

--- a/src/eradiate/data/_blind_online.py
+++ b/src/eradiate/data/_blind_online.py
@@ -16,7 +16,7 @@ from ..util.misc import LoggingContext
 
 @parse_docs
 @attr.s
-class BlindDataStore(DataStore):
+class BlindOnlineDataStore(DataStore):
     """
     Serve data downloaded from a remote source without integrity check.
     """

--- a/src/eradiate/data/_multi.py
+++ b/src/eradiate/data/_multi.py
@@ -16,7 +16,7 @@ class MultiDataStore(DataStore):
     """
     Chain requests on multiple data stores.
 
-    Calls to the :meth:`.fetch` method are successively redirected to each
+    Calls to the :meth:`~.MultiDataStore.fetch` method are successively redirected to each
     referenced data store. The first successful request is served.
     """
 

--- a/src/eradiate/data/_safe_directory.py
+++ b/src/eradiate/data/_safe_directory.py
@@ -15,7 +15,7 @@ from ..typing import PathLike
 
 @parse_docs
 @attr.s
-class DirectoryDataStore(DataStore):
+class SafeDirectoryDataStore(DataStore):
     """
     Serve files stored in a directory. This data store will only serve files
     listed in its registry.

--- a/src/eradiate/data/_safe_online.py
+++ b/src/eradiate/data/_safe_online.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 
 @attr.s(repr=False, init=False)
-class OnlineDataStore(DataStore):
+class SafeOnlineDataStore(DataStore):
     """
     Serve files located online, with integrity check.
 
@@ -75,7 +75,7 @@ class OnlineDataStore(DataStore):
             ]
         ]
 
-        return f"OnlineDataStore({', '.join(attr_reprs)})"
+        return f"SafeOnlineDataStore({', '.join(attr_reprs)})"
 
     @property
     def base_url(self) -> str:

--- a/src/eradiate/data/_store.py
+++ b/src/eradiate/data/_store.py
@@ -1,9 +1,9 @@
 from collections import OrderedDict
 
-from ._blind import BlindDataStore
-from ._directory import DirectoryDataStore
+from ._blind_online import BlindOnlineDataStore
 from ._multi import MultiDataStore
-from ._online import OnlineDataStore
+from ._safe_directory import SafeDirectoryDataStore
+from ._safe_online import SafeOnlineDataStore
 from .._config import config
 
 #: Global data store.
@@ -21,18 +21,18 @@ def init_data_store():
             [
                 (
                     "small_files",
-                    DirectoryDataStore(path=config.source_dir / "resources/data/"),
+                    SafeDirectoryDataStore(path=config.source_dir / "resources/data/"),
                 ),
                 (
                     "large_files_stable",
-                    OnlineDataStore(
+                    SafeOnlineDataStore(
                         base_url="http://eradiate.eu/data/store/stable/",
                         path=config.download_dir / "stable",
                     ),
                 ),
                 (
                     "large_files_unstable",
-                    BlindDataStore(
+                    BlindOnlineDataStore(
                         base_url="http://eradiate.eu/data/store/unstable/",
                         path=config.download_dir / "unstable",
                     ),

--- a/src/eradiate/data/_store.py
+++ b/src/eradiate/data/_store.py
@@ -7,27 +7,40 @@ from ._online import OnlineDataStore
 from .._config import config
 
 #: Global data store.
-data_store = MultiDataStore(
-    stores=OrderedDict(
-        [
-            (
-                "small_files",
-                DirectoryDataStore(path=config.source_dir / "resources/data/"),
-            ),
-            (
-                "large_files_stable",
-                OnlineDataStore(
-                    base_url="http://eradiate.eu/data/store/stable/",
-                    path=config.download_dir / "stable",
+data_store: MultiDataStore = None
+
+
+def init_data_store():
+    """
+    Initialise the global data store.
+    """
+    global data_store
+
+    data_store = MultiDataStore(
+        stores=OrderedDict(
+            [
+                (
+                    "small_files",
+                    DirectoryDataStore(path=config.source_dir / "resources/data/"),
                 ),
-            ),
-            (
-                "large_files_unstable",
-                BlindDataStore(
-                    base_url="http://eradiate.eu/data/store/unstable/",
-                    path=config.download_dir / "unstable",
+                (
+                    "large_files_stable",
+                    OnlineDataStore(
+                        base_url="http://eradiate.eu/data/store/stable/",
+                        path=config.download_dir / "stable",
+                    ),
                 ),
-            ),
-        ]
+                (
+                    "large_files_unstable",
+                    BlindDataStore(
+                        base_url="http://eradiate.eu/data/store/unstable/",
+                        path=config.download_dir / "unstable",
+                    ),
+                ),
+            ]
+        )
     )
-)
+
+
+# Initialise the data store upon module import
+init_data_store()

--- a/src/eradiate/data/_store.py
+++ b/src/eradiate/data/_store.py
@@ -1,5 +1,7 @@
+import typing as t
 from collections import OrderedDict
 
+from ._blind_directory import BlindDirectoryDataStore
 from ._blind_online import BlindOnlineDataStore
 from ._multi import MultiDataStore
 from ._safe_directory import SafeDirectoryDataStore
@@ -10,36 +12,70 @@ from .._config import config
 data_store: MultiDataStore = None
 
 
-def init_data_store():
+def init_data_store(offline: t.Optional[bool] = None) -> None:
     """
     Initialise the global data store.
+
+    Parameters
+    ----------
+    offline : bool, optional
+        If ``True``, replace all online data stores with blind directory data
+        stores. If unset, the global offline configuration is used.
     """
     global data_store
 
-    data_store = MultiDataStore(
-        stores=OrderedDict(
-            [
-                (
-                    "small_files",
-                    SafeDirectoryDataStore(path=config.source_dir / "resources/data/"),
-                ),
-                (
-                    "large_files_stable",
-                    SafeOnlineDataStore(
-                        base_url="http://eradiate.eu/data/store/stable/",
-                        path=config.download_dir / "stable",
+    if offline is None:
+        offline = config.offline
+
+    if not offline:
+        data_store = MultiDataStore(
+            stores=OrderedDict(
+                [
+                    (
+                        "small_files",
+                        SafeDirectoryDataStore(
+                            path=config.source_dir / "resources/data/"
+                        ),
                     ),
-                ),
-                (
-                    "large_files_unstable",
-                    BlindOnlineDataStore(
-                        base_url="http://eradiate.eu/data/store/unstable/",
-                        path=config.download_dir / "unstable",
+                    (
+                        "large_files_stable",
+                        SafeOnlineDataStore(
+                            base_url="http://eradiate.eu/data/store/stable/",
+                            path=config.download_dir / "stable",
+                        ),
                     ),
-                ),
-            ]
+                    (
+                        "large_files_unstable",
+                        BlindOnlineDataStore(
+                            base_url="http://eradiate.eu/data/store/unstable/",
+                            path=config.download_dir / "unstable",
+                        ),
+                    ),
+                ]
+            )
         )
-    )
+
+    else:
+        data_store = MultiDataStore(
+            stores=OrderedDict(
+                [
+                    (
+                        "small_files",
+                        SafeDirectoryDataStore(
+                            path=config.source_dir / "resources/data/"
+                        ),
+                    ),
+                    (
+                        "large_files_stable",
+                        BlindDirectoryDataStore(path=config.download_dir / "stable"),
+                    ),
+                    (
+                        "large_files_unstable",
+                        BlindDirectoryDataStore(path=config.download_dir / "unstable"),
+                    ),
+                ]
+            )
+        )
 
 
 # Initialise the data store upon module import

--- a/tests/02_eradiate/01_unit/data/test_blind_directory.py
+++ b/tests/02_eradiate/01_unit/data/test_blind_directory.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+import pytest
+
+import eradiate
+from eradiate.data import BlindDirectoryDataStore
+from eradiate.exceptions import DataError
+
+TEST_FILE_EXISTS = Path("tests/data/git/registered_dataset.nc")
+TEST_FILE_DOES_NOT_EXIST = Path("tests/data/git/does_not_exist.nc")
+
+
+def test_directory_data_store_fetch():
+    # The data submodule can be instantiated
+    data_store = BlindDirectoryDataStore(
+        path=eradiate.config.source_dir / "resources/data"
+    )
+
+    # We can fetch the test file
+    assert data_store.fetch(TEST_FILE_EXISTS)
+
+    # A missing file raises
+    with pytest.raises(DataError):
+        data_store.fetch(TEST_FILE_DOES_NOT_EXIST)

--- a/tests/02_eradiate/01_unit/data/test_blind_online.py
+++ b/tests/02_eradiate/01_unit/data/test_blind_online.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from eradiate.data import BlindDataStore
+from eradiate.data import BlindOnlineDataStore
 from eradiate.exceptions import DataError
 
 TEST_STORE = "http://eradiate.eu/data/store/stable"
@@ -13,8 +13,8 @@ TEST_STORE = "http://eradiate.eu/data/store/stable"
 def test_blind_data_store_fetch(tmpdir):
     test_file = Path("tests/data/online/unregistered_dataset.nc")
 
-    # Using an empty storage directory, a BlindDataStore instance can be created
-    store = BlindDataStore(base_url=TEST_STORE, path=tmpdir)
+    # Using an empty storage directory, a BlindOnlineDataStore instance can be created
+    store = BlindOnlineDataStore(base_url=TEST_STORE, path=tmpdir)
 
     # We can download a resource if it is available online
     fpath = store.fetch(test_file)
@@ -35,7 +35,7 @@ def test_blind_data_store_fetch(tmpdir):
 
 @pytest.mark.parametrize("keep", [False, True])
 def test_blind_data_store_purge(tmpdir, keep):
-    store = BlindDataStore(base_url=TEST_STORE, path=tmpdir)
+    store = BlindOnlineDataStore(base_url=TEST_STORE, path=tmpdir)
 
     files = [
         "tests/data/online/unregistered_dataset.nc.gz",

--- a/tests/02_eradiate/01_unit/data/test_multi.py
+++ b/tests/02_eradiate/01_unit/data/test_multi.py
@@ -1,7 +1,7 @@
 import pytest
 
 import eradiate
-from eradiate.data import DirectoryDataStore, MultiDataStore, OnlineDataStore
+from eradiate.data import MultiDataStore, SafeDirectoryDataStore, SafeOnlineDataStore
 from eradiate.exceptions import DataError
 
 TEST_STORE = "http://eradiate.eu/data/store/stable"
@@ -17,11 +17,13 @@ def test_multi_data_store(tmpdir):
         [
             (
                 "1",
-                DirectoryDataStore(path=eradiate.config.source_dir / "resources/data"),
+                SafeDirectoryDataStore(
+                    path=eradiate.config.source_dir / "resources/data"
+                ),
             ),
             (
                 "2",
-                OnlineDataStore(base_url=TEST_STORE, path=tmpdir),
+                SafeOnlineDataStore(base_url=TEST_STORE, path=tmpdir),
             ),
         ]
     )

--- a/tests/02_eradiate/01_unit/data/test_safe_directory.py
+++ b/tests/02_eradiate/01_unit/data/test_safe_directory.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pytest
 
 import eradiate
-from eradiate.data import DirectoryDataStore
+from eradiate.data import SafeDirectoryDataStore
 from eradiate.exceptions import DataError
 
 TEST_FILE_REGISTERED = Path("tests/data/git/registered_dataset.nc")
@@ -12,7 +12,9 @@ TEST_FILE_UNREGISTERED = Path("tests/data/git/unregistered_dataset.nc")
 
 def test_directory_data_store_fetch():
     # The data submodule can be instantiated
-    data_store = DirectoryDataStore(path=eradiate.config.source_dir / "resources/data")
+    data_store = SafeDirectoryDataStore(
+        path=eradiate.config.source_dir / "resources/data"
+    )
 
     # We can fetch the test file
     assert data_store.fetch(TEST_FILE_REGISTERED)

--- a/tests/02_eradiate/01_unit/data/test_safe_online.py
+++ b/tests/02_eradiate/01_unit/data/test_safe_online.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 import xarray as xr
 
-from eradiate.data._online import OnlineDataStore
+from eradiate.data import SafeOnlineDataStore
 from eradiate.exceptions import DataError
 
 TEST_STORE = "http://eradiate.eu/data/store/stable"
@@ -13,8 +13,8 @@ TEST_FILE = Path("tests/data/online/registered_dataset.nc")
 
 
 def test_online_data_store_registry(tmpdir):
-    # Using an empty storage directory, an OnlineDataStore instance can be created
-    store = OnlineDataStore(base_url=TEST_STORE, path=tmpdir)
+    # Using an empty storage directory, a SafeOnlineDataStore instance can be created
+    store = SafeOnlineDataStore(base_url=TEST_STORE, path=tmpdir)
 
     # The registry file is downloaded
     registry_filename = store.registry_fetch()
@@ -36,7 +36,7 @@ def test_online_data_store_registry(tmpdir):
 
 
 def test_oneline_data_store_is_registered(tmpdir):
-    store = OnlineDataStore(base_url=TEST_STORE, path=tmpdir)
+    store = SafeOnlineDataStore(base_url=TEST_STORE, path=tmpdir)
 
     # Default behaviour allows matching compressed files
     filename = store.is_registered(TEST_FILE)
@@ -49,7 +49,7 @@ def test_oneline_data_store_is_registered(tmpdir):
 
 
 def test_online_data_store_fetch(tmpdir):
-    store = OnlineDataStore(base_url=TEST_STORE, path=tmpdir)
+    store = SafeOnlineDataStore(base_url=TEST_STORE, path=tmpdir)
     filename = os.path.join(tmpdir, TEST_FILE)
 
     # Upon calling fetch(), gzip detection is successful: the gz file is downloaded
@@ -76,7 +76,7 @@ def test_online_data_store_purge(tmpdir):
     # We create a data store and fetch a file:
     # we expect the directory to contain exactly 2 elements (the registry file
     # and the directory containing the fetched file)
-    store = OnlineDataStore(base_url=TEST_STORE, path=tmpdir)
+    store = SafeOnlineDataStore(base_url=TEST_STORE, path=tmpdir)
     store.fetch(TEST_FILE)
     assert len(list(os.scandir(tmpdir))) == 2
     assert store.registry_path.is_file()


### PR DESCRIPTION
# Description

This PR closes eradiate/eradiate-issues#174. Changes are as follows:

- Data store classes are renamed for improved consistency.
- Data store initialisation is now done by a dedicated function, which can be called again after module import. This allows to update the data store if its configuration is modified.
- A new `config.offline` variable now controls whether Eradiate is operated without Internet connection.
- A new ` BlindDirectoryDataStore` class allows for a very simple filesystem lookup.

The offline mode can, as usual, be activated with environment variables or settings. For instance:
```
ERADIATE_OFFLINE=1 pytest tests
```
If you activate the offline mode in a script, you will have to reinitialise the data store to update its state:
```python
eradiate.config.offline = True
eradiate.data.init_data_store()
```

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
