### PR TITLE
Substiantial speedup for large biosphere scenes

### DIFF
--- a/src/eradiate/scenes/biosphere/_core.py
+++ b/src/eradiate/scenes/biosphere/_core.py
@@ -376,11 +376,9 @@ class InstancedCanopyElement(SceneElement):
             f"{self.canopy_element.id}_instance_{i}": {
                 "type": "instance",
                 "group": {"type": "ref", "id": self.canopy_element.id},
-                "to_world": mi.ScalarTransform4f.translate(
-                    position.m_as(kernel_length)
-                ),
+                "to_world": mi.ScalarTransform4f.translate(position),
             }
-            for i, position in enumerate(self.instance_positions)
+            for i, position in enumerate(self.instance_positions.m_as(kernel_length))
         }
 
     def kernel_dict(self, ctx: KernelDictContext) -> KernelDict:


### PR DESCRIPTION
# Description

Profiling the execution of RAMI scenes, @wint3ria and me found that up to 30% of the time spent in a simulation is due to calls to `pint.Quantity.m_as()`. I investigated and found that the `eradiate.scenes.biosphere._core.InstancedCanopyElement.kernel_instances()` method was treating the instance positions in a very inefficient way.

When creating the dictionary entries for the instances, it would basically call `m_as()` a couple million times like this:

```python
for position in self.instance_positions:
    pos_mag = position.m_as(kernel_length)
```

Changing the code to call `m_as()` only once on the entire array of positions, reduces the time spent there to basically nothing:

```python
for position in self.instance_positions.m_as(kernel_length):
    pos_mag = position
```

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
