### PR TITLE
Update Mitsuba to v3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,10 +57,13 @@ when necessary—we also advise to not ignore `DeprecationWarning`s.
   significantly decreases import time for most use cases.
 
 % ### Documentation
-%
+
 ### Internal changes
 
-* Updated Mitsuba submodule ({ghpr}`250`).
+* Updated Mitsuba submodule twice up to v3.0.1 ({ghpr}`250`, {ghpr}`255`). This
+  notably fixes the sampling method of the `tabphase` plugin.
+* Aligned the `tabphase_irregular` plugin with the fix `tabphase` code 
+  ({ghpr}`255`).
 
 ## v0.22.4 (17 June 2022)
 

--- a/README.md
+++ b/README.md
@@ -26,13 +26,6 @@ equation.
 For build and usage instructions, please refer to the
 [documentation](https://eradiate.readthedocs.org).
 
-**Important**: Eradiate uses the Mitsuba rendering system, developed by the 
-Realistic Graphics Lab, as its radiometric kernel. The version of Mitsuba used 
-by Eradiate is currently under submission for publication and we can not release
-it yet. **This situation is temporary.** See the
-[documentation](https://eradiate.readthedocs.io/en/latest/rst/getting_started/install.html) 
-for details.
-
 ## Support
 
 Got a question? Please visit our
@@ -44,7 +37,7 @@ Eradiate is developed by a core team consisting of Vincent Leroy, Yvan Nollet,
 Sebastian Schunke, Nicolas Misk and Yves Govaerts.
 
 Eradiate uses the
-[Mitsuba 2 renderer](https://github.com/mitsuba-renderer/mitsuba2), developed by
+[Mitsuba 3 renderer](https://github.com/mitsuba-renderer/mitsuba3), developed by
 the [Realistic Graphics Lab](https://rgl.epfl.ch/),
 taking advantage of its Python interface and proven architecture, and extends it
 with components implementing numerical methods and models used in radiative

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,8 +16,8 @@ Eradiate Documentation
 
 Eradiate is a modern radiative transfer simulation software package written in
 Python and C++17. It relies on a computational kernel based on the
-`Mitsuba 2 <https://github.com/mitsuba-renderer/mitsuba2>`_ rendering system
-:cite:`Nimier-David2019MitsubaRetargetableForward`.
+`Mitsuba 3 <https://github.com/mitsuba-renderer/mitsuba3>`_ rendering system
+:cite:`Jakob2022DrJitJustInTime`.
 
 .. grid:: 1 2 auto auto
    :gutter: 3

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -19,9 +19,7 @@
   doi          = {10.1016/0032-0633(84)90102-8},
   issn         = {0032-0633},
   url          = {http://www.sciencedirect.com/science/article/pii/0032063384901028},
-  urldate      = {2020-06-02},
   shortjournal = {Planetary and Space Science},
-  langid       = {english}
 }
 @article{Eberhard2010CorrectEquationsCommon,
   title        = {Correct equations and common approximations for calculating {Rayleigh} scatter in pure gases and mixtures and evaluation of differences},
@@ -35,8 +33,6 @@
   doi          = {10.1364/AO.49.001116},
   issn         = {2155-3165},
   url          = {https://www.osapublishing.org/ao/abstract.cfm?uri=ao-49-7-1116},
-  urldate      = {2020-02-21},
-  language     = {EN}
 }
 @techreport{EradiateScientificHandbook2020,
   title        = {Eradiate Scientific Handbook},
@@ -51,7 +47,6 @@
   year         = 2017,
   number       = {COPE-GSEG-EOPG-TN-15-0007},
   url          = {https://sentinel.esa.int/documents/247904/685211/S2-SRF_COPE-GSEG-EOPG-TN-15-0007_3.0.xlsx},
-  urldate      = {2021-04-07},
   issue        = 3,
   institution  = {European Space Agency}
 }
@@ -77,7 +72,6 @@
   doi          = {10.1175/1520-0469(1992)049<2139:OTCDMF>2.0.CO;2},
   issn         = {0022-4928},
   url          = {https://journals.ametsoc.org/doi/abs/10.1175/1520-0469%281992%29049%3C2139%3AOTCDMF%3E2.0.CO%3B2},
-  urldate      = {2019-07-19}
 }
 @article{Gordon2016HITRAN2016MolecularSpectroscopic,
   title        = {The {HITRAN2016} Molecular Spectroscopic Database},
@@ -119,7 +113,6 @@
   title        = {80000-2:2019 — {{Quantities}} and Units — {{Part}} 2: {{Mathematics}}},
   author       = {ISO},
   url          = {https://www.iso.org/standard/64973.html},
-  urldate      = {2022-03-17},
   year         = 2019
 }
 @article{Jakob2022DrJitJustInTime,
@@ -160,13 +153,11 @@
   doi          = {10.1145/3306346.3323025},
   issn         = {0730-0301},
   url          = {http://doi.acm.org/10.1145/3306346.3323025},
-  urldate      = {2019-09-24}
 }
 @misc{MODIS2004,
   author       = {MODIS Characterization Support Team},
   year         = 2004,
   url          = {https://mcst.gsfc.nasa.gov/sites/default/files/file_attachments/MODIS_PFM_IB_OOB_RSR_merged.xls},
-  urldate      = {2021-04-08},
   institution  = {National Aeronautics and Space Administration},
   howpublished = {https://mcst.gsfc.nasa.gov/calibration/parameters}
 }
@@ -177,7 +168,6 @@
   year         = 1976,
   number       = {NASA-TM-X-74335},
   url          = {https://ntrs.nasa.gov/search.jsp?R=19770009539},
-  urldate      = {2019-10-25},
   type         = {techreport},
   institution  = {National Aeronautics and Space Administration}
 }
@@ -193,9 +183,7 @@
   doi          = {10.1145/3355089.3356498},
   issn         = {0730-0301},
   url          = {http://rgl.epfl.ch/publications/NimierDavidVicini2019Mitsuba2},
-  urldate      = {2020-05-08},
   shortjournal = {ACM Trans. Graph.},
-  langid       = {english}
 }
 @article{Peck1972DispersionAir,
   title        = {Dispersion of air},
@@ -231,7 +219,6 @@
   year         = 2015,
   number       = {S3-RP-RAL-SL-102},
   url          = {https://earth.esa.int/documents/247904/322305/SLSTR+Spectral+Calibration+Function},
-  urldate      = {2020-11-13},
   type         = {techreport},
   institution  = {Rutherford Appleton Laboratory}
 }
@@ -241,7 +228,6 @@
   year         = 2017,
   number       = {S3-RP-RAL-SL-114},
   url          = {https://sentinel.esa.int/documents/247904/3347387/Sentinel-3-SLSTR-Spectral-Calibration-Report},
-  urldate      = {2020-11-13},
   type         = {techreport},
   institution  = {Rutherford Appleton Laboratory}
 }
@@ -256,7 +242,6 @@
   doi          = {10.1007/978-3-642-75389-3_14},
   isbn         = {978-3-642-75389-3},
   url          = {https://doi.org/10.1007/978-3-642-75389-3_14},
-  urldate      = {2021-03-22},
   editor       = {Myneni, Ranga B. and Ross, Juhan}
 }
 @techreport{Sentinel3CalValTeam2016OLCIASpectralResponse,
@@ -265,7 +250,6 @@
   year         = 2016,
   number       = {S3-TN-ESA-OL-660},
   url          = {https://sentinel.esa.int/documents/247904/2700436/Sentinel-3-OLCI-A-spectral-response-functions},
-  urldate      = {2021-04-08},
   issue        = 2,
   institution  = {European Space Research and Technology Centre, European Space Agency}
 }
@@ -275,7 +259,6 @@
   year         = 2016,
   number       = {S3-TN-ESA-OL-660},
   url          = {https://sentinel.esa.int/documents/247904/2700436/Sentinel-3-OLCI-B-spectral-response-functions},
-  urldate      = {2021-04-08},
   issue        = 1,
   institution  = {European Space Research and Technology Centre, European Space Agency}
 }
@@ -296,10 +279,8 @@
   doi          = {10.1023/A:1024048429145},
   issn         = {1573-093X},
   url          = {https://doi.org/10.1023/A:1024048429145},
-  urldate      = {2020-03-02},
   shortjournal = {Solar Physics},
   date         = {2003-05-01},
-  langid       = {english}
 }
 @inproceedings{Widlowski2006Rayspread,
   title        = {Rayspread: {{A Virtual Laboratory}} for {{Rapid BRF Simulations Over}} 3-{{D Plant Canopies}}},
@@ -335,5 +316,4 @@
   issn         = {2155-3165},
   url          = {https://www.osapublishing.org/ao/abstract.cfm?uri=ao-19-20-3427},
   shortjournal = {Appl. Opt., AO},
-  langid       = {english}
 }

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -1,6 +1,5 @@
 % Formatted and sorted with bibtex-tidy
 % https://github.com/FlamingTempura/bibtex-tidy
-
 @techreport{Anderson1986AtmosphericConstituentProfiles,
   title        = {AFGL Atmospheric Constituent Profiles (0-120) km},
   author       = {G.P. Anderson and J.H Chetwynd and S.A. Clough and E.P. Shettle and F.X. Kneizys},
@@ -67,21 +66,19 @@
   doi          = {https://doi.org/10.2134/agronj1984.00021962007600050021x},
   url          = {https://acsess.onlinelibrary.wiley.com/doi/abs/10.2134/agronj1984.00021962007600050021x}
 }
-
 @article{Fu1992CorrelatedDistributionMethod,
-	title     = {On the {Correlated} k-{Distribution} {Method} for {Radiative} {Transfer} in {Nonhomogeneous} {Atmospheres}},
-	volume    = {49},
-	issn      = {0022-4928},
-	url       = {https://journals.ametsoc.org/doi/abs/10.1175/1520-0469%281992%29049%3C2139%3AOTCDMF%3E2.0.CO%3B2},
-	doi       = {10.1175/1520-0469(1992)049<2139:OTCDMF>2.0.CO;2},
-	number    = {22},
-  urldate   = {2019-07-19},
-	journal   = {Journal of the Atmospheric Sciences},
-	author    = {Fu, Qiang and Liou, K. N.},
-	year      = {1992},
-	pages     = {2139--2156},
+  title        = {On the {Correlated} k-{Distribution} {Method} for {Radiative} {Transfer} in {Nonhomogeneous} {Atmospheres}},
+  author       = {Fu, Qiang and Liou, K. N.},
+  year         = 1992,
+  journal      = {Journal of the Atmospheric Sciences},
+  volume       = 49,
+  number       = 22,
+  pages        = {2139--2156},
+  doi          = {10.1175/1520-0469(1992)049<2139:OTCDMF>2.0.CO;2},
+  issn         = {0022-4928},
+  url          = {https://journals.ametsoc.org/doi/abs/10.1175/1520-0469%281992%29049%3C2139%3AOTCDMF%3E2.0.CO%3B2},
+  urldate      = {2019-07-19}
 }
-
 @article{Gordon2016HITRAN2016MolecularSpectroscopic,
   title        = {The {HITRAN2016} Molecular Spectroscopic Database},
   author       = {I.E. Gordon and L.S. Rothman and C. Hill and R.V. Kochanov and Y. Tan and P.F. Bernath and M. Birk and V. Boudon and A. Campargue and K.V. Chance and B.J. Drouin and J.-M. Flaud and R.R. Gamache and J.T. Hodges and D. Jacquemart and V.I. Perevalov and A. Perrin and K.P. Shine and M.-A.H. Smith and J. Tennyson and G.C. Toon and H. Tran and V.G. Tyuterev and A. Barbe and A.G. Császár and V.M. Devi and T. Furtenbacher and J.J. Harrison and J.-M. Hartmann and A. Jolly and T.J. Johnson and T. Karman and I. Kleiner and A.A. Kyuberis and J. Loos and O.M. Lyulin and S.T. Massie and S.N. Mikhailenko and N. Moazzen-Ahmadi and H.S.P. Müller and O.V. Naumenko and A.V. Nikitin and O.L. Polyansky and M. Rey and M. Rotger and S.W. Sharpe and K. Sung and E. Starikova and S.A. Tashkun and J. Vander Auwera and G. Wagner and J. Wilzewski and P. Wcisło and S. Yu and E.J. Zak},
@@ -123,7 +120,19 @@
   author       = {ISO},
   url          = {https://www.iso.org/standard/64973.html},
   urldate      = {2022-03-17},
-  date         = 2019
+  year         = 2019
+}
+@article{Jakob2022DrJitJustInTime,
+  title        = {Dr.{{Jit}}: {{A Just-In-Time Compiler}} for {{Differentiable Rendering}}},
+  author       = {Jakob, Wenzel and Speierer, Sébastien and Roussel, Nicolas and Vicini, Delio},
+  journal      = {ACM Transactions on Graphics},
+  volume       = 41,
+  number       = 4,
+  pages        = {1--19},
+  doi          = {10.1145/3528223.3530099},
+  issn         = {0730-0301, 1557-7368},
+  url          = {http://arxiv.org/abs/2202.01284},
+  year         = 2022
 }
 @book{Liou2002IntroductionAtmosphericRadiation,
   title        = {An Introduction to Atmospheric Radiation},

--- a/docs/rst/getting_started/index.rst
+++ b/docs/rst/getting_started/index.rst
@@ -18,7 +18,7 @@ Eradiate is a modern radiative transfer model for Earth observation
 applications. It primarily targets calibration/validation applications and
 focuses on delivering highly accurate results.
 
-Eradiate is built around a radiometric kernel based on the Mitsuba 2 rendering
+Eradiate is built around a radiometric kernel based on the Mitsuba 3 rendering
 system. It provides abstractions to conveniently build scenes, manage kernel
 runs and collect results.
 

--- a/docs/rst/getting_started/install.rst
+++ b/docs/rst/getting_started/install.rst
@@ -3,25 +3,6 @@
 Installation guide
 ==================
 
-.. admonition:: Important
-   :class: warning
-
-   The Mitsuba renderer, developed by the
-   `Realistic Graphics Lab <https://rgl.epfl.ch>`_ and used by Eradiate as its
-   radiometric kernel, is undergoing heavy refactoring. This upcoming version
-   contains updates which solve critical issues we've had in the past.
-
-   This new version of the Mitsuba 3 component is currently under submission for
-   publication and we can currently not release it.
-
-   Consequently, we are currently restricting kernel code access to users who
-   join our Preview team on GitHub. Please note that you will need to join the
-   Preview team in order to get a functioning clone of the Eradiate codebase. To
-   be added to the team, please send an email to news@eradiate.eu with your
-   GitHub username.
-
-   **This situation is temporary.**
-
 This guide covers all steps necessary to get Eradiate running on your machine.
 
 .. warning::
@@ -120,7 +101,7 @@ machine meets the requirements listed below.
       favourite!
 
       .. note:: We currently recommend compiling the C++ code with Clang based on
-         `upstream advice from the Mitsuba development team <https://eradiate-kernel.readthedocs.io/en/latest/src/getting_started/compiling.html#linux>`_.
+         `upstream advice from the Mitsuba development team <https://mitsuba.readthedocs.io/en/latest/src/developer_guide/compiling.html#linux>`_.
          We also recommend using Clang 11 — not another version — because we also
          encountered issues building with other versions. We hope to improve
          compiler support in the future.
@@ -160,7 +141,7 @@ Cloning the repository
    Eradiate relies on the `Git source code management tool <https://git-scm.com/>`_.
    It also depends on multiple external dependencies, some of which (*e.g.* its
    radiometric kernel based on
-   `Mitsuba 2 <https://github.com/mitsuba-renderer/mitsuba2>`_) are directly
+   `Mitsuba 3 <https://github.com/mitsuba-renderer/mitsuba3>`_) are directly
    referred to using
    `Git submodules <https://git-scm.com/book/en/v2/Git-Tools-Submodules>`_.
 
@@ -250,8 +231,8 @@ Once your Conda environment is configured, you should reactivate it:
 
 .. _sec-getting_started-install-compiling:
 
-Compiling the kernel
---------------------
+Compiling the radiometric kernel
+--------------------------------
 
 Configure CMake for compilation:
 

--- a/docs/rst/user_guide/basic_concepts.rst
+++ b/docs/rst/user_guide/basic_concepts.rst
@@ -17,7 +17,7 @@ Kernel
 ------
 
 Eradiate's low-level abstractions are handled by its *radiometric kernel*. This
-component consists of the Mitsuba 2 rendering system with custom extensions and
+component consists of the Mitsuba 3 rendering system with custom extensions and
 it implements the Monte Carlo integration framework Eradiate uses to compute
 radiative transfer. The kernel takes as its input a
 :term:`kernel scene description <kernel dictionary>` specified as a Python

--- a/tests/01_plugins/phase/test_tabphase_irregular.py
+++ b/tests/01_plugins/phase/test_tabphase_irregular.py
@@ -75,6 +75,36 @@ def test_eval(variant_scalar_rgb):
     assert np.allclose(ref_eval, tab_eval)
 
 
+def test_sample(variant_scalar_rgb):
+    """
+    Check if the sampling routine uses consistent incoming-outgoing orientation
+    conventions.
+    """
+
+    tab = mi.load_dict(
+        {"type": "tabphase_irregular", "values": "0.0, 0.5, 1.0", "nodes": "-1,0,1"}
+    )
+    ctx = mi.PhaseFunctionContext(None)
+    mei = mi.MediumInteraction3f()
+    mei.t = 0.1
+    mei.p = [0, 0, 0]
+    mei.sh_frame = mi.Frame3f([0, 0, 1])
+    mei.wi = [0, 0, 1]
+
+    # The passed sample corresponds to forward scattering
+    wo, pdf = tab.sample(ctx, mei, 0, (1, 0))
+
+    # The sampled direction indicates forward scattering in the "graphics"
+    # convention
+    assert dr.allclose(wo, [0, 0, -1])
+
+    # The expected value was derived manually from the PDF expression.
+    # An incorrect convention (i.e. using -cos θ to fetch the PDF value) will
+    # yield 0 thanks to the values used to initialize the distribution and will
+    # make the test fail.
+    assert dr.allclose(pdf, 0.5 / dr.pi)
+
+
 def test_chi2(variants_vec_backends_once_rgb):
     sample_func, pdf_func = mi.chi2.PhaseFunctionAdapter(
         "tabphase_irregular",


### PR DESCRIPTION
# Description

This commit updates the Mitsuba submodule to v3.0.1. This is the second public release of Mitsuba 3. This PR has to be followed up with an update of the installation instructions: our special installation protocol is no longer needed.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
