### PR TITLE
ExponentialParticleDistribution: Use rate-based formula

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,8 @@ when necessary—we also advise to not ignore `DeprecationWarning`s.
   full scattering phase matrix ({ghpr}`259`).
 * Allow mixing a purely absorbing `MolecularAtmosphere` with a `ParticleLayer`
   ({ghpr}`239`).
+* Change the `ExponentialParticleDistribution` formulation to rate-based; allow
+  scale-based parametrisation for initialisation ({ghpr}`271`).
 
 ### Documentation
 

--- a/tests/02_eradiate/01_unit/scenes/atmosphere/test_particle_dist.py
+++ b/tests/02_eradiate/01_unit/scenes/atmosphere/test_particle_dist.py
@@ -29,11 +29,25 @@ def test_particle_dist_uniform():
     assert np.allclose(expected, dist(x))
 
 
-def test_particle_dist_exponential():
-    dist = ExponentialParticleDistribution(scale=1.0)
-    x = np.linspace(0, 1, 11)
-    expected = np.exp(-x)
-    assert np.allclose(expected, dist(x))
+@pytest.mark.parametrize(
+    "rate, scale, raises",
+    [
+        (None, None, False),
+        (5.0, None, False),
+        (None, 0.2, False),
+        (1.0, 1.0, True),
+    ],
+)
+def test_particle_dist_exponential(rate, scale, raises):
+    if raises:
+        with pytest.raises(ValueError):
+            ExponentialParticleDistribution(rate=rate, scale=scale)
+    else:
+        dist = ExponentialParticleDistribution(rate=rate, scale=scale)
+        print(dist)
+        x = np.linspace(0, 1, 11)
+        expected = 5.0 * np.exp(-5.0 * x) / (1.0 - np.exp(-5.0))
+        assert np.allclose(expected, dist(x))
 
 
 def test_particle_dist_gaussian():


### PR DESCRIPTION
# Description

This PR changes the exponential particle distribution function to a rate-based formula. The original formula 

$f : x \mapsto \dfrac{1}{\beta} \exp \left( - x / \beta \right)$ 

does not feel natural to all users (including myself), who may prefer the rate-based formula 

$f : x \mapsto \dfrac{\lambda e^{-\lambda x}}{1 - e^{-\lambda}}$.

This PR still keeps the option of initialising this function with a `scale` parameter.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
