### PR TITLE
Add sys_info module, upgrade eradiate show with system information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@ when necessary—we also advise to not ignore `DeprecationWarning`s.
   `InstancedCanopyElement.kernel_instances()` ({ghpr}`256`).
 * Fixed incorrect scaling formula for datetime-based scaling of Solar irradiance
   spectra ({ghpr}`258`).
+* Added system information report to the `eradiate show` command-line utility
+  ({ghpr}`264`).
 
 % ### Documentation
 

--- a/src/eradiate/cli.py
+++ b/src/eradiate/cli.py
@@ -16,7 +16,7 @@ from ruamel.yaml import YAML
 import eradiate
 from eradiate.exceptions import DataError
 
-console = Console()
+console = Console(color_system=None)
 
 
 @click.group()
@@ -44,28 +44,40 @@ def show():
     """
     Display information useful for debugging.
     """
-    mi.set_variant("scalar_rgb")
+    import eradiate.util.sys_info
+
+    console = Console(color_system=None)
+    sys_info = eradiate.util.sys_info.show()
 
     def section(title, newline=True):
         if newline:
             console.print()
-        console.rule(title)
+        console.rule("── " + title, align="left")
         console.print()
 
     def message(text):
         console.print(text)
 
-    section("Versions", newline=False)
+    section("System", newline=False)
+    message(f"CPU: {sys_info['cpu_info']}")
+    message(f"OS: {sys_info['os']}")
+    message(f"Python: {sys_info['python']}")
+
+    section("Versions")
     message(f"• eradiate {eradiate.__version__}")
-    message(f"• mitsuba {mi.MI_VERSION}")
+    message(f"• drjit {sys_info['drjit_version']}")
+    message(f"• mitsuba {sys_info['mitsuba_version']}")
 
     section("Available Mitsuba variants")
     message("\n".join([f"• {variant}" for variant in mi.variants()]))
 
     section("Configuration")
-    for var in [x.name for x in eradiate.config.__attrs_attrs__]:
+    for var in sorted(x.name for x in eradiate.config.__attrs_attrs__):
         value = getattr(eradiate.config, var)
-        var_repr = f"{value!r}" if var == "progress" else str(value)
+        if var == "progress":
+            var_repr = f"{str(value)} ({value.value})"
+        else:
+            var_repr = str(value)
         message(f"• ERADIATE_{var.upper()}: {var_repr}")
 
 

--- a/src/eradiate/util/sys_info.py
+++ b/src/eradiate/util/sys_info.py
@@ -1,0 +1,96 @@
+"""
+System information display. This script is useful to collect environment
+information. It is the fundamental building block of the `eradiate show`
+command.
+
+This code is partly taken from `mitsuba.sys_info`.
+"""
+
+import locale
+import platform
+import re
+import subprocess
+import sys
+
+import drjit as dr
+import mitsuba as mi
+
+
+def _run(command):
+    "Returns (return-code, stdout, stderr)"
+    p = subprocess.Popen(
+        command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True
+    )
+    raw_output, raw_err = p.communicate()
+    rc = p.returncode
+    if sys.platform.startswith("win32"):
+        enc = "oem"
+    else:
+        enc = locale.getpreferredencoding()
+    output = raw_output.decode(enc)
+    err = raw_err.decode(enc)
+    return rc, output.strip(), err.strip()
+
+
+def _run_and_match(command, regex):
+    "Runs command and returns the first regex match if it exists"
+    rc, out, _ = _run(command)
+    if rc != 0:
+        return None
+    match = re.search(regex, out)
+    if match is None:
+        return None
+    return match.group(1)
+
+
+def _get_cpu_info():
+    if sys.platform.startswith("win32"):
+        return platform.processor()
+    elif sys.platform.startswith("darwin"):
+        return subprocess.check_output(
+            ["/usr/sbin/sysctl", "-n", "machdep.cpu.brand_string"]
+        ).strip()
+    elif sys.platform.startswith("linux"):
+        command = "cat /proc/cpuinfo"
+        all_info = subprocess.check_output(command, shell=True).decode().strip()
+        for line in all_info.split("\n"):
+            if "model name" in line:
+                return re.sub(r".*model name.*:", "", line, 1)[1:]
+    return None
+
+
+def show() -> dict:
+    mi.set_variant("scalar_rgb")
+    result = {}
+
+    if sys.platform.startswith("darwin"):
+        result["os"] = _run_and_match("sw_vers -productVersion", r"(.*)")
+    elif sys.platform.startswith("win32"):
+        result["os"] = platform.platform(terse=True)
+    else:
+        result["os"] = _run_and_match("lsb_release -a", r"Description:\t(.*)")
+
+    result["cpu_info"] = _get_cpu_info()
+    result["python"] = sys.version.replace("\n", "")
+    # result["llvm_version"] = dr.llvm_version()  # Commented until we bump mitsuba and drjit
+    result["drjit_version"] = dr.__version__ + (" (DEBUG)" if dr.DEBUG else "")
+    result["mitsuba_version"] = mi.MI_VERSION + (" (DEBUG)" if mi.DEBUG else "")
+    # result["mitsuba_compiler"] = import_module("mitsuba.config").CXX_COMPILER  # Commented until we bump mitsuba and drjit
+
+    return result
+
+
+if __name__ == "__main__":
+    sys_info = show()
+
+    print("System")
+    print(f"  CPU: {sys_info['cpu_info']}")
+    print(f"  OS: {sys_info['os']}")
+    print(f"  Python: {sys_info['python']}")
+
+    print("\nVersions")
+    print(f"  drjit {sys_info['drjit_version']}")
+    print(f"  mitsuba {sys_info['mitsuba_version']}")
+
+    print("\nMitsuba variants")
+    print("\n".join([f"  {variant}" for variant in mi.variants()]))


### PR DESCRIPTION
# Description

This PR adds a module which implements system information retrieval utilities. Basic output can be displayed in the terminal:
```
python -m eradiate.util.sys_info
```
The `eradiate show` command-line utility also benefits from this and now displays information about the Python interpreter, the OS and CPU.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
