### PR TITLE
Added new sahara and continental particle radiative properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,8 @@ when necessary—we also advise to not ignore `DeprecationWarning`s.
 * Added system information report to the `eradiate show` command-line utility
   ({ghpr}`264`).
 * Some dependencies are now optional, although recommended ({ghpr}`266`).
+* Added new sahara and continental particle radiative properties including the
+  full scattering phase matrix ({ghpr}`259`).
 
 ### Documentation
 


### PR DESCRIPTION
# Description

## Summary

This is a simple submodule update to add 4 new particle radiative properties data sets.

## Detailed description

This pull request is to add 4 new particle radiative properties data sets, namely:

* aeronet_continental_clean_spherical_RAMIA_GENERIC.nc
* aeronet_continental_clean_spherical_RAMIA_GENERIC_extrapolated.nc
* aeronet_sahara_spherical_RAMIA_GENERIC.nc
* aeronet_sahara_spherical_RAMIA_GENERIC_extrapolated.nc

Because they are based on the same refractive index data and particle size distributions, these data sets are very similar to the following existing data sets:
* govaerts_2021-continental.nc
* govaerts_2021-continental-extrapolated.nc
* govaerts_2021-desert.nc
* govaerts_2021-desert-extrapolated.nc

with the following differences (more in-depth comparison below):

* the new data sets provide the full scattering phase **matrix**, whereas the other data sets provide only the scattering phase function. This is a first step towards supporting polarisation in Eradiate.
* the new data sets were computed using [moyo](https://gitlab.rayference.dansaert.be/yvan/moyo), version `0.2.1`. They are completely reproducible (at Rayference, `moyo` being closed source at the moment) using the `.json` files stored alongside the data sets.
* The scattering phase function normalisation convention is so that the integral of the scattering phase function over all solid angles is 1.0 (see [here](https://miepython.readthedocs.io/en/latest/03a_normalization.html)) -- previously, it was 1  /4π.

## Comparison between existing and new data sets
All figures below are in `svg` format so that they can be opened on the side and zoomed in, if necessary.

### `govaerts_2021-continental` VS `aeronet_continental_clean_spherical_RAMIA_GENERIC`

The albedo data is almost identical: 

![ALBEDO-govaerts_2021-continental-VS-aeronet_continental_clean_spherical_RAMIA_GENERIC](https://user-images.githubusercontent.com/62285993/186746502-5448dedd-1d7b-4aae-b1b3-e7c50812c584.svg)

So as the extinction coefficient data:

![SIGMA_T-govaerts_2021-continental-VS-aeronet_continental_clean_spherical_RAMIA_GENERIC](https://user-images.githubusercontent.com/62285993/186746533-2b662e0c-690f-4264-ac79-39f25b87b17c.svg)

To compare scattering phase functions, the new scattering phase function was multiplied by 4 * pi to account for the different normalisation conventions.
After that multiplication, the scattering phase function show relatively minor differences, < 1%, except around the backscattering direction where the bias peaks at ~ 2 % at the shortest wavelengths.

![PHASE-govaerts_2021-continental-VS-aeronet_continental_clean_spherical_RAMIA_GENERIC](https://user-images.githubusercontent.com/62285993/186746562-72aade6d-e1b8-4cfc-b99b-fc3029ac65bf.svg)

![PHASE_BIAS-govaerts_2021-continental-VS-aeronet_continental_clean_spherical_RAMIA_GENERIC](https://user-images.githubusercontent.com/62285993/186746592-4a83894b-84f3-4e69-ae4f-528db2aa47d9.svg)

### `govaerts_2021-desert` VS `aeronet_sahara_spherical_RAMIA_GENERIC`

The albedo data is almost identical: 

![ALBEDO-govaerts_2021-desert-VS-aeronet_sahara_spherical_RAMIA_GENERIC](https://user-images.githubusercontent.com/62285993/186746736-ef47a8de-6037-41eb-8fca-f090bd402e37.svg)

So as the extinction coefficient data:

![SIGMA_T-govaerts_2021-desert-VS-aeronet_sahara_spherical_RAMIA_GENERIC](https://user-images.githubusercontent.com/62285993/186746753-0455c651-1f81-47ad-b66b-f39a04aa26e9.svg)

To compare scattering phase functions, the new scattering phase function was multiplied by 4 * pi to account for the different normalisation conventions.
After that multiplication, the scattering phase function show relatively minor differences, < 1%, except around the backscattering direction where the bias peaks at ~ 1.5 % at the shortest wavelengths.

![PHASE-govaerts_2021-desert-VS-aeronet_sahara_spherical_RAMIA_GENERIC](https://user-images.githubusercontent.com/62285993/186746781-fab22b2f-a7fc-4901-8d4d-e94bc580a799.svg)

![PHASE_BIAS-govaerts_2021-desert-VS-aeronet_sahara_spherical_RAMIA_GENERIC](https://user-images.githubusercontent.com/62285993/186746809-d9afde83-60e3-4737-b467-a992defa737c.svg)

## Extrapolated data sets?

The difference between the `<name>.nc` data sets and `<name>_extrapolated.nc` data sets is that the extrapolated data sets cover the entire Eradiate wavelength range, but not the non-extrapolated ones.
The non-extrapolated data sets do no go below 350 nm in wavelength. To extend the data sets to reach 280 nm, I have simply extrapolated the refractive index data to 280 nm (linearly, using `scipy.interpolate.interp1d` with `fill_value="extrapolate"`). Since this extrapolation is questionable, the extrapolated data sets are distinguised from the non-extrapolated data sets.
The extrapolated data sets are provided for the user that wants full coverage of Eradiate wavelength range.
To stay on the safe side of things, it is recommended to use the non-extrapolated data sets.

# Checklist

- [ ] ~~The code follows the relevant coding guidelines~~
- [ ] ~~The code generates no new warnings~~
- [ ] ~~The code is appropriately documented~~
- [ ] ~~The code is tested to prove its function~~
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
