### PR TITLE
Update Mitsuba

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,11 +43,13 @@ when necessary—we also advise to not ignore `DeprecationWarning`s.
 %
 ### Improvements and fixes
 
-* Added the atmo-centimeter, a.k. atm-cm, to the unit registry ({ghpr}`245`).
+* Added the atmo-centimeter, a.k.a. atm-cm, to the unit registry ({ghpr}`245`).
 
 % ### Documentation
 %
-% ### Internal changes
+### Internal changes
+
+* Updated Mitsuba submodule ({ghpr}`250`).
 
 ## v0.22.4 (17 June 2022)
 

--- a/resources/generate_stub_files.py
+++ b/resources/generate_stub_files.py
@@ -1,0 +1,1 @@
+../ext/mitsuba/resources/generate_stub_files.py

--- a/src/eradiate/kernel/_bitmap.py
+++ b/src/eradiate/kernel/_bitmap.py
@@ -58,7 +58,12 @@ def bitmap_to_dataset(bmp: "mitsuba.Bitmap", dtype=float) -> xr.Dataset:
     width = img.shape[1]
 
     result = xr.Dataset(
-        data_vars={"img": (["y_index", "x_index", "channel"], img)},
+        data_vars={
+            "img": (
+                ["y_index", "x_index", "channel"],
+                np.reshape(img, (height, width, -1)),
+            )
+        },
         coords={
             "y_index": (
                 "y_index",

--- a/src/eradiate/test_tools/plugin.py
+++ b/src/eradiate/test_tools/plugin.py
@@ -56,7 +56,7 @@ def sample_eval_pdf_bsdf(
     # Invoke sampling strategy
     n = dr.width(sample)
     ctx = mi.BSDFContext()
-    si = dr.zero(mi.SurfaceInteraction3f, n)
+    si = dr.zeros(mi.SurfaceInteraction3f, n)
     si.wi = wi
     bs, weight = plugin.sample(ctx, si, sample[0], [sample[1], sample[2]])
 

--- a/src/plugins/src/bsdfs/bilambertian.cpp
+++ b/src/plugins/src/bsdfs/bilambertian.cpp
@@ -66,18 +66,18 @@ public:
 
         if (unlikely(dr::none_or<false>(active) ||
                      (!has_reflect && !has_transmit)))
-            return { dr::zero<BSDFSample3f>(), UnpolarizedSpectrum(0.f) };
+            return { dr::zeros<BSDFSample3f>(), UnpolarizedSpectrum(0.f) };
 
         Float cos_theta_i = Frame3f::cos_theta(si.wi);
         Vector3f wo       = warp::square_to_cosine_hemisphere(sample2);
 
-        BSDFSample3f bs = dr::zero<BSDFSample3f>();
+        BSDFSample3f bs = dr::zeros<BSDFSample3f>();
         UnpolarizedSpectrum value(0.f);
 
         // Select the lobe to be sampled
         UnpolarizedSpectrum r              = m_reflectance->eval(si, active),
                             t              = m_transmittance->eval(si, active);
-        Float reflection_sampling_weight   = hmean(r / (r + t)),
+        Float reflection_sampling_weight   = dr::mean(r / (r + t)),
               transmission_sampling_weight = 1.f - reflection_sampling_weight;
 
         // Handle case where r = t = 0
@@ -178,7 +178,7 @@ public:
 
         UnpolarizedSpectrum r              = m_reflectance->eval(si, active),
                             t              = m_transmittance->eval(si, active);
-        Float reflection_sampling_weight   = hmean(r / (r + t)),
+        Float reflection_sampling_weight   = dr::mean(r / (r + t)),
               transmission_sampling_weight = 1.f - reflection_sampling_weight;
 
         // Handle case where r = t = 0

--- a/src/plugins/src/bsdfs/rpv.cpp
+++ b/src/plugins/src/bsdfs/rpv.cpp
@@ -108,7 +108,7 @@ public:
         MI_MASKED_FUNCTION(ProfilerPhase::BSDFSample, active);
 
         Float cos_theta_i = Frame3f::cos_theta(si.wi);
-        BSDFSample3f bs = dr::zero<BSDFSample3f>();
+        BSDFSample3f bs = dr::zeros<BSDFSample3f>();
 
         active &= cos_theta_i > 0.f;
         if (unlikely(dr::none_or<false>(active) ||

--- a/src/plugins/src/sensors/distantflux.cpp
+++ b/src/plugins/src/sensors/distantflux.cpp
@@ -73,8 +73,7 @@ public:
 
     DistantFluxSensor(const Properties &props) : Base(props) {
         // Check reconstruction filter radius
-        if (m_film->rfilter()->radius() >
-            0.5f + math::RayEpsilon<Float>) {
+        if (m_film->rfilter()->radius() > 0.5f + math::RayEpsilon<Float>) {
             Log(Warn, "This sensor is best used with a reconstruction filter "
                       "with a radius of 0.5 or lower (e.g. default box)");
         }
@@ -84,12 +83,12 @@ public:
         // Get target
         if (props.has_property("target")) {
             if (props.type("target") == Properties::Type::Array3f) {
-                m_target_type  = RayTargetType::Point;
+                m_target_type = RayTargetType::Point;
                 m_target_point = props.get<ScalarPoint3f>("target");
             } else if (props.type("target") == Properties::Type::Object) {
                 // We assume it's a shape
-                m_target_type  = RayTargetType::Shape;
-                auto obj       = props.object("target");
+                m_target_type = RayTargetType::Shape;
+                auto obj = props.object("target");
                 m_target_shape = dynamic_cast<Shape *>(obj.get());
 
                 if (!m_target_shape)
@@ -113,8 +112,8 @@ public:
     void set_scene(const Scene *scene) override {
         m_bsphere = scene->bbox().bounding_sphere();
         m_bsphere.radius =
-            dr::max(math::RayEpsilon<Float>,
-                    m_bsphere.radius * (1.f + math::RayEpsilon<Float>) );
+            dr::maximum(math::RayEpsilon<Float>,
+                        m_bsphere.radius * (1.f + math::RayEpsilon<Float>));
     }
 
     std::pair<Ray3f, Spectrum> sample_ray_impl(Float time,

--- a/src/plugins/src/sensors/hdistant.cpp
+++ b/src/plugins/src/sensors/hdistant.cpp
@@ -205,8 +205,8 @@ public:
     void set_scene(const Scene *scene) override {
         m_bsphere = scene->bbox().bounding_sphere();
         m_bsphere.radius =
-            dr::max(math::RayEpsilon<Float>,
-                    m_bsphere.radius * (1.f + math::RayEpsilon<Float>) );
+            dr::maximum(math::RayEpsilon<Float>,
+                        m_bsphere.radius * (1.f + math::RayEpsilon<Float>) );
     }
 
     std::pair<Ray3f, Spectrum> sample_ray(Float time, Float wavelength_sample,

--- a/src/plugins/src/sensors/mdistant.cpp
+++ b/src/plugins/src/sensors/mdistant.cpp
@@ -156,8 +156,8 @@ public:
     void set_scene(const Scene *scene) override {
         m_bsphere = scene->bbox().bounding_sphere();
         m_bsphere.radius =
-            dr::max(math::RayEpsilon<Float>,
-                    m_bsphere.radius * (1.f + math::RayEpsilon<Float>) );
+            dr::maximum(math::RayEpsilon<Float>,
+                        m_bsphere.radius * (1.f + math::RayEpsilon<Float>) );
     }
 
     std::pair<Ray3f, Spectrum> sample_ray(Float time, Float wavelength_sample,

--- a/tests/01_plugins/bsdfs/test_bilambertian.py
+++ b/tests/01_plugins/bsdfs/test_bilambertian.py
@@ -48,7 +48,7 @@ def test_eval_pdf(variant_scalar_rgb, r, t):
         si.sh_frame = mi.Frame3f(si.n)
 
         for i in range(20):
-            theta = i / 19.0 * dr.Pi  # We cover the entire circle
+            theta = i / 19.0 * dr.pi  # We cover the entire circle
 
             wo = [dr.sin(theta), 0, dr.cos(theta)]
             v_pdf = bsdf.pdf(ctx, si, wo=wo)
@@ -56,12 +56,12 @@ def test_eval_pdf(variant_scalar_rgb, r, t):
 
             if dr.dot(wi, wo) > 0:
                 # reflection
-                assert dr.allclose(r * dr.abs(wo[2]) / dr.Pi, v_eval)
-                assert dr.allclose(r / albedo * dr.abs(wo[2]) / dr.Pi, v_pdf)
+                assert dr.allclose(r * dr.abs(wo[2]) / dr.pi, v_eval)
+                assert dr.allclose(r / albedo * dr.abs(wo[2]) / dr.pi, v_pdf)
             else:
                 # transmission
-                assert dr.allclose(t * dr.abs(wo[2]) / dr.Pi, v_eval)
-                assert dr.allclose(t / albedo * dr.abs(wo[2]) / dr.Pi, v_pdf)
+                assert dr.allclose(t * dr.abs(wo[2]) / dr.pi, v_eval)
+                assert dr.allclose(t / albedo * dr.abs(wo[2]) / dr.pi, v_pdf)
 
 
 @pytest.mark.parametrize(

--- a/tests/01_plugins/conftest.py
+++ b/tests/01_plugins/conftest.py
@@ -60,7 +60,7 @@ def clean_up():
 
     if hasattr(dr, "sync_thread"):
         dr.sync_thread()
-        dr.registry_trim()
+        dr.registry_clear()
         dr.set_flags(dr.JitFlag.Default)
 
 
@@ -147,7 +147,6 @@ del variants
 for name, variants in variant_groups.items():
     generate_fixture_group(name, variants)
 del generate_fixture_group
-
 
 # ------------------------------------------------------------------------------
 #                              Other configuration

--- a/tests/01_plugins/phase/test_tabphase_irregular.py
+++ b/tests/01_plugins/phase/test_tabphase_irregular.py
@@ -122,4 +122,4 @@ def test_traverse(variant_scalar_rgb):
     mei = mi.MediumInteraction3f()
     mei.wi = np.array([0, 0, -1])
     wo = [0, 0, 1]
-    assert dr.allclose(phase.eval(ctx, mei, wo), dr.InvTwoPi * 1.5 / ref_integral)
+    assert dr.allclose(phase.eval(ctx, mei, wo), dr.inv_two_pi * 1.5 / ref_integral)

--- a/tests/01_plugins/sensors/test_hdistant.py
+++ b/tests/01_plugins/sensors/test_hdistant.py
@@ -229,7 +229,7 @@ def test_sample_target(variant_scalar_rgb, sensor_setup, w_e):
 
     l_o = l_e * cos_theta_e * rho / np.pi  # Outgoing radiance
     expected = {  # Special expected values for some cases
-        "default": l_o * 2.0 / dr.Pi,
+        "default": l_o * 2.0 / dr.pi,
         "target_square_large": l_o * 0.25,
     }
     expected_value = expected.get(sensor_setup, l_o)
@@ -349,5 +349,5 @@ def test_checkerboard(variants_all_rgb):
         .convert(mi.Bitmap.PixelFormat.RGB, mi.Struct.Type.Float32, False)
     ).squeeze()
 
-    expected = l_e * 0.5 * (rho0 + rho1) / dr.Pi
+    expected = l_e * 0.5 * (rho0 + rho1) / dr.pi
     assert np.allclose(expected, result, atol=1e-3)


### PR DESCRIPTION
# Description

This PR updates Mitsuba to the latest `master`. Subsequent changes include:

* the upgrade to the latest low-level calculus idioms;
* a soft link to the stub generation script (not looked up from the Mitsuba root but from the CMake project root);
* a minor update to the Mitsuba wrapper function which is no longer always outputting a (M, N, P)-shaped array.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
