### PR TITLE
Transition to attrs next-generation APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,6 @@ when necessary—we also advise to not ignore `DeprecationWarning`s.
   * `RamiExperiment` ⇒ `CanopyExperiment`
   * `Rami4ATMExperiment` ⇒ `CanopyAtmosphereExperiment`
 
-
 ### Improvements and fixes
 
 * Added the atmo-centimeter, a.k.a. atm-cm, to the unit registry ({ghpr}`245`).
@@ -78,6 +77,11 @@ when necessary—we also advise to not ignore `DeprecationWarning`s.
   warning on some Linux machines.
 * Aligned the `tabphase_irregular` plugin with the fix `tabphase` code
   ({ghpr}`255`).
+* Updated codebase to use ``attrs``'
+  [next-generation APIs](https://www.attrs.org/en/stable/names.html#tl-dr)
+  ({ghpr}`268`).
+
+---
 
 ## v0.22.4 (17 June 2022)
 
@@ -124,6 +128,8 @@ when necessary—we also advise to not ignore `DeprecationWarning`s.
 * Updated Mitsuba submodule ({ghpr}`228`).
 * Removed the angular regridding feature in `TabulatedPhaseFunction` and
   replaced with plugin selection ({ghpr}`229`).
+
+---
 
 ## v0.22.3 (22 May 2022)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ requires-python = ">=3.8"
 
 dependencies = [
   "aenum",
-  "attrs",
+  "attrs>=21.4",
   "click",
   "dessinemoi>=22.2.0",
   "environ-config",
@@ -96,7 +96,7 @@ git_describe_command = [
   "--long",
   "--match",
   "v[0-9]*",
-] # Redefined to avoid crashing with special build tags 
+] # Redefined to avoid crashing with special build tags
 version_scheme = "post-release" # Count commits since last tag, don't anticipate new version
 
 [tool.isort]

--- a/src/eradiate/_config.py
+++ b/src/eradiate/_config.py
@@ -10,7 +10,7 @@ import os.path
 import pathlib
 import warnings
 
-import attr
+import attrs
 import environ
 from environ._environ_config import CNF_KEY, RAISE, _ConfigEntry
 from environ.exceptions import ConfigError
@@ -58,15 +58,15 @@ def var(
     help : str
         A help string that is used by `generate_help`.
 
-    on_setattr : callable or list of callables or None or attr.setters.NO_OP, optional
-        This argument is directly forwarded to :func:`attr.ib`, with the notable
+    on_setattr : callable or list of callables or None or attrs.setters.NO_OP, optional
+        This argument is directly forwarded to :func:`attrs.field`, with the notable
         difference that the default behaviour executes converters and
         validators.
     """
     if on_setattr is None:
-        on_setattr = attr.setters.pipe(attr.setters.convert, attr.setters.validate)
+        on_setattr = attrs.setters.pipe(attrs.setters.convert, attrs.setters.validate)
 
-    return attr.ib(
+    return attrs.field(
         default=default,
         metadata={CNF_KEY: _ConfigEntry(name, default, None, None, help)},
         converter=converter,
@@ -213,7 +213,7 @@ class EradiateConfig:
     azimuth_convention = var(
         default="EAST_RIGHT",
         converter=lambda x: AzimuthConvention[x.upper()] if isinstance(x, str) else x,
-        validator=attr.validators.instance_of(AzimuthConvention),
+        validator=attrs.validators.instance_of(AzimuthConvention),
         help="The convention applied when interpreting azimuth values as part "
         "of the specification of a direction (see :class:`.AzimuthConvention`). "
         'Values are preferably set using strings (*e.g.* ``"EAST_RIGHT"``, '

--- a/src/eradiate/_factory.py
+++ b/src/eradiate/_factory.py
@@ -1,13 +1,13 @@
 import typing as t
 
-import attr
+import attrs
 import dessinemoi
 import pinttr
 
 from .units import unit_registry as ureg
 
 
-@attr.s
+@attrs.define
 class Factory(dessinemoi.Factory):
     """
     Object factory.

--- a/src/eradiate/_mode.py
+++ b/src/eradiate/_mode.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import enum
 import typing as t
 
-import attr
+import attrs
 import mitsuba
 
 from .attrs import documented, parse_docs
@@ -97,7 +97,7 @@ _mode_registry = {
 
 
 @parse_docs
-@attr.s(frozen=True, slots=True)
+@attrs.frozen
 class Mode:
     """
     Data structure describing Eradiate's operational mode and associated
@@ -107,19 +107,19 @@ class Mode:
     """
 
     id: str = documented(
-        attr.ib(converter=attr.converters.optional(str)),
+        attrs.field(converter=attrs.converters.optional(str)),
         doc="Mode identifier.",
         type="str",
     )
 
     flags: ModeFlags = documented(
-        attr.ib(converter=ModeFlags),
+        attrs.field(converter=ModeFlags),
         doc="Mode flags.",
         type=":class:`.ModeFlags`",
     )
 
     spectral_coord_label: str = documented(
-        attr.ib(converter=attr.converters.optional(str)),
+        attrs.field(converter=attrs.converters.optional(str)),
         doc="Mode spectral coordinate label.",
         type="str",
     )

--- a/src/eradiate/attrs.py
+++ b/src/eradiate/attrs.py
@@ -5,7 +5,7 @@ import re
 import typing as t
 from textwrap import dedent, indent
 
-import attr
+import attrs
 
 from .util import numpydoc
 
@@ -71,14 +71,14 @@ class DocFlags(enum.Flag):
 # ------------------------------------------------------------------------------
 
 
-@attr.s
+@attrs.define
 class _FieldDoc:
     """Internal convenience class to store field documentation information."""
 
-    doc = attr.ib(default=None)
-    type = attr.ib(default=None)
-    init_type = attr.ib(default=None)
-    default = attr.ib(default=None)
+    doc = attrs.field(default=None)
+    type = attrs.field(default=None)
+    init_type = attrs.field(default=None)
+    default = attrs.field(default=None)
 
 
 def _eradiate_formatter(cls_doc, field_docs):
@@ -240,7 +240,8 @@ def parse_docs(cls):
     Notes
     -----
     * Meant to be used as a class decorator.
-    * Must be applied **after** :func:`@attr.s <attr.s>`.
+    * Must be applied **after** :func:`@attr.s <attr.s>` (or any other
+      attrs decorator).
     * Fields must be documented using :func:`documented`.
     """
     formatter = _numpy_formatter
@@ -281,7 +282,7 @@ def documented(attrib, doc=None, type=None, init_type=None, default=None):
 
     Parameters
     ----------
-    attrib : :class:`attr.Attribute`
+    attrib : attrs.Attribute
         ``attrs`` attribute definition to which documentation is to be attached.
 
     doc : str, optional
@@ -299,12 +300,12 @@ def documented(attrib, doc=None, type=None, init_type=None, default=None):
 
     Returns
     -------
-    :class:`attr.Attribute`
+    attrs.Attribute
         ``attrib``, with metadata updated with documentation contents.
 
     See Also
     --------
-    :func:`attr.ib`, :func:`pinttr.ib`, :func:`parse_docs`
+    :func:`attrs.field`, :func:`pinttr.field`, :func:`parse_docs`
     """
     if doc is not None:
         attrib.metadata[MetadataKey.DOC] = doc
@@ -323,8 +324,8 @@ def documented(attrib, doc=None, type=None, init_type=None, default=None):
 
 def get_doc(cls: t.Type, attrib: str, field: str) -> str:
     """
-    Fetch attribute documentation field. Requires fields metadata to be
-    processed with :func:`documented`.
+    Fetch attribute documentation field. Requires field metadata to be processed
+    with :func:`documented`.
 
     Parameters
     ----------
@@ -353,16 +354,16 @@ def get_doc(cls: t.Type, attrib: str, field: str) -> str:
     """
     try:
         if field == "doc":
-            return attr.fields_dict(cls)[attrib].metadata[MetadataKey.DOC]
+            return attrs.fields_dict(cls)[attrib].metadata[MetadataKey.DOC]
 
         if field == "type":
-            return attr.fields_dict(cls)[attrib].metadata[MetadataKey.TYPE]
+            return attrs.fields_dict(cls)[attrib].metadata[MetadataKey.TYPE]
 
         if field == "init_type":
-            return attr.fields_dict(cls)[attrib].metadata[MetadataKey.INIT_TYPE]
+            return attrs.fields_dict(cls)[attrib].metadata[MetadataKey.INIT_TYPE]
 
         if field == "default":
-            return attr.fields_dict(cls)[attrib].metadata[MetadataKey.DEFAULT]
+            return attrs.fields_dict(cls)[attrib].metadata[MetadataKey.DEFAULT]
     except KeyError:
         raise ValueError(
             f"{cls.__name__}.{attrib} has no documented field " f"'{field}'"

--- a/src/eradiate/ckd.py
+++ b/src/eradiate/ckd.py
@@ -4,7 +4,7 @@ import functools
 import typing as t
 from collections import abc
 
-import attr
+import attrs
 import pint
 import pinttr
 import xarray as xr
@@ -21,20 +21,20 @@ from .units import unit_registry as ureg
 
 
 @parse_docs
-@attr.s(frozen=True)
+@attrs.frozen
 class Bin:
     """
     A data class representing a spectral bin in CKD modes.
     """
 
     id: str = documented(
-        attr.ib(converter=str),
+        attrs.field(converter=str),
         doc="Bin identifier.",
         type="str",
     )
 
     wmin: pint.Quantity = documented(
-        pinttr.ib(
+        pinttr.field(
             units=ucc.deferred("wavelength"),
             on_setattr=None,  # frozen instance: on_setattr must be disabled
         ),
@@ -44,7 +44,7 @@ class Bin:
     )
 
     wmax: pint.Quantity = documented(
-        pinttr.ib(
+        pinttr.field(
             units=ucc.deferred("wavelength"),
             on_setattr=None,  # frozen instance: on_setattr must be disabled
         ),
@@ -62,8 +62,8 @@ class Bin:
             )
 
     quad: Quad = documented(
-        attr.ib(
-            repr=lambda x: x.str_summary, validator=attr.validators.instance_of(Quad)
+        attrs.field(
+            repr=lambda x: x.str_summary, validator=attrs.validators.instance_of(Quad)
         ),
         doc="Quadrature rule attached to the CKD bin.",
         type=":class:`.Quad`",
@@ -100,20 +100,20 @@ class Bin:
 
 
 @parse_docs
-@attr.s(frozen=True)
+@attrs.frozen
 class Bindex:
     """
     A data class representing a CKD (bin, index) pair.
     """
 
     bin: Bin = documented(
-        attr.ib(converter=Bin.convert),
+        attrs.field(converter=Bin.convert),
         doc="CKD bin.",
         type=":class:`.Bin`",
     )
 
     index: int = documented(
-        attr.ib(),
+        attrs.field(),
         doc="Quadrature point index.",
         type="int",
     )
@@ -266,33 +266,33 @@ def bin_filter(type: str, filter_kwargs: t.Dict[str, t.Any]):
 
 
 @parse_docs
-@attr.s(frozen=True)
+@attrs.frozen
 class BinSet:
     """
     A data class representing a quadrature definition used in CKD mode.
     """
 
     id: str = documented(
-        attr.ib(converter=str),
+        attrs.field(converter=str),
         doc="Bin set identifier.",
         type="str",
     )
 
     quad: Quad = documented(
-        attr.ib(repr=lambda x: x.str_summary),
+        attrs.field(repr=lambda x: x.str_summary),
         doc="Quadrature rule associated with this spectral bin set.",
         type=":class:`.Quad`",
     )
 
     bins: t.Tuple[Bin, ...] = documented(
-        attr.ib(
+        attrs.field(
             converter=lambda x: tuple(
                 sorted(
                     x, key=lambda y: (y.wmin, y.wmax, y.id)
                 )  # Specify field priority for sorting and exclude quad (which is irrelevant)
             ),
-            validator=attr.validators.deep_iterable(
-                member_validator=attr.validators.instance_of(Bin)
+            validator=attrs.validators.deep_iterable(
+                member_validator=attrs.validators.instance_of(Bin)
             ),
             repr=lambda x: f"tuple<{len(x)}>("
             f"Bin({repr(x[0].id)}, ... ), "

--- a/src/eradiate/data/_blind_directory.py
+++ b/src/eradiate/data/_blind_directory.py
@@ -1,7 +1,7 @@
 import typing as t
 from pathlib import Path
 
-import attr
+import attrs
 
 from ._core import DataStore
 from ..attrs import documented, parse_docs
@@ -10,14 +10,14 @@ from ..typing import PathLike
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class BlindDirectoryDataStore(DataStore):
     """
     Serve files stored in a directory.
     """
 
     path: Path = documented(
-        attr.ib(converter=lambda x: Path(x).absolute()),
+        attrs.field(converter=lambda x: Path(x).absolute()),
         type="Path",
         init_type="path-like",
         doc="Path to the root of the directory referenced by this data store.",

--- a/src/eradiate/data/_blind_online.py
+++ b/src/eradiate/data/_blind_online.py
@@ -3,7 +3,7 @@ import shutil
 import typing as t
 from pathlib import Path
 
-import attr
+import attrs
 import pooch
 from requests import RequestException
 
@@ -15,20 +15,20 @@ from ..util.misc import LoggingContext
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class BlindOnlineDataStore(DataStore):
     """
     Serve data downloaded from a remote source without integrity check.
     """
 
     _base_url: str = documented(
-        attr.ib(converter=lambda x: x + "/" if not x.endswith("/") else x),
+        attrs.field(converter=lambda x: x + "/" if not x.endswith("/") else x),
         type="str",
         doc="URL to the online storage location.",
     )
 
     path: Path = documented(
-        attr.ib(converter=lambda x: Path(x).absolute()),
+        attrs.field(converter=lambda x: Path(x).absolute()),
         type="Path",
         init_type="path-like",
         doc="Path to the local cache location.",

--- a/src/eradiate/data/_core.py
+++ b/src/eradiate/data/_core.py
@@ -4,7 +4,7 @@ import warnings
 from abc import ABC, abstractmethod
 from pathlib import Path
 
-import attr
+import attrs
 import pooch
 import tqdm
 from ruamel.yaml import YAML
@@ -12,7 +12,7 @@ from ruamel.yaml import YAML
 from ..typing import PathLike
 
 
-@attr.s
+@attrs.define
 class DataStore(ABC):
     """
     Interface class for all data stores.

--- a/src/eradiate/data/_multi.py
+++ b/src/eradiate/data/_multi.py
@@ -2,7 +2,7 @@ import typing as t
 from collections import OrderedDict
 from pathlib import Path
 
-import attr
+import attrs
 
 from ._core import DataStore
 from ..attrs import documented, parse_docs
@@ -11,17 +11,17 @@ from ..typing import PathLike
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class MultiDataStore(DataStore):
     """
     Chain requests on multiple data stores.
 
-    Calls to the :meth:`~.MultiDataStore.fetch` method are successively redirected 
+    Calls to the :meth:`~.MultiDataStore.fetch` method are successively redirected
     to each referenced data store. The first successful request is served.
     """
 
     stores: OrderedDict = documented(
-        attr.ib(factory=OrderedDict, converter=OrderedDict),
+        attrs.field(factory=OrderedDict, converter=OrderedDict),
         type="collections.OrderedDict",
         init_type="mapping",
         default="{}",

--- a/src/eradiate/data/_safe_directory.py
+++ b/src/eradiate/data/_safe_directory.py
@@ -5,7 +5,7 @@ import os
 import typing as t
 from pathlib import Path
 
-import attr
+import attrs
 
 from ._core import DataStore, load_rules, make_registry, registry_from_file
 from ..attrs import documented, parse_docs
@@ -14,7 +14,7 @@ from ..typing import PathLike
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class SafeDirectoryDataStore(DataStore):
     """
     Serve files stored in a directory. This data store will only serve files
@@ -22,14 +22,14 @@ class SafeDirectoryDataStore(DataStore):
     """
 
     path: Path = documented(
-        attr.ib(converter=lambda x: Path(x).absolute()),
+        attrs.field(converter=lambda x: Path(x).absolute()),
         type="Path",
         init_type="path-like",
         doc="Path to the root of the directory referenced by this data store.",
     )
 
     registry_fname: Path = documented(
-        attr.ib(default="registry.txt", converter=Path),
+        attrs.field(default="registry.txt", converter=Path),
         type="Path",
         init_type="path-like",
         default='"registry.txt"',
@@ -44,7 +44,9 @@ class SafeDirectoryDataStore(DataStore):
                 "only paths relative to the store root path are allowed"
             )
 
-    _registry: t.Dict = attr.ib(factory=dict, converter=dict, repr=False, init=False)
+    _registry: t.Dict = attrs.field(
+        factory=dict, converter=dict, repr=False, init=False
+    )
 
     def __attrs_post_init__(self):
         self.registry_reload()

--- a/src/eradiate/data/_safe_online.py
+++ b/src/eradiate/data/_safe_online.py
@@ -4,7 +4,7 @@ import shutil
 import typing as t
 from pathlib import Path
 
-import attr
+import attrs
 import pooch
 
 from ._core import DataStore, expand_rules, registry_from_file
@@ -15,7 +15,7 @@ from ..util.misc import LoggingContext
 logger = logging.getLogger(__name__)
 
 
-@attr.s(repr=False, init=False)
+@attrs.define(repr=False, init=False)
 class SafeOnlineDataStore(DataStore):
     """
     Serve files located online, with integrity check.
@@ -44,8 +44,8 @@ class SafeOnlineDataStore(DataStore):
     This class basically wraps a :class:`pooch.Pooch` instance.
     """
 
-    manager: pooch.Pooch = attr.ib()
-    registry_fname: Path = attr.ib(converter=Path)
+    manager: pooch.Pooch = attrs.field()
+    registry_fname: Path = attrs.field(converter=Path)
 
     def __init__(
         self, base_url: str, path: PathLike, registry_fname: PathLike = "registry.txt"

--- a/src/eradiate/experiments/_atmosphere.py
+++ b/src/eradiate/experiments/_atmosphere.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import typing as t
 import warnings
 
-import attr
+import attrs
 
 from ._core import EarthObservationExperiment, Experiment
 from ..attrs import AUTO, documented, get_doc, parse_docs
@@ -81,7 +81,7 @@ def _surface_converter(value):
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class AtmosphereExperiment(EarthObservationExperiment):
     """
     Simulate radiation in a one-dimensional scene. This experiment approximates
@@ -105,10 +105,10 @@ class AtmosphereExperiment(EarthObservationExperiment):
     """
 
     geometry: t.Union[PlaneParallelGeometry, SphericalShellGeometry] = documented(
-        attr.ib(
+        attrs.field(
             default="plane_parallel",
             converter=AtmosphereGeometry.convert,
-            validator=attr.validators.instance_of(
+            validator=attrs.validators.instance_of(
                 (PlaneParallelGeometry, SphericalShellGeometry)
             ),
         ),
@@ -119,10 +119,12 @@ class AtmosphereExperiment(EarthObservationExperiment):
     )
 
     atmosphere: t.Optional[Atmosphere] = documented(
-        attr.ib(
+        attrs.field(
             factory=HomogeneousAtmosphere,
-            converter=attr.converters.optional(atmosphere_factory.convert),
-            validator=attr.validators.optional(attr.validators.instance_of(Atmosphere)),
+            converter=attrs.converters.optional(atmosphere_factory.convert),
+            validator=attrs.validators.optional(
+                attrs.validators.instance_of(Atmosphere)
+            ),
         ),
         doc="Atmosphere specification. If set to ``None``, no atmosphere will "
         "be added. "
@@ -134,11 +136,11 @@ class AtmosphereExperiment(EarthObservationExperiment):
     )
 
     surface: t.Optional[BasicSurface] = documented(
-        attr.ib(
+        attrs.field(
             factory=lambda: BasicSurface(bsdf=LambertianBSDF()),
-            converter=attr.converters.optional(_surface_converter),
-            validator=attr.validators.optional(
-                attr.validators.instance_of(BasicSurface)
+            converter=attrs.converters.optional(_surface_converter),
+            validator=attrs.validators.optional(
+                attrs.validators.instance_of(BasicSurface)
             ),
         ),
         doc="Surface specification. If set to ``None``, no surface will be "
@@ -150,10 +152,12 @@ class AtmosphereExperiment(EarthObservationExperiment):
     )
 
     dem: t.Optional[DEMSurface] = documented(
-        attr.ib(
+        attrs.field(
             default=None,
-            converter=attr.converters.optional(surface_factory.convert),
-            validator=attr.validators.optional(attr.validators.instance_of(DEMSurface)),
+            converter=attrs.converters.optional(surface_factory.convert),
+            validator=attrs.validators.optional(
+                attrs.validators.instance_of(DEMSurface)
+            ),
         ),
         doc="Digital elevation model (DEM) specification. If set to ``None``, no DEM will be "
         "added. This parameter can be specified as a dictionary which will be "
@@ -164,10 +168,10 @@ class AtmosphereExperiment(EarthObservationExperiment):
     )
 
     _integrator: Integrator = documented(
-        attr.ib(
+        attrs.field(
             factory=VolPathIntegrator,
             converter=integrator_factory.convert,
-            validator=attr.validators.instance_of(Integrator),
+            validator=attrs.validators.instance_of(Integrator),
         ),
         doc=get_doc(Experiment, attrib="_integrator", field="doc"),
         type=get_doc(Experiment, attrib="_integrator", field="type"),
@@ -187,7 +191,7 @@ class AtmosphereExperiment(EarthObservationExperiment):
 
         # Process atmosphere
         if self.atmosphere is not None:
-            atmosphere = attr.evolve(self.atmosphere, geometry=self.geometry)
+            atmosphere = attrs.evolve(self.atmosphere, geometry=self.geometry)
             result.add(atmosphere, ctx=ctx)
         else:
             atmosphere = None
@@ -206,7 +210,7 @@ class AtmosphereExperiment(EarthObservationExperiment):
                     )
                     altitude = 0.0 * ureg.km
 
-                surface = attr.evolve(
+                surface = attrs.evolve(
                     self.surface,
                     shape=RectangleShape.surface(altitude=altitude, width=width),
                 )
@@ -217,7 +221,7 @@ class AtmosphereExperiment(EarthObservationExperiment):
                 else:
                     altitude = 0.0 * ureg.km
 
-                surface = attr.evolve(
+                surface = attrs.evolve(
                     self.surface,
                     shape=SphereShape.surface(
                         altitude=altitude, planet_radius=self.geometry.planet_radius

--- a/src/eradiate/experiments/_canopy.py
+++ b/src/eradiate/experiments/_canopy.py
@@ -1,6 +1,6 @@
 import typing as t
 
-import attr
+import attrs
 
 from ._core import EarthObservationExperiment, Experiment
 from .. import validators
@@ -37,7 +37,7 @@ def _surface_converter(value):
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class CanopyExperiment(EarthObservationExperiment):
     """
     Simulate radiation in a scene with an explicit canopy and no atmosphere.
@@ -55,10 +55,10 @@ class CanopyExperiment(EarthObservationExperiment):
     """
 
     canopy: t.Optional[Canopy] = documented(
-        attr.ib(
+        attrs.field(
             default=None,
-            converter=attr.converters.optional(biosphere_factory.convert),
-            validator=attr.validators.optional(attr.validators.instance_of(Canopy)),
+            converter=attrs.converters.optional(biosphere_factory.convert),
+            validator=attrs.validators.optional(attrs.validators.instance_of(Canopy)),
         ),
         doc="Canopy specification. "
         "This parameter can be specified as a dictionary which will be "
@@ -69,7 +69,7 @@ class CanopyExperiment(EarthObservationExperiment):
     )
 
     padding: int = documented(
-        attr.ib(default=0, converter=int, validator=validators.is_positive),
+        attrs.field(default=0, converter=int, validator=validators.is_positive),
         doc="Padding level. The scene will be padded with copies to account for "
         "adjacency effects. This, in practice, has effects similar to "
         "making the scene periodic."
@@ -82,11 +82,11 @@ class CanopyExperiment(EarthObservationExperiment):
     )
 
     surface: t.Union[None, BasicSurface] = documented(
-        attr.ib(
+        attrs.field(
             factory=lambda: LambertianBSDF(),
-            converter=attr.converters.optional(_surface_converter),
-            validator=attr.validators.optional(
-                attr.validators.instance_of(BasicSurface)
+            converter=attrs.converters.optional(_surface_converter),
+            validator=attrs.validators.optional(
+                attrs.validators.instance_of(BasicSurface)
             ),
         ),
         doc="Surface specification. If set to ``None``, no surface will be "
@@ -100,10 +100,10 @@ class CanopyExperiment(EarthObservationExperiment):
     )
 
     _integrator: Integrator = documented(
-        attr.ib(
+        attrs.field(
             factory=PathIntegrator,
             converter=integrator_factory.convert,
-            validator=attr.validators.instance_of(Integrator),
+            validator=attrs.validators.instance_of(Integrator),
         ),
         doc=get_doc(Experiment, attrib="_integrator", field="doc"),
         type=get_doc(Experiment, attrib="_integrator", field="type"),
@@ -131,7 +131,7 @@ class CanopyExperiment(EarthObservationExperiment):
 
             # Surface size always matches canopy size
             if self.surface is not None:
-                surface = attr.evolve(
+                surface = attrs.evolve(
                     self.surface,
                     shape=RectangleShape(center=[0, 0, 0], edges=scene_width),
                 )
@@ -140,7 +140,7 @@ class CanopyExperiment(EarthObservationExperiment):
                 surface = None
 
         else:
-            surface = attr.evolve(self.surface)
+            surface = attrs.evolve(self.surface)
 
         # Process surface
         if surface is not None:

--- a/src/eradiate/experiments/_canopy_atmosphere.py
+++ b/src/eradiate/experiments/_canopy_atmosphere.py
@@ -1,6 +1,6 @@
 import typing as t
 
-import attr
+import attrs
 
 from ._atmosphere import measure_inside_atmosphere
 from ._core import EarthObservationExperiment
@@ -53,7 +53,7 @@ def _surface_converter(value):
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class CanopyAtmosphereExperiment(EarthObservationExperiment):
     """
     Simulate radiation in a scene with an explicit canopy and atmosphere.
@@ -86,10 +86,10 @@ class CanopyAtmosphereExperiment(EarthObservationExperiment):
     """
 
     geometry: t.Union[PlaneParallelGeometry, SphericalShellGeometry] = documented(
-        attr.ib(
+        attrs.field(
             default="plane_parallel",
             converter=AtmosphereGeometry.convert,
-            validator=attr.validators.instance_of(
+            validator=attrs.validators.instance_of(
                 (PlaneParallelGeometry, SphericalShellGeometry)
             ),
         ),
@@ -100,10 +100,12 @@ class CanopyAtmosphereExperiment(EarthObservationExperiment):
     )
 
     atmosphere: t.Optional[Atmosphere] = documented(
-        attr.ib(
+        attrs.field(
             factory=HomogeneousAtmosphere,
-            converter=attr.converters.optional(atmosphere_factory.convert),
-            validator=attr.validators.optional(attr.validators.instance_of(Atmosphere)),
+            converter=attrs.converters.optional(atmosphere_factory.convert),
+            validator=attrs.validators.optional(
+                attrs.validators.instance_of(Atmosphere)
+            ),
         ),
         doc="Atmosphere specification. If set to ``None``, no atmosphere will "
         "be added. "
@@ -115,10 +117,10 @@ class CanopyAtmosphereExperiment(EarthObservationExperiment):
     )
 
     canopy: t.Optional[Canopy] = documented(
-        attr.ib(
+        attrs.field(
             default=None,
-            converter=attr.converters.optional(biosphere_factory.convert),
-            validator=attr.validators.optional(attr.validators.instance_of(Canopy)),
+            converter=attrs.converters.optional(biosphere_factory.convert),
+            validator=attrs.validators.optional(attrs.validators.instance_of(Canopy)),
         ),
         doc="Canopy specification. "
         "This parameter can be specified as a dictionary which will be "
@@ -129,7 +131,7 @@ class CanopyAtmosphereExperiment(EarthObservationExperiment):
     )
 
     padding: int = documented(
-        attr.ib(default=0, converter=int, validator=validators.is_positive),
+        attrs.field(default=0, converter=int, validator=validators.is_positive),
         doc="Padding level. The canopy will be padded with copies to account for "
         "adjacency effects. This, in practice, has effects similar to "
         "making the scene periodic."
@@ -143,11 +145,11 @@ class CanopyAtmosphereExperiment(EarthObservationExperiment):
     )
 
     surface: t.Union[BasicSurface, CentralPatchSurface, None] = documented(
-        attr.ib(
+        attrs.field(
             factory=lambda: BasicSurface(bsdf=LambertianBSDF()),
-            converter=attr.converters.optional(_surface_converter),
-            validator=attr.validators.optional(
-                attr.validators.instance_of((BasicSurface, CentralPatchSurface))
+            converter=attrs.converters.optional(_surface_converter),
+            validator=attrs.validators.optional(
+                attrs.validators.instance_of((BasicSurface, CentralPatchSurface))
             ),
         ),
         doc="Surface specification. A :class:`.Surface` object may be passed: "
@@ -164,11 +166,11 @@ class CanopyAtmosphereExperiment(EarthObservationExperiment):
     )
 
     _integrator: Integrator = documented(
-        attr.ib(
+        attrs.field(
             default=AUTO,
             converter=converters.auto_or(integrator_factory.convert),
             validator=validators.auto_or(
-                attr.validators.instance_of(Integrator),
+                attrs.validators.instance_of(Integrator),
             ),
         ),
         doc="Monte Carlo integration algorithm specification. "
@@ -218,7 +220,7 @@ class CanopyAtmosphereExperiment(EarthObservationExperiment):
 
         # Pre-process atmosphere
         if self.atmosphere is not None:
-            atmosphere = attr.evolve(self.atmosphere, geometry=self.geometry)
+            atmosphere = attrs.evolve(self.atmosphere, geometry=self.geometry)
             atmosphere_width = atmosphere.kernel_width_plane_parallel(ctx)
         else:
             atmosphere = None
@@ -249,7 +251,7 @@ class CanopyAtmosphereExperiment(EarthObservationExperiment):
         # Pre-process surface
         if self.surface is not None:
             altitude = atmosphere.bottom if atmosphere is not None else 0.0 * ureg.km
-            surface = attr.evolve(
+            surface = attrs.evolve(
                 self.surface,
                 shape=RectangleShape.surface(altitude=altitude, width=surface_width),
             )

--- a/src/eradiate/experiments/_core.py
+++ b/src/eradiate/experiments/_core.py
@@ -5,7 +5,7 @@ import logging
 import typing as t
 from abc import ABC, abstractmethod
 
-import attr
+import attrs
 import mitsuba as mi
 import pinttr
 import xarray as xr
@@ -199,7 +199,7 @@ def run(
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class Experiment(ABC):
     """
     Base class for experiment simulations.
@@ -210,15 +210,15 @@ class Experiment(ABC):
     # --------------------------------------------------------------------------
 
     measures: t.List[Measure] = documented(
-        attr.ib(
+        attrs.field(
             factory=lambda: [MultiDistantMeasure()],
             converter=lambda value: [
                 measure_factory.convert(x) for x in pinttr.util.always_iterable(value)
             ]
             if not isinstance(value, dict)
             else [measure_factory.convert(value)],
-            validator=attr.validators.deep_iterable(
-                member_validator=attr.validators.instance_of(Measure)
+            validator=attrs.validators.deep_iterable(
+                member_validator=attrs.validators.instance_of(Measure)
             ),
         ),
         doc="List of measure specifications. The passed list may contain "
@@ -233,10 +233,10 @@ class Experiment(ABC):
     )
 
     _integrator: Integrator = documented(
-        attr.ib(
+        attrs.field(
             factory=PathIntegrator,
             converter=integrator_factory.convert,
-            validator=attr.validators.instance_of(Integrator),
+            validator=attrs.validators.instance_of(Integrator),
         ),
         doc="Monte Carlo integration algorithm specification. "
         "This parameter can be specified as a dictionary which will be "
@@ -254,7 +254,7 @@ class Experiment(ABC):
         return self._integrator
 
     _results: t.Dict[str, xr.Dataset] = documented(
-        attr.ib(factory=dict, init=False, repr=False),
+        attrs.field(factory=dict, init=False, repr=False),
         doc="Post-processed simulation results. Each entry uses a measure ID as "
         "its key and holds a value consisting of a :class:`~xarray.Dataset` "
         "holding one variable per physical quantity computed by the measure.",
@@ -551,7 +551,7 @@ class Experiment(ABC):
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class EarthObservationExperiment(Experiment, ABC):
     """
     A base class used for Earth observation simulations. These experiments
@@ -559,10 +559,10 @@ class EarthObservationExperiment(Experiment, ABC):
     """
 
     illumination: t.Union[DirectionalIllumination, ConstantIllumination] = documented(
-        attr.ib(
+        attrs.field(
             factory=DirectionalIllumination,
             converter=illumination_factory.convert,
-            validator=attr.validators.instance_of(
+            validator=attrs.validators.instance_of(
                 (DirectionalIllumination, ConstantIllumination)
             ),
         ),

--- a/src/eradiate/pipelines/_aggregate.py
+++ b/src/eradiate/pipelines/_aggregate.py
@@ -2,7 +2,7 @@ import itertools
 import typing as t
 from collections import OrderedDict
 
-import attr
+import attrs
 import numpy as np
 import xarray as xr
 
@@ -17,7 +17,7 @@ from ..units import unit_context_kernel as uck
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class AggregateSampleCount(PipelineStep):
     """
     Aggregate sample count.
@@ -40,7 +40,7 @@ class AggregateSampleCount(PipelineStep):
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class AggregateCKDQuad(PipelineStep):
     """
     Compute CKD quadrature.
@@ -66,8 +66,8 @@ class AggregateCKDQuad(PipelineStep):
     """
 
     measure: Measure = documented(
-        attr.ib(
-            validator=attr.validators.instance_of(Measure),
+        attrs.field(
+            validator=attrs.validators.instance_of(Measure),
             repr=lambda self: f"{self.__class__.__name__}(id='{self.id}', ...)",
         ),
         doc="Measure from which the processed data was obtained.",
@@ -75,7 +75,7 @@ class AggregateCKDQuad(PipelineStep):
     )
 
     var: str = documented(
-        attr.ib(default="img", validator=attr.validators.instance_of(str)),
+        attrs.field(default="img", validator=attrs.validators.instance_of(str)),
         doc="Name of the variable for which CKD quadrature computation "
         "is to be performed.",
         type="str",
@@ -195,14 +195,16 @@ class AggregateCKDQuad(PipelineStep):
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class AggregateRadiosity(PipelineStep):
     """
     Aggregate flux density field.
     """
 
     sector_radiosity_var: str = documented(
-        attr.ib(default="sector_radiosity", validator=attr.validators.instance_of(str)),
+        attrs.field(
+            default="sector_radiosity", validator=attrs.validators.instance_of(str)
+        ),
         doc="Name of the variable containing radiosity values for the "
         "hemisphere sector corresponding to each film pixel. This quantity is "
         "expressed in flux units (typically W/m²) and, when summed over the "
@@ -212,7 +214,7 @@ class AggregateRadiosity(PipelineStep):
     )
 
     radiosity_var: str = documented(
-        attr.ib(default="radiosity", validator=attr.validators.instance_of(str)),
+        attrs.field(default="radiosity", validator=attrs.validators.instance_of(str)),
         doc="Name of the variable storing the computed radiosity "
         "(leaving flux) value.",
         type="str",

--- a/src/eradiate/pipelines/_assemble.py
+++ b/src/eradiate/pipelines/_assemble.py
@@ -1,7 +1,7 @@
 import typing as t
 import warnings
 
-import attr
+import attrs
 import numpy as np
 import pint
 import pinttr
@@ -22,7 +22,7 @@ from ..units import unit_registry as ureg
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class AddIllumination(PipelineStep):
     """
     Add illumination data.
@@ -37,8 +37,8 @@ class AddIllumination(PipelineStep):
     """
 
     illumination: t.Union[DirectionalIllumination, ConstantIllumination] = documented(
-        attr.ib(
-            validator=attr.validators.instance_of(
+        attrs.field(
+            validator=attrs.validators.instance_of(
                 (DirectionalIllumination, ConstantIllumination)
             ),
             repr=lambda self: f"{self.__class__.__name__}(id='{self.id}', ...)",
@@ -49,8 +49,8 @@ class AddIllumination(PipelineStep):
     )
 
     measure: Measure = documented(
-        attr.ib(
-            validator=attr.validators.instance_of(Measure),
+        attrs.field(
+            validator=attrs.validators.instance_of(Measure),
             repr=lambda self: f"{self.__class__.__name__}(id='{self.id}', ...)",
         ),
         doc="A :class:`.Measure` instance from the data originates.",
@@ -58,7 +58,7 @@ class AddIllumination(PipelineStep):
     )
 
     irradiance_var: str = documented(
-        attr.ib(default="irradiance", validator=attr.validators.instance_of(str)),
+        attrs.field(default="irradiance", validator=attrs.validators.instance_of(str)),
         doc="Name of the variable storing irradiance (incoming flux) values.",
         type="str",
         default='"irradiance"',
@@ -164,7 +164,7 @@ class AddIllumination(PipelineStep):
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class AddViewingAngles(PipelineStep):
     """
     Create new ``vza`` and ``vaa`` coordinate variables mapping viewing angles
@@ -172,8 +172,8 @@ class AddViewingAngles(PipelineStep):
     """
 
     measure: Measure = documented(
-        attr.ib(
-            validator=attr.validators.instance_of(Measure),
+        attrs.field(
+            validator=attrs.validators.instance_of(Measure),
             repr=lambda self: f"{self.__class__.__name__}(id='{self.id}', ...)",
         ),
         doc="A :class:`.Measure` instance from which the processed data originates.",
@@ -291,7 +291,7 @@ _is_sorted = lambda a: np.all(a[:-1] <= a[1:])
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class AddSpectralResponseFunction(PipelineStep):
     """
     Add spectral response function data.
@@ -301,8 +301,8 @@ class AddSpectralResponseFunction(PipelineStep):
     """
 
     measure: Measure = documented(
-        attr.ib(
-            validator=attr.validators.instance_of(Measure),
+        attrs.field(
+            validator=attrs.validators.instance_of(Measure),
             repr=lambda self: f"{self.__class__.__name__}(id='{self.id}', ...)",
         ),
         doc="A :class:`.Measure` instance from which the processed data originates.",

--- a/src/eradiate/pipelines/_compute.py
+++ b/src/eradiate/pipelines/_compute.py
@@ -1,6 +1,6 @@
 import typing as t
 
-import attr
+import attrs
 import numpy as np
 from pinttr.util import always_iterable
 
@@ -13,7 +13,7 @@ from ..units import unit_registry as ureg
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class ApplySpectralResponseFunction(PipelineStep):
     """
     Apply spectral response function to specified variables.
@@ -30,8 +30,8 @@ class ApplySpectralResponseFunction(PipelineStep):
     """
 
     measure: Measure = documented(
-        attr.ib(
-            validator=attr.validators.instance_of(Measure),
+        attrs.field(
+            validator=attrs.validators.instance_of(Measure),
             repr=lambda self: f"{self.__class__.__name__}(id='{self.id}', ...)",
         ),
         doc="A :class:`.Measure` instance from which the processed data originates.",
@@ -39,11 +39,11 @@ class ApplySpectralResponseFunction(PipelineStep):
     )
 
     vars: t.List[str] = documented(
-        attr.ib(
+        attrs.field(
             factory=list,
             converter=lambda x: list(always_iterable(x)),
-            validator=attr.validators.deep_iterable(
-                member_validator=attr.validators.instance_of(str)
+            validator=attrs.validators.deep_iterable(
+                member_validator=attrs.validators.instance_of(str)
             ),
         ),
         doc="List of variables to which the spectral response function is to be "
@@ -126,35 +126,35 @@ class ApplySpectralResponseFunction(PipelineStep):
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class ComputeReflectance(PipelineStep):
     """
     Derive reflectance from radiance and irradiance values.
     """
 
     radiance_var: str = documented(
-        attr.ib(default="radiance", validator=attr.validators.instance_of(str)),
+        attrs.field(default="radiance", validator=attrs.validators.instance_of(str)),
         doc="Name of the variable storing leaving radiance values.",
         type="str",
         default='"radiance"',
     )
 
     irradiance_var: str = documented(
-        attr.ib(default="irradiance", validator=attr.validators.instance_of(str)),
+        attrs.field(default="irradiance", validator=attrs.validators.instance_of(str)),
         doc="Name of the variable storing irradiance (incoming flux) values.",
         type="str",
         default='"irradiance"',
     )
 
     brdf_var: str = documented(
-        attr.ib(default="brdf", validator=attr.validators.instance_of(str)),
+        attrs.field(default="brdf", validator=attrs.validators.instance_of(str)),
         doc="Name of the variable storing BRDF values.",
         type="str",
         default='"brdf"',
     )
 
     brf_var: str = documented(
-        attr.ib(default="brf", validator=attr.validators.instance_of(str)),
+        attrs.field(default="brf", validator=attrs.validators.instance_of(str)),
         doc="Name of the variable storing BRF values.",
         type="str",
         default='"brf"',
@@ -183,28 +183,28 @@ class ComputeReflectance(PipelineStep):
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class ComputeAlbedo(PipelineStep):
     """
     Derive the albedo from radiosity and irradiance fields.
     """
 
     radiosity_var: str = documented(
-        attr.ib(default="radiosity", validator=attr.validators.instance_of(str)),
+        attrs.field(default="radiosity", validator=attrs.validators.instance_of(str)),
         doc="Name of the variable storing the radiosity (leaving flux) value.",
         type="str",
         default='"radiosity"',
     )
 
     irradiance_var: str = documented(
-        attr.ib(default="irradiance", validator=attr.validators.instance_of(str)),
+        attrs.field(default="irradiance", validator=attrs.validators.instance_of(str)),
         doc="Name of the variable storing the irradiance (incoming flux) value.",
         type="str",
         default='"irradiance"',
     )
 
     albedo_var: str = documented(
-        attr.ib(default="albedo", validator=attr.validators.instance_of(str)),
+        attrs.field(default="albedo", validator=attrs.validators.instance_of(str)),
         doc="Name of the variable storing the albedo value.",
         type="str",
         default='"albedo"',

--- a/src/eradiate/pipelines/_core.py
+++ b/src/eradiate/pipelines/_core.py
@@ -5,7 +5,7 @@ import typing as t
 from abc import ABC, abstractmethod
 from collections import Counter
 
-import attr
+import attrs
 
 from ..attrs import documented, parse_docs
 from ..util.misc import camel_to_snake
@@ -32,14 +32,14 @@ def _pipeline_steps_converter(value):
 # ------------------------------------------------------------------------------
 
 
-@attr.s
+@attrs.define
 class Pipeline:
     """
     A simple data processing pipeline remotely inspired from scikit-learn's
     ``Pipeline`` class.
     """
 
-    steps: t.List[t.Tuple[str, PipelineStep]] = attr.ib(
+    steps: t.List[t.Tuple[str, PipelineStep]] = attrs.field(
         factory=list, converter=_pipeline_steps_converter
     )
 
@@ -60,7 +60,7 @@ class Pipeline:
                     f"step name {name}"
                 )
 
-    _names: t.List[str] = attr.ib(factory=list, init=False, repr=False)
+    _names: t.List[str] = attrs.field(factory=list, init=False, repr=False)
 
     def __attrs_post_init__(self):
         self.update()
@@ -231,7 +231,7 @@ class Pipeline:
             return x
 
 
-@attr.s
+@attrs.define
 class PipelineStep(ABC):
     """
     Interface for pipeline step definitions.
@@ -256,14 +256,14 @@ class PipelineStep(ABC):
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class ApplyCallable(PipelineStep):
     """
     Turn a callable into a pipeline step.
     """
 
     callable: t.Callable = documented(
-        attr.ib(validator=attr.validators.is_callable()),
+        attrs.field(validator=attrs.validators.is_callable()),
         type="callable",
         doc="Callable with signature ``f(x: Any) -> Any``.",
     )

--- a/src/eradiate/pipelines/_gather.py
+++ b/src/eradiate/pipelines/_gather.py
@@ -1,7 +1,7 @@
 import re
 import typing as t
 
-import attr
+import attrs
 import numpy as np
 import xarray as xr
 from pinttr.util import always_iterable
@@ -39,7 +39,7 @@ def _spectral_dims():
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class Gather(PipelineStep):
     """
     Gather raw kernel results (output as nested dictionaries) into an xarray
@@ -58,7 +58,7 @@ class Gather(PipelineStep):
     """
 
     prefix: str = documented(
-        attr.ib(default=r".*"),
+        attrs.field(default=r".*"),
         default='".*"',
         type="str",
         init_type="str, optional",
@@ -67,9 +67,9 @@ class Gather(PipelineStep):
     )
 
     sensor_dims: t.Sequence = documented(
-        attr.ib(
+        attrs.field(
             factory=list,
-            validator=attr.validators.instance_of((list, tuple)),
+            validator=attrs.validators.instance_of((list, tuple)),
         ),
         default="[]",
         type="list of (str or tuple)",
@@ -79,7 +79,7 @@ class Gather(PipelineStep):
     )
 
     var: t.Union[str, t.Tuple[str, t.Dict]] = documented(
-        attr.ib(default="img"),
+        attrs.field(default="img"),
         default='"img"',
         type="str or tuple[str, dict]",
         init_type="str or tuple[str, dict], optional",

--- a/src/eradiate/quad.py
+++ b/src/eradiate/quad.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import typing as t
 from enum import Enum
 
-import attr
+import attrs
 import numpy as np
 
 from .attrs import documented, parse_docs
@@ -20,7 +20,7 @@ class QuadType(Enum):
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class Quad:
     """
     A data class storing information about a quadrature rule. Nodes and weights
@@ -35,20 +35,20 @@ class Quad:
     """
 
     type: QuadType = documented(
-        attr.ib(converter=QuadType, repr=lambda x: str(x)),
+        attrs.field(converter=QuadType, repr=lambda x: str(x)),
         doc="Quadrature type. If a string is passed, it is converted to a "
         ":class:`.QuadType`.",
         type=":class:`.QuadType`",
     )
 
     nodes: np.ndarray = documented(
-        attr.ib(converter=np.array, repr=str_summary_numpy),
+        attrs.field(converter=np.array, repr=str_summary_numpy),
         doc="Quadrature rule nodes.",
         type="ndarray",
     )
 
     weights: np.ndarray = documented(
-        attr.ib(converter=np.array, repr=str_summary_numpy),
+        attrs.field(converter=np.array, repr=str_summary_numpy),
         doc="Quadrature rule weights.",
         type="ndarray",
     )

--- a/src/eradiate/radprops/_afgl1986.py
+++ b/src/eradiate/radprops/_afgl1986.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import functools
 import typing as t
 
-import attr
+import attrs
 import numpy as np
 import pint
 import xarray as xr
@@ -38,7 +38,7 @@ def _convert_thermoprops_afgl_1986(
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class AFGL1986RadProfile(RadProfile):
     """
     Radiative properties profile corresponding to the AFGL (1986) atmospheric
@@ -51,10 +51,10 @@ class AFGL1986RadProfile(RadProfile):
     """
 
     _thermoprops: xr.Dataset = documented(
-        attr.ib(
+        attrs.field(
             factory=lambda: afgl_1986.make_profile(),
             converter=_convert_thermoprops_afgl_1986,
-            validator=attr.validators.instance_of(xr.Dataset),
+            validator=attrs.validators.instance_of(xr.Dataset),
         ),
         doc="Thermophysical properties.",
         type=":class:`~xarray.Dataset`",
@@ -62,10 +62,10 @@ class AFGL1986RadProfile(RadProfile):
     )
 
     has_absorption: bool = documented(
-        attr.ib(
+        attrs.field(
             default=True,
             converter=bool,
-            validator=attr.validators.instance_of(bool),
+            validator=attrs.validators.instance_of(bool),
         ),
         doc="Absorption switch. If ``True``, the absorption coefficient is "
         "computed. Else, the absorption coefficient is not computed and "
@@ -75,10 +75,10 @@ class AFGL1986RadProfile(RadProfile):
     )
 
     has_scattering: bool = documented(
-        attr.ib(
+        attrs.field(
             default=True,
             converter=bool,
-            validator=attr.validators.instance_of(bool),
+            validator=attrs.validators.instance_of(bool),
         ),
         doc="Scattering switch. If ``True``, the scattering coefficient is "
         "computed. Else, the scattering coefficient is not computed and "

--- a/src/eradiate/radprops/_array.py
+++ b/src/eradiate/radprops/_array.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pathlib
 import typing as t
 
-import attr
+import attrs
 import pint
 import pinttr
 import xarray as xr
@@ -20,7 +20,7 @@ from ..units import unit_registry as ureg
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class ArrayRadProfile(RadProfile):
     """
     A flexible 1D radiative property profile whose level altitudes, albedo
@@ -28,7 +28,7 @@ class ArrayRadProfile(RadProfile):
     """
 
     levels: pint.Quantity = documented(
-        pinttr.ib(units=ucc.deferred("length")),
+        pinttr.field(units=ucc.deferred("length")),
         doc="Level altitudes. **Required, no default**.\n"
         "\n"
         "Unit-enabled field (default: ucc['length']).",
@@ -36,7 +36,7 @@ class ArrayRadProfile(RadProfile):
     )
 
     albedo_values: pint.Quantity = documented(
-        pinttr.ib(
+        pinttr.field(
             validator=[validators.all_positive, pinttr.validators.has_compatible_units],
             units=ureg.dimensionless,
         ),
@@ -47,7 +47,7 @@ class ArrayRadProfile(RadProfile):
     )
 
     sigma_t_values: pint.Quantity = documented(
-        pinttr.ib(
+        pinttr.field(
             validator=[validators.all_positive, pinttr.validators.has_compatible_units],
             units=ucc.deferred("collision_coefficient"),
         ),

--- a/src/eradiate/radprops/_core.py
+++ b/src/eradiate/radprops/_core.py
@@ -4,7 +4,7 @@ import datetime
 import typing as t
 from abc import ABC
 
-import attr
+import attrs
 import numpy as np
 import pint
 import xarray as xr
@@ -167,7 +167,7 @@ def make_dataset(
     )
 
 
-@attr.s
+@attrs.define
 class RadProfile(ABC):
     """
     An abstract base class for radiative property profiles. Classes deriving

--- a/src/eradiate/radprops/_us76_approx.py
+++ b/src/eradiate/radprops/_us76_approx.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import typing as t
 
-import attr
+import attrs
 import numpy as np
 import pint
 import xarray as xr
@@ -30,7 +30,7 @@ def _convert_thermoprops_us76_approx(
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class US76ApproxRadProfile(RadProfile):
     """
     Radiative properties profile approximately corresponding to an
@@ -108,10 +108,10 @@ class US76ApproxRadProfile(RadProfile):
     """
 
     _thermoprops: xr.Dataset = documented(
-        attr.ib(
+        attrs.field(
             factory=lambda: us76.make_profile(),
             converter=_convert_thermoprops_us76_approx,
-            validator=attr.validators.instance_of(xr.Dataset),
+            validator=attrs.validators.instance_of(xr.Dataset),
         ),
         doc="Thermophysical properties.",
         type=":class:`~xarray.Dataset`",
@@ -119,10 +119,10 @@ class US76ApproxRadProfile(RadProfile):
     )
 
     has_absorption: bool = documented(
-        attr.ib(
+        attrs.field(
             default=True,
             converter=bool,
-            validator=attr.validators.instance_of(bool),
+            validator=attrs.validators.instance_of(bool),
         ),
         doc="Absorption switch. If ``True``, the absorption coefficient is "
         "computed. Else, the absorption coefficient is not computed and "
@@ -132,10 +132,10 @@ class US76ApproxRadProfile(RadProfile):
     )
 
     has_scattering: bool = documented(
-        attr.ib(
+        attrs.field(
             default=True,
             converter=bool,
-            validator=attr.validators.instance_of(bool),
+            validator=attrs.validators.instance_of(bool),
         ),
         doc="Scattering switch. If ``True``, the scattering coefficient is "
         "computed. Else, the scattering coefficient is not computed and "
@@ -145,10 +145,10 @@ class US76ApproxRadProfile(RadProfile):
     )
 
     absorption_data_set: t.Optional[str] = documented(
-        attr.ib(
+        attrs.field(
             default=None,
-            converter=attr.converters.optional(str),
-            validator=attr.validators.optional(attr.validators.instance_of(str)),
+            converter=attrs.converters.optional(str),
+            validator=attrs.validators.optional(attrs.validators.instance_of(str)),
         ),
         doc="Absorption data set file path. If ``None``, the default "
         "absorption data sets will be used to compute the absorption "

--- a/src/eradiate/rng.py
+++ b/src/eradiate/rng.py
@@ -6,18 +6,18 @@ Inspired by `SeedBank <https://github.com/lenskit/seedbank>`_.
 
 import typing as t
 
-import attr
+import attrs
 import numpy as np
 import numpy.random
 
 
-@attr.s
+@attrs.define
 class SeedState:
     """
     Manage a root seed and facilities to derive seeds.
     """
 
-    _seed: t.Optional[np.random.SeedSequence] = attr.ib(
+    _seed: t.Optional[np.random.SeedSequence] = attrs.field(
         default=None,
         converter=lambda x: x
         if isinstance(x, np.random.SeedSequence)

--- a/src/eradiate/scenes/atmosphere/_core.py
+++ b/src/eradiate/scenes/atmosphere/_core.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import typing as t
 from abc import ABC, abstractmethod
 
-import attr
+import attrs
 import mitsuba as mi
 import numpy as np
 import pint
@@ -52,7 +52,7 @@ atmosphere_factory.register_lazy_batch(
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class AtmosphereGeometry:
     """
     Base class defining the geometry of the atmosphere.
@@ -105,7 +105,7 @@ class AtmosphereGeometry:
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class PlaneParallelGeometry(AtmosphereGeometry):
     """
     Plane parallel geometry.
@@ -118,7 +118,7 @@ class PlaneParallelGeometry(AtmosphereGeometry):
     """
 
     width: t.Union[pint.Quantity, AutoType] = documented(
-        pinttr.ib(
+        pinttr.field(
             default=AUTO,
             converter=converters.auto_or(
                 pinttr.converters.to_units(ucc.deferred("length"))
@@ -134,7 +134,7 @@ class PlaneParallelGeometry(AtmosphereGeometry):
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class SphericalShellGeometry(AtmosphereGeometry):
     """
     Spherical shell geometry.
@@ -145,7 +145,7 @@ class SphericalShellGeometry(AtmosphereGeometry):
     """
 
     planet_radius: pint.Quantity = documented(
-        pinttr.ib(default=6378.1 * ureg.km, units=ucc.deferred("length")),
+        pinttr.field(default=6378.1 * ureg.km, units=ucc.deferred("length")),
         doc="Planet radius. Defaults to Earth's radius.",
         type="quantity",
         init_type="quantity or float",
@@ -154,7 +154,7 @@ class SphericalShellGeometry(AtmosphereGeometry):
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class Atmosphere(SceneElement, ABC):
     """
     An abstract base class defining common facilities for all atmospheres.
@@ -164,9 +164,9 @@ class Atmosphere(SceneElement, ABC):
     """
 
     id: t.Optional[str] = documented(
-        attr.ib(
+        attrs.field(
             default="atmosphere",
-            validator=attr.validators.optional(attr.validators.instance_of(str)),
+            validator=attrs.validators.optional(attrs.validators.instance_of(str)),
         ),
         doc=get_doc(SceneElement, "id", "doc"),
         type=get_doc(SceneElement, "id", "type"),
@@ -175,11 +175,11 @@ class Atmosphere(SceneElement, ABC):
     )
 
     geometry: t.Optional[AtmosphereGeometry] = documented(
-        attr.ib(
+        attrs.field(
             default=None,
-            converter=attr.converters.optional(AtmosphereGeometry.convert),
-            validator=attr.validators.optional(
-                attr.validators.instance_of(AtmosphereGeometry)
+            converter=attrs.converters.optional(AtmosphereGeometry.convert),
+            validator=attrs.validators.optional(
+                attrs.validators.instance_of(AtmosphereGeometry)
             ),
         ),
         doc="Parameters defining the basic geometry of the atmosphere.",
@@ -425,7 +425,7 @@ class Atmosphere(SceneElement, ABC):
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class AbstractHeterogeneousAtmosphere(Atmosphere, ABC):
     """
     Heterogeneous atmosphere base class. This class defines the basic interface
@@ -433,10 +433,10 @@ class AbstractHeterogeneousAtmosphere(Atmosphere, ABC):
     """
 
     scale: t.Optional[float] = documented(
-        attr.ib(
+        attrs.field(
             default=None,
-            converter=attr.converters.optional(float),
-            validator=attr.validators.optional(attr.validators.instance_of(float)),
+            converter=attrs.converters.optional(float),
+            validator=attrs.validators.optional(attrs.validators.instance_of(float)),
         ),
         doc="If set, the extinction coefficient is scaled by the corresponding "
         "amount during computation.",

--- a/src/eradiate/scenes/atmosphere/_heterogeneous.py
+++ b/src/eradiate/scenes/atmosphere/_heterogeneous.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import typing as t
 from collections import abc as cabc
 
-import attr
+import attrs
 import numpy as np
 import pint
 import xarray as xr
@@ -97,20 +97,20 @@ def _heterogeneous_atmosphere_particle_converter(value):
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class HeterogeneousAtmosphere(AbstractHeterogeneousAtmosphere):
     """
     Heterogeneous atmosphere scene element [``heterogeneous``].
     """
 
     molecular_atmosphere: t.Optional[MolecularAtmosphere] = documented(
-        attr.ib(
+        attrs.field(
             default=None,
-            converter=attr.converters.optional(
+            converter=attrs.converters.optional(
                 _heterogeneous_atmosphere_molecular_converter
             ),
-            validator=attr.validators.optional(
-                attr.validators.instance_of(MolecularAtmosphere)
+            validator=attrs.validators.optional(
+                attrs.validators.instance_of(MolecularAtmosphere)
             ),
         ),
         doc="Molecular atmosphere. Can be specified as a dictionary interpreted "
@@ -146,11 +146,11 @@ class HeterogeneousAtmosphere(AbstractHeterogeneousAtmosphere):
             )
 
     particle_layers: t.List[ParticleLayer] = documented(
-        attr.ib(
+        attrs.field(
             factory=list,
             converter=_heterogeneous_atmosphere_particle_converter,
-            validator=attr.validators.deep_iterable(
-                attr.validators.instance_of(ParticleLayer)
+            validator=attrs.validators.deep_iterable(
+                attrs.validators.instance_of(ParticleLayer)
             ),
         ),
         doc="Particle layers. Can be specified as a dictionary interpreted "

--- a/src/eradiate/scenes/atmosphere/_homogeneous.py
+++ b/src/eradiate/scenes/atmosphere/_homogeneous.py
@@ -1,4 +1,4 @@
-import attr
+import attrs
 import pint
 import pinttr
 
@@ -15,7 +15,7 @@ from ...validators import has_quantity
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class HomogeneousAtmosphere(Atmosphere):
     """
     Homogeneous atmosphere scene element [``homogeneous``].
@@ -26,7 +26,7 @@ class HomogeneousAtmosphere(Atmosphere):
     """
 
     _bottom: pint.Quantity = documented(
-        pinttr.ib(
+        pinttr.field(
             default=ureg.Quantity(0.0, ureg.km),
             units=ucc.deferred("length"),
         ),
@@ -37,7 +37,7 @@ class HomogeneousAtmosphere(Atmosphere):
     )
 
     _top: pint.Quantity = documented(
-        pinttr.ib(
+        pinttr.field(
             default=ureg.Quantity(10.0, ureg.km),
             units=ucc.deferred("length"),
         ),
@@ -54,11 +54,11 @@ class HomogeneousAtmosphere(Atmosphere):
             raise ValueError("bottom altitude must be lower than top altitude")
 
     sigma_s: Spectrum = documented(
-        attr.ib(
+        attrs.field(
             factory=AirScatteringCoefficientSpectrum,
             converter=spectrum_factory.converter("collision_coefficient"),
             validator=[
-                attr.validators.instance_of(Spectrum),
+                attrs.validators.instance_of(Spectrum),
                 has_quantity("collision_coefficient"),
             ],
         ),
@@ -72,11 +72,11 @@ class HomogeneousAtmosphere(Atmosphere):
     )
 
     sigma_a: Spectrum = documented(
-        attr.ib(
+        attrs.field(
             default=0.0,
             converter=spectrum_factory.converter("collision_coefficient"),
             validator=[
-                attr.validators.instance_of(Spectrum),
+                attrs.validators.instance_of(Spectrum),
                 has_quantity("collision_coefficient"),
             ],
         ),
@@ -90,10 +90,10 @@ class HomogeneousAtmosphere(Atmosphere):
     )
 
     phase: PhaseFunction = documented(
-        attr.ib(
+        attrs.field(
             factory=lambda: RayleighPhaseFunction(),
             converter=phase_function_factory.convert,
-            validator=attr.validators.instance_of(PhaseFunction),
+            validator=attrs.validators.instance_of(PhaseFunction),
         ),
         doc="Scattering phase function.\n"
         "\n"

--- a/src/eradiate/scenes/atmosphere/_molecular_atmosphere.py
+++ b/src/eradiate/scenes/atmosphere/_molecular_atmosphere.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import typing as t
 
-import attr
+import attrs
 import numpy as np
 import pint
 import pinttr
@@ -29,7 +29,7 @@ from ...units import unit_registry as ureg
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class MolecularAtmosphere(AbstractHeterogeneousAtmosphere):
     """
     Molecular atmosphere scene element [``molecular``].
@@ -43,9 +43,9 @@ class MolecularAtmosphere(AbstractHeterogeneousAtmosphere):
     """
 
     _thermoprops: xr.Dataset = documented(
-        attr.ib(
+        attrs.field(
             factory=us76.make_profile,
-            validator=attr.validators.instance_of(xr.Dataset),
+            validator=attrs.validators.instance_of(xr.Dataset),
         ),
         doc="Thermophysical properties.",
         type="Dataset",
@@ -53,10 +53,10 @@ class MolecularAtmosphere(AbstractHeterogeneousAtmosphere):
     )
 
     phase: PhaseFunction = documented(
-        attr.ib(
+        attrs.field(
             factory=lambda: RayleighPhaseFunction(),
             converter=phase_function_factory.convert,
-            validator=attr.validators.instance_of(PhaseFunction),
+            validator=attrs.validators.instance_of(PhaseFunction),
         ),
         doc="Phase function.",
         type=":class:`.PhaseFunction`",
@@ -65,7 +65,7 @@ class MolecularAtmosphere(AbstractHeterogeneousAtmosphere):
     )
 
     has_absorption: bool = documented(
-        attr.ib(
+        attrs.field(
             default=True,
             converter=bool,
         ),
@@ -77,7 +77,7 @@ class MolecularAtmosphere(AbstractHeterogeneousAtmosphere):
     )
 
     has_scattering: bool = documented(
-        attr.ib(
+        attrs.field(
             default=True,
             converter=bool,
         ),
@@ -98,10 +98,10 @@ class MolecularAtmosphere(AbstractHeterogeneousAtmosphere):
             )
 
     absorption_data_sets: t.Optional[t.Dict[str, str]] = documented(
-        attr.ib(
+        attrs.field(
             default=None,
-            converter=attr.converters.optional(dict),
-            validator=attr.validators.optional(attr.validators.instance_of(dict)),
+            converter=attrs.converters.optional(dict),
+            validator=attrs.validators.optional(attrs.validators.instance_of(dict)),
         ),
         doc="Mapping of species and absorption data set files paths. If "
         "``None``, the default absorption data sets are used to compute "

--- a/src/eradiate/scenes/atmosphere/_particle_dist.py
+++ b/src/eradiate/scenes/atmosphere/_particle_dist.py
@@ -14,7 +14,7 @@ for normalising returned values.
 import typing as t
 from abc import ABC, abstractmethod
 
-import attr
+import attrs
 import numpy as np
 import scipy.interpolate
 
@@ -35,7 +35,7 @@ particle_distribution_factory.register_lazy_batch(
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class ParticleDistribution(ABC):
     """
     Abstract base class for particle distributions used to define particle
@@ -52,7 +52,7 @@ class ParticleDistribution(ABC):
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class UniformParticleDistribution(ParticleDistribution):
     r"""
     Uniform particle distribution. Returns values given by the uniform PDF
@@ -69,7 +69,9 @@ class UniformParticleDistribution(ParticleDistribution):
     """
 
     bounds: np.ndarray = documented(
-        attr.ib(default=[0.0, 1.0], converter=lambda x: np.atleast_1d(np.squeeze(x))),
+        attrs.field(
+            default=[0.0, 1.0], converter=lambda x: np.atleast_1d(np.squeeze(x))
+        ),
         type="array",
         init_type="array-like, optional",
         default="[0, 1]",
@@ -99,7 +101,7 @@ class UniformParticleDistribution(ParticleDistribution):
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class ExponentialParticleDistribution(ParticleDistribution):
     r"""
     Exponential particle distribution. Returns values given by the exponential
@@ -108,7 +110,7 @@ class ExponentialParticleDistribution(ParticleDistribution):
     where :math:`\beta = \mathtt{scale}`.
     """
     scale: float = documented(
-        attr.ib(default=5.0, converter=float),
+        attrs.field(default=5.0, converter=float),
         type="float",
         init_type="float, optional",
         default="5.0",
@@ -122,7 +124,7 @@ class ExponentialParticleDistribution(ParticleDistribution):
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class GaussianParticleDistribution(ParticleDistribution):
     r"""
     Gaussian particle distribution. Returns values given by the Gaussian
@@ -139,7 +141,7 @@ class GaussianParticleDistribution(ParticleDistribution):
     """
 
     mean: float = documented(
-        attr.ib(default=0.5, converter=float),
+        attrs.field(default=0.5, converter=float),
         type="float",
         init_type="float, optional",
         default="0.5",
@@ -148,7 +150,7 @@ class GaussianParticleDistribution(ParticleDistribution):
     )
 
     std: float = documented(
-        attr.ib(default=0.5 / 3, converter=float),
+        attrs.field(default=0.5 / 3, converter=float),
         type="float",
         init_type="float, optional",
         default="1/6",
@@ -164,14 +166,14 @@ class GaussianParticleDistribution(ParticleDistribution):
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class ArrayParticleDistribution(ParticleDistribution):
     """
     Particle distribution specified by an array of values.
     """
 
     values: np.typing.ArrayLike = documented(
-        attr.ib(converter=np.array, kw_only=True),
+        attrs.field(converter=np.array, kw_only=True),
         type="ndarray",
         init_type="array-like",
         doc="An array of particle fraction values.",
@@ -191,8 +193,8 @@ class ArrayParticleDistribution(ParticleDistribution):
             )
 
     coords: np.ndarray = documented(
-        attr.ib(
-            default=attr.Factory(
+        attrs.field(
+            default=attrs.Factory(
                 lambda x: np.arange(
                     0.5 / len(x.values),
                     1,
@@ -219,10 +221,10 @@ class ArrayParticleDistribution(ParticleDistribution):
             )
 
     method: str = documented(
-        attr.ib(
+        attrs.field(
             default="linear",
             converter=str,
-            validator=attr.validators.in_(
+            validator=attrs.validators.in_(
                 {
                     "linear",
                     "nearest",
@@ -245,10 +247,10 @@ class ArrayParticleDistribution(ParticleDistribution):
     )
 
     extrapolate: str = documented(
-        attr.ib(
+        attrs.field(
             default="zero",
             converter=str,
-            validator=attr.validators.in_({"zero", "nearest", "method", "nan"}),
+            validator=attrs.validators.in_({"zero", "nearest", "method", "nan"}),
         ),
         type="str",
         init_type='{ "zero", "nearest", "method", "nan" }',
@@ -292,7 +294,7 @@ class ArrayParticleDistribution(ParticleDistribution):
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class InterpolatorParticleDistribution(ParticleDistribution):
     """
     A flexible particle distribution which redirects its calls to an
@@ -300,7 +302,7 @@ class InterpolatorParticleDistribution(ParticleDistribution):
     """
 
     interpolator: t.Callable[[np.typing.ArrayLike], np.ndarray] = documented(
-        attr.ib(validator=attr.validators.is_callable, kw_only=True),
+        attrs.field(validator=attrs.validators.is_callable, kw_only=True),
         type="callable",
         doc="A callable with signature "
         ":code:`f(x: np.typing.ArrayLike) -> np.ndarray`. Typically, "

--- a/src/eradiate/scenes/atmosphere/_particle_layer.py
+++ b/src/eradiate/scenes/atmosphere/_particle_layer.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import typing as t
 
-import attr
+import attrs
 import numpy as np
 import pint
 import pinttr
@@ -42,7 +42,7 @@ def _particle_layer_distribution_converter(value):
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class ParticleLayer(AbstractHeterogeneousAtmosphere):
     """
     Particle layer scene element [``particle_layer``].
@@ -64,7 +64,7 @@ class ParticleLayer(AbstractHeterogeneousAtmosphere):
     """
 
     _bottom: pint.Quantity = documented(
-        pinttr.ib(
+        pinttr.field(
             default=ureg.Quantity(0.0, ureg.km),
             validator=[
                 is_positive,
@@ -81,7 +81,7 @@ class ParticleLayer(AbstractHeterogeneousAtmosphere):
     )
 
     _top: pint.Quantity = documented(
-        pinttr.ib(
+        pinttr.field(
             units=ucc.deferred("length"),
             default=ureg.Quantity(1.0, ureg.km),
             validator=[
@@ -108,10 +108,10 @@ class ParticleLayer(AbstractHeterogeneousAtmosphere):
             )
 
     distribution: ParticleDistribution = documented(
-        attr.ib(
+        attrs.field(
             default="uniform",
             converter=_particle_layer_distribution_converter,
-            validator=attr.validators.instance_of(ParticleDistribution),
+            validator=attrs.validators.instance_of(ParticleDistribution),
         ),
         doc="Particle distribution. Simple defaults can be set using a string: "
         '``"uniform"`` (resp. ``"gaussian"``, ``"exponential"``) is converted to '
@@ -125,7 +125,7 @@ class ParticleLayer(AbstractHeterogeneousAtmosphere):
     )
 
     w_ref: pint.Quantity = documented(
-        pinttr.ib(
+        pinttr.field(
             units=ucc.deferred("length"),
             default=550 * ureg.nm,
             validator=[
@@ -143,7 +143,7 @@ class ParticleLayer(AbstractHeterogeneousAtmosphere):
     )
 
     tau_ref: pint.Quantity = documented(
-        pinttr.ib(
+        pinttr.field(
             units=ucc.deferred("dimensionless"),
             default=ureg.Quantity(0.2, ureg.dimensionless),
             validator=[
@@ -160,10 +160,10 @@ class ParticleLayer(AbstractHeterogeneousAtmosphere):
     )
 
     n_layers: int = documented(
-        attr.ib(
+        attrs.field(
             default=16,
             converter=int,
-            validator=attr.validators.instance_of(int),
+            validator=attrs.validators.instance_of(int),
         ),
         doc="Number of layers in which the particle layer is discretised.",
         type="int",
@@ -171,10 +171,10 @@ class ParticleLayer(AbstractHeterogeneousAtmosphere):
     )
 
     dataset: xr.Dataset = documented(
-        attr.ib(
+        attrs.field(
             default="spectra/particles/govaerts_2021-continental.nc",
             converter=converters.load_dataset,
-            validator=attr.validators.instance_of(xr.Dataset),
+            validator=attrs.validators.instance_of(xr.Dataset),
         ),
         doc="Particle radiative property data set. If a path is passed, the "
         "converter tries to open the corresponding file on the hard drive; "
@@ -185,7 +185,7 @@ class ParticleLayer(AbstractHeterogeneousAtmosphere):
         default="spectra/particles/govaerts_2021-continental.nc",
     )
 
-    _phase: t.Optional[TabulatedPhaseFunction] = attr.ib(default=None, init=False)
+    _phase: t.Optional[TabulatedPhaseFunction] = attrs.field(default=None, init=False)
 
     def update(self) -> None:
         super().update()

--- a/src/eradiate/scenes/biosphere/_core.py
+++ b/src/eradiate/scenes/biosphere/_core.py
@@ -4,7 +4,7 @@ import os
 import typing as t
 from abc import ABC, abstractmethod
 
-import attr
+import attrs
 import mitsuba as mi
 import numpy as np
 import pint
@@ -54,16 +54,16 @@ biosphere_factory.register_lazy_batch(
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class Canopy(SceneElement, ABC):
     """
     An abstract base class defining a base type for all canopies.
     """
 
     id: t.Optional[str] = documented(
-        attr.ib(
+        attrs.field(
             default="canopy",
-            validator=attr.validators.optional(attr.validators.instance_of(str)),
+            validator=attrs.validators.optional(attrs.validators.instance_of(str)),
         ),
         doc=get_doc(SceneElement, "id", "doc"),
         type=get_doc(SceneElement, "id", "type"),
@@ -72,9 +72,9 @@ class Canopy(SceneElement, ABC):
     )
 
     size: t.Optional[pint.Quantity] = documented(
-        pinttr.ib(
+        pinttr.field(
             default=None,
-            validator=attr.validators.optional(
+            validator=attrs.validators.optional(
                 [
                     pinttr.validators.has_compatible_units,
                     validators.on_quantity(validators.is_vector3),
@@ -129,7 +129,7 @@ class Canopy(SceneElement, ABC):
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class CanopyElement(SceneElement, ABC):
     """
     An abstract class representing a component of a :class:`.Canopy` object.
@@ -181,7 +181,7 @@ class CanopyElement(SceneElement, ABC):
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class InstancedCanopyElement(SceneElement):
     """
     Instanced canopy element [``instanced``].
@@ -197,10 +197,10 @@ class InstancedCanopyElement(SceneElement):
     """
 
     canopy_element: t.Optional[CanopyElement] = documented(
-        attr.ib(
+        attrs.field(
             default=None,
-            validator=attr.validators.optional(
-                attr.validators.instance_of(CanopyElement)
+            validator=attrs.validators.optional(
+                attrs.validators.instance_of(CanopyElement)
             ),
             converter=biosphere_factory.convert,
         ),
@@ -210,7 +210,7 @@ class InstancedCanopyElement(SceneElement):
     )
 
     instance_positions: pint.Quantity = documented(
-        pinttr.ib(
+        pinttr.field(
             factory=list,
             units=ucc.deferred("length"),
         ),

--- a/src/eradiate/scenes/biosphere/_discrete.py
+++ b/src/eradiate/scenes/biosphere/_discrete.py
@@ -5,7 +5,7 @@ import typing as t
 from collections.abc import MutableMapping
 from copy import deepcopy
 
-import attr
+import attrs
 import numpy as np
 import pint
 import pinttr
@@ -28,7 +28,7 @@ def _instanced_canopy_elements_converter(value):
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class DiscreteCanopy(Canopy):
     """
     Discrete canopy scene element [``discrete_canopy``].
@@ -58,7 +58,7 @@ class DiscreteCanopy(Canopy):
     # --------------------------------------------------------------------------
 
     instanced_canopy_elements: t.List[InstancedCanopyElement] = documented(
-        attr.ib(
+        attrs.field(
             factory=list,
             converter=lambda value: [
                 _instanced_canopy_elements_converter(x)
@@ -66,8 +66,8 @@ class DiscreteCanopy(Canopy):
             ]
             if not isinstance(value, t.MutableMapping)
             else [_instanced_canopy_elements_converter(value)],
-            validator=attr.validators.deep_iterable(
-                member_validator=attr.validators.instance_of(InstancedCanopyElement)
+            validator=attrs.validators.deep_iterable(
+                member_validator=attrs.validators.instance_of(InstancedCanopyElement)
             ),
         ),
         doc="List of :class:`.CanopyElement` defining the canopy. Can be "

--- a/src/eradiate/scenes/biosphere/_leaf_cloud.py
+++ b/src/eradiate/scenes/biosphere/_leaf_cloud.py
@@ -4,7 +4,7 @@ import os
 import typing as t
 import warnings
 
-import attr
+import attrs
 import mitsuba as mi
 import numpy as np
 import pint
@@ -210,7 +210,7 @@ def _leaf_cloud_radii(n_leaves, leaf_radius):
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class LeafCloudParams:
     """
     Base class to implement advanced parameter checking for :class:`.LeafCloud`
@@ -218,22 +218,22 @@ class LeafCloudParams:
     """
 
     _id = documented(
-        attr.ib(default="leaf_cloud"),
+        attrs.field(default="leaf_cloud"),
         doc="Leaf cloud identifier.",
         type="str",
         default='"leaf_cloud"',
     )
 
     _leaf_reflectance = documented(
-        attr.ib(default=0.5), doc="Leaf reflectance.", type="float", default="0.5"
+        attrs.field(default=0.5), doc="Leaf reflectance.", type="float", default="0.5"
     )
 
     _leaf_transmittance = documented(
-        attr.ib(default=0.5), doc="Leaf transmittance.", type="float", default="0.5"
+        attrs.field(default=0.5), doc="Leaf transmittance.", type="float", default="0.5"
     )
 
     _mu = documented(
-        attr.ib(default=1.066),
+        attrs.field(default=1.066),
         doc="First parameter of the inverse beta distribution approximation used "
         "to generate leaf orientations.",
         type="float",
@@ -241,17 +241,19 @@ class LeafCloudParams:
     )
 
     _nu = documented(
-        attr.ib(default=1.853),
+        attrs.field(default=1.853),
         doc="Second parameter of the inverse beta distribution approximation used "
         "to generate leaf orientations.",
         type="float",
         default="1.853",
     )
 
-    _n_leaves = documented(attr.ib(default=None), doc="Number of leaves.", type="int")
+    _n_leaves = documented(
+        attrs.field(default=None), doc="Number of leaves.", type="int"
+    )
 
     _leaf_radius = documented(
-        pinttr.ib(default=None, units=ucc.deferred("length")),
+        pinttr.field(default=None, units=ucc.deferred("length")),
         doc="Leaf radius.\n\nUnit-enabled field (default: ucc['length']).",
         type="float",
     )
@@ -298,7 +300,7 @@ class LeafCloudParams:
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class CuboidLeafCloudParams(LeafCloudParams):
     """
     Advanced parameter checking class for the cuboid :class:`.LeafCloud`
@@ -335,7 +337,7 @@ class CuboidLeafCloudParams(LeafCloudParams):
     """
 
     _l_horizontal = documented(
-        pinttr.ib(default=None, units=ucc.deferred("length")),
+        pinttr.field(default=None, units=ucc.deferred("length")),
         doc="Leaf cloud horizontal extent. *Suggested default: 30 m.*\n"
         "\n"
         "Unit-enabled field (default: ucc['length']).",
@@ -343,7 +345,7 @@ class CuboidLeafCloudParams(LeafCloudParams):
     )
 
     _l_vertical = documented(
-        pinttr.ib(default=None, units=ucc.deferred("length")),
+        pinttr.field(default=None, units=ucc.deferred("length")),
         doc="Leaf cloud vertical extent. *Suggested default: 3 m.*\n"
         "\n"
         "Unit-enabled field (default: ucc['length']).",
@@ -351,7 +353,7 @@ class CuboidLeafCloudParams(LeafCloudParams):
     )
 
     _lai = documented(
-        pinttr.ib(default=None, units=ureg.dimensionless),
+        pinttr.field(default=None, units=ureg.dimensionless),
         doc="Leaf cloud leaf area index (LAI). *Physical range: [0, 10]; "
         "suggested default: 3.*\n"
         "\n"
@@ -360,7 +362,7 @@ class CuboidLeafCloudParams(LeafCloudParams):
     )
 
     _hdo = documented(
-        pinttr.ib(default=None, units=ucc.deferred("length")),
+        pinttr.field(default=None, units=ucc.deferred("length")),
         doc="Mean horizontal distance between leaves.\n"
         "\n"
         "Unit-enabled field (default: ucc['length']).",
@@ -368,7 +370,7 @@ class CuboidLeafCloudParams(LeafCloudParams):
     )
 
     _hvr = documented(
-        pinttr.ib(default=None),
+        pinttr.field(default=None),
         doc="Ratio of mean horizontal leaf distance and vertical leaf cloud extent. "
         "*Suggested default: 0.1.*",
         type="float",
@@ -442,7 +444,7 @@ class CuboidLeafCloudParams(LeafCloudParams):
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class SphereLeafCloudParams(LeafCloudParams):
     """
     Advanced parameter checking class for the sphere :class:`.LeafCloud`
@@ -454,7 +456,7 @@ class SphereLeafCloudParams(LeafCloudParams):
     """
 
     _radius = documented(
-        pinttr.ib(default=1.0 * ureg.m, units=ucc.deferred("length")),
+        pinttr.field(default=1.0 * ureg.m, units=ucc.deferred("length")),
         doc="Leaf cloud radius.\n\nUnit-enabled field (default: ucc[length]).",
         type="float",
         default="1 m",
@@ -466,7 +468,7 @@ class SphereLeafCloudParams(LeafCloudParams):
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class EllipsoidLeafCloudParams(LeafCloudParams):
     """
     Advanced parameter checking class for the ellipsoid :class:`.LeafCloud`
@@ -481,21 +483,21 @@ class EllipsoidLeafCloudParams(LeafCloudParams):
     """
 
     _a = documented(
-        pinttr.ib(default=1.0 * ureg.m, units=ucc.deferred("length")),
+        pinttr.field(default=1.0 * ureg.m, units=ucc.deferred("length")),
         doc="Leaf cloud radius.\n\nUnit-enabled field (default: ucc[length]).",
         type="float",
         default="1 m",
     )
 
     _b = documented(
-        pinttr.ib(default=None, units=ucc.deferred("length")),
+        pinttr.field(default=None, units=ucc.deferred("length")),
         doc="Leaf cloud radius.\n\nUnit-enabled field (default: ucc[length]).",
         type="float",
         default="1 m",
     )
 
     _c = documented(
-        pinttr.ib(default=None, units=ucc.deferred("length")),
+        pinttr.field(default=None, units=ucc.deferred("length")),
         doc="Leaf cloud radius.\n\nUnit-enabled field (default: ucc[length]).",
         type="float",
         default="1 m",
@@ -531,7 +533,7 @@ class EllipsoidLeafCloudParams(LeafCloudParams):
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class CylinderLeafCloudParams(LeafCloudParams):
     """
     Advanced parameter checking class for the cylinder :class:`.LeafCloud`
@@ -543,14 +545,14 @@ class CylinderLeafCloudParams(LeafCloudParams):
     """
 
     _radius = documented(
-        pinttr.ib(default=1.0 * ureg.m, units=ucc.deferred("length")),
+        pinttr.field(default=1.0 * ureg.m, units=ucc.deferred("length")),
         doc="Leaf cloud radius.\n\nUnit-enabled field (default: ucc[length]).",
         type="float",
         default="1 m",
     )
 
     _l_vertical = documented(
-        pinttr.ib(default=1.0 * ureg.m, units=ucc.deferred("length")),
+        pinttr.field(default=1.0 * ureg.m, units=ucc.deferred("length")),
         doc="Leaf cloud vertical extent.\n\nUnit-enabled field (default: ucc[length]).",
         type="float",
         default="1 m",
@@ -566,7 +568,7 @@ class CylinderLeafCloudParams(LeafCloudParams):
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class ConeLeafCloudParams(LeafCloudParams):
     """
     Advanced parameter checking class for the cone :class:`.LeafCloud`
@@ -578,14 +580,14 @@ class ConeLeafCloudParams(LeafCloudParams):
     """
 
     _radius = documented(
-        pinttr.ib(default=1.0 * ureg.m, units=ucc.deferred("length")),
+        pinttr.field(default=1.0 * ureg.m, units=ucc.deferred("length")),
         doc="Leaf cloud radius.\n\nUnit-enabled field (default: ucc[length]).",
         type="float",
         default="1 m",
     )
 
     _l_vertical = documented(
-        pinttr.ib(default=1.0 * ureg.m, units=ucc.deferred("length")),
+        pinttr.field(default=1.0 * ureg.m, units=ucc.deferred("length")),
         doc="Leaf cloud vertical extent.\n\nUnit-enabled field (default: ucc[length]).",
         type="float",
         default="1 m",
@@ -601,7 +603,7 @@ class ConeLeafCloudParams(LeafCloudParams):
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class LeafCloud(CanopyElement):
     """
     A container class for leaf clouds in abstract discrete canopies.
@@ -637,9 +639,9 @@ class LeafCloud(CanopyElement):
     # --------------------------------------------------------------------------
 
     id: t.Optional[str] = documented(
-        attr.ib(
+        attrs.field(
             default="leaf_cloud",
-            validator=attr.validators.optional(attr.validators.instance_of(str)),
+            validator=attrs.validators.optional(attrs.validators.instance_of(str)),
         ),
         doc=get_doc(SceneElement, "id", "doc"),
         type=get_doc(SceneElement, "id", "type"),
@@ -648,7 +650,7 @@ class LeafCloud(CanopyElement):
     )
 
     leaf_positions: pint.Quantity = documented(
-        pinttr.ib(factory=list, units=ucc.deferred("length")),
+        pinttr.field(factory=list, units=ucc.deferred("length")),
         doc="Leaf positions in cartesian coordinates as a (n, 3)-array.\n"
         "\n"
         "Unit-enabled field (default: ucc['length']).",
@@ -658,7 +660,7 @@ class LeafCloud(CanopyElement):
     )
 
     leaf_orientations: np.ndarray = documented(
-        attr.ib(factory=list, converter=np.array),
+        attrs.field(factory=list, converter=np.array),
         doc="Leaf orientations (normal vectors) in Cartesian coordinates as a "
         "(n, 3)-array.",
         type="ndarray",
@@ -666,11 +668,11 @@ class LeafCloud(CanopyElement):
     )
 
     leaf_radii: pint.Quantity = documented(
-        pinttr.ib(
+        pinttr.field(
             factory=list,
             validator=[
                 pinttr.validators.has_compatible_units,
-                attr.validators.deep_iterable(member_validator=validators.is_positive),
+                attrs.validators.deep_iterable(member_validator=validators.is_positive),
             ],
             units=ucc.deferred("length"),
         ),
@@ -711,11 +713,11 @@ class LeafCloud(CanopyElement):
             )
 
     leaf_reflectance: Spectrum = documented(
-        attr.ib(
+        attrs.field(
             default=0.5,
             converter=spectrum_factory.converter("reflectance"),
             validator=[
-                attr.validators.instance_of(Spectrum),
+                attrs.validators.instance_of(Spectrum),
                 validators.has_quantity("reflectance"),
             ],
         ),
@@ -727,11 +729,11 @@ class LeafCloud(CanopyElement):
     )
 
     leaf_transmittance: Spectrum = documented(
-        attr.ib(
+        attrs.field(
             default=0.5,
             converter=spectrum_factory.converter("transmittance"),
             validator=[
-                attr.validators.instance_of(Spectrum),
+                attrs.validators.instance_of(Spectrum),
                 validators.has_quantity("transmittance"),
             ],
         ),
@@ -1235,4 +1237,4 @@ class LeafCloud(CanopyElement):
                 f"{self.leaf_positions.shape} do not match"
             )
 
-        return attr.evolve(self, leaf_positions=self.leaf_positions + xyz)
+        return attrs.evolve(self, leaf_positions=self.leaf_positions + xyz)

--- a/src/eradiate/scenes/biosphere/_tree.py
+++ b/src/eradiate/scenes/biosphere/_tree.py
@@ -5,7 +5,7 @@ from abc import ABC
 from collections.abc import MutableMapping
 from pathlib import Path
 
-import attr
+import attrs
 import mitsuba as mi
 import pint
 import pinttr
@@ -23,7 +23,7 @@ from ...units import unit_registry as ureg
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class Tree(CanopyElement, ABC):
     """
     Abstract base class for tree-like canopy elements.
@@ -42,7 +42,7 @@ def _leaf_cloud_converter(value):
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class AbstractTree(Tree):
     """
     A container class for abstract trees in discrete canopies.
@@ -62,9 +62,9 @@ class AbstractTree(Tree):
     """
 
     id: t.Optional[str] = documented(
-        attr.ib(
+        attrs.field(
             default="abstract_tree",
-            validator=attr.validators.optional(attr.validators.instance_of(str)),
+            validator=attrs.validators.optional(attrs.validators.instance_of(str)),
         ),
         doc=get_doc(SceneElement, "id", "doc"),
         type=get_doc(SceneElement, "id", "type"),
@@ -73,10 +73,12 @@ class AbstractTree(Tree):
     )
 
     leaf_cloud: t.Optional[LeafCloud] = documented(
-        attr.ib(
+        attrs.field(
             default=None,
-            converter=attr.converters.optional(_leaf_cloud_converter),
-            validator=attr.validators.optional(attr.validators.instance_of(LeafCloud)),
+            converter=attrs.converters.optional(_leaf_cloud_converter),
+            validator=attrs.validators.optional(
+                attrs.validators.instance_of(LeafCloud)
+            ),
         ),
         doc="Instanced leaf cloud. Can be specified as a dictionary, which will "
         "be interpreted by :data:`.biosphere_factory`. If the latter case, the "
@@ -87,7 +89,7 @@ class AbstractTree(Tree):
     )
 
     trunk_height: pint.Quantity = documented(
-        pinttr.ib(default=1.0 * ureg.m, units=ucc.deferred("length")),
+        pinttr.field(default=1.0 * ureg.m, units=ucc.deferred("length")),
         doc='Trunk height. Unit-enabled field (default: ucc["length"]).',
         type="quantity",
         init_type="quantity or float",
@@ -95,7 +97,7 @@ class AbstractTree(Tree):
     )
 
     trunk_radius: pint.Quantity = documented(
-        pinttr.ib(default=0.1 * ureg.m, units=ucc.deferred("length")),
+        pinttr.field(default=0.1 * ureg.m, units=ucc.deferred("length")),
         doc='Trunk radius. Unit-enabled field (default: ucc["length"]).',
         type="quantity",
         init_type="quantity or float, optional",
@@ -103,11 +105,11 @@ class AbstractTree(Tree):
     )
 
     trunk_reflectance: Spectrum = documented(
-        attr.ib(
+        attrs.field(
             default=0.5,
             converter=spectrum_factory.converter("reflectance"),
             validator=[
-                attr.validators.instance_of(Spectrum),
+                attrs.validators.instance_of(Spectrum),
                 validators.has_quantity("reflectance"),
             ],
         ),
@@ -119,7 +121,7 @@ class AbstractTree(Tree):
     )
 
     leaf_cloud_extra_offset: pint.Quantity = documented(
-        pinttr.ib(factory=lambda: [0, 0, 0], units=ucc.deferred("length")),
+        pinttr.field(factory=lambda: [0, 0, 0], units=ucc.deferred("length")),
         doc="Additional offset for the leaf cloud. 3-vector. "
         'Unit-enabled field (default: ucc["length"])',
         type="quantity",
@@ -211,7 +213,7 @@ class AbstractTree(Tree):
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class MeshTree(Tree):
     """
     A container class for mesh based tree-like objects in canopies.
@@ -224,9 +226,9 @@ class MeshTree(Tree):
     """
 
     id: str = documented(
-        attr.ib(
+        attrs.field(
             default="mesh_tree",
-            validator=attr.validators.optional(attr.validators.instance_of(str)),
+            validator=attrs.validators.optional(attrs.validators.instance_of(str)),
         ),
         doc=get_doc(SceneElement, "id", "doc"),
         type=get_doc(SceneElement, "id", "type"),
@@ -235,7 +237,7 @@ class MeshTree(Tree):
     )
 
     mesh_tree_elements: t.List[MeshTree] = documented(
-        attr.ib(
+        attrs.field(
             factory=list,
             converter=lambda value: [
                 MeshTreeElement.convert(x) for x in pinttr.util.always_iterable(value)
@@ -270,7 +272,7 @@ class MeshTree(Tree):
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class MeshTreeElement:
     """
     Container class for mesh based constituents of tree-like objects in a canopy.
@@ -289,16 +291,16 @@ class MeshTreeElement:
     """
 
     id: t.Optional[str] = documented(
-        attr.ib(
+        attrs.field(
             default="mesh_tree_element",
-            validator=attr.validators.optional(attr.validators.instance_of(str)),
+            validator=attrs.validators.optional(attrs.validators.instance_of(str)),
         ),
         doc="User-defined object identifier.",
         type="str, optional",
     )
 
     mesh_filename: Path = documented(
-        attr.ib(
+        attrs.field(
             converter=Path,
             kw_only=True,
         ),
@@ -318,9 +320,9 @@ class MeshTreeElement:
             )
 
     mesh_units: t.Optional[pint.Unit] = documented(
-        attr.ib(
+        attrs.field(
             default=None,
-            converter=attr.converters.optional(ureg.Unit),
+            converter=attrs.converters.optional(ureg.Unit),
         ),
         doc="Units the mesh was defined in. Used to convert to kernel units. "
         "If this value is ``None``, the mesh is interpreted as being defined in"
@@ -338,11 +340,11 @@ class MeshTreeElement:
             )
 
     reflectance: Spectrum = documented(
-        attr.ib(
+        attrs.field(
             default=0.5,
             converter=spectrum_factory.converter("reflectance"),
             validator=[
-                attr.validators.instance_of(Spectrum),
+                attrs.validators.instance_of(Spectrum),
                 validators.has_quantity("reflectance"),
             ],
         ),
@@ -354,11 +356,11 @@ class MeshTreeElement:
     )
 
     transmittance: Spectrum = documented(
-        attr.ib(
+        attrs.field(
             default=0.0,
             converter=spectrum_factory.converter("transmittance"),
             validator=[
-                attr.validators.instance_of(Spectrum),
+                attrs.validators.instance_of(Spectrum),
                 validators.has_quantity("transmittance"),
             ],
         ),

--- a/src/eradiate/scenes/bsdfs/_black.py
+++ b/src/eradiate/scenes/bsdfs/_black.py
@@ -1,11 +1,11 @@
-import attr
+import attrs
 
 from ._core import BSDF
 from ..core import KernelDict
 from ...contexts import KernelDictContext
 
 
-@attr.s
+@attrs.define
 class BlackBSDF(BSDF):
     """
     Black BSDF [``black``].

--- a/src/eradiate/scenes/bsdfs/_checkerboard.py
+++ b/src/eradiate/scenes/bsdfs/_checkerboard.py
@@ -1,4 +1,4 @@
-import attr
+import attrs
 import mitsuba as mi
 
 from ._core import BSDF
@@ -10,7 +10,7 @@ from ...contexts import KernelDictContext
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class CheckerboardBSDF(BSDF):
     """
     Checkerboard BSDF [``checkerboard``].
@@ -19,11 +19,11 @@ class CheckerboardBSDF(BSDF):
     """
 
     reflectance_a: Spectrum = documented(
-        attr.ib(
+        attrs.field(
             default=0.2,
             converter=spectrum_factory.converter("reflectance"),
             validator=[
-                attr.validators.instance_of(Spectrum),
+                attrs.validators.instance_of(Spectrum),
                 validators.has_quantity("reflectance"),
             ],
         ),
@@ -35,11 +35,11 @@ class CheckerboardBSDF(BSDF):
     )
 
     reflectance_b: Spectrum = documented(
-        attr.ib(
+        attrs.field(
             default=0.8,
             converter=spectrum_factory.converter("reflectance"),
             validator=[
-                attr.validators.instance_of(Spectrum),
+                attrs.validators.instance_of(Spectrum),
                 validators.has_quantity("reflectance"),
             ],
         ),
@@ -51,8 +51,8 @@ class CheckerboardBSDF(BSDF):
     )
 
     scale_pattern: float = documented(
-        attr.ib(
-            default=2.0, converter=float, validator=attr.validators.instance_of(float)
+        attrs.field(
+            default=2.0, converter=float, validator=attrs.validators.instance_of(float)
         ),
         doc="Scaling factor for the checkerboard pattern. The higher the value, "
         "the more checkboard patterns will fit on the surface to which this "

--- a/src/eradiate/scenes/bsdfs/_core.py
+++ b/src/eradiate/scenes/bsdfs/_core.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import typing as t
 from abc import ABC
 
-import attr
+import attrs
 
 from ..core import SceneElement
 from ..._factory import Factory
@@ -21,16 +21,16 @@ bsdf_factory.register_lazy_batch(
 )
 
 
-@attr.s
+@attrs.define
 class BSDF(SceneElement, ABC):
     """
     Abstract interface for all BSDF scene elements.
     """
 
     id: t.Optional[str] = documented(
-        attr.ib(
+        attrs.field(
             default="bsdf",
-            validator=attr.validators.optional(attr.validators.instance_of(str)),
+            validator=attrs.validators.optional(attrs.validators.instance_of(str)),
         ),
         doc=get_doc(SceneElement, "id", "doc"),
         type=get_doc(SceneElement, "id", "type"),

--- a/src/eradiate/scenes/bsdfs/_lambertian.py
+++ b/src/eradiate/scenes/bsdfs/_lambertian.py
@@ -1,4 +1,4 @@
-import attr
+import attrs
 
 from ._core import BSDF
 from ..core import KernelDict
@@ -10,7 +10,7 @@ from ...util.misc import onedict_value
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class LambertianBSDF(BSDF):
     """
     Lambertian BSDF [``lambertian``].
@@ -25,11 +25,11 @@ class LambertianBSDF(BSDF):
     """
 
     reflectance: Spectrum = documented(
-        attr.ib(
+        attrs.field(
             default=0.5,
             converter=spectrum_factory.converter("reflectance"),
             validator=[
-                attr.validators.instance_of(Spectrum),
+                attrs.validators.instance_of(Spectrum),
                 validators.has_quantity("reflectance"),
             ],
         ),

--- a/src/eradiate/scenes/bsdfs/_rpv.py
+++ b/src/eradiate/scenes/bsdfs/_rpv.py
@@ -1,6 +1,6 @@
 import typing as t
 
-import attr
+import attrs
 
 from ._core import BSDF
 from ..core import KernelDict
@@ -12,7 +12,7 @@ from ...util.misc import onedict_value
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class RPVBSDF(BSDF):
     """
     RPV BSDF [``rpv``].
@@ -37,11 +37,11 @@ class RPVBSDF(BSDF):
     """
 
     rho_0: Spectrum = documented(
-        attr.ib(
+        attrs.field(
             default=0.183,
             converter=spectrum_factory.converter("dimensionless"),
             validator=[
-                attr.validators.instance_of(Spectrum),
+                attrs.validators.instance_of(Spectrum),
                 validators.has_quantity("dimensionless"),
             ],
         ),
@@ -53,14 +53,14 @@ class RPVBSDF(BSDF):
     )
 
     rho_c: t.Optional[Spectrum] = documented(
-        attr.ib(
+        attrs.field(
             default=None,
-            converter=attr.converters.optional(
+            converter=attrs.converters.optional(
                 spectrum_factory.converter("dimensionless")
             ),
-            validator=attr.validators.optional(
+            validator=attrs.validators.optional(
                 [
-                    attr.validators.instance_of(Spectrum),
+                    attrs.validators.instance_of(Spectrum),
                     validators.has_quantity("dimensionless"),
                 ]
             ),
@@ -74,11 +74,11 @@ class RPVBSDF(BSDF):
     )
 
     k: Spectrum = documented(
-        attr.ib(
+        attrs.field(
             default=0.780,
             converter=spectrum_factory.converter("dimensionless"),
             validator=[
-                attr.validators.instance_of(Spectrum),
+                attrs.validators.instance_of(Spectrum),
                 validators.has_quantity("dimensionless"),
             ],
         ),
@@ -90,11 +90,11 @@ class RPVBSDF(BSDF):
     )
 
     g: Spectrum = documented(
-        attr.ib(
+        attrs.field(
             default=-0.1,
             converter=spectrum_factory.converter("dimensionless"),
             validator=[
-                attr.validators.instance_of(Spectrum),
+                attrs.validators.instance_of(Spectrum),
                 validators.has_quantity("dimensionless"),
             ],
         ),

--- a/src/eradiate/scenes/core.py
+++ b/src/eradiate/scenes/core.py
@@ -6,7 +6,7 @@ from abc import ABC, abstractmethod
 from collections import abc as collections_abc
 from typing import Mapping, Sequence
 
-import attr
+import attrs
 import mitsuba as mi
 import numpy as np
 import pint
@@ -33,7 +33,7 @@ def _kernel_dict_get_mitsuba_variant() -> str:
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class KernelDict(collections_abc.MutableMapping):
     """
     A dictionary-like object designed to contain a scene specification
@@ -44,7 +44,7 @@ class KernelDict(collections_abc.MutableMapping):
     """
 
     data: dict = documented(
-        attr.ib(
+        attrs.field(
             factory=dict,
             converter=dict,
         ),
@@ -54,7 +54,7 @@ class KernelDict(collections_abc.MutableMapping):
     )
 
     post_load: dict = documented(
-        attr.ib(
+        attrs.field(
             factory=dict,
             converter=dict,
         ),
@@ -64,9 +64,9 @@ class KernelDict(collections_abc.MutableMapping):
     )
 
     variant: str = documented(
-        attr.ib(
+        attrs.field(
             factory=_kernel_dict_get_mitsuba_variant,
-            validator=attr.validators.instance_of(str),
+            validator=attrs.validators.instance_of(str),
         ),
         doc="Kernel variant for which the dictionary is created. Defaults to "
         "currently active variant (if any; otherwise raises).",
@@ -270,7 +270,7 @@ class KernelDict(collections_abc.MutableMapping):
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class SceneElement(ABC):
     """
     Abstract class for all scene elements.
@@ -280,9 +280,9 @@ class SceneElement(ABC):
     """
 
     id: t.Optional[str] = documented(
-        attr.ib(
+        attrs.field(
             default=None,
-            validator=attr.validators.optional(attr.validators.instance_of(str)),
+            validator=attrs.validators.optional(attrs.validators.instance_of(str)),
         ),
         doc="User-defined object identifier.",
         type="str or None",
@@ -320,7 +320,7 @@ class SceneElement(ABC):
 
 
 @parse_docs
-@attr.s(frozen=True)
+@attrs.frozen
 class BoundingBox:
     """
     A basic data class representing an axis-aligned bounding box with
@@ -332,7 +332,7 @@ class BoundingBox:
     """
 
     min: pint.Quantity = documented(
-        pinttr.ib(
+        pinttr.field(
             units=ucc.get("length"),
             on_setattr=None,  # frozen instance: on_setattr must be disabled
         ),
@@ -342,7 +342,7 @@ class BoundingBox:
     )
 
     max: pint.Quantity = documented(
-        pinttr.ib(
+        pinttr.field(
             units=ucc.get("length"),
             on_setattr=None,  # frozen instance: on_setattr must be disabled
         ),

--- a/src/eradiate/scenes/illumination/_constant.py
+++ b/src/eradiate/scenes/illumination/_constant.py
@@ -1,4 +1,4 @@
-import attr
+import attrs
 
 from ._core import Illumination
 from ..core import KernelDict
@@ -9,17 +9,20 @@ from ...validators import has_quantity
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class ConstantIllumination(Illumination):
     """
     Constant illumination scene element [``constant``].
     """
 
     radiance: Spectrum = documented(
-        attr.ib(
+        attrs.field(
             default=1.0,
             converter=spectrum_factory.converter("radiance"),
-            validator=[attr.validators.instance_of(Spectrum), has_quantity("radiance")],
+            validator=[
+                attrs.validators.instance_of(Spectrum),
+                has_quantity("radiance"),
+            ],
         ),
         doc="Emitted radiance spectrum. Must be a radiance spectrum "
         "(in W/m²/sr/nm or compatible units).",

--- a/src/eradiate/scenes/illumination/_core.py
+++ b/src/eradiate/scenes/illumination/_core.py
@@ -1,7 +1,7 @@
 import typing as t
 from abc import ABC
 
-import attr
+import attrs
 
 from ..core import SceneElement
 from ..._factory import Factory
@@ -18,16 +18,16 @@ illumination_factory.register_lazy_batch(
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class Illumination(SceneElement, ABC):
     """
     Abstract base class for all illumination scene elements.
     """
 
     id: t.Optional[str] = documented(
-        attr.ib(
+        attrs.field(
             default="illumination",
-            validator=attr.validators.optional(attr.validators.instance_of(str)),
+            validator=attrs.validators.optional(attrs.validators.instance_of(str)),
         ),
         doc=get_doc(SceneElement, "id", "doc"),
         type=get_doc(SceneElement, "id", "type"),

--- a/src/eradiate/scenes/illumination/_directional.py
+++ b/src/eradiate/scenes/illumination/_directional.py
@@ -1,4 +1,4 @@
-import attr
+import attrs
 import numpy as np
 import pint
 import pinttr
@@ -16,7 +16,7 @@ from ...validators import has_quantity, is_positive
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class DirectionalIllumination(Illumination):
     """
     Directional illumination scene element [``directional``].
@@ -26,7 +26,7 @@ class DirectionalIllumination(Illumination):
     """
 
     zenith: pint.Quantity = documented(
-        pinttr.ib(
+        pinttr.field(
             default=0.0 * ureg.deg,
             validator=[is_positive, pinttr.validators.has_compatible_units],
             units=ucc.deferred("angle"),
@@ -38,7 +38,7 @@ class DirectionalIllumination(Illumination):
     )
 
     azimuth: pint.Quantity = documented(
-        pinttr.ib(
+        pinttr.field(
             default=0.0 * ureg.deg,
             validator=[is_positive, pinttr.validators.has_compatible_units],
             units=ucc.deferred("angle"),
@@ -52,12 +52,12 @@ class DirectionalIllumination(Illumination):
     )
 
     azimuth_convention: AzimuthConvention = documented(
-        attr.ib(
+        attrs.field(
             default=None,
             converter=lambda x: config.azimuth_convention
             if x is None
             else (AzimuthConvention[x.upper()] if isinstance(x, str) else x),
-            validator=attr.validators.instance_of(AzimuthConvention),
+            validator=attrs.validators.instance_of(AzimuthConvention),
         ),
         doc="Azimuth convention. If ``None``, the global default configuration "
         "is used (see :class:`.EradiateConfig`).",
@@ -67,11 +67,11 @@ class DirectionalIllumination(Illumination):
     )
 
     irradiance: Spectrum = documented(
-        attr.ib(
+        attrs.field(
             factory=SolarIrradianceSpectrum,
             converter=spectrum_factory.converter("irradiance"),
             validator=[
-                attr.validators.instance_of(Spectrum),
+                attrs.validators.instance_of(Spectrum),
                 has_quantity("irradiance"),
             ],
         ),

--- a/src/eradiate/scenes/integrators/_core.py
+++ b/src/eradiate/scenes/integrators/_core.py
@@ -1,6 +1,6 @@
 import typing as t
 
-import attr
+import attrs
 
 from ..core import SceneElement
 from ..._factory import Factory
@@ -18,16 +18,16 @@ integrator_factory.register_lazy_batch(
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class Integrator(SceneElement):
     """
     Abstract base class for all integrator elements.
     """
 
     id: t.Optional[str] = documented(
-        attr.ib(
+        attrs.field(
             default="integrator",
-            validator=attr.validators.optional(attr.validators.instance_of(str)),
+            validator=attrs.validators.optional(attrs.validators.instance_of(str)),
         ),
         doc=get_doc(SceneElement, "id", "doc"),
         type=get_doc(SceneElement, "id", "type"),

--- a/src/eradiate/scenes/integrators/_path_tracers.py
+++ b/src/eradiate/scenes/integrators/_path_tracers.py
@@ -1,6 +1,6 @@
 import typing as t
 
-import attr
+import attrs
 
 from ._core import Integrator
 from ..core import KernelDict
@@ -9,7 +9,7 @@ from ...contexts import KernelDictContext
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class MonteCarloIntegrator(Integrator):
     """
     Base class for integrator elements wrapping kernel classes
@@ -20,7 +20,7 @@ class MonteCarloIntegrator(Integrator):
     """
 
     max_depth: t.Optional[int] = documented(
-        attr.ib(default=None, converter=attr.converters.optional(int)),
+        attrs.field(default=None, converter=attrs.converters.optional(int)),
         doc="Longest path depth in the generated measure data (where -1 "
         "corresponds to ∞). A value of 1 will display only visible emitters. 2 "
         "computes only direct illumination (no multiple scattering), etc. If "
@@ -29,7 +29,7 @@ class MonteCarloIntegrator(Integrator):
     )
 
     rr_depth: t.Optional[int] = documented(
-        attr.ib(default=None, converter=attr.converters.optional(int)),
+        attrs.field(default=None, converter=attrs.converters.optional(int)),
         doc="Minimum path depth after which the implementation starts applying "
         "the Russian roulette path termination criterion. If unset, the kernel "
         "default value (5) is used.",
@@ -37,7 +37,7 @@ class MonteCarloIntegrator(Integrator):
     )
 
     hide_emitters: t.Optional[bool] = documented(
-        attr.ib(default=None, converter=attr.converters.optional(bool)),
+        attrs.field(default=None, converter=attrs.converters.optional(bool)),
         doc="Hide directly visible emitters. If unset, the kernel default "
         "value (``false``) is used.",
         type="bool, optional",
@@ -57,7 +57,7 @@ class MonteCarloIntegrator(Integrator):
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class PathIntegrator(MonteCarloIntegrator):
     """
     A thin interface to the `path tracer kernel plugin <https://eradiate-kernel.readthedocs.io/en/latest/generated/plugins.html#path-tracer-path>`_.
@@ -74,7 +74,7 @@ class PathIntegrator(MonteCarloIntegrator):
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class VolPathIntegrator(MonteCarloIntegrator):
     """
     A thin interface to the volumetric path tracer kernel plugin.
@@ -90,7 +90,7 @@ class VolPathIntegrator(MonteCarloIntegrator):
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class VolPathMISIntegrator(MonteCarloIntegrator):
     """
     A thin interface to the volumetric path tracer (with spectral multiple
@@ -98,7 +98,9 @@ class VolPathMISIntegrator(MonteCarloIntegrator):
     :cite:`Miller2019NullscatteringPathIntegral`.
     """
 
-    use_spectral_mis = attr.ib(default=None, converter=attr.converters.optional(bool))
+    use_spectral_mis = attrs.field(
+        default=None, converter=attrs.converters.optional(bool)
+    )
 
     def kernel_dict(self, ctx: KernelDictContext) -> KernelDict:
         result = super(VolPathMISIntegrator, self).kernel_dict(ctx)

--- a/src/eradiate/scenes/measure/_core.py
+++ b/src/eradiate/scenes/measure/_core.py
@@ -6,7 +6,7 @@ import warnings
 from abc import ABC, abstractmethod
 from collections import abc
 
-import attr
+import attrs
 import numpy as np
 import pint
 import pinttr
@@ -81,7 +81,7 @@ def _measure_spectral_config_srf_converter(value: t.Any) -> Spectrum:
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class MeasureSpectralConfig(ABC):
     """
     Data structure specifying the spectral configuration of a :class:`.Measure`.
@@ -96,7 +96,7 @@ class MeasureSpectralConfig(ABC):
     # --------------------------------------------------------------------------
 
     srf: Spectrum = documented(
-        attr.ib(
+        attrs.field(
             factory=lambda: UniformSpectrum(value=1.0),
             converter=_measure_spectral_config_srf_converter,
             validator=validators.has_quantity(PhysicalQuantity.DIMENSIONLESS),
@@ -225,7 +225,7 @@ class MeasureSpectralConfig(ABC):
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class MonoMeasureSpectralConfig(MeasureSpectralConfig):
     """
     A data structure specifying the spectral configuration of a :class:`.Measure`
@@ -237,7 +237,7 @@ class MonoMeasureSpectralConfig(MeasureSpectralConfig):
     # --------------------------------------------------------------------------
 
     _wavelengths: pint.Quantity = documented(
-        pinttr.ib(
+        pinttr.field(
             default=ureg.Quantity([550.0], ureg.nm),
             units=ucc.deferred("wavelength"),
             converter=lambda x: converters.on_quantity(np.atleast_1d)(
@@ -364,7 +364,7 @@ def _active(bin: Bin, srf: Spectrum) -> bool:
 
 
 @parse_docs
-@attr.s(frozen=True)
+@attrs.frozen
 class CKDMeasureSpectralConfig(MeasureSpectralConfig):
     """
     A data structure specifying the spectral configuration of a
@@ -376,10 +376,10 @@ class CKDMeasureSpectralConfig(MeasureSpectralConfig):
     # --------------------------------------------------------------------------
 
     bin_set: ckd.BinSet = documented(
-        attr.ib(
+        attrs.field(
             default="10nm",
             converter=ckd.BinSet.convert,
-            validator=attr.validators.instance_of(ckd.BinSet),
+            validator=attrs.validators.instance_of(ckd.BinSet),
         ),
         doc="CKD bin set definition. If a string is passed, the data "
         "repository is queried for the corresponding identifier using "
@@ -390,7 +390,7 @@ class CKDMeasureSpectralConfig(MeasureSpectralConfig):
     )
 
     _bins: t.Union[t.List[str], AutoType] = documented(
-        attr.ib(
+        attrs.field(
             default=AUTO,
             converter=converters.auto_or(_ckd_measure_spectral_config_bins_converter),
         ),
@@ -477,7 +477,7 @@ def _str_summary_raw(x):
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class Measure(SceneElement, ABC):
     """
     Abstract base class for all measure scene elements.
@@ -508,15 +508,15 @@ class Measure(SceneElement, ABC):
     # --------------------------------------------------------------------------
 
     flags: MeasureFlags = documented(
-        attr.ib(default=0, converter=MeasureFlags, init=False),
+        attrs.field(default=0, converter=MeasureFlags, init=False),
         doc="Measure flags.",
         type=":class:`.MeasureFlags",
     )
 
     id: t.Optional[str] = documented(
-        attr.ib(
+        attrs.field(
             default="measure",
-            validator=attr.validators.optional((attr.validators.instance_of(str))),
+            validator=attrs.validators.optional((attrs.validators.instance_of(str))),
         ),
         doc=get_doc(SceneElement, "id", "doc"),
         type=get_doc(SceneElement, "id", "type"),
@@ -525,14 +525,14 @@ class Measure(SceneElement, ABC):
     )
 
     results: t.Dict = documented(
-        attr.ib(factory=dict, repr=_str_summary_raw, init=False),
+        attrs.field(factory=dict, repr=_str_summary_raw, init=False),
         doc="Storage for raw results yielded by the kernel.",
         type="dict",
         default="{}",
     )
 
     spectral_cfg: MeasureSpectralConfig = documented(
-        attr.ib(
+        attrs.field(
             factory=MeasureSpectralConfig.new,
             converter=MeasureSpectralConfig.convert,
         ),
@@ -545,17 +545,17 @@ class Measure(SceneElement, ABC):
     )
 
     spp: int = documented(
-        attr.ib(default=1000, converter=int, validator=validators.is_positive),
+        attrs.field(default=1000, converter=int, validator=validators.is_positive),
         doc="Number of samples per pixel.",
         type="int",
         default="1000",
     )
 
     split_spp: t.Optional[int] = documented(
-        attr.ib(
+        attrs.field(
             default=None,
-            converter=attr.converters.optional(int),
-            validator=attr.validators.optional(validators.is_positive),
+            converter=attrs.converters.optional(int),
+            validator=attrs.validators.optional(validators.is_positive),
         ),
         type="int",
         init_type="int, optional",

--- a/src/eradiate/scenes/measure/_distant_flux.py
+++ b/src/eradiate/scenes/measure/_distant_flux.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import typing as t
 
-import attr
+import attrs
 import mitsuba as mi
 import numpy as np
 import pint
@@ -21,7 +21,7 @@ from ...warp import square_to_uniform_hemisphere
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class DistantFluxMeasure(Measure):
     """
     Distant radiosity measure scene element [``distant_flux``].
@@ -49,12 +49,12 @@ class DistantFluxMeasure(Measure):
     # --------------------------------------------------------------------------
 
     azimuth_convention: frame.AzimuthConvention = documented(
-        attr.ib(
+        attrs.field(
             default=None,
             converter=lambda x: config.azimuth_convention
             if x is None
             else (frame.AzimuthConvention[x.upper()] if isinstance(x, str) else x),
-            validator=attr.validators.instance_of(frame.AzimuthConvention),
+            validator=attrs.validators.instance_of(frame.AzimuthConvention),
         ),
         doc="Azimuth convention. If ``None``, the global default configuration "
         "is used (see :class:`.EradiateConfig`).",
@@ -64,7 +64,7 @@ class DistantFluxMeasure(Measure):
     )
 
     direction: np.ndarray = documented(
-        attr.ib(
+        attrs.field(
             default=[0, 0, 1],
             converter=np.array,
             validator=validators.is_vector3,
@@ -76,18 +76,20 @@ class DistantFluxMeasure(Measure):
     )
 
     target: t.Optional[Target] = documented(
-        attr.ib(
+        attrs.field(
             default=None,
-            converter=attr.converters.optional(Target.convert),
-            validator=attr.validators.optional(
-                attr.validators.instance_of(
+            converter=attrs.converters.optional(Target.convert),
+            validator=attrs.validators.optional(
+                attrs.validators.instance_of(
                     (
                         TargetPoint,
                         TargetRectangle,
                     )
                 )
             ),
-            on_setattr=attr.setters.pipe(attr.setters.convert, attr.setters.validate),
+            on_setattr=attrs.setters.pipe(
+                attrs.setters.convert, attrs.setters.validate
+            ),
         ),
         doc="Target specification. The target can be specified using an "
         "array-like with 3 elements (which will be converted to a "
@@ -101,10 +103,10 @@ class DistantFluxMeasure(Measure):
     )
 
     _film_resolution: t.Tuple[int, int] = documented(
-        attr.ib(
+        attrs.field(
             default=(32, 32),
-            validator=attr.validators.deep_iterable(
-                member_validator=attr.validators.instance_of(int),
+            validator=attrs.validators.deep_iterable(
+                member_validator=attrs.validators.instance_of(int),
                 iterable_validator=validators.has_len(2),
             ),
         ),
@@ -118,7 +120,7 @@ class DistantFluxMeasure(Measure):
         return self._film_resolution
 
     flags: MeasureFlags = documented(
-        attr.ib(default=MeasureFlags.DISTANT, converter=MeasureFlags, init=False),
+        attrs.field(default=MeasureFlags.DISTANT, converter=MeasureFlags, init=False),
         doc=get_doc(Measure, "flags", "doc"),
         type=get_doc(Measure, "flags", "type"),
     )

--- a/src/eradiate/scenes/measure/_hemispherical_distant.py
+++ b/src/eradiate/scenes/measure/_hemispherical_distant.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import typing as t
 
-import attr
+import attrs
 import drjit as dr
 import mitsuba as mi
 import numpy as np
@@ -24,7 +24,7 @@ from ...warp import square_to_uniform_hemisphere
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class HemisphericalDistantMeasure(Measure):
     """
     Hemispherical distant radiance measure scene element
@@ -52,12 +52,12 @@ class HemisphericalDistantMeasure(Measure):
     # --------------------------------------------------------------------------
 
     azimuth_convention: frame.AzimuthConvention = documented(
-        attr.ib(
+        attrs.field(
             default=None,
             converter=lambda x: config.azimuth_convention
             if x is None
             else (frame.AzimuthConvention[x.upper()] if isinstance(x, str) else x),
-            validator=attr.validators.instance_of(frame.AzimuthConvention),
+            validator=attrs.validators.instance_of(frame.AzimuthConvention),
         ),
         doc="Azimuth convention. If ``None``, the global default configuration "
         "is used (see :class:`.EradiateConfig`).",
@@ -67,10 +67,10 @@ class HemisphericalDistantMeasure(Measure):
     )
 
     _film_resolution: t.Tuple[int, int] = documented(
-        attr.ib(
+        attrs.field(
             default=(32, 32),
-            validator=attr.validators.deep_iterable(
-                member_validator=attr.validators.instance_of(int),
+            validator=attrs.validators.deep_iterable(
+                member_validator=attrs.validators.instance_of(int),
                 iterable_validator=validators.has_len(2),
             ),
         ),
@@ -82,7 +82,7 @@ class HemisphericalDistantMeasure(Measure):
     )
 
     orientation: pint.Quantity = documented(
-        pinttr.ib(
+        pinttr.field(
             default=ureg.Quantity(0.0, ureg.deg),
             validator=[validators.is_positive, pinttr.validators.has_compatible_units],
             units=ucc.deferred("angle"),
@@ -96,7 +96,7 @@ class HemisphericalDistantMeasure(Measure):
     )
 
     direction = documented(
-        attr.ib(
+        attrs.field(
             default=[0, 0, 1],
             converter=np.array,
             validator=validators.is_vector3,
@@ -107,18 +107,20 @@ class HemisphericalDistantMeasure(Measure):
     )
 
     target: t.Optional[Target] = documented(
-        attr.ib(
+        attrs.field(
             default=None,
-            converter=attr.converters.optional(Target.convert),
-            validator=attr.validators.optional(
-                attr.validators.instance_of(
+            converter=attrs.converters.optional(Target.convert),
+            validator=attrs.validators.optional(
+                attrs.validators.instance_of(
                     (
                         TargetPoint,
                         TargetRectangle,
                     )
                 )
             ),
-            on_setattr=attr.setters.pipe(attr.setters.convert, attr.setters.validate),
+            on_setattr=attrs.setters.pipe(
+                attrs.setters.convert, attrs.setters.validate
+            ),
         ),
         doc="Target specification. The target can be specified using an "
         "array-like with 3 elements (which will be converted to a "
@@ -136,7 +138,7 @@ class HemisphericalDistantMeasure(Measure):
         return self._film_resolution
 
     flags: MeasureFlags = documented(
-        attr.ib(default=MeasureFlags.DISTANT, converter=MeasureFlags, init=False),
+        attrs.field(default=MeasureFlags.DISTANT, converter=MeasureFlags, init=False),
         doc=get_doc(Measure, "flags", "doc"),
         type=get_doc(Measure, "flags", "type"),
     )

--- a/src/eradiate/scenes/measure/_multi_distant.py
+++ b/src/eradiate/scenes/measure/_multi_distant.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import typing as t
 
-import attr
+import attrs
 import numpy as np
 import pint
 import pinttr
@@ -21,7 +21,7 @@ from ...units import unit_registry as ureg
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class MultiDistantMeasure(Measure):
     """
     Multi-distant radiance measure scene element [``distant``, ``mdistant``, \
@@ -51,7 +51,7 @@ class MultiDistantMeasure(Measure):
     # --------------------------------------------------------------------------
 
     hplane: t.Optional[pint.Quantity] = documented(
-        pinttr.ib(default=None, units=ucc.deferred("angle")),
+        pinttr.field(default=None, units=ucc.deferred("angle")),
         doc="If all directions are expected to be within a hemisphere plane cut, "
         "the azimuth value of that plane. Unitless values are converted to "
         "``ucc['angle']``. The convention specified as the "
@@ -82,12 +82,12 @@ class MultiDistantMeasure(Measure):
             ) from e
 
     azimuth_convention: frame.AzimuthConvention = documented(
-        attr.ib(
+        attrs.field(
             default=None,
             converter=lambda x: config.azimuth_convention
             if x is None
             else (frame.AzimuthConvention[x.upper()] if isinstance(x, str) else x),
-            validator=attr.validators.instance_of(frame.AzimuthConvention),
+            validator=attrs.validators.instance_of(frame.AzimuthConvention),
         ),
         doc="Azimuth convention. If ``None``, the global default configuration "
         "is used (see :class:`.EradiateConfig`).",
@@ -97,7 +97,7 @@ class MultiDistantMeasure(Measure):
     )
 
     directions: np.ndarray = documented(
-        attr.ib(
+        attrs.field(
             default=np.array([[0.0, 0.0, -1.0]]),
             converter=np.array,
         ),
@@ -108,18 +108,20 @@ class MultiDistantMeasure(Measure):
     )
 
     target: t.Optional[Target] = documented(
-        attr.ib(
+        attrs.field(
             default=None,
-            converter=attr.converters.optional(Target.convert),
-            validator=attr.validators.optional(
-                attr.validators.instance_of(
+            converter=attrs.converters.optional(Target.convert),
+            validator=attrs.validators.optional(
+                attrs.validators.instance_of(
                     (
                         TargetPoint,
                         TargetRectangle,
                     )
                 )
             ),
-            on_setattr=attr.setters.pipe(attr.setters.convert, attr.setters.validate),
+            on_setattr=attrs.setters.pipe(
+                attrs.setters.convert, attrs.setters.validate
+            ),
         ),
         doc="Target specification. The target can be specified using an "
         "array-like with 3 elements (which will be converted to a "
@@ -161,7 +163,7 @@ class MultiDistantMeasure(Measure):
         return (self.directions.shape[0], 1)
 
     flags: MeasureFlags = documented(
-        attr.ib(default=MeasureFlags.DISTANT, converter=MeasureFlags, init=False),
+        attrs.field(default=MeasureFlags.DISTANT, converter=MeasureFlags, init=False),
         doc=get_doc(Measure, "flags", "doc"),
         type=get_doc(Measure, "flags", "type"),
     )

--- a/src/eradiate/scenes/measure/_multi_radiancemeter.py
+++ b/src/eradiate/scenes/measure/_multi_radiancemeter.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import typing as t
 
-import attr
+import attrs
 import numpy as np
 import pint
 import pinttr
@@ -18,7 +18,7 @@ from ...units import unit_registry as ureg
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class MultiRadiancemeterMeasure(Measure):
     """
     Radiance meter array measure scene element [``mradiancemeter``,
@@ -35,7 +35,7 @@ class MultiRadiancemeterMeasure(Measure):
     # --------------------------------------------------------------------------
 
     origins: pint.Quantity = documented(
-        pinttr.ib(
+        pinttr.field(
             default=ureg.Quantity([[0.0, 0.0, 0.0]], ureg.m),
             units=ucc.deferred("length"),
         ),
@@ -48,7 +48,7 @@ class MultiRadiancemeterMeasure(Measure):
     )
 
     directions: np.ndarray = documented(
-        attr.ib(
+        attrs.field(
             default=np.array([[0.0, 0.0, 1.0]]),
             converter=np.array,
         ),

--- a/src/eradiate/scenes/measure/_perspective.py
+++ b/src/eradiate/scenes/measure/_perspective.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import typing as t
 
-import attr
+import attrs
 import mitsuba as mi
 import numpy as np
 import pint
@@ -20,7 +20,7 @@ from ...units import unit_registry as ureg
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class PerspectiveCameraMeasure(Measure):
     """
     Perspective camera scene element [``perspective``].
@@ -35,18 +35,18 @@ class PerspectiveCameraMeasure(Measure):
     # --------------------------------------------------------------------------
 
     spp: int = documented(
-        attr.ib(default=32, converter=int, validator=validators.is_positive),
+        attrs.field(default=32, converter=int, validator=validators.is_positive),
         doc="Number of samples per pixel.",
         type="int",
         default="32",
     )
 
     _film_resolution: t.Tuple[int, int] = documented(
-        attr.ib(
+        attrs.field(
             default=(32, 32),
             converter=tuple,
-            validator=attr.validators.deep_iterable(
-                member_validator=attr.validators.instance_of(int),
+            validator=attrs.validators.deep_iterable(
+                member_validator=attrs.validators.instance_of(int),
                 iterable_validator=validators.has_len(2),
             ),
         ),
@@ -61,7 +61,7 @@ class PerspectiveCameraMeasure(Measure):
         return self._film_resolution
 
     origin: pint.Quantity = documented(
-        pinttr.ib(
+        pinttr.field(
             factory=lambda: [1, 1, 1] * ureg.m,
             validator=[validators.has_len(3), pinttr.validators.has_compatible_units],
             units=ucc.deferred("length"),
@@ -75,7 +75,7 @@ class PerspectiveCameraMeasure(Measure):
     )
 
     target: pint.Quantity = documented(
-        pinttr.ib(
+        pinttr.field(
             factory=lambda: [0, 0, 0] * ureg.m,
             validator=[validators.has_len(3), pinttr.validators.has_compatible_units],
             units=ucc.deferred("length"),
@@ -99,7 +99,7 @@ class PerspectiveCameraMeasure(Measure):
             )
 
     up: np.ndarray = documented(
-        attr.ib(
+        attrs.field(
             factory=lambda: [0, 0, 1],
             converter=np.array,
             validator=validators.has_len(3),
@@ -122,7 +122,7 @@ class PerspectiveCameraMeasure(Measure):
             )
 
     far_clip: pint.Quantity = documented(
-        pinttr.ib(
+        pinttr.field(
             default=1e4 * ureg.km,
             units=ucc.deferred("length"),
         ),
@@ -135,7 +135,7 @@ class PerspectiveCameraMeasure(Measure):
     )
 
     fov: pint.Quantity = documented(
-        pinttr.ib(default=50.0 * ureg.deg, units=ureg.deg),
+        pinttr.field(default=50.0 * ureg.deg, units=ureg.deg),
         doc="Camera field of view.\n\nUnit-enabled field (default: degree).",
         type="quantity",
         init_type="quantity or float",

--- a/src/eradiate/scenes/measure/_radiancemeter.py
+++ b/src/eradiate/scenes/measure/_radiancemeter.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import typing as t
 
-import attr
+import attrs
 import numpy as np
 import pint
 import pinttr
@@ -19,7 +19,7 @@ from ...units import unit_registry as ureg
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class RadiancemeterMeasure(Measure):
     """
     Radiance meter measure scene element [``radiancemeter``].
@@ -34,7 +34,7 @@ class RadiancemeterMeasure(Measure):
     # --------------------------------------------------------------------------
 
     origin: pint.Quantity = documented(
-        pinttr.ib(
+        pinttr.field(
             default=ureg.Quantity([0.0, 0.0, 0.0], ureg.m),
             validator=[validators.has_len(3), pinttr.validators.has_compatible_units],
             units=ucc.deferred("length"),
@@ -48,7 +48,7 @@ class RadiancemeterMeasure(Measure):
     )
 
     target: pint.Quantity = documented(
-        pinttr.ib(
+        pinttr.field(
             default=ureg.Quantity([0.0, 0.0, 1.0], ureg.m),
             validator=[validators.has_len(3), pinttr.validators.has_compatible_units],
             units=ucc.deferred("length"),

--- a/src/eradiate/scenes/measure/_target.py
+++ b/src/eradiate/scenes/measure/_target.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import typing as t
 from copy import deepcopy
 
-import attr
+import attrs
 import mitsuba as mi
 import pint
 import pinttr
@@ -15,7 +15,7 @@ from ...units import unit_context_kernel as uck
 from ...util.misc import is_vector3
 
 
-@attr.s
+@attrs.define
 class Target:
     """
     Interface for target selection objects used by distant measure classes.
@@ -89,7 +89,7 @@ def _target_point_rectangle_xyz_converter(x):
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class TargetPoint(Target):
     """
     Point target or origin specification.
@@ -97,7 +97,7 @@ class TargetPoint(Target):
 
     # Target point in config units
     xyz: pint.Quantity = documented(
-        pinttr.ib(units=ucc.deferred("length")),
+        pinttr.field(units=ucc.deferred("length")),
         doc="Point coordinates.\n\nUnit-enabled field (default: ucc['length']).",
         type="quantity",
         init_type="array-like",
@@ -117,7 +117,7 @@ class TargetPoint(Target):
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class TargetRectangle(Target):
     """
     Rectangle target origin specification.
@@ -127,7 +127,7 @@ class TargetRectangle(Target):
     """
 
     xmin: pint.Quantity = documented(
-        pinttr.ib(
+        pinttr.field(
             converter=_target_point_rectangle_xyz_converter,
             units=ucc.deferred("length"),
         ),
@@ -139,7 +139,7 @@ class TargetRectangle(Target):
     )
 
     xmax: pint.Quantity = documented(
-        pinttr.ib(
+        pinttr.field(
             converter=_target_point_rectangle_xyz_converter,
             units=ucc.deferred("length"),
         ),
@@ -151,7 +151,7 @@ class TargetRectangle(Target):
     )
 
     ymin: pint.Quantity = documented(
-        pinttr.ib(
+        pinttr.field(
             converter=_target_point_rectangle_xyz_converter,
             units=ucc.deferred("length"),
         ),
@@ -163,7 +163,7 @@ class TargetRectangle(Target):
     )
 
     ymax: pint.Quantity = documented(
-        pinttr.ib(
+        pinttr.field(
             converter=_target_point_rectangle_xyz_converter,
             units=ucc.deferred("length"),
         ),
@@ -175,7 +175,7 @@ class TargetRectangle(Target):
     )
 
     z: pint.Quantity = documented(
-        pinttr.ib(
+        pinttr.field(
             default=0.0,
             converter=_target_point_rectangle_xyz_converter,
             units=ucc.deferred("length"),

--- a/src/eradiate/scenes/phase/_blend.py
+++ b/src/eradiate/scenes/phase/_blend.py
@@ -1,6 +1,6 @@
 import typing as t
 
-import attr
+import attrs
 import mitsuba as mi
 import numpy as np
 
@@ -29,7 +29,7 @@ def _weights_converter(value: np.typing.ArrayLike) -> np.ndarray:
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class BlendPhaseFunction(PhaseFunction):
     """
     Blended phase function [``blend_phase``].
@@ -40,10 +40,10 @@ class BlendPhaseFunction(PhaseFunction):
     """
 
     components: t.List[PhaseFunction] = documented(
-        attr.ib(
+        attrs.field(
             converter=lambda x: [phase_function_factory.convert(y) for y in x],
-            validator=attr.validators.deep_iterable(
-                attr.validators.instance_of(PhaseFunction)
+            validator=attrs.validators.deep_iterable(
+                attrs.validators.instance_of(PhaseFunction)
             ),
             kw_only=True,
         ),
@@ -61,7 +61,7 @@ class BlendPhaseFunction(PhaseFunction):
             )
 
     weights: np.ndarray = documented(
-        attr.ib(
+        attrs.field(
             converter=_weights_converter,
             kw_only=True,
         ),
@@ -89,11 +89,11 @@ class BlendPhaseFunction(PhaseFunction):
             )
 
     bbox: t.Optional[BoundingBox] = documented(
-        attr.ib(
+        attrs.field(
             default=None,
             converter=BoundingBox.convert,
-            validator=attr.validators.optional(
-                attr.validators.instance_of(BoundingBox)
+            validator=attrs.validators.optional(
+                attrs.validators.instance_of(BoundingBox)
             ),
         ),
         default="None",

--- a/src/eradiate/scenes/phase/_core.py
+++ b/src/eradiate/scenes/phase/_core.py
@@ -1,7 +1,7 @@
 import typing as t
 from abc import ABC
 
-import attr
+import attrs
 
 from ..core import SceneElement
 from ..._factory import Factory
@@ -41,16 +41,16 @@ phase_function_factory.register_lazy_batch(
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class PhaseFunction(SceneElement, ABC):
     """
     An abstract base class defining common facilities for all phase functions.
     """
 
     id: t.Optional[str] = documented(
-        attr.ib(
+        attrs.field(
             default="phase",
-            validator=attr.validators.optional(attr.validators.instance_of(str)),
+            validator=attrs.validators.optional(attrs.validators.instance_of(str)),
         ),
         doc=get_doc(SceneElement, "id", "doc"),
         type=get_doc(SceneElement, "id", "type"),

--- a/src/eradiate/scenes/phase/_hg.py
+++ b/src/eradiate/scenes/phase/_hg.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import attr
+import attrs
 
 import eradiate
 
@@ -15,7 +15,7 @@ from ...util.misc import onedict_value
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class HenyeyGreensteinPhaseFunction(PhaseFunction):
     """
     Henyey-Greenstein phase function [``hg``].
@@ -29,11 +29,11 @@ class HenyeyGreensteinPhaseFunction(PhaseFunction):
     """
 
     g: Spectrum = documented(
-        attr.ib(
+        attrs.field(
             default=0.0,
             converter=spectrum_factory.converter("dimensionless"),
             validator=[
-                attr.validators.instance_of(Spectrum),
+                attrs.validators.instance_of(Spectrum),
                 validators.has_quantity("dimensionless"),
             ],
         ),

--- a/src/eradiate/scenes/phase/_isotropic.py
+++ b/src/eradiate/scenes/phase/_isotropic.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import attr
+import attrs
 
 from ._core import PhaseFunction
 from ..core import KernelDict
@@ -9,7 +9,7 @@ from ...contexts import KernelDictContext
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class IsotropicPhaseFunction(PhaseFunction):
     """
     Isotropic phase function [``isotropic``].

--- a/src/eradiate/scenes/phase/_rayleigh.py
+++ b/src/eradiate/scenes/phase/_rayleigh.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import attr
+import attrs
 
 from ._core import PhaseFunction
 from ..core import KernelDict
@@ -9,7 +9,7 @@ from ...contexts import KernelDictContext
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class RayleighPhaseFunction(PhaseFunction):
     """
     Rayleigh phase function [``rayleigh``].

--- a/src/eradiate/scenes/phase/_tabulated.py
+++ b/src/eradiate/scenes/phase/_tabulated.py
@@ -1,4 +1,4 @@
-import attr
+import attrs
 import numpy as np
 import pint
 import xarray as xr
@@ -50,7 +50,7 @@ def _validate_data(instance, attribute, value):
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class TabulatedPhaseFunction(PhaseFunction):
     r"""
     Tabulated phase function [``tab_phase``].
@@ -69,9 +69,9 @@ class TabulatedPhaseFunction(PhaseFunction):
     """
 
     data: xr.DataArray = documented(
-        attr.ib(
+        attrs.field(
             converter=_convert_data,
-            validator=[attr.validators.instance_of(xr.DataArray), _validate_data],
+            validator=[attrs.validators.instance_of(xr.DataArray), _validate_data],
             kw_only=True,
         ),
         type="DataArray",

--- a/src/eradiate/scenes/shapes/_buffermesh.py
+++ b/src/eradiate/scenes/shapes/_buffermesh.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import attr
+import attrs
 import mitsuba as mi
 import numpy as np
 import pint
@@ -15,7 +15,7 @@ from ...units import unit_context_kernel as uck
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class BufferMeshShape(Shape):
     """
     Buffer mesh shape [``buffer_mesh``].
@@ -25,7 +25,7 @@ class BufferMeshShape(Shape):
     """
 
     vertices: pint.Quantity = documented(
-        pinttr.ib(
+        pinttr.field(
             validator=pinttr.validators.has_compatible_units,
             units=ucc.deferred("length"),
             kw_only=True,
@@ -37,7 +37,7 @@ class BufferMeshShape(Shape):
     )
 
     faces: np.ndarray = documented(
-        attr.ib(
+        attrs.field(
             kw_only=True,
             converter=np.array,
         ),

--- a/src/eradiate/scenes/shapes/_core.py
+++ b/src/eradiate/scenes/shapes/_core.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import typing as t
 from abc import ABC
 
-import attr
+import attrs
 
 from ..bsdfs import BSDF, bsdf_factory
 from ..core import SceneElement
@@ -17,23 +17,23 @@ shape_factory.register_lazy_batch(
         ("_rectangle.RectangleShape", "rectangle", {}),
         ("_sphere.SphereShape", "sphere", {}),
         ("_filemesh.FileMeshShape", "file_mesh", {}),
-        ("_buffermesh.BufferMeshShape", "buffer_mesh", {})
+        ("_buffermesh.BufferMeshShape", "buffer_mesh", {}),
     ],
     cls_prefix="eradiate.scenes.shapes",
 )
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class Shape(SceneElement, ABC):
     """
     Abstract interface for all shape scene elements.
     """
 
     id: t.Optional[str] = documented(
-        attr.ib(
+        attrs.field(
             default="shape",
-            validator=attr.validators.optional(attr.validators.instance_of(str)),
+            validator=attrs.validators.optional(attrs.validators.instance_of(str)),
         ),
         doc=get_doc(SceneElement, "id", "doc"),
         type=get_doc(SceneElement, "id", "type"),
@@ -42,10 +42,10 @@ class Shape(SceneElement, ABC):
     )
 
     bsdf: t.Optional[BSDF] = documented(
-        attr.ib(
+        attrs.field(
             default=None,
-            converter=attr.converters.optional(bsdf_factory.convert),
-            validator=attr.validators.optional(attr.validators.instance_of(BSDF)),
+            converter=attrs.converters.optional(bsdf_factory.convert),
+            validator=attrs.validators.optional(attrs.validators.instance_of(BSDF)),
         ),
         doc="BSDF attached to the shape. If a dictionary is passed, it is "
         "interpreted by :class:`bsdf_factory.convert() <.Factory>`. "

--- a/src/eradiate/scenes/shapes/_cuboid.py
+++ b/src/eradiate/scenes/shapes/_cuboid.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import typing as t
 
-import attr
+import attrs
 import mitsuba as mi
 import numpy as np
 import pint
@@ -36,7 +36,7 @@ def _edges_converter(x):
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class CuboidShape(Shape):
     """
     Cuboid shape [``cuboid``].
@@ -46,7 +46,7 @@ class CuboidShape(Shape):
     """
 
     center: pint.Quantity = documented(
-        pinttr.ib(factory=lambda: [0, 0, 0], units=ucc.deferred("length")),
+        pinttr.field(factory=lambda: [0, 0, 0], units=ucc.deferred("length")),
         doc="Coordinates of the centre of the cube. "
         'Unit-enabled field (default: ``ucc["length"]``).',
         type="quantity",
@@ -55,7 +55,7 @@ class CuboidShape(Shape):
     )
 
     edges: pint.Quantity = documented(
-        pinttr.ib(
+        pinttr.field(
             factory=lambda: [1, 1, 1],
             converter=_edges_converter,
             units=ucc.deferred("length"),

--- a/src/eradiate/scenes/shapes/_filemesh.py
+++ b/src/eradiate/scenes/shapes/_filemesh.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import attr
+import attrs
 
 from ._core import Shape, shape_factory
 from ..core import KernelDict
@@ -12,7 +12,7 @@ from ...util.misc import onedict_value
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class FileMeshShape(Shape):
     """
     File based mesh shape [``file_mesh``].
@@ -23,7 +23,7 @@ class FileMeshShape(Shape):
     """
 
     filename: Path = documented(
-        attr.ib(converter=Path, kw_only=True),
+        attrs.field(converter=Path, kw_only=True),
         type="Path",
         init_type="path-like",
         doc="Path to the mesh file.",

--- a/src/eradiate/scenes/shapes/_rectangle.py
+++ b/src/eradiate/scenes/shapes/_rectangle.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import typing as t
 
-import attr
+import attrs
 import mitsuba as mi
 import numpy as np
 import pint
@@ -41,7 +41,7 @@ def _edges_converter(value):
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class RectangleShape(Shape):
     """
     Rectangle shape [``rectangle``].
@@ -52,7 +52,7 @@ class RectangleShape(Shape):
     """
 
     edges: pint.Quantity = documented(
-        pinttr.ib(
+        pinttr.field(
             factory=lambda: [1, 1],
             converter=_edges_converter,
             units=ucc.deferred("length"),
@@ -65,7 +65,7 @@ class RectangleShape(Shape):
     )
 
     center: pint.Quantity = documented(
-        pinttr.ib(factory=lambda: [0, 0, 0], units=ucc.deferred("length")),
+        pinttr.field(factory=lambda: [0, 0, 0], units=ucc.deferred("length")),
         doc="Cartesian coordinates of the rectangle's central point. "
         'Unit-enabled field (default: ``ucc["length"]``).',
         type="quantity",
@@ -74,7 +74,7 @@ class RectangleShape(Shape):
     )
 
     normal: np.ndarray = documented(
-        attr.ib(
+        attrs.field(
             factory=lambda: [0, 0, 1],
             converter=_normalize,
             validator=validators.is_vector3,
@@ -87,7 +87,7 @@ class RectangleShape(Shape):
     )
 
     up: np.ndarray = documented(
-        attr.ib(
+        attrs.field(
             factory=lambda: [0, 1, 0],
             converter=_normalize,
             validator=validators.is_vector3,

--- a/src/eradiate/scenes/shapes/_sphere.py
+++ b/src/eradiate/scenes/shapes/_sphere.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import typing as t
 
-import attr
+import attrs
 import numpy as np
 import pint
 import pinttr
@@ -24,7 +24,7 @@ def _normalize(v: np.typing.ArrayLike) -> np.ndarray:
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class SphereShape(Shape):
     """
     Sphere shape [``sphere``].
@@ -33,7 +33,7 @@ class SphereShape(Shape):
     """
 
     center: pint.Quantity = documented(
-        pinttr.ib(factory=lambda: [0, 0, 0], units=ucc.deferred("length")),
+        pinttr.field(factory=lambda: [0, 0, 0], units=ucc.deferred("length")),
         doc="Location of the centre of the sphere. Unit-enabled field "
         '(default: ``ucc["length"]``).',
         type="quantity",
@@ -42,7 +42,7 @@ class SphereShape(Shape):
     )
 
     radius: pint.Quantity = documented(
-        pinttr.ib(
+        pinttr.field(
             factory=lambda: 1.0 * ucc.get("length"), units=ucc.deferred("length")
         ),
         doc='Sphere radius. Unit-enabled field (default: ``ucc["length"]``).',

--- a/src/eradiate/scenes/spectra/_air_scattering_coefficient.py
+++ b/src/eradiate/scenes/spectra/_air_scattering_coefficient.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import attr
+import attrs
 import numpy as np
 import pint
 
@@ -30,7 +30,7 @@ def _eval_impl_ckd(w: pint.Quantity) -> pint.Quantity:
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class AirScatteringCoefficientSpectrum(Spectrum):
     """
     Air scattering coefficient spectrum [``air_scattering_coefficient``].
@@ -50,7 +50,7 @@ class AirScatteringCoefficientSpectrum(Spectrum):
       rule).
     """
 
-    quantity: PhysicalQuantity = attr.ib(
+    quantity: PhysicalQuantity = attrs.field(
         default=PhysicalQuantity.COLLISION_COEFFICIENT,
         init=False,
         repr=False,

--- a/src/eradiate/scenes/spectra/_core.py
+++ b/src/eradiate/scenes/spectra/_core.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import typing as t
 from abc import ABC, abstractmethod
 
-import attr
+import attrs
 import pint
 
 import eradiate
@@ -106,14 +106,14 @@ spectrum_factory.register_lazy_batch(
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class Spectrum(SceneElement, ABC):
     """
     Spectrum abstract base class.
     """
 
     quantity: PhysicalQuantity = documented(
-        attr.ib(
+        attrs.field(
             default="dimensionless",
             converter=PhysicalQuantity,
             repr=lambda x: f"{x.value.upper()}",

--- a/src/eradiate/scenes/spectra/_interpolated.py
+++ b/src/eradiate/scenes/spectra/_interpolated.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import typing as t
 
-import attr
+import attrs
 import numpy as np
 import pint
 import pinttr
@@ -24,7 +24,7 @@ from ...units import unit_context_kernel as uck
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class InterpolatedSpectrum(Spectrum):
     """
     Linearly interpolated spectrum [``interpolated``].
@@ -47,7 +47,7 @@ class InterpolatedSpectrum(Spectrum):
     """
 
     wavelengths: pint.Quantity = documented(
-        pinttr.ib(
+        pinttr.field(
             units=ucc.deferred("wavelength"),
             kw_only=True,
         ),
@@ -56,7 +56,7 @@ class InterpolatedSpectrum(Spectrum):
     )
 
     values: pint.Quantity = documented(
-        attr.ib(
+        attrs.field(
             converter=converters.on_quantity(np.atleast_1d),
             kw_only=True,
         ),
@@ -86,7 +86,7 @@ class InterpolatedSpectrum(Spectrum):
     @wavelengths.validator
     def _values_wavelengths_validator(self, attribute, value):
         # Check that attribute is an array
-        validators.on_quantity(attr.validators.instance_of(np.ndarray))(
+        validators.on_quantity(attrs.validators.instance_of(np.ndarray))(
             self, attribute, value
         )
 

--- a/src/eradiate/scenes/spectra/_solar_irradiance.py
+++ b/src/eradiate/scenes/spectra/_solar_irradiance.py
@@ -4,7 +4,7 @@ import datetime
 import typing as t
 import warnings
 
-import attr
+import attrs
 import numpy as np
 import pint
 import xarray as xr
@@ -71,7 +71,7 @@ def _datetime_converter(x: t.Any):
 
 
 @parse_docs
-@attr.s(frozen=True)
+@attrs.frozen
 class SolarIrradianceSpectrum(Spectrum):
     """
     Solar irradiance spectrum [``solar_irradiance``].
@@ -118,15 +118,15 @@ class SolarIrradianceSpectrum(Spectrum):
     #                           Fields and properties
     # --------------------------------------------------------------------------
 
-    quantity: PhysicalQuantity = attr.ib(
+    quantity: PhysicalQuantity = attrs.field(
         default=PhysicalQuantity.IRRADIANCE, init=False, repr=False
     )
 
     dataset: xr.Dataset = documented(
-        attr.ib(
+        attrs.field(
             default="thuillier_2003_extrapolated",
             converter=_dataset_converter,
-            validator=attr.validators.instance_of(xr.Dataset),
+            validator=attrs.validators.instance_of(xr.Dataset),
         ),
         doc="Solar spectrum dataset. If a string is passed, it is first "
         "interpreted as a Solar irradiance spectrum identifier "
@@ -141,7 +141,7 @@ class SolarIrradianceSpectrum(Spectrum):
     )
 
     scale: float = documented(
-        attr.ib(default=1.0, converter=float, validator=validators.is_positive),
+        attrs.field(default=1.0, converter=float, validator=validators.is_positive),
         doc="Arbitrary scaling factor. This scaling factor is applied in "
         "addition to the datetime-based scaling controlled by the *datetime* "
         "parameter.",
@@ -151,7 +151,7 @@ class SolarIrradianceSpectrum(Spectrum):
     )
 
     datetime: t.Optional[datetime.datetime] = documented(
-        attr.ib(
+        attrs.field(
             default=None,
             converter=_datetime_converter,
         ),

--- a/src/eradiate/scenes/spectra/_uniform.py
+++ b/src/eradiate/scenes/spectra/_uniform.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import attr
+import attrs
 import numpy as np
 import pint
 import pinttr
@@ -15,14 +15,14 @@ from ...units import unit_context_kernel as uck
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class UniformSpectrum(Spectrum):
     """
     Uniform spectrum [``uniform``] (*i.e.* constant vs wavelength).
     """
 
     value: pint.Quantity = documented(
-        attr.ib(
+        attrs.field(
             converter=lambda x: float(x) if isinstance(x, int) else x,
             repr=lambda x: f"{x:~P}",
             kw_only=True,

--- a/src/eradiate/scenes/surface/_basic.py
+++ b/src/eradiate/scenes/surface/_basic.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import typing as t
 import warnings
 
-import attr
+import attrs
 
 from ._core import Surface
 from ..bsdfs import BSDF, LambertianBSDF, bsdf_factory
@@ -15,7 +15,7 @@ from ...exceptions import OverriddenValueWarning
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class BasicSurface(Surface):
     """
     Basic surface [``basic``].
@@ -24,11 +24,11 @@ class BasicSurface(Surface):
     """
 
     shape: t.Optional[Shape] = documented(
-        attr.ib(
+        attrs.field(
             default=None,
-            converter=attr.converters.optional(shape_factory.convert),
-            validator=attr.validators.optional(
-                attr.validators.instance_of((RectangleShape, SphereShape))
+            converter=attrs.converters.optional(shape_factory.convert),
+            validator=attrs.validators.optional(
+                attrs.validators.instance_of((RectangleShape, SphereShape))
             ),
         ),
         doc="Shape describing the surface. This parameter may be left unset "
@@ -53,10 +53,10 @@ class BasicSurface(Surface):
                 )
 
     bsdf: BSDF = documented(
-        attr.ib(
+        attrs.field(
             factory=LambertianBSDF,
             converter=bsdf_factory.convert,
-            validator=attr.validators.instance_of(BSDF),
+            validator=attrs.validators.instance_of(BSDF),
         ),
         doc="The reflection model attached to the surface.",
         type=".BSDF",

--- a/src/eradiate/scenes/surface/_central_patch.py
+++ b/src/eradiate/scenes/surface/_central_patch.py
@@ -1,7 +1,7 @@
 import typing as t
 import warnings
 
-import attr
+import attrs
 import mitsuba as mi
 import numpy as np
 import pint
@@ -36,7 +36,7 @@ def _edges_converter(value):
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class CentralPatchSurface(Surface):
     """
     Central patch surface [``central_patch``].
@@ -63,11 +63,11 @@ class CentralPatchSurface(Surface):
     """
 
     shape: t.Optional[RectangleShape] = documented(
-        attr.ib(
+        attrs.field(
             default=None,
-            converter=attr.converters.optional(shape_factory.convert),
-            validator=attr.validators.optional(
-                attr.validators.instance_of(RectangleShape)
+            converter=attrs.converters.optional(shape_factory.convert),
+            validator=attrs.validators.optional(
+                attrs.validators.instance_of(RectangleShape)
             ),
         ),
         doc="Shape describing the surface. This parameter may be left unset "
@@ -92,10 +92,10 @@ class CentralPatchSurface(Surface):
                 )
 
     bsdf: BSDF = documented(
-        attr.ib(
+        attrs.field(
             factory=LambertianBSDF,
             converter=bsdf_factory.convert,
-            validator=attr.validators.instance_of(BSDF),
+            validator=attrs.validators.instance_of(BSDF),
         ),
         doc="The reflection model attached to the surface.",
         type=".BSDF",
@@ -104,9 +104,9 @@ class CentralPatchSurface(Surface):
     )
 
     patch_edges: t.Optional[pint.Quantity] = documented(
-        pinttr.ib(
+        pinttr.field(
             default=None,
-            converter=attr.converters.optional(_edges_converter),
+            converter=attrs.converters.optional(_edges_converter),
             units=ucc.deferred("length"),
         ),
         doc="Length of the central patch's edges. If unset, the central patch "
@@ -117,10 +117,10 @@ class CentralPatchSurface(Surface):
     )
 
     patch_bsdf: BSDF = documented(
-        attr.ib(
+        attrs.field(
             factory=BlackBSDF,
             converter=bsdf_factory.convert,
-            validator=attr.validators.instance_of(BSDF),
+            validator=attrs.validators.instance_of(BSDF),
         ),
         doc="The reflection model attached to the central patch.",
         type=".BSDF",

--- a/src/eradiate/scenes/surface/_core.py
+++ b/src/eradiate/scenes/surface/_core.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import typing as t
 from abc import ABC, abstractmethod
 
-import attr
+import attrs
 
 from ..core import KernelDict, SceneElement
 from ..._factory import Factory
@@ -16,23 +16,23 @@ surface_factory.register_lazy_batch(
     [
         ("_basic.BasicSurface", "basic", {}),
         ("_central_patch.CentralPatchSurface", "central_patch", {}),
-        ("_dem.DEMSurface", "dem", {})
+        ("_dem.DEMSurface", "dem", {}),
     ],
     cls_prefix="eradiate.scenes.surface",
 )
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class Surface(SceneElement, ABC):
     """
     An abstract base class defining common facilities for all surfaces.
     """
 
     id: t.Optional[str] = documented(
-        attr.ib(
+        attrs.field(
             default="surface",
-            validator=attr.validators.optional(attr.validators.instance_of(str)),
+            validator=attrs.validators.optional(attrs.validators.instance_of(str)),
         ),
         doc=get_doc(SceneElement, "id", "doc"),
         type=get_doc(SceneElement, "id", "type"),

--- a/src/eradiate/scenes/surface/_dem.py
+++ b/src/eradiate/scenes/surface/_dem.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import typing as t
 
-import attr
+import attrs
 import numpy as np
 import pint
 import xarray as xr
@@ -20,7 +20,7 @@ from ...util.misc import onedict_value
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class DEMSurface(Surface):
     """
     DEM surface [``dem``]
@@ -46,9 +46,9 @@ class DEMSurface(Surface):
     """
 
     id: t.Optional[str] = documented(
-        attr.ib(
+        attrs.field(
             default="terrain",
-            validator=attr.validators.optional(attr.validators.instance_of(str)),
+            validator=attrs.validators.optional(attrs.validators.instance_of(str)),
         ),
         doc=get_doc(Surface, "id", "doc"),
         type=get_doc(Surface, "id", "type"),
@@ -57,10 +57,10 @@ class DEMSurface(Surface):
     )
 
     shape: Shape = documented(
-        attr.ib(
-            converter=attr.converters.optional(shape_factory.convert),
-            validator=attr.validators.optional(
-                attr.validators.instance_of((BufferMeshShape, FileMeshShape))
+        attrs.field(
+            converter=attrs.converters.optional(shape_factory.convert),
+            validator=attrs.validators.optional(
+                attrs.validators.instance_of((BufferMeshShape, FileMeshShape))
             ),
             kw_only=True,
         ),
@@ -70,10 +70,10 @@ class DEMSurface(Surface):
     )
 
     bsdf: BSDF = documented(
-        attr.ib(
+        attrs.field(
             factory=LambertianBSDF,
             converter=bsdf_factory.convert,
-            validator=attr.validators.instance_of(BSDF),
+            validator=attrs.validators.instance_of(BSDF),
         ),
         doc="The reflection model attached to the surface.",
         type=".BSDF",
@@ -138,8 +138,8 @@ class DEMSurface(Surface):
         mean_lon = lon_rad.mean()
         lon_range = lon_rad.max() - lon_rad.min()
         lat_range = lat_rad.max() - lat_rad.min()
-        lon_length = (lon_range * radius)
-        lat_length = (lat_range * radius * np.cos(mean_lon))
+        lon_length = lon_range * radius
+        lat_length = lat_range * radius * np.cos(mean_lon)
 
         lat_range = list(np.linspace(-lat_length / 2.0, lat_length / 2.0, len_lat))
         # Duplicate the first and last entry for the extra vertices, which form the

--- a/src/eradiate/test_tools/regression.py
+++ b/src/eradiate/test_tools/regression.py
@@ -3,7 +3,7 @@ import typing as t
 from abc import ABC, abstractmethod
 from pathlib import Path
 
-import attr
+import attrs
 import matplotlib.pyplot as plt
 import mitsuba as mi
 import numpy as np
@@ -89,7 +89,7 @@ def reference_converter(value):
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class RegressionTest(ABC):
     """
     Common interface for tests based on the comparison of a result array against
@@ -97,27 +97,29 @@ class RegressionTest(ABC):
     """
 
     # Name used for the reference metric. Must be set be subclasses.
-    METRIC_NAME: t.Optional[str] = None
+    METRIC_NAME: t.ClassVar[t.Optional[str]] = None
 
     name: str = documented(
-        attr.ib(validator=attr.validators.instance_of(str)),
+        attrs.field(validator=attrs.validators.instance_of(str)),
         doc="Test case name.",
         type="str",
         init_type="str",
     )
 
     value: xr.Dataset = documented(
-        attr.ib(validator=attr.validators.instance_of(xr.Dataset)),
+        attrs.field(validator=attrs.validators.instance_of(xr.Dataset)),
         doc="Simulation result. Must be specified as a dataset.",
         type=":class:`xarray.Dataset`",
         init_type=":class:`xarray.Dataset`",
     )
 
     reference: t.Optional[xr.Dataset] = documented(
-        attr.ib(
+        attrs.field(
             default=None,
             converter=reference_converter,
-            validator=attr.validators.optional(attr.validators.instance_of(xr.Dataset)),
+            validator=attrs.validators.optional(
+                attrs.validators.instance_of(xr.Dataset)
+            ),
         ),
         doc="Reference data. Can be specified as an xarray dataset, a path to a "
         "NetCDF file or a path to a resource served by the data store.",
@@ -127,14 +129,14 @@ class RegressionTest(ABC):
     )
 
     threshold: float = documented(
-        attr.ib(kw_only=True),
+        attrs.field(kw_only=True),
         doc="Threshold for test evaluation",
         type="float",
         init_type="float",
     )
 
     archive_dir: Path = documented(
-        attr.ib(kw_only=True, converter=Path),
+        attrs.field(kw_only=True, converter=Path),
         doc="Path to output artefact storage directory. Relative paths are "
         "interpreted with respect to the current working directory.",
         type=":class:`pathlib.Path`",
@@ -266,7 +268,7 @@ class RegressionTest(ABC):
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class RMSETest(RegressionTest):
     """
     This class implements a simple test based on the root mean squared
@@ -295,7 +297,7 @@ class RMSETest(RegressionTest):
 
 
 @parse_docs
-@attr.s
+@attrs.define
 class Chi2Test(RegressionTest):
     """
     This class implements a statistical test for the regression testing

--- a/src/eradiate/validators.py
+++ b/src/eradiate/validators.py
@@ -1,7 +1,7 @@
 import typing as t
 from numbers import Number
 
-import attr
+import attrs
 import numpy as np
 
 from .attrs import AUTO
@@ -47,7 +47,7 @@ def is_vector3(instance, attribute, value):
     TypeError
         If value cannot be converted to a (3,) :class:`numpy.ndarray`.
     """
-    return attr.validators.deep_iterable(
+    return attrs.validators.deep_iterable(
         member_validator=is_number, iterable_validator=has_len(3)
     )(instance, attribute, value)
 


### PR DESCRIPTION
# Description

This PR updates the Eradiate codebase to use the [next-generation API](https://www.attrs.org/en/stable/names.html#tl-dr) of the `attrs` library.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
