### PR TITLE
Add grid support to `MultipleDistantMeasure` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,15 +12,13 @@ Updates are tracked in this change log. Every time you decide to update to a
 newer version, we recommend that you to go through the list of changes.
 We try hard to remain backward-compatible and warn in advance for deprecation
 when necessary—we also advise to not ignore `DeprecationWarning`s.
+
+Entries marked with a  ︎⚠️ symbol require particular attention during upgrade.
 ```
 
 % HEREAFTER IS A TEMPLATE FOR THE NEXT RELEASE
 %
 % ## vXX.YY.ZZ (upcoming release)
-%
-% ### New features
-%
-% ### Breaking changes
 %
 % ### Deprecations and removals
 %
@@ -33,16 +31,23 @@ when necessary—we also advise to not ignore `DeprecationWarning`s.
 
 ## v0.22.6 (upcoming release)
 
-% ### New features
-%
-% ### Breaking changes
-%
-% ### Deprecations and removals
-%
+### Deprecations and removals
+
+* The `MultiDistantMeasure.from_viewing_angles()` constructor is deprecated and
+  will be removed in v0.23.1.
+
 ### Improvements and fixes
 
 * Added support for loading spectral response function data sets from custom
   paths ({ghpr}`270`).
+* ⚠️ Complete rewrite of the {class}`.MultiDistantMeasure` construction code 
+  ({ghpr}`274`). Previous functionality is preserved in the form of more 
+  specialised and simpler interfaces, and we now support a gridded coverage of 
+  the hemisphere specified as the Cartesian product of zenith and azimuth 
+  lists of values.
+* Added a helper to grid against VZA and VAA the results obtained with a 
+  `MultiDistantMeasure` with a grid layout ({ghpr}`274`). See 
+  {meth}`~eradiate.xarray.unstack_mdistant_grid`.
 
 % ### Documentation
 %

--- a/docs/rst/reference_api/scenes.rst
+++ b/docs/rst/reference_api/scenes.rst
@@ -279,6 +279,20 @@
   TargetPoint
   TargetRectangle
 
+**Viewing direction layouts**
+
+*Used as input to the* :class:`.MultiDistantMeasure`\ ``.layout`` *field.*
+
+.. autosummary::
+   :toctree: generated/autosummary/
+
+   Layout
+   AngleLayout
+   AzimuthRingLayout
+   DirectionLayout
+   GridLayout
+   HemispherePlaneLayout
+
 ``eradiate.scenes.phase``
 -------------------------
 

--- a/docs/rst/reference_api/xarray.rst
+++ b/docs/rst/reference_api/xarray.rst
@@ -2,6 +2,7 @@
 ===================
 
 .. automodule:: eradiate.xarray
+   :members:
 
 ``eradiate.xarray.interp``
 --------------------------

--- a/docs/rst/user_guide/onedim_experiment.rst
+++ b/docs/rst/user_guide/onedim_experiment.rst
@@ -83,8 +83,7 @@ Distant radiancemeter [:class:`.MultiDistantMeasure`, ``distant``]
     This flexible measure records radiance exiting the scene. In practice, it
     outputs the top-of-atmosphere radiance under the set illumination
     conditions. The viewing directions for which radiance is computed can be
-    controlled easily using the :meth:`.MultiDistantMeasure.from_viewing_angles`
-    constructor.
+    controlled easily using various class method constructors.
 
     When this measure is used, a number of derived quantities are
     computed. In the next paragraph, quantities available after post-processing

--- a/src/eradiate/frame.py
+++ b/src/eradiate/frame.py
@@ -77,9 +77,14 @@ def normalize_azimuth(angles: np.typing.ArrayLike, inplace: bool = False) -> np.
 
     # Snap close-to-2π values to 0 to compensate for numerical precision-related
     # unwanted shifts (may happen with angles computed from directions)
-    result[:] = np.where(
+    snapped = np.where(
         np.isclose(result, 2.0 * np.pi, rtol=0.0, atol=1e-6 * np.pi), 0.0, result
     )
+
+    if inplace:
+        result[:] = snapped
+    else:
+        result = snapped
 
     return result
 

--- a/src/eradiate/pipelines/_assemble.py
+++ b/src/eradiate/pipelines/_assemble.py
@@ -14,7 +14,7 @@ from ..attrs import documented, parse_docs
 from ..exceptions import UnsupportedModeError
 from ..frame import angles_in_hplane
 from ..scenes.illumination import ConstantIllumination, DirectionalIllumination
-from ..scenes.measure import Measure, MultiDistantMeasure
+from ..scenes.measure import Measure
 from ..scenes.spectra import InterpolatedSpectrum, Spectrum, UniformSpectrum
 from ..units import symbol, to_quantity
 from ..units import unit_context_kernel as uck
@@ -188,15 +188,7 @@ class AddViewingAngles(PipelineStep):
         theta = viewing_angles[:, :, 0]
         phi = viewing_angles[:, :, 1]
 
-        # Handle special case of hemisphere plane cut
-        if isinstance(measure, MultiDistantMeasure) and measure.hplane is not None:
-            # Note: Flattening angle arrays is required
-            theta_remapped, phi_remapped = _remap_viewing_angles_plane(
-                measure.hplane, theta.ravel(), phi.ravel()
-            )
-            theta = theta_remapped.reshape(theta.shape)
-            phi = phi_remapped.reshape(phi.shape)
-
+        # Attach coordinates
         with xr.set_options(keep_attrs=True):
             result = x.assign_coords(
                 {

--- a/src/eradiate/scenes/measure/__init__.pyi
+++ b/src/eradiate/scenes/measure/__init__.pyi
@@ -5,6 +5,12 @@ from ._distant_flux import DistantFluxMeasure as DistantFluxMeasure
 from ._hemispherical_distant import (
     HemisphericalDistantMeasure as HemisphericalDistantMeasure,
 )
+from ._multi_distant import AngleLayout as AngleLayout
+from ._multi_distant import AzimuthRingLayout as AzimuthRingLayout
+from ._multi_distant import DirectionLayout as DirectionLayout
+from ._multi_distant import GridLayout as GridLayout
+from ._multi_distant import HemispherePlaneLayout as HemispherePlaneLayout
+from ._multi_distant import Layout as Layout
 from ._multi_distant import MultiDistantMeasure as MultiDistantMeasure
 from ._multi_radiancemeter import MultiRadiancemeterMeasure as MultiRadiancemeterMeasure
 from ._perspective import PerspectiveCameraMeasure as PerspectiveCameraMeasure

--- a/src/eradiate/xarray/__init__.pyi
+++ b/src/eradiate/xarray/__init__.pyi
@@ -1,1 +1,2 @@
 from . import interp as interp
+from ._helpers import unstack_mdistant_grid as unstack_mdistant_grid

--- a/src/eradiate/xarray/_helpers.py
+++ b/src/eradiate/xarray/_helpers.py
@@ -1,0 +1,52 @@
+import typing as t
+
+import pandas as pd
+import xarray as xr
+
+XarrayObj = t.Union[xr.DataArray, xr.Dataset]
+
+
+def unstack_mdistant_grid(obj: XarrayObj) -> XarrayObj:
+    """
+    Reindex data produced by a :meth:`.MultiDistantMeasure.grid()` measure on
+    (VAA, VZA) dimensions.
+
+    This effectively reshapes the data, which is initially indexed on film width
+    and height dimensions (the latter having a single element).
+
+    Parameters
+    ----------
+    obj : DataArray or Dataset
+        An xarray object produced by processing a
+        :meth:`.MultiDistantMeasure.grid()` measure, indexed on film dimensions.
+
+    Returns
+    -------
+    DataArray or Dataset
+        An object of the same type, reindexed on VZA and VAA coordinates.
+    """
+    # Collect metadata
+    vza_attrs = obj["vza"].attrs
+    vaa_attrs = obj["vaa"].attrs
+
+    # Build new index
+    idx = pd.MultiIndex.from_arrays(
+        (obj.vza.values.flatten(), obj.vaa.values.flatten()), names=("vza", "vaa")
+    )
+
+    # Reindex object
+    result = (
+        obj.drop_vars(
+            # First remove the target coords, as well as the indexing dim and associated coords
+            # Also remove the x film coordinate (irrelevant after unstacking)
+            ("vza", "vaa", "x_index", "x")
+        )
+        .reindex(x_index=idx)
+        .unstack()
+    )  # Apply the new index and unstack
+
+    # Reapply metadata
+    result["vza"].attrs = vza_attrs
+    result["vaa"].attrs = vaa_attrs
+
+    return result

--- a/tests/01_plugins/bsdfs/test_rpv.py
+++ b/tests/01_plugins/bsdfs/test_rpv.py
@@ -81,7 +81,7 @@ def test_eval(variant_llvm_ad_rgb, rho_0, k, g):
     values = eval_bsdf(rpv, wi, wo)
     reference = rpv_reference(rho_0, rho_0, g, k, theta_i, phi_i, theta_o, phi_o)
 
-    assert dr.allclose(reference, values, rtol=1e-3, atol=1e-3)
+    assert dr.allclose(values, reference, rtol=1e-3, atol=1e-3)
 
 
 @pytest.mark.parametrize("rho_0", [0.0, 0.5, 1.0])
@@ -108,7 +108,7 @@ def test_eval_diffuse(variant_llvm_ad_rgb, rho_0):
     values = eval_bsdf(rpv, wi, wo)
     reference = eval_bsdf(diffuse, wi, wo)
 
-    assert np.allclose(reference, values)
+    assert np.allclose(values, reference)
 
 
 def test_chi2_rpv3(variant_llvm_ad_rgb):

--- a/tests/01_plugins/phase/test_tabphase_irregular.py
+++ b/tests/01_plugins/phase/test_tabphase_irregular.py
@@ -72,7 +72,7 @@ def test_eval(variant_scalar_rgb):
         tab_eval[i] = tab.eval(ctx, mei, wo)
 
     # Compare reference and plugin outputs
-    assert np.allclose(ref_eval, tab_eval)
+    assert np.allclose(tab_eval, ref_eval)
 
 
 def test_sample(variant_scalar_rgb):

--- a/tests/01_plugins/sensors/test_hdistant.py
+++ b/tests/01_plugins/sensors/test_hdistant.py
@@ -240,7 +240,7 @@ def test_sample_target(variant_scalar_rgb, sensor_setup, w_e):
     }
     rtol_value = rtol.get(sensor_setup, 5e-3)
 
-    assert np.allclose(expected_value, result, rtol=rtol_value)
+    assert np.allclose(result, expected_value, rtol=rtol_value)
 
 
 @pytest.mark.parametrize("target", ("point", "shape"))
@@ -350,4 +350,4 @@ def test_checkerboard(variants_all_rgb):
     ).squeeze()
 
     expected = l_e * 0.5 * (rho0 + rho1) / dr.pi
-    assert np.allclose(expected, result, atol=1e-3)
+    assert np.allclose(result, expected, atol=1e-3)

--- a/tests/01_plugins/sensors/test_mdistant.py
+++ b/tests/01_plugins/sensors/test_mdistant.py
@@ -284,7 +284,7 @@ def test_sample_target(variant_scalar_rgb, sensor_setup, w_e, w_o):
     }
     rtol_value = rtol.get(sensor_setup, 5e-3)
 
-    assert np.allclose(expected_value, result, rtol=rtol_value)
+    assert np.allclose(result, expected_value, rtol=rtol_value)
 
 
 def test_checkerboard(variant_scalar_rgb):
@@ -358,4 +358,4 @@ def test_checkerboard(variant_scalar_rgb):
     ).squeeze()
 
     expected = l_o * 0.5 * (rho0 + rho1) / np.pi
-    assert np.allclose(expected, result, atol=1e-3)
+    assert np.allclose(result, expected, atol=1e-3)

--- a/tests/01_plugins/sensors/test_mradiancemeter.py
+++ b/tests/01_plugins/sensors/test_mradiancemeter.py
@@ -129,8 +129,8 @@ def test_sample_ray_compare(variant_scalar_rgb):
                 time, wavelength_sample, film_sample, aperture_sample
             )
 
-            assert dr.allclose(ray_rad.o, ray_mrad.o, atol=1e-4)
-            assert dr.allclose(ray_rad.d, ray_mrad.d)
+            assert dr.allclose(ray_mrad.o, ray_rad.o, atol=1e-4)
+            assert dr.allclose(ray_mrad.d, ray_rad.d)
 
 
 def test_sample_ray_multi(variant_scalar_rgb):
@@ -150,11 +150,11 @@ def test_sample_ray_multi(variant_scalar_rgb):
         )[0]
 
         if position_sample[0] < 0.5:
-            assert dr.allclose([0, 0, 0], ray.o)
-            assert dr.allclose([1, 0, 0], ray.d)
+            assert dr.allclose(ray.o, [0, 0, 0])
+            assert dr.allclose(ray.d, [1, 0, 0])
         else:
-            assert dr.allclose([1, 0, 1], ray.o)
-            assert dr.allclose(dr.normalize(mi.ScalarVector3f(1, 1, 1)), ray.d)
+            assert dr.allclose(ray.o, [1, 0, 1])
+            assert dr.allclose(ray.d, dr.normalize(mi.ScalarVector3f(1, 1, 1)))
 
 
 @pytest.mark.parametrize("radiance", [10**x for x in range(-3, 4)])

--- a/tests/02_eradiate/01_unit/pipelines/test_aggregate.py
+++ b/tests/02_eradiate/01_unit/pipelines/test_aggregate.py
@@ -30,7 +30,7 @@ def test_aggregate_sample_count(results_mono_spp):
     # Sample counts are summed
     assert result.spp == 250
     # Radiance values are averaged
-    assert np.allclose(2.0 / np.pi, result.img.values)
+    assert np.allclose(result.img.values, 2.0 / np.pi)
 
 
 def test_aggregate_ckd(results_ckd):
@@ -58,7 +58,7 @@ def test_aggregate_ckd(results_ckd):
     assert result.bin_wmax.dims == ("w",)
 
     # In the present case, the quadrature evaluates to 2/π
-    assert np.allclose(2.0 / np.pi, result["radiance"].values)
+    assert np.allclose(result["radiance"].values, 2.0 / np.pi)
     # Metadata of the variable for which aggregation is performed are copied
     assert result["radiance"].attrs == values["radiance"].attrs
     # Sample counts are averaged

--- a/tests/02_eradiate/01_unit/pipelines/test_assemble.py
+++ b/tests/02_eradiate/01_unit/pipelines/test_assemble.py
@@ -150,8 +150,8 @@ def test_add_viewing_angles(mode_mono, measure_type, expected_zenith, expected_a
     assert "vaa" in result.coords
 
     # Viewing angles are set to appropriate values
-    assert np.allclose(expected_zenith, result.coords["vza"].values.squeeze())
-    assert np.allclose(expected_azimuth, result.coords["vaa"].values.squeeze())
+    assert np.allclose(result.coords["vza"].values.squeeze(), expected_zenith)
+    assert np.allclose(result.coords["vaa"].values.squeeze(), expected_azimuth)
 
 
 def test_add_srf(modes_all_single):

--- a/tests/02_eradiate/01_unit/pipelines/test_assemble.py
+++ b/tests/02_eradiate/01_unit/pipelines/test_assemble.py
@@ -89,7 +89,11 @@ def test_remap_viewing_angles_plane():
 @pytest.mark.parametrize(
     "measure_type, expected_zenith, expected_azimuth",
     (
-        ("multi_distant-nohplane", [60, 45, 0, 45, 60], [180, 180, 0, 0, 0]),
+        (
+            "multi_distant-aring",
+            [45, 45, 45, 45, 45, 45, 45, 45],
+            [0, 45, 90, 135, 180, 225, 270, 315],
+        ),
         ("multi_distant-hplane", [-60, -45, 0, 45, 60], [0, 0, 0, 0, 0]),
         (
             "hemispherical_distant",
@@ -104,34 +108,29 @@ def test_remap_viewing_angles_plane():
         ),
     ),
     ids=(
-        "multi_distant-nohplane",
+        "multi_distant-aring",
         "multi_distant-hplane",
         "hemispherical_distant",
     ),
 )
 def test_add_viewing_angles(mode_mono, measure_type, expected_zenith, expected_azimuth):
     # Initialise test data
-    if measure_type == "multi_distant-nohplane":
-        measure = MultiDistantMeasure.from_viewing_angles(
-            zeniths=[-60, -45, 0, 45, 60],
-            azimuths=0.0,
-            auto_hplane=False,
+    if measure_type == "multi_distant-aring":
+        measure = MultiDistantMeasure.aring(
+            zenith=45,
+            azimuths=np.linspace(0.0, 360.0, 8, endpoint=False),
             spp=1,
         )
 
     elif measure_type == "multi_distant-hplane":
-        measure = MultiDistantMeasure.from_viewing_angles(
+        measure = MultiDistantMeasure.hplane(
             zeniths=[-60, -45, 0, 45, 60],
-            azimuths=0.0,
-            auto_hplane=True,
+            azimuth=0.0,
             spp=1,
         )
 
     elif measure_type == "hemispherical_distant":
-        measure = HemisphericalDistantMeasure(
-            film_resolution=(2, 2),
-            spp=1,
-        )
+        measure = HemisphericalDistantMeasure(film_resolution=(2, 2), spp=1)
 
     else:
         assert False

--- a/tests/02_eradiate/01_unit/pipelines/test_gather.py
+++ b/tests/02_eradiate/01_unit/pipelines/test_gather.py
@@ -38,7 +38,7 @@ def test_pipeline_step_assemble_mono(results_mono):
     )
 
     # Check radiance and sample count values
-    assert np.allclose(2.0 / np.pi, result[var].values)
+    assert np.allclose(result[var].values, 2.0 / np.pi)
     assert np.all([250] == result.spp.values)
 
 
@@ -77,7 +77,7 @@ def test_pipeline_step_assemble_ckd(results_ckd):
     )
 
     # Check radiance and sample count values
-    assert np.allclose(2.0 / np.pi, result[var].values)
+    assert np.allclose(result[var].values, 2.0 / np.pi)
     assert np.all([250] == result.spp.values)
 
 
@@ -115,7 +115,7 @@ def test_pipeline_step_assemble_mono_spp(results_mono_spp):
     )
 
     # Check radiance and sample count values
-    assert np.allclose(2.0 / np.pi, result[var].values)
+    assert np.allclose(result[var].values, 2.0 / np.pi)
     assert np.all([100, 100, 50] == result.spp.values)
 
 
@@ -153,7 +153,7 @@ def test_pipeline_step_assemble_ckd_spp(results_ckd_spp):
     )
 
     # Check radiance and sample count values
-    assert np.allclose(2.0 / np.pi, result[var].values)
+    assert np.allclose(result[var].values, 2.0 / np.pi)
     assert np.all([100, 100, 50] == result.spp.values)
 
 

--- a/tests/02_eradiate/01_unit/scenes/atmosphere/test_heterogeneous.py
+++ b/tests/02_eradiate/01_unit/scenes/atmosphere/test_heterogeneous.py
@@ -186,7 +186,7 @@ def test_heterogeneous_mix_collision_coefficients(modes_all_double, field):
     for z in collision_coefficient.keys():
         total = collision_coefficient[z]["mixed"]
         expected = sum(collision_coefficient[z][component] for component in components)
-        assert np.allclose(expected, total), f"{z = }"
+        assert np.allclose(total, expected), f"{z = }"
 
 
 def test_heterogeneous_mix_weight(modes_all_double):

--- a/tests/02_eradiate/01_unit/scenes/atmosphere/test_particle_dist.py
+++ b/tests/02_eradiate/01_unit/scenes/atmosphere/test_particle_dist.py
@@ -26,7 +26,7 @@ def test_particle_dist_uniform():
     dist = UniformParticleDistribution(bounds=[0.0, 0.5])
     x = np.linspace(-0.5, 1.0, 7)
     expected = np.array([0, 0, 2, 2, 2, 0, 0])
-    assert np.allclose(expected, dist(x))
+    assert np.allclose(dist(x), expected)
 
 
 @pytest.mark.parametrize(
@@ -47,14 +47,14 @@ def test_particle_dist_exponential(rate, scale, raises):
         print(dist)
         x = np.linspace(0, 1, 11)
         expected = 5.0 * np.exp(-5.0 * x) / (1.0 - np.exp(-5.0))
-        assert np.allclose(expected, dist(x))
+        assert np.allclose(dist(x), expected)
 
 
 def test_particle_dist_gaussian():
     dist = GaussianParticleDistribution(mean=0.0, std=1.0)
     x = np.linspace(0, 1, 11)
     expected = np.exp(-0.5 * np.square(x)) / np.sqrt(2.0 * np.pi)
-    assert np.allclose(expected, dist(x))
+    assert np.allclose(dist(x), expected)
 
 
 def test_particle_dist_array_construct():
@@ -110,7 +110,7 @@ def test_particle_dist_array_call(method, expected):
     )
     x = np.linspace(0, 1, 11)
     result = dist(x)
-    assert np.allclose(expected, result)
+    assert np.allclose(result, expected)
 
 
 @pytest.mark.parametrize(
@@ -132,6 +132,6 @@ def test_particle_dist_array_extrapolate(extrapolate, expected):
     result = dist([0.0, 1.0])
 
     if extrapolate != "nan":
-        assert np.allclose(expected, result)
+        assert np.allclose(result, expected)
     else:
         assert np.isnan(result).all()

--- a/tests/02_eradiate/01_unit/scenes/measure/test_distant_flux.py
+++ b/tests/02_eradiate/01_unit/scenes/measure/test_distant_flux.py
@@ -70,4 +70,4 @@ def test_distant_flux_viewing_angles(mode_mono):
         )
         * ureg.deg
     )
-    assert np.allclose(expected, d.viewing_angles)
+    assert np.allclose(d.viewing_angles, expected)

--- a/tests/02_eradiate/01_unit/scenes/measure/test_hemispherical_distant.py
+++ b/tests/02_eradiate/01_unit/scenes/measure/test_hemispherical_distant.py
@@ -43,4 +43,4 @@ def test_hemispherical_distant_viewing_angles(mode_mono):
         )
         * ureg.deg
     )
-    assert np.allclose(expected, d.viewing_angles)
+    assert np.allclose(d.viewing_angles, expected)

--- a/tests/02_eradiate/01_unit/scenes/measure/test_multi_distant.py
+++ b/tests/02_eradiate/01_unit/scenes/measure/test_multi_distant.py
@@ -56,9 +56,7 @@ def test_layout_azimuth_convention(mode_mono, convention, expected):
     layout = AngleLayout(
         angles=[[90, 0], [90, 90]] * ureg.deg, azimuth_convention=convention
     )
-    assert np.allclose(
-        expected, layout.directions
-    ), f"\nexpected {expected}\ngot      {layout.directions}"
+    assert np.allclose(layout.directions, expected)
 
 
 def test_direction_layout(mode_mono):
@@ -200,17 +198,13 @@ def test_multi_distant_measure_viewing_angles(mode_mono):
         * ureg.deg
     )
 
-    assert np.allclose(
-        expected, measure.viewing_angles
-    ), f"\nexpected {expected},\ngot      {measure.viewing_angles}"
+    assert np.allclose(measure.viewing_angles, expected)
 
     # Directions which would normally map to the [-π, 0] domain are normalised
     # to [0, 2π]
     measure = MultiDistantMeasure(direction_layout=[[0, -1, 1]])
     expected = [45, 270] * ureg.deg
-    assert np.allclose(
-        expected, measure.viewing_angles
-    ), f"\nexpected {expected},\ngot      {measure.viewing_angles}"
+    assert np.allclose(measure.viewing_angles, expected)
 
 
 def test_multi_distant_measure_from_viewing_angles(mode_mono):
@@ -223,10 +217,7 @@ def test_multi_distant_measure_from_viewing_angles(mode_mono):
     angles = np.reshape(np.stack((zeniths, azimuths), axis=-1), (-1, 1, 2)) * ureg.deg
 
     measure = MultiDistantMeasure.from_viewing_angles(zeniths, azimuths)
-    print(measure.direction_layout)
-    assert np.allclose(
-        angles, measure.viewing_angles
-    ), f"\n{angles} vs\n{measure.viewing_angles}"
+    assert np.allclose(measure.viewing_angles, angles)
 
     # Specifying the hplane param will have the validation step raise
     with pytest.raises(TypeError):
@@ -246,9 +237,7 @@ def test_multi_distant_measure_from_viewing_angles(mode_mono):
         )
         * ureg.deg
     )
-    assert np.allclose(
-        angles, measure.viewing_angles
-    ), f"\n{angles} vs\n{measure.viewing_angles}"
+    assert np.allclose(measure.viewing_angles, angles)
 
     # Construct from viewing angles within the same plane using a single azimuth value
     zeniths = np.array([-60, -45, -30, -15, 0, 15, 30, 45, 60])
@@ -264,9 +253,7 @@ def test_multi_distant_measure_from_viewing_angles(mode_mono):
         )
         * ureg.deg
     )
-    assert np.allclose(
-        angles, measure.viewing_angles
-    ), f"\n{angles} vs\n{measure.viewing_angles}"
+    assert np.allclose(measure.viewing_angles, angles)
 
     # Construct an azimuthal ring
     zeniths = 45
@@ -282,7 +269,7 @@ def test_multi_distant_measure_from_viewing_angles(mode_mono):
         )
         * ureg.deg
     )
-    assert np.allclose(angles, measure.viewing_angles)
+    assert np.allclose(measure.viewing_angles, angles)
 
 
 def test_multi_distant_measure_from_viewing_angles_convention(mode_mono):
@@ -313,7 +300,7 @@ def test_multi_distant_measure_from_viewing_angles_convention(mode_mono):
         [60, 0],
     ] * ureg.deg
     result = measure.viewing_angles.squeeze()
-    assert np.allclose(expected, result), f"\n{expected} vs\n{result}"
+    assert np.allclose(result, expected)
 
     # Another check of the azimuth values: computed viewing angles are expressed
     # in the specified convention
@@ -324,7 +311,7 @@ def test_multi_distant_measure_from_viewing_angles_convention(mode_mono):
     )
     expected = [[45, 0], [45, 45], [45, 90], [45, 180], [45, 0]] * ureg.deg
     result = measure.viewing_angles.squeeze()
-    assert np.allclose(expected, result), f"\n{expected} vs\n{result}"
+    assert np.allclose(result, expected)
 
     # Check that generated directions are correct: the constructor internally
     # performs a transform to East right

--- a/tests/02_eradiate/01_unit/scenes/phase/test_blend.py
+++ b/tests/02_eradiate/01_unit/scenes/phase/test_blend.py
@@ -31,7 +31,7 @@ def test_blend_construct_basic():
         components=[{"type": "isotropic"}, {"type": "rayleigh"}, {"type": "hg"}],
         weights=[1, 1, 2],
     )
-    assert np.allclose([0.25, 0.25, 0.5], phase.weights)
+    assert np.allclose(phase.weights, [0.25, 0.25, 0.5])
 
     # Improper weight array shape raises
     with pytest.raises(ValueError):
@@ -66,26 +66,26 @@ def test_blend_bbox(mode_mono):
         bbox=([0, 0, 0] * ureg.m, [1, 1, 1] * ureg.m),
     )
     assert np.allclose(
+        np.array(phase._gridvolume_transform().matrix),
         [
             [1, 0, 0, -0.5],
             [0, 1, 0, -0.5],
             [0, 0, 1, 0],
             [0, 0, 0, 1],
         ],
-        np.array(phase._gridvolume_transform().matrix),
     )
 
     # Nested BlendPhaseFunction objects must have the same bbox
     for comp in phase.components:
         if isinstance(comp, BlendPhaseFunction):
             assert np.allclose(
+                np.array(comp._gridvolume_transform().matrix),
                 [
                     [1, 0, 0, -0.5],
                     [0, 1, 0, -0.5],
                     [0, 0, 1, 0],
                     [0, 0, 0, 1],
                 ],
-                np.array(comp._gridvolume_transform().matrix),
             )
 
 
@@ -182,7 +182,7 @@ def test_blend_array(modes_all_double):
     )
 
     # Weights are normalised
-    assert np.allclose(1 / 3, phase.weights)
+    assert np.allclose(phase.weights, 1 / 3)
 
     # Kernel dict generation succeeds
     ctx = KernelDictContext()

--- a/tests/02_eradiate/01_unit/scenes/surface/test_central_patch.py
+++ b/tests/02_eradiate/01_unit/scenes/surface/test_central_patch.py
@@ -49,7 +49,7 @@ def test_central_patch_texture_scale(mode_mono):
         shape={"type": "rectangle", "edges": 10.0},
         patch_edges=[10.0, 10.0 / 3.0],
     )
-    assert np.allclose([1.0 / 3.0, 1.0], surface._texture_scale())
+    assert np.allclose(surface._texture_scale(), [1.0 / 3.0, 1.0])
 
 
 def test_central_patch_scale_kernel_dict(mode_mono):
@@ -68,4 +68,4 @@ def test_central_patch_scale_kernel_dict(mode_mono):
         @ mi.ScalarTransform4f.translate((-0.45, -0.45, 0))
     ).matrix
 
-    assert dr.allclose(expected, result)
+    assert dr.allclose(result, expected)

--- a/tests/02_eradiate/01_unit/scenes/test_core.py
+++ b/tests/02_eradiate/01_unit/scenes/test_core.py
@@ -146,17 +146,17 @@ def test_bbox_convert():
     bbox_ref = BoundingBox([0, 0, 0], [1, 1, 1])
 
     bbox_convert = BoundingBox.convert([[0, 0, 0], [1, 1, 1]])
-    assert np.allclose(bbox_ref.min, bbox_convert.min)
-    assert np.allclose(bbox_ref.max, bbox_convert.max)
+    assert np.allclose(bbox_convert.min, bbox_ref.min)
+    assert np.allclose(bbox_convert.max, bbox_ref.max)
 
     bbox_convert = BoundingBox.convert(np.array([[0, 0, 0], [1, 1, 1]]))
-    assert np.allclose(bbox_ref.min, bbox_convert.min)
-    assert np.allclose(bbox_ref.max, bbox_convert.max)
+    assert np.allclose(bbox_convert.min, bbox_ref.min)
+    assert np.allclose(bbox_convert.max, bbox_ref.max)
 
     bbox_ref = BoundingBox([0, 0, 0] * ureg.m, [1, 1, 1] * ureg.m)
     bbox_convert = BoundingBox.convert([[0, 0, 0], [1, 1, 1]] * ureg.m)
-    assert np.allclose(bbox_ref.min, bbox_convert.min)
-    assert np.allclose(bbox_ref.max, bbox_convert.max)
+    assert np.allclose(bbox_convert.min, bbox_ref.min)
+    assert np.allclose(bbox_convert.max, bbox_ref.max)
 
 
 def test_bbox_contains():

--- a/tests/02_eradiate/01_unit/test_frame.py
+++ b/tests/02_eradiate/01_unit/test_frame.py
@@ -58,7 +58,7 @@ def test_transform_azimuth_to_east_right(from_convention, expected, normalize):
         from_convention=from_convention,
         normalize=normalize,
     )
-    assert np.allclose(expected, np.rad2deg(result))
+    assert np.allclose(np.rad2deg(result), expected)
 
 
 @pytest.mark.parametrize(
@@ -85,7 +85,7 @@ def test_transform_azimuth_from_east_right(to_convention, initial, normalize):
         to_convention=to_convention,
         normalize=normalize,
     )
-    assert np.allclose(expected, result), np.rad2deg(result)
+    assert np.allclose(result, expected)
 
 
 def test_angles_to_direction():

--- a/tests/02_eradiate/01_unit/test_frame.py
+++ b/tests/02_eradiate/01_unit/test_frame.py
@@ -58,7 +58,7 @@ def test_transform_azimuth_to_east_right(from_convention, expected, normalize):
         from_convention=from_convention,
         normalize=normalize,
     )
-    assert np.allclose(np.rad2deg(result), expected)
+    assert np.allclose(expected, np.rad2deg(result))
 
 
 @pytest.mark.parametrize(
@@ -73,6 +73,9 @@ def test_transform_azimuth_to_east_right(from_convention, expected, normalize):
         ("south_right", True, [270.0, 315.0, 45.0]),
         ("south_left", True, [270.0, 225.0, 135.0]),
         ("south_right", False, [270.0, 315.0, 405.0]),
+        # The following configurations test for close-to-zero value snapping
+        ("east_right", True, [360.0 - 1e-4, 45.0, 135.0]),
+        ("north_right", True, [90.0 - 1e-4, 135.0, 225.0]),
     ],
 )
 def test_transform_azimuth_from_east_right(to_convention, initial, normalize):
@@ -82,7 +85,7 @@ def test_transform_azimuth_from_east_right(to_convention, initial, normalize):
         to_convention=to_convention,
         normalize=normalize,
     )
-    assert np.allclose(result, expected)
+    assert np.allclose(expected, result), np.rad2deg(result)
 
 
 def test_angles_to_direction():

--- a/tests/02_eradiate/02_system/test_onedim_ckd_vs_mono.py
+++ b/tests/02_eradiate/02_system/test_onedim_ckd_vs_mono.py
@@ -250,7 +250,7 @@ def test_550(reflectance, artefact_dir):
     # Assert averaged mono results are consistent with ckd results within 5 %
     mono_brf = mono_results_integrated.brf.squeeze().values
     ckd_brf = ckd_results.brf.squeeze().values
-    assert np.allclose(mono_brf, ckd_brf, rtol=0.05)
+    assert np.allclose(ckd_brf, mono_brf, rtol=0.05)
 
 
 @pytest.mark.parametrize("reflectance", [0.0, 0.5, 1.0])
@@ -396,4 +396,4 @@ def test_1050(reflectance, artefact_dir):
     # Assert averaged mono results are consistent with ckd results within 5 %
     mono_brf = mono_results_averaged.brf.squeeze().values
     ckd_brf = ckd_results.brf.squeeze().values
-    assert np.allclose(mono_brf, ckd_brf, rtol=0.05)
+    assert np.allclose(ckd_brf, mono_brf, rtol=0.05)

--- a/tests/02_eradiate/02_system/test_onedim_rpv.py
+++ b/tests/02_eradiate/02_system/test_onedim_rpv.py
@@ -758,4 +758,6 @@ def test_rpv_vs_lambertian(mode_mono, atmosphere, reflectance, artefact_dir):
     if atmosphere is None:
         assert np.all(results["rpv"].brf.values == results["lambertian"].brf.values)
     else:
-        assert np.allclose(results["rpv"].brf, results["rpv"].brf, rtol=1e-2, atol=1e-3)
+        assert np.allclose(
+            results["rpv"].brf, results["lambertian"].brf, rtol=1e-2, atol=1e-3
+        )


### PR DESCRIPTION
# Description

This PR adds support for gridded viewing angle layouts to `MultipleDistantMeasure`. Changes are as follows:

* `MultipleDistantMeasure` is reworked. The `hplane` and `directions` fields are replaced with a generic `direction_layout` field which holds a `Layout` instance. This field is dict-constructible, as always (I didn't use a Dessine-moi factory for this, it would be overkill IMO).
* `Layout` defines an interface to generate a sequence of viewing directions and angles. This has several advantages:
  * Adding a new implementation is very simple.
  * The layout type can be used for specific operations (this is however no longer needed, see below!).
  * There are currently 5 layouts: 
    * Directions: explicit specification of viewing directions as vectors.
    * Angles: explicit specification of viewing directions as angle pairs.
    * Hemisphere plane cut: as before, negative zenith values work naturally and no longer require fiddling with the output data during post-processing.
    * Azimuthal ring: as before.
    * Grid: directions are generated by making the Cartesian product of zenith and azimuth vectors.
* The `MultipleDistantMeasure.from_viewing_angles()` constructor is deprecated and replaced by specialised constructors, all accessible directly or from the dict API using the `construct` key.
* Post-processing is simpler: the assembly step no longer requires special treatment for the `hplane` layout.
* A helper function is defined to help users grid against (VZA, VAA) the output of a gridded `mdistant` measure. For an example, see the `unstack_gridded_helper.ipynb` file in [that gist](https://gist.github.com/leroyvn/6fac961c93631cbf34c0b0f6f738aef3).

This PR also contains small fixes and changes:

* Azimuth normalisation now also snaps close-to-zero negative values to 0 to avoid irrelevant offsetting of inaccurately positioned values.
* Tests are modified to use the `numpy.allclose()` function the way it is supposed to be, *i.e.* with the first argument as the reference.

# To do

* Code
  * [x] Decide whether to remove or deprecate `from_viewing_angles()`
  * [x] Add gridding helper function (see [this gist](https://gist.github.com/leroyvn/6fac961c93631cbf34c0b0f6f738aef3) for the basic principle)
  * [x] Check if test coverage is sufficient
* Docs
  * [x] Add docstrings
  * [x] Add `Layout` API docs
  * [x] Update tutorials
  * [x] ~~Add measure guide explaining how all this works (other PR maybe?)~~
  * [x] ~~Add measure tutorial (other PR maybe?)~~
  * [x] Add changelog entry

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
