### PR TITLE
Load SRF from custom path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,8 +39,11 @@ when necessary—we also advise to not ignore `DeprecationWarning`s.
 %
 % ### Deprecations and removals
 %
-% ### Improvements and fixes
-%
+### Improvements and fixes
+
+* Added support for loading spectral response function data sets from custom
+  paths ({ghpr}`270`).
+
 % ### Documentation
 %
 % ### Internal changes

--- a/docs/rst/reference_api/srf_tools.rst
+++ b/docs/rst/reference_api/srf_tools.rst
@@ -21,7 +21,7 @@ Filtering algorithms
 
 .. autofunction:: threshold_filter
 
-.. autofunction:: filter
+.. autofunction:: filter_srf
 
 Plotting
 --------

--- a/src/eradiate/cli/srf.py
+++ b/src/eradiate/cli/srf.py
@@ -29,15 +29,21 @@ def srf():
 @click.argument("output", type=click.Path())
 @click.option("-v", "--verbose", is_flag=True, help="Display filtering summary.")
 @click.option(
-    "-i",
-    "--interactive",
+    "-s",
+    "--show-plot",
     is_flag=True,
-    help="Prompt before writing filtered data to disk.",
+    help="Show plot of the filtered region.",
 )
 @click.option(
     "-d", "--dry-run", is_flag=True, help="Do not write filtered data to disk."
 )
-def trim(filename, output, verbose, interactive, dry_run):
+@click.option(
+    "-i",
+    "--interactive",
+    is_flag=True,
+    help="Prompt user to proceed to saving the filtered dataset.",
+)
+def trim(filename, output, verbose, show_plot, dry_run, interactive):
     """
     Trim a spectral response function.
 
@@ -50,8 +56,9 @@ def trim(filename, output, verbose, interactive, dry_run):
         srf=filename,
         path=output,
         verbose=verbose,
-        interactive=interactive,
+        show_plot=show_plot,
         dry_run=dry_run,
+        interactive=interactive,
     )
 
 
@@ -110,7 +117,13 @@ def text_input_to_quantity(
     "-i",
     "--interactive",
     is_flag=True,
-    help="Prompt before writing filtered data to disk.",
+    help="Prompt user to proceed to saving the filtered dataset.",
+)
+@click.option(
+    "-s",
+    "--show-plot",
+    is_flag=True,
+    help="Show plot of the filtered region.",
 )
 @click.option(
     "-t",
@@ -141,6 +154,7 @@ def filter(
     verbose,
     dry_run,
     interactive,
+    show_plot,
     threshold,
     wmin,
     wmax,
@@ -159,13 +173,14 @@ def filter(
     wmax = text_input_to_quantity(value=wmax)
 
     # filter
-    srf_tools.filter(
+    srf_tools.filter_srf(
         srf=srf,
         path=output,
         trim_prior=trim,
         verbose=verbose,
-        interactive=interactive,
+        show_plot=show_plot,
         dry_run=dry_run,
+        interactive=interactive,
         threshold=threshold,
         wmin=wmin,
         wmax=wmax,

--- a/src/eradiate/srf_tools.py
+++ b/src/eradiate/srf_tools.py
@@ -219,8 +219,9 @@ def trim_and_save(
     srf: t.Union[PathLike, xr.Dataset],
     path: PathLike,
     verbose=False,
-    interactive: bool = False,
+    show_plot: bool = False,
     dry_run: bool = False,
+    interactive: bool = False,
 ) -> None:
     """
     Wraps around :meth:`trim` to save the filtered dataset.
@@ -230,20 +231,23 @@ def trim_and_save(
     srf: path-like, Dataset
         Data set to trim.
 
-    verbose: bool
-        If ``True``, display a summary of the trimming operation.
-
     path: path-like
         Path to which to save the filtered dataset.
 
-    interactive: bool
-        If ``True``, display a figure illustrating the filtered region and
-        prompt for confirmation before proceeding to saving the dataset to the
-        disk.
+    verbose : bool
+        If ``True``, display a summary of the trimming operation.
+
+    show_plot: bool
+        If ``True``, display a figure illustrating the filtered region.
 
     dry_run: bool
         If ``True``, displays where the trimmed data set would be saved but
         does not save it.
+
+    interactive: bool
+        If ``True``, prompt the user to proceed to saving the filtered dataset.
+        This is useful in combination with ``verbose=True`` and
+        ``show_plot=True``.
 
     See Also
     --------
@@ -262,7 +266,7 @@ def trim_and_save(
         rich.print(table)
 
     # save trimmed dataset
-    if interactive:
+    if show_plot:
         show(
             ds=ds,
             title=" ".join(
@@ -275,23 +279,16 @@ def trim_and_save(
             percentage=None,
         )
 
-        if Confirm.ask("Save trimmed dataset?"):
-            save(
-                ds=trimmed,
-                path=output_path,
-                verbose=verbose,
-                dry_run=dry_run,
-            )
-        else:
-            if verbose:
-                rich.print("Aborted!")
-    else:
-        save(
-            ds=trimmed,
-            path=output_path,
-            verbose=verbose,
-            dry_run=dry_run,
-        )
+    if interactive:
+        if not Confirm.ask("Save filtered dataset?"):
+            return
+
+    save(
+        ds=trimmed,
+        path=output_path,
+        verbose=verbose,
+        dry_run=dry_run,
+    )
 
 
 def spectral_filter(
@@ -709,12 +706,13 @@ def show(
     plt.show()
 
 
-def filter(
+def filter_srf(
     srf: t.Union[PathLike, xr.Dataset],
     path: PathLike,
     verbose: bool = False,
-    interactive: bool = False,
+    show_plot: bool = False,
     dry_run: bool = False,
+    interactive: bool = False,
     trim_prior: bool = True,
     threshold: t.Optional[float] = None,
     wmin: t.Optional[pint.Quantity] = None,
@@ -733,15 +731,20 @@ def filter(
         Path to which to save the filtered data set.
 
     verbose: bool
-        If ``True``, display afiltering summary table and the path to which
+        If ``True``, display a filtering summary table and the path to which
         filtered data set is saved.
 
-    interactive: bool
+    show_plot: bool
         If ``True``, display a figure emphasizing the filtered region.
 
     dry_run: bool
         If ``True``, display the path to which the filtered data set would be
         saved, but does not write the data set to the disk.
+
+    interactive: bool
+        If ``True``, prompt the user to proceed to saving the filtered dataset.
+        This is useful in combination with ``verbose=True`` and
+        ``show_plot=True``.
 
     trim_prior: bool
         Trim the data set prior to filtering.
@@ -808,7 +811,7 @@ def filter(
         rich.print(table)
 
     # save filtered dataset
-    if interactive:
+    if show_plot:
         show(
             ds=trimmed,
             title=" ".join(
@@ -821,20 +824,13 @@ def filter(
             percentage=percentage,
         )
 
-        if Confirm.ask("Save filtered dataset?"):
-            save(
-                ds=filtered,
-                path=output_path,
-                verbose=verbose,
-                dry_run=dry_run,
-            )
-        else:
-            if verbose:
-                rich.print("Aborted!")
-    else:
-        save(
-            ds=filtered,
-            path=output_path,
-            verbose=verbose,
-            dry_run=dry_run,
-        )
+    if interactive:
+        if not Confirm.ask("Save filtered dataset?"):
+            return
+
+    save(
+        ds=filtered,
+        path=output_path,
+        verbose=verbose,
+        dry_run=dry_run,
+    )


### PR DESCRIPTION
# Description

Resolves eradiate/eradiate-issues#178

* Load a SRF from the data store:

  ```python
  measure = MultiDistantMeasure(
      spectral_cfg=MeasureSpectralConfig.new(srf="aqua-modis-14")
  )
  ```

* Load a SRF from a local file:

  ```python
  measure = MultiDistantMeasure(
      spectral_cfg=MeasureSpectralConfig.new(srf="path/to/my_srf.nc")
  )
  ```

The following additional changes were made:

* `srf_tools.py`
  * renamed `filter` -> `filter_srf` to avoid conflict with builtin Python method.
  * added `show_plot` parameter to `trim_and_save` and `filter_srf`. If `show_plot=True`, a plot of the SRF filtered region is shown. Previously, this was triggered by `interactive=True`, but this would also prompt the user to save the filtered dataset.
  * the parameter `interactive` now simply prompts the user to proceed to saving the filtered dataset.
* `cli/srf.py`: added support for `show_plot` parameter.
* updated tutorial `tutorials/howto/srf_filtering/srf_filtering.ipynb`
* updated API Reference page `eradiate.srf_tools`

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
