### PR TITLE
Add spectral response functions from JPSS1 and NPP platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ when necessary—we also advise to not ignore `DeprecationWarning`s.
 ### Improvements and fixes
 
 * Added the atmo-centimeter, a.k.a. atm-cm, to the unit registry ({ghpr}`245`).
+* Added spectral response functions for the VIIRS instrument onboard JPSS1 and NPP platforms ({ghpr}`253`)
 
 % ### Documentation
 %


### PR DESCRIPTION
# Description

Add spectral response functions from JPSS1 and NPP platforms (VIIRS instrument).

This is just a data submodule (and changelog) update.

45 spectral response function data sets were added.


# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
