### PR TITLE
Fix incorrect Earth-Sun distance-based scaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ when necessary—we also advise to not ignore `DeprecationWarning`s.
   significantly decreases import time for most use cases.
 * Optimised calls to `Quantity.m_as()` in
   `InstancedCanopyElement.kernel_instances()` ({ghpr}`256`).
+* Fixed incorrect scaling formula for datetime-based scaling of Solar irradiance
+  spectra ({ghpr}`258`).
 
 % ### Documentation
 

--- a/tests/02_eradiate/01_unit/scenes/spectra/test_solar_irradiance.py
+++ b/tests/02_eradiate/01_unit/scenes/spectra/test_solar_irradiance.py
@@ -82,5 +82,5 @@ def test_solar_irradiance_datetime(mode_mono):
     )
     assert np.isclose(
         s_scaled_datetime.eval_mono(550.0 * ureg.nm),
-        s.eval_mono(550.0 * ureg.nm) * 0.98854537**2,
+        s.eval_mono(550.0 * ureg.nm) / 0.98854537**2,
     )


### PR DESCRIPTION
# Description

This PR fixes the incorrect datetime-based scaling of Solar irradiance spectra.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
