### PR TITLE
util: Update lazy loader to v0.1rc3, add stub files for lazy imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,8 +57,8 @@ when necessary—we also advise to not ignore `DeprecationWarning`s.
 * Added the atmo-centimeter, a.k.a. atm-cm, to the unit registry ({ghpr}`245`).
 * Added spectral response functions for the VIIRS instrument onboard JPSS1 and
   NPP platforms ({ghpr}`253`).
-* Submodules and packages are now imported lazily ({ghpr}`254`). This
-  significantly decreases import time for most use cases.
+* Submodules and packages are now imported lazily ({ghpr}`254`, {ghpr}`261`).
+  This significantly decreases import time for most use cases.
 * Optimised calls to `Quantity.m_as()` in
   `InstancedCanopyElement.kernel_instances()` ({ghpr}`256`).
 * Fixed incorrect scaling formula for datetime-based scaling of Solar irradiance

--- a/docs/rst/developer_guide/lazy_loading.rst
+++ b/docs/rst/developer_guide/lazy_loading.rst
@@ -42,7 +42,8 @@ Using ``lazy_loader``
 
 Usage is documented in the
 `SPEC <https://scientific-python.org/specs/spec-0001/>`_. Docstrings also
-provide useful usage information.
+provide useful usage information. Be sure to read the **TYPE CHECKERS** section
+carefully as it describes how we use stub files.
 
 In addition, checking that all lazy imports can be resolved is recommended. The
 way to do so is to use the ``EAGER_IMPORT`` environment variable, *e.g.*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,11 +83,17 @@ eradiate = "eradiate.cli:main"
 ertdata = "eradiate.cli:data"
 ertshow = "eradiate.cli:show"
 
+[tool.setuptools]
+zip-safe = false  # Required because of package data
+
 [tool.setuptools.packages.find]
 exclude = ["plugins"]
 include = ["eradiate*"]
 namespaces = false
 where = ["src"]
+
+[tool.setuptools.package-data]
+eradiate = ["py.typed", "*.pyi"]  # Required by PEP 561 https://mypy.readthedocs.io/en/stable/installed_packages.html#creating-pep-561-compatible-packages
 
 [tool.setuptools_scm]
 git_describe_command = [

--- a/src/eradiate/__init__.py
+++ b/src/eradiate/__init__.py
@@ -9,39 +9,6 @@ __version__ = _version  #: Eradiate version string.
 
 from .util import lazy_loader
 
-__getattr__, __dir__, __all__ = lazy_loader.attach(
-    __name__,
-    submodules=[
-        "ckd",
-        "contexts",
-        "converters",
-        "data",
-        "experiments",
-        "kernel",
-        "notebook",
-        "pipelines",
-        "plot",
-        "rng",
-        "scenes",
-        "units",
-        "validators",
-        "xarray",
-    ],
-    submod_attrs={
-        "_config": ["config"],
-        "_mode": [
-            "mode",
-            "modes",
-            "set_mode",
-            "supported_mode",
-            "unsupported_mode",
-            "Mode",
-            "ModeFlags",
-        ],
-        "experiments": ["run"],
-        "notebook": ["load_ipython_extension"],
-        "units": ["unit_registry", "unit_context_config", "unit_context_kernel"],
-    },
-)
+__getattr__, __dir__, __all__ = lazy_loader.attach_stub(__name__, __file__)
 
 del lazy_loader

--- a/src/eradiate/__init__.pyi
+++ b/src/eradiate/__init__.pyi
@@ -1,0 +1,27 @@
+from . import ckd as ckd
+from . import contexts as contexts
+from . import converters as converters
+from . import data as data
+from . import experiments as experiments
+from . import kernel as kernel
+from . import notebook as notebook
+from . import pipelines as pipelines
+from . import plot as plot
+from . import rng as rng
+from . import scenes as scenes
+from . import units as units
+from . import validators as validators
+from . import xarray as xarray
+from ._config import config
+from ._mode import Mode as Mode
+from ._mode import ModeFlags as ModeFlags
+from ._mode import mode as mode
+from ._mode import modes as modes
+from ._mode import set_mode as set_mode
+from ._mode import supported_mode as supported_mode
+from ._mode import unsupported_mode as unsupported_mode
+from .experiments import run as run
+from .notebook import load_ipython_extension as load_ipython_extension
+from .units import unit_context_config as unit_context_config
+from .units import unit_context_kernel as unit_context_kernel
+from .units import unit_registry as unit_registry

--- a/src/eradiate/data/__init__.py
+++ b/src/eradiate/data/__init__.py
@@ -7,18 +7,7 @@ import sys
 from ..typing import PathLike
 from ..util import lazy_loader
 
-__getattr__, __dir__, __all__ = lazy_loader.attach(
-    __name__,
-    submod_attrs={
-        "_store": ["data_store", "init_data_store"],
-        "_core": ["DataStore"],
-        "_blind_directory": ["BlindDirectoryDataStore"],
-        "_blind_online": ["BlindOnlineDataStore"],
-        "_safe_directory": ["SafeDirectoryDataStore"],
-        "_safe_online": ["SafeOnlineDataStore"],
-        "_multi": ["MultiDataStore"],
-    },
-)
+__getattr__, __dir__, __all__ = lazy_loader.attach_stub(__name__, __file__)
 xr = lazy_loader.load("xarray")
 
 del lazy_loader

--- a/src/eradiate/data/__init__.pyi
+++ b/src/eradiate/data/__init__.pyi
@@ -1,0 +1,8 @@
+from ._blind_directory import BlindDirectoryDataStore as BlindDirectoryDataStore
+from ._blind_online import BlindOnlineDataStore as BlindOnlineDataStore
+from ._core import DataStore as DataStore
+from ._multi import MultiDataStore as MultiDataStore
+from ._safe_directory import SafeDirectoryDataStore as SafeDirectoryDataStore
+from ._safe_online import SafeOnlineDataStore as SafeOnlineDataStore
+from ._store import data_store as data_store
+from ._store import init_data_store as init_data_store

--- a/src/eradiate/experiments/__init__.py
+++ b/src/eradiate/experiments/__init__.py
@@ -1,13 +1,5 @@
 from ..util import lazy_loader
 
-__getattr__, __dir__, __all__ = lazy_loader.attach(
-    __name__,
-    submod_attrs={
-        "_core": ["EarthObservationExperiment", "Experiment", "mitsuba_run", "run"],
-        "_atmosphere": ["AtmosphereExperiment", "OneDimExperiment"],
-        "_canopy": ["CanopyExperiment", "RamiExperiment"],
-        "_canopy_atmosphere": ["CanopyAtmosphereExperiment", "Rami4ATMExperiment"],
-    },
-)
+__getattr__, __dir__, __all__ = lazy_loader.attach_stub(__name__, __file__)
 
 del lazy_loader

--- a/src/eradiate/experiments/__init__.pyi
+++ b/src/eradiate/experiments/__init__.pyi
@@ -1,0 +1,10 @@
+from ._atmosphere import AtmosphereExperiment as AtmosphereExperiment
+from ._atmosphere import OneDimExperiment as OneDimExperiment
+from ._canopy import CanopyExperiment as CanopyExperiment
+from ._canopy import RamiExperiment as RamiExperiment
+from ._canopy_atmosphere import CanopyAtmosphereExperiment as CanopyAtmosphereExperiment
+from ._canopy_atmosphere import Rami4ATMExperiment as Rami4ATMExperiment
+from ._core import EarthObservationExperiment as EarthObservationExperiment
+from ._core import Experiment as Experiment
+from ._core import mitsuba_run as mitsuba_run
+from ._core import run as run

--- a/src/eradiate/kernel/__init__.py
+++ b/src/eradiate/kernel/__init__.py
@@ -18,10 +18,6 @@ except (ImportError, ModuleNotFoundError) as e:
 
 from ..util import lazy_loader
 
-__getattr__, __dir__, __all__ = lazy_loader.attach(
-    __name__,
-    ["gridvolume", "logging", "transform"],
-    {"_bitmap": ["bitmap_to_dataset"]},
-)
+__getattr__, __dir__, __all__ = lazy_loader.attach_stub(__name__, __file__)
 
 del lazy_loader

--- a/src/eradiate/kernel/__init__.pyi
+++ b/src/eradiate/kernel/__init__.pyi
@@ -1,0 +1,3 @@
+from . import logging as logging
+from . import transform as transform
+from ._bitmap import bitmap_to_dataset as bitmap_to_dataset

--- a/src/eradiate/pipelines/__init__.py
+++ b/src/eradiate/pipelines/__init__.py
@@ -1,31 +1,5 @@
 from ..util import lazy_loader
 
-__getattr__, __dir__, __all__ = lazy_loader.attach(
-    __name__,
-    submod_attrs={
-        # Basic pipeline infrastructure
-        "_core": ["Pipeline", "PipelineStep"],
-        # Gather step
-        "_gather": ["Gather"],
-        # Aggregate steps
-        "_aggregate": [
-            "AggregateCKDQuad",
-            "AggregateRadiosity",
-            "AggregateSampleCount",
-        ],
-        # Assemble steps
-        "_assemble": [
-            "AddIllumination",
-            "AddSpectralResponseFunction",
-            "AddViewingAngles",
-        ],
-        # Compute steps
-        "_compute": [
-            "ApplySpectralResponseFunction",
-            "ComputeAlbedo",
-            "ComputeReflectance",
-        ],
-    },
-)
+__getattr__, __dir__, __all__ = lazy_loader.attach_stub(__name__, __file__)
 
 del lazy_loader

--- a/src/eradiate/pipelines/__init__.pyi
+++ b/src/eradiate/pipelines/__init__.pyi
@@ -1,0 +1,20 @@
+# Basic pipeline infrastructure
+from ._core import Pipeline as Pipeline, PipelineStep as PipelineStep  # isort: skip
+
+# Aggregate steps
+from ._aggregate import AggregateCKDQuad as AggregateCKDQuad
+from ._aggregate import AggregateRadiosity as AggregateRadiosity
+from ._aggregate import AggregateSampleCount as AggregateSampleCount
+
+# Assemble steps
+from ._assemble import AddIllumination as AddIllumination
+from ._assemble import AddSpectralResponseFunction as AddSpectralResponseFunction
+from ._assemble import AddViewingAngles as AddViewingAngles
+
+# Compute steps
+from ._compute import ApplySpectralResponseFunction as ApplySpectralResponseFunction
+from ._compute import ComputeAlbedo as ComputeAlbedo
+from ._compute import ComputeReflectance as ComputeReflectance
+
+# Gather step
+from ._gather import Gather as Gather

--- a/src/eradiate/radprops/__init__.py
+++ b/src/eradiate/radprops/__init__.py
@@ -5,14 +5,6 @@ Atmospheric radiative properties calculation package.
 
 from ..util import lazy_loader
 
-__getattr__, __dir__, __all__ = lazy_loader.attach(
-    __name__,
-    submod_attrs={
-        "_core": ["RadProfile", "rad_profile_factory"],
-        "_us76_approx": ["US76ApproxRadProfile"],
-        "_afgl1986": ["AFGL1986RadProfile"],
-        "_array": ["ArrayRadProfile"],
-    },
-)
+__getattr__, __dir__, __all__ = lazy_loader.attach_stub(__name__, __file__)
 
 del lazy_loader

--- a/src/eradiate/radprops/__init__.pyi
+++ b/src/eradiate/radprops/__init__.pyi
@@ -1,0 +1,5 @@
+from ._afgl1986 import AFGL1986RadProfile as AFGL1986RadProfile
+from ._array import ArrayRadProfile as ArrayRadProfile
+from ._core import RadProfile as RadProfile
+from ._core import rad_profile_factory as rad_profile_factory
+from ._us76_approx import US76ApproxRadProfile as US76ApproxRadProfile

--- a/src/eradiate/scenes/__init__.py
+++ b/src/eradiate/scenes/__init__.py
@@ -1,20 +1,5 @@
 from ..util import lazy_loader
 
-__getattr__, __dir__, __all__ = lazy_loader.attach(
-    __name__,
-    submodules=[
-        "atmosphere",
-        "biosphere",
-        "bsdfs",
-        "core",
-        "illumination",
-        "integrators",
-        "measure",
-        "phase",
-        "shapes",
-        "spectra",
-        "surface",
-    ],
-)
+__getattr__, __dir__, __all__ = lazy_loader.attach_stub(__name__, __file__)
 
 del lazy_loader

--- a/src/eradiate/scenes/__init__.pyi
+++ b/src/eradiate/scenes/__init__.pyi
@@ -1,0 +1,11 @@
+from . import atmosphere as atmosphere
+from . import biosphere as biosphere
+from . import bsdfs as bsdfs
+from . import core as core
+from . import illumination as illumination
+from . import integrators as integrators
+from . import measure as measure
+from . import phase as phase
+from . import shapes as shapes
+from . import spectra as spectra
+from . import surface as surface

--- a/src/eradiate/scenes/atmosphere/__init__.py
+++ b/src/eradiate/scenes/atmosphere/__init__.py
@@ -1,30 +1,5 @@
 from ...util import lazy_loader
 
-__getattr__, __dir__, __all__ = lazy_loader.attach(
-    __name__,
-    submod_attrs={
-        "_core": [
-            "AbstractHeterogeneousAtmosphere",
-            "Atmosphere",
-            "AtmosphereGeometry",
-            "PlaneParallelGeometry",
-            "SphericalShellGeometry",
-            "atmosphere_factory",
-        ],
-        "_heterogeneous": ["HeterogeneousAtmosphere"],
-        "_homogeneous": ["HomogeneousAtmosphere"],
-        "_molecular_atmosphere": ["MolecularAtmosphere"],
-        "_particle_dist": [
-            "ArrayParticleDistribution",
-            "ExponentialParticleDistribution",
-            "GaussianParticleDistribution",
-            "InterpolatorParticleDistribution",
-            "ParticleDistribution",
-            "UniformParticleDistribution",
-            "particle_distribution_factory",
-        ],
-        "_particle_layer": ["ParticleLayer"],
-    },
-)
+__getattr__, __dir__, __all__ = lazy_loader.attach_stub(__name__, __file__)
 
 del lazy_loader

--- a/src/eradiate/scenes/atmosphere/__init__.pyi
+++ b/src/eradiate/scenes/atmosphere/__init__.pyi
@@ -1,0 +1,23 @@
+from ._core import AbstractHeterogeneousAtmosphere as AbstractHeterogeneousAtmosphere
+from ._core import Atmosphere as Atmosphere
+from ._core import AtmosphereGeometry as AtmosphereGeometry
+from ._core import PlaneParallelGeometry as PlaneParallelGeometry
+from ._core import SphericalShellGeometry as SphericalShellGeometry
+from ._core import atmosphere_factory as atmosphere_factory
+from ._heterogeneous import HeterogeneousAtmosphere as HeterogeneousAtmosphere
+from ._homogeneous import HomogeneousAtmosphere as HomogeneousAtmosphere
+from ._molecular_atmosphere import MolecularAtmosphere as MolecularAtmosphere
+from ._particle_dist import ArrayParticleDistribution as ArrayParticleDistribution
+from ._particle_dist import (
+    ExponentialParticleDistribution as ExponentialParticleDistribution,
+)
+from ._particle_dist import GaussianParticleDistribution as GaussianParticleDistribution
+from ._particle_dist import (
+    InterpolatorParticleDistribution as InterpolatorParticleDistribution,
+)
+from ._particle_dist import ParticleDistribution as ParticleDistribution
+from ._particle_dist import UniformParticleDistribution as UniformParticleDistribution
+from ._particle_dist import (
+    particle_distribution_factory as particle_distribution_factory,
+)
+from ._particle_layer import ParticleLayer as ParticleLayer

--- a/src/eradiate/scenes/biosphere/__init__.py
+++ b/src/eradiate/scenes/biosphere/__init__.py
@@ -1,18 +1,6 @@
 from ...util import lazy_loader
 
-__getattr__, __dir__, __all__ = lazy_loader.attach(
-    __name__,
-    submod_attrs={
-        "_core": [
-            "Canopy",
-            "CanopyElement",
-            "InstancedCanopyElement",
-            "biosphere_factory",
-        ],
-        "_discrete": ["DiscreteCanopy"],
-        "_leaf_cloud": ["LeafCloud"],
-        "_tree": ["AbstractTree", "MeshTree", "MeshTreeElement"],
-    },
-)
+__getattr__, __dir__, __all__ = lazy_loader.attach_stub(__name__, __file__)
+
 
 del lazy_loader

--- a/src/eradiate/scenes/biosphere/__init__.pyi
+++ b/src/eradiate/scenes/biosphere/__init__.pyi
@@ -1,0 +1,9 @@
+from ._core import Canopy as Canopy
+from ._core import CanopyElement as CanopyElement
+from ._core import InstancedCanopyElement as InstancedCanopyElement
+from ._core import biosphere_factory as biosphere_factory
+from ._discrete import DiscreteCanopy as DiscreteCanopy
+from ._leaf_cloud import LeafCloud as LeafCloud
+from ._tree import AbstractTree as AbstractTree
+from ._tree import MeshTree as MeshTree
+from ._tree import MeshTreeElement as MeshTreeElement

--- a/src/eradiate/scenes/bsdfs/__init__.py
+++ b/src/eradiate/scenes/bsdfs/__init__.py
@@ -1,14 +1,6 @@
 from ...util import lazy_loader
 
-__getattr__, __dir__, __all__ = lazy_loader.attach(
-    __name__,
-    submod_attrs={
-        "_core": ["BSDF", "bsdf_factory"],
-        "_black": ["BlackBSDF"],
-        "_checkerboard": ["CheckerboardBSDF"],
-        "_lambertian": ["LambertianBSDF"],
-        "_rpv": ["RPVBSDF"],
-    },
-)
+__getattr__, __dir__, __all__ = lazy_loader.attach_stub(__name__, __file__)
+
 
 del lazy_loader

--- a/src/eradiate/scenes/bsdfs/__init__.pyi
+++ b/src/eradiate/scenes/bsdfs/__init__.pyi
@@ -1,0 +1,6 @@
+from ._black import BlackBSDF as BlackBSDF
+from ._checkerboard import CheckerboardBSDF as CheckerboardBSDF
+from ._core import BSDF as BSDF
+from ._core import bsdf_factory as bsdf_factory
+from ._lambertian import LambertianBSDF as LambertianBSDF
+from ._rpv import RPVBSDF as RPVBSDF

--- a/src/eradiate/scenes/illumination/__init__.py
+++ b/src/eradiate/scenes/illumination/__init__.py
@@ -1,12 +1,5 @@
 from ...util import lazy_loader
 
-__getattr__, __dir__, __all__ = lazy_loader.attach(
-    __name__,
-    submod_attrs={
-        "_core": ["Illumination", "illumination_factory"],
-        "_constant": ["ConstantIllumination"],
-        "_directional": ["DirectionalIllumination"],
-    },
-)
+__getattr__, __dir__, __all__ = lazy_loader.attach_stub(__name__, __file__)
 
 del lazy_loader

--- a/src/eradiate/scenes/illumination/__init__.pyi
+++ b/src/eradiate/scenes/illumination/__init__.pyi
@@ -1,0 +1,4 @@
+from ._constant import ConstantIllumination as ConstantIllumination
+from ._core import Illumination as Illumination
+from ._core import illumination_factory as illumination_factory
+from ._directional import DirectionalIllumination as DirectionalIllumination

--- a/src/eradiate/scenes/integrators/__init__.py
+++ b/src/eradiate/scenes/integrators/__init__.py
@@ -1,15 +1,5 @@
 from ...util import lazy_loader
 
-__getattr__, __dir__, __all__ = lazy_loader.attach(
-    __name__,
-    submod_attrs={
-        "_core": ["Integrator", "integrator_factory"],
-        "_path_tracers": [
-            "PathIntegrator",
-            "VolPathIntegrator",
-            "VolPathMISIntegrator",
-        ],
-    },
-)
+__getattr__, __dir__, __all__ = lazy_loader.attach_stub(__name__, __file__)
 
 del lazy_loader

--- a/src/eradiate/scenes/integrators/__init__.pyi
+++ b/src/eradiate/scenes/integrators/__init__.pyi
@@ -1,0 +1,5 @@
+from ._core import Integrator as Integrator
+from ._core import integrator_factory as integrator_factory
+from ._path_tracers import PathIntegrator as PathIntegrator
+from ._path_tracers import VolPathIntegrator as VolPathIntegrator
+from ._path_tracers import VolPathMISIntegrator as VolPathMISIntegrator

--- a/src/eradiate/scenes/measure/__init__.py
+++ b/src/eradiate/scenes/measure/__init__.py
@@ -1,17 +1,5 @@
 from ...util import lazy_loader
 
-__getattr__, __dir__, __all__ = lazy_loader.attach(
-    __name__,
-    submod_attrs={
-        "_core": ["Measure", "MeasureSpectralConfig", "measure_factory"],
-        "_target": ["Target", "TargetPoint", "TargetRectangle"],
-        "_distant_flux": ["DistantFluxMeasure"],
-        "_hemispherical_distant": ["HemisphericalDistantMeasure"],
-        "_multi_distant": ["MultiDistantMeasure"],
-        "_multi_radiancemeter": ["MultiRadiancemeterMeasure"],
-        "_perspective": ["PerspectiveCameraMeasure"],
-        "_radiancemeter": ["RadiancemeterMeasure"],
-    },
-)
+__getattr__, __dir__, __all__ = lazy_loader.attach_stub(__name__, __file__)
 
 del lazy_loader

--- a/src/eradiate/scenes/measure/__init__.pyi
+++ b/src/eradiate/scenes/measure/__init__.pyi
@@ -1,0 +1,14 @@
+from ._core import Measure as Measure
+from ._core import MeasureSpectralConfig as MeasureSpectralConfig
+from ._core import measure_factory as measure_factory
+from ._distant_flux import DistantFluxMeasure as DistantFluxMeasure
+from ._hemispherical_distant import (
+    HemisphericalDistantMeasure as HemisphericalDistantMeasure,
+)
+from ._multi_distant import MultiDistantMeasure as MultiDistantMeasure
+from ._multi_radiancemeter import MultiRadiancemeterMeasure as MultiRadiancemeterMeasure
+from ._perspective import PerspectiveCameraMeasure as PerspectiveCameraMeasure
+from ._radiancemeter import RadiancemeterMeasure as RadiancemeterMeasure
+from ._target import Target as Target
+from ._target import TargetPoint as TargetPoint
+from ._target import TargetRectangle as TargetRectangle

--- a/src/eradiate/scenes/phase/__init__.py
+++ b/src/eradiate/scenes/phase/__init__.py
@@ -1,15 +1,5 @@
 from ...util import lazy_loader
 
-__getattr__, __dir__, __all__ = lazy_loader.attach(
-    __name__,
-    submod_attrs={
-        "_blend": ["BlendPhaseFunction"],
-        "_core": ["PhaseFunction", "phase_function_factory"],
-        "_hg": ["HenyeyGreensteinPhaseFunction"],
-        "_isotropic": ["IsotropicPhaseFunction"],
-        "_rayleigh": ["RayleighPhaseFunction"],
-        "_tabulated": ["TabulatedPhaseFunction"],
-    },
-)
+__getattr__, __dir__, __all__ = lazy_loader.attach_stub(__name__, __file__)
 
 del lazy_loader

--- a/src/eradiate/scenes/phase/__init__.pyi
+++ b/src/eradiate/scenes/phase/__init__.pyi
@@ -1,0 +1,7 @@
+from ._blend import BlendPhaseFunction as BlendPhaseFunction
+from ._core import PhaseFunction as PhaseFunction
+from ._core import phase_function_factory as phase_function_factory
+from ._hg import HenyeyGreensteinPhaseFunction as HenyeyGreensteinPhaseFunction
+from ._isotropic import IsotropicPhaseFunction as IsotropicPhaseFunction
+from ._rayleigh import RayleighPhaseFunction as RayleighPhaseFunction
+from ._tabulated import TabulatedPhaseFunction as TabulatedPhaseFunction

--- a/src/eradiate/scenes/shapes/__init__.py
+++ b/src/eradiate/scenes/shapes/__init__.py
@@ -1,15 +1,5 @@
 from ...util import lazy_loader
 
-__getattr__, __dir__, __all__ = lazy_loader.attach(
-    __name__,
-    submod_attrs={
-        "_core": ["Shape", "shape_factory"],
-        "_cuboid": ["CuboidShape"],
-        "_rectangle": ["RectangleShape"],
-        "_sphere": ["SphereShape"],
-        "_filemesh": ["FileMeshShape"],
-        "_buffermesh": ["BufferMeshShape"],
-    },
-)
+__getattr__, __dir__, __all__ = lazy_loader.attach_stub(__name__, __file__)
 
 del lazy_loader

--- a/src/eradiate/scenes/shapes/__init__.pyi
+++ b/src/eradiate/scenes/shapes/__init__.pyi
@@ -1,0 +1,7 @@
+from ._buffermesh import BufferMeshShape as BufferMeshShape
+from ._core import Shape as Shape
+from ._core import shape_factory as shape_factory
+from ._cuboid import CuboidShape as CuboidShape
+from ._filemesh import FileMeshShape as FileMeshShape
+from ._rectangle import RectangleShape as RectangleShape
+from ._sphere import SphereShape as SphereShape

--- a/src/eradiate/scenes/spectra/__init__.py
+++ b/src/eradiate/scenes/spectra/__init__.py
@@ -1,14 +1,5 @@
 from ...util import lazy_loader
 
-__getattr__, __dir__, __all__ = lazy_loader.attach(
-    __name__,
-    submod_attrs={
-        "_core": ["Spectrum", "spectrum_factory"],
-        "_air_scattering_coefficient": ["AirScatteringCoefficientSpectrum"],
-        "_interpolated": ["InterpolatedSpectrum"],
-        "_solar_irradiance": ["SolarIrradianceSpectrum"],
-        "_uniform": ["UniformSpectrum"],
-    },
-)
+__getattr__, __dir__, __all__ = lazy_loader.attach_stub(__name__, __file__)
 
 del lazy_loader

--- a/src/eradiate/scenes/spectra/__init__.pyi
+++ b/src/eradiate/scenes/spectra/__init__.pyi
@@ -1,0 +1,8 @@
+from ._air_scattering_coefficient import (
+    AirScatteringCoefficientSpectrum as AirScatteringCoefficientSpectrum,
+)
+from ._core import Spectrum as Spectrum
+from ._core import spectrum_factory as spectrum_factory
+from ._interpolated import InterpolatedSpectrum as InterpolatedSpectrum
+from ._solar_irradiance import SolarIrradianceSpectrum as SolarIrradianceSpectrum
+from ._uniform import UniformSpectrum as UniformSpectrum

--- a/src/eradiate/scenes/surface/__init__.py
+++ b/src/eradiate/scenes/surface/__init__.py
@@ -1,13 +1,5 @@
 from ...util import lazy_loader
 
-__getattr__, __dir__, __all__ = lazy_loader.attach(
-    __name__,
-    submod_attrs={
-        "_core": ["Surface", "surface_factory"],
-        "_basic": ["BasicSurface"],
-        "_central_patch": ["CentralPatchSurface"],
-        "_dem": ["DEMSurface"],
-    },
-)
+__getattr__, __dir__, __all__ = lazy_loader.attach_stub(__name__, __file__)
 
 del lazy_loader

--- a/src/eradiate/scenes/surface/__init__.pyi
+++ b/src/eradiate/scenes/surface/__init__.pyi
@@ -1,0 +1,5 @@
+from ._basic import BasicSurface as BasicSurface
+from ._central_patch import CentralPatchSurface as CentralPatchSurface
+from ._core import Surface as Surface
+from ._core import surface_factory as surface_factory
+from ._dem import DEMSurface as DEMSurface

--- a/src/eradiate/util/lazy_loader.py
+++ b/src/eradiate/util/lazy_loader.py
@@ -5,10 +5,11 @@
 
    Copied from https://github.com/scientific-python/lazy_loader.
 
-   * **Date:** 2022-06-25
-   * **Version:** v1.0rc2
+   * **Date:** 2022-08-29
+   * **Version:** v1.0rc3
 """
 
+import ast
 import importlib
 import importlib.util
 import inspect
@@ -16,7 +17,7 @@ import os
 import sys
 import types
 
-__all__ = ["attach", "load"]
+__all__ = ["attach", "load", "attach_stub"]
 
 
 def attach(package_name, submodules=None, submod_attrs=None):
@@ -194,3 +195,60 @@ def load(fullname, error_on_import=False):
     loader.exec_module(module)
 
     return module
+
+
+class _StubVisitor(ast.NodeVisitor):
+    """AST visitor to parse a stub file for submodules and submod_attrs."""
+
+    def __init__(self):
+        self._submodules = set()
+        self._submod_attrs = {}
+
+    def visit_ImportFrom(self, node: ast.ImportFrom):
+        if node.level != 1:
+            raise ValueError(
+                "Only within-module imports are supported (`from .* import`)"
+            )
+        if node.module:
+            attrs: list = self._submod_attrs.setdefault(node.module, [])
+            attrs.extend(alias.name for alias in node.names)
+        else:
+            self._submodules.update(alias.name for alias in node.names)
+
+
+def attach_stub(package_name: str, filename: str):
+    """Attach lazily loaded submodules, functions from a type stub.
+    This is a variant on ``attach`` that will parse a `.pyi` stub file to
+    infer ``submodules`` and ``submod_attrs``. This allows static type checkers
+    to find imports, while still providing lazy loading at runtime.
+
+    Parameters
+    ----------
+    package_name : str
+        Typically use ``__name__``.
+    filename : str
+        Path to `.py` file which has an adjacent `.pyi` file.
+        Typically use ``__file__``.
+
+    Returns
+    -------
+    __getattr__, __dir__, __all__
+        The same output as ``attach``.
+
+    Raises
+    ------
+    ValueError
+        If a stub file is not found for `filename`, or if the stubfile is formmated
+        incorrectly (e.g. if it contains an relative import from outside of the module)
+    """
+    stubfile = filename if filename.endswith("i") else f"{filename}i"
+
+    if not os.path.exists(stubfile):
+        raise ValueError(f"Cannot load imports from non-existent stub {stubfile!r}")
+
+    with open(stubfile) as f:
+        stub_node = ast.parse(f.read())
+
+    visitor = _StubVisitor()
+    visitor.visit(stub_node)
+    return attach(package_name, visitor._submodules, visitor._submod_attrs)

--- a/src/eradiate/xarray/__init__.py
+++ b/src/eradiate/xarray/__init__.py
@@ -3,14 +3,9 @@ from . import _accessors  # isort: skip
 
 del _accessors
 
-
-# -- Lazy imports ------------------------------------------------------
-
+# Lazy imports
 from ..util import lazy_loader
 
-__getattr__, __dir__, __all__ = lazy_loader.attach(
-    __name__,
-    submodules=["interp"],
-)
+__getattr__, __dir__, __all__ = lazy_loader.attach_stub(__name__, __file__)
 
 del lazy_loader

--- a/src/eradiate/xarray/__init__.pyi
+++ b/src/eradiate/xarray/__init__.pyi
@@ -1,0 +1,1 @@
+from . import interp as interp


### PR DESCRIPTION
# Description

This PR leverages the new [stub-based lazy import definition system](https://github.com/scientific-python/lazy_loader#lazily-load-subpackages-and-functions-from-type-stubs) introduced in [lazy_loader v0.1rc3](https://github.com/scientific-python/lazy_loader/releases/tag/v0.1rc3). It transfers lazy loading definitions to stub files, thus making it possible for IDEs and type checkers to find dynamic imports.

# To do

- [x] Check if stubs are correctly used by IDEs when using a regular setup (~~doesn't so far~~ see scientific-python/lazy_loader#28)

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
