### PR TITLE
Distant measures: Allow manual ray offset control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,10 @@ Entries marked with a  ︎⚠️ symbol require particular attention during upgr
   in the case where `srf` is specified by a keyword ({ghpr}`278`).
 * Fixed the behaviour of the `MeshTreeElement` constructor when no units are 
   specified ({ghpr}`279`).
+* Extended the distant measure line with the possibility to control the
+  distance between ray origins and the target ({ghpr}`275`). The default 
+  behaviour is unchanged, effectively positioning ray origins at an infinite 
+  distance from the target.   
 
 % ### Documentation
 %

--- a/src/eradiate/experiments/_canopy_atmosphere.py
+++ b/src/eradiate/experiments/_canopy_atmosphere.py
@@ -25,6 +25,7 @@ from ..scenes.integrators import (
     integrator_factory,
 )
 from ..scenes.measure import Measure, TargetPoint, TargetRectangle
+from ..scenes.measure._distant import DistantMeasure
 from ..scenes.shapes import RectangleShape
 from ..scenes.surface import BasicSurface, CentralPatchSurface, surface_factory
 from ..units import unit_context_config as ucc
@@ -293,7 +294,7 @@ class CanopyAtmosphereExperiment(EarthObservationExperiment):
         overridden if relevant.
         """
         for measure in self.measures:
-            if measure.is_distant():
+            if isinstance(measure, DistantMeasure):
                 if measure.target is None:
                     if (
                         self.canopy is None

--- a/src/eradiate/experiments/_core.py
+++ b/src/eradiate/experiments/_core.py
@@ -35,7 +35,7 @@ from ..scenes.measure import (
     MultiDistantMeasure,
     measure_factory,
 )
-from ..util.deprecation import deprecated
+from ..scenes.measure._distant import DistantMeasure
 
 logger = logging.getLogger(__name__)
 
@@ -592,7 +592,7 @@ class EarthObservationExperiment(Experiment, ABC):
                 ),
             )
 
-            if measure.is_distant():
+            if isinstance(measure, DistantMeasure):
                 pipeline.add(
                     "add_viewing_angles", pipelines.AddViewingAngles(measure=measure)
                 )

--- a/src/eradiate/scenes/measure/__init__.pyi
+++ b/src/eradiate/scenes/measure/__init__.pyi
@@ -1,6 +1,9 @@
 from ._core import Measure as Measure
 from ._core import MeasureSpectralConfig as MeasureSpectralConfig
 from ._core import measure_factory as measure_factory
+from ._distant import Target as Target
+from ._distant import TargetPoint as TargetPoint
+from ._distant import TargetRectangle as TargetRectangle
 from ._distant_flux import DistantFluxMeasure as DistantFluxMeasure
 from ._hemispherical_distant import (
     HemisphericalDistantMeasure as HemisphericalDistantMeasure,
@@ -15,6 +18,3 @@ from ._multi_distant import MultiDistantMeasure as MultiDistantMeasure
 from ._multi_radiancemeter import MultiRadiancemeterMeasure as MultiRadiancemeterMeasure
 from ._perspective import PerspectiveCameraMeasure as PerspectiveCameraMeasure
 from ._radiancemeter import RadiancemeterMeasure as RadiancemeterMeasure
-from ._target import Target as Target
-from ._target import TargetPoint as TargetPoint
-from ._target import TargetRectangle as TargetRectangle

--- a/src/eradiate/scenes/measure/_hemispherical_distant.py
+++ b/src/eradiate/scenes/measure/_hemispherical_distant.py
@@ -9,13 +9,10 @@ import numpy as np
 import pint
 import pinttr
 
-from ._core import Measure, MeasureFlags
-from ._target import Target, TargetPoint, TargetRectangle
-from ..core import KernelDict
+from ._distant import DistantMeasure
 from ... import frame, validators
 from ..._config import config
-from ...attrs import documented, get_doc, parse_docs
-from ...contexts import KernelDictContext
+from ...attrs import documented, parse_docs
 from ...units import symbol
 from ...units import unit_context_config as ucc
 from ...units import unit_context_kernel as uck
@@ -25,7 +22,7 @@ from ...warp import square_to_uniform_hemisphere
 
 @parse_docs
 @attrs.define
-class HemisphericalDistantMeasure(Measure):
+class HemisphericalDistantMeasure(DistantMeasure):
     """
     Hemispherical distant radiance measure scene element
     [``hdistant``, ``hemispherical_distant``].
@@ -106,42 +103,9 @@ class HemisphericalDistantMeasure(Measure):
         default="[0, 0, 1]",
     )
 
-    target: t.Optional[Target] = documented(
-        attrs.field(
-            default=None,
-            converter=attrs.converters.optional(Target.convert),
-            validator=attrs.validators.optional(
-                attrs.validators.instance_of(
-                    (
-                        TargetPoint,
-                        TargetRectangle,
-                    )
-                )
-            ),
-            on_setattr=attrs.setters.pipe(
-                attrs.setters.convert, attrs.setters.validate
-            ),
-        ),
-        doc="Target specification. The target can be specified using an "
-        "array-like with 3 elements (which will be converted to a "
-        ":class:`.TargetPoint`) or a dictionary interpreted by "
-        ":meth:`Target.convert() <.Target.convert>`. If set to "
-        "``None`` (not recommended), the default target point selection "
-        "method is used: rays will not target a particular region of the "
-        "scene.",
-        type=":class:`.Target` or None",
-        init_type=":class:`.Target` or dict or array-like, optional",
-    )
-
     @property
     def film_resolution(self):
         return self._film_resolution
-
-    flags: MeasureFlags = documented(
-        attrs.field(default=MeasureFlags.DISTANT, converter=MeasureFlags, init=False),
-        doc=get_doc(Measure, "flags", "doc"),
-        type=get_doc(Measure, "flags", "type"),
-    )
 
     @property
     def viewing_angles(self) -> pint.Quantity:
@@ -179,7 +143,7 @@ class HemisphericalDistantMeasure(Measure):
     #                       Kernel dictionary generation
     # --------------------------------------------------------------------------
 
-    def _kernel_dict(self, sensor_id, spp):
+    def _kernel_dict_impl(self, sensor_id, spp):
         # Inherit docstring
 
         up = dr.normalize(
@@ -216,15 +180,8 @@ class HemisphericalDistantMeasure(Measure):
         if self.target is not None:
             result["target"] = self.target.kernel_item()
 
-        return result
-
-    def kernel_dict(self, ctx: KernelDictContext) -> KernelDict:
-        sensor_ids = self._sensor_ids()
-        sensor_spps = self._sensor_spps()
-        result = KernelDict()
-
-        for spp, sensor_id in zip(sensor_spps, sensor_ids):
-            result.data[sensor_id] = self._kernel_dict(sensor_id, spp)
+        if self.ray_offset is not None:
+            result["ray_offset"] = self.ray_offset.m_as(uck.get("length"))
 
         return result
 

--- a/src/eradiate/scenes/measure/_multi_radiancemeter.py
+++ b/src/eradiate/scenes/measure/_multi_radiancemeter.py
@@ -8,9 +8,7 @@ import pint
 import pinttr
 
 from ._core import Measure
-from ..core import KernelDict
 from ...attrs import documented, parse_docs
-from ...contexts import KernelDictContext
 from ...units import symbol
 from ...units import unit_context_config as ucc
 from ...units import unit_context_kernel as uck
@@ -83,7 +81,7 @@ class MultiRadiancemeterMeasure(Measure):
     #                       Kernel dictionary generation
     # --------------------------------------------------------------------------
 
-    def _kernel_dict(self, sensor_id, spp):
+    def _kernel_dict_impl(self, sensor_id, spp):
         origins = self.origins.m_as(uck.get("length"))
         directions = self.directions
 
@@ -105,25 +103,6 @@ class MultiRadiancemeterMeasure(Measure):
                 "rfilter": {"type": "box"},
             },
         }
-
-        return result
-
-    def kernel_dict(self, ctx: KernelDictContext) -> KernelDict:
-        sensor_ids = self._sensor_ids()
-        sensor_spps = self._sensor_spps()
-        result = KernelDict()
-
-        for spp, sensor_id in zip(sensor_spps, sensor_ids):
-            result_dict = self._kernel_dict(sensor_id, spp)
-            try:
-                result_dict["medium"] = {
-                    "type": "ref",
-                    "id": ctx.atmosphere_medium_id,
-                }
-            except AttributeError:
-                pass
-
-            result.data[sensor_id] = result_dict
 
         return result
 

--- a/src/eradiate/scenes/measure/_perspective.py
+++ b/src/eradiate/scenes/measure/_perspective.py
@@ -9,10 +9,8 @@ import pint
 import pinttr
 
 from ._core import Measure
-from ..core import KernelDict
 from ... import validators
 from ...attrs import documented, parse_docs
-from ...contexts import KernelDictContext
 from ...units import symbol
 from ...units import unit_context_config as ucc
 from ...units import unit_context_kernel as uck
@@ -146,8 +144,7 @@ class PerspectiveCameraMeasure(Measure):
     #                       Kernel dictionary generation
     # --------------------------------------------------------------------------
 
-    def _kernel_dict(self, sensor_id, spp):
-
+    def _kernel_dict_impl(self, sensor_id, spp):
         target = self.target.m_as(uck.get("length"))
         origin = self.origin.m_as(uck.get("length"))
 
@@ -172,27 +169,6 @@ class PerspectiveCameraMeasure(Measure):
                 "rfilter": {"type": "box"},
             },
         }
-
-        return result
-
-    @KernelDictContext.DYNAMIC_FIELDS.register("atmosphere_medium_id")
-    def kernel_dict(self, ctx: KernelDictContext) -> KernelDict:
-        sensor_ids = self._sensor_ids()
-        sensor_spps = self._sensor_spps()
-        result = KernelDict()
-
-        for spp, sensor_id in zip(sensor_spps, sensor_ids):
-            result_dict = self._kernel_dict(sensor_id, spp)
-
-            try:
-                result_dict["medium"] = {
-                    "type": "ref",
-                    "id": ctx.atmosphere_medium_id,
-                }
-            except AttributeError:
-                pass
-
-            result.data[sensor_id] = result_dict
 
         return result
 

--- a/src/eradiate/scenes/measure/_radiancemeter.py
+++ b/src/eradiate/scenes/measure/_radiancemeter.py
@@ -8,10 +8,8 @@ import pint
 import pinttr
 
 from ._core import Measure
-from ..core import KernelDict
 from ... import validators
 from ...attrs import documented, parse_docs
-from ...contexts import KernelDictContext
 from ...units import symbol
 from ...units import unit_context_config as ucc
 from ...units import unit_context_kernel as uck
@@ -79,7 +77,7 @@ class RadiancemeterMeasure(Measure):
     #                       Kernel dictionary generation
     # --------------------------------------------------------------------------
 
-    def _kernel_dict(self, sensor_id, spp):
+    def _kernel_dict_impl(self, sensor_id, spp):
         target = self.target.m_as(uck.get("length"))
         origin = self.origin.m_as(uck.get("length"))
         direction = target - origin
@@ -102,27 +100,6 @@ class RadiancemeterMeasure(Measure):
                 "rfilter": {"type": "box"},
             },
         }
-
-        return result
-
-    @KernelDictContext.DYNAMIC_FIELDS.register("atmosphere_medium_id")
-    def kernel_dict(self, ctx: KernelDictContext) -> KernelDict:
-        sensor_ids = self._sensor_ids()
-        sensor_spps = self._sensor_spps()
-        result = KernelDict()
-
-        for spp, sensor_id in zip(sensor_spps, sensor_ids):
-            result_dict = self._kernel_dict(sensor_id, spp)
-
-            try:
-                result_dict["medium"] = {
-                    "type": "ref",
-                    "id": ctx.atmosphere_medium_id,
-                }
-            except AttributeError:
-                pass
-
-            result.data[sensor_id] = result_dict
 
         return result
 

--- a/tests/02_eradiate/01_unit/scenes/measure/test_core.py
+++ b/tests/02_eradiate/01_unit/scenes/measure/test_core.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-import attr
 import pytest
 
 from eradiate import data
@@ -12,7 +11,6 @@ from eradiate.quad import Quad
 from eradiate.scenes.measure import Measure, MeasureSpectralConfig
 from eradiate.scenes.measure._core import (
     CKDMeasureSpectralConfig,
-    MeasureFlags,
     MonoMeasureSpectralConfig,
     _active,
 )
@@ -143,26 +141,6 @@ def test_ckd_spectral_config(modes_all_ckd):
     assert all(isinstance(ctx, CKDSpectralContext) for ctx in ctxs)
 
 
-def test_measure_flags(mode_mono):
-    @attr.s
-    class MyMeasure(Measure):
-        flags = attr.ib(
-            default=MeasureFlags.DISTANT,
-            converter=MeasureFlags,
-            init=False,
-        )
-
-        @property
-        def film_resolution(self):
-            return (32, 32)
-
-        def kernel_dict(self, ctx):
-            pass
-
-    measure = MyMeasure()
-    assert measure.flags & MeasureFlags.DISTANT
-
-
 def test_spp_splitting(mode_mono):
     """
     Unit tests for SPP splitting.
@@ -173,7 +151,7 @@ def test_spp_splitting(mode_mono):
         def film_resolution(self):
             return (32, 32)
 
-        def kernel_dict(self, ctx):
+        def _kernel_dict_impl(self, sensor_id, spp):
             pass
 
     m = MyMeasure(id="my_measure", spp=256, split_spp=100)

--- a/tests/02_eradiate/01_unit/scenes/measure/test_target.py
+++ b/tests/02_eradiate/01_unit/scenes/measure/test_target.py
@@ -6,7 +6,7 @@ import pytest
 from eradiate import unit_context_config as ucc
 from eradiate import unit_context_kernel as uck
 from eradiate import unit_registry as ureg
-from eradiate.scenes.measure._target import Target, TargetPoint, TargetRectangle
+from eradiate.scenes.measure._distant import Target, TargetPoint, TargetRectangle
 
 
 def test_target_origin(modes_all):

--- a/tests/02_eradiate/02_system/test_ckd_basic.py
+++ b/tests/02_eradiate/02_system/test_ckd_basic.py
@@ -58,6 +58,7 @@ def test_ckd_basic(modes_all_ckd):
         ],
     )
     results = eradiate.run(exp)
+    results = np.squeeze(results.data_vars["brf"].values)
 
     # Reflectance is uniform, equal to 1
-    assert np.allclose(results.data_vars["brf"], 1.0)
+    assert np.allclose(results, 1.0), f"diff = {results - 1.0}"

--- a/tests/02_eradiate/02_system/test_mdistant_insitu.py
+++ b/tests/02_eradiate/02_system/test_mdistant_insitu.py
@@ -1,0 +1,120 @@
+import os
+
+import attrs
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+import xarray as xr
+
+import eradiate
+from eradiate import unit_registry as ureg
+
+
+def compute(l="distant", sigma=1.0, rho=1.0, exp_cls="AtmosphereExperiment"):
+    result = []
+    spps = [4**i for i in range(0, 11)]
+
+    for spp in spps:
+        exp = getattr(eradiate.experiments, exp_cls)(
+            atmosphere={
+                "type": "homogeneous",
+                "sigma_a": sigma * ureg("m^-1"),
+                "sigma_s": 0.0,
+                "top": 1.0 * ureg.m,
+            },
+            illumination={"type": "directional", "irradiance": 1.0},
+            surface={"type": "lambertian", "reflectance": rho},
+            measures={
+                "type": "mdistant",
+                "construct": "hplane",
+                "zeniths": 0.0,
+                "azimuth": 0.0,
+                "ray_offset": None,
+                "spp": spp,
+            },
+        )
+
+        if l != "distant":
+            exp = attrs.evolve(
+                exp,
+                measures={
+                    "type": "mdistant",
+                    "construct": "hplane",
+                    "zeniths": 0.0,
+                    "azimuth": 0.0,
+                    "ray_offset": l * ureg.m,
+                    "spp": spp,
+                },
+            )
+
+        result.append(eradiate.run(exp).radiance.squeeze(drop=True))
+
+    return xr.concat(result, dim="spp").assign_coords(spp=spps)
+
+
+@pytest.mark.parametrize(
+    "exp_cls", ["AtmosphereExperiment", "CanopyAtmosphereExperiment"]
+)
+def test_mdistant_insitu(artefact_dir, mode_mono, exp_cls):
+    r"""
+    In-situ multi-distant sensor
+    ============================
+
+    This test checks that the in-situ multi-distant sensor feature is correctly
+    implemented. The test is performed for the following experiment classes:
+
+    - ``AtmosphereExperiment``
+    - ``CanopyAtmosphereExperiment``
+
+    Rationale
+    ---------
+
+    - Surface: a Lambertian surface reflectance :math:`\rho = 1`.
+    - Atmosphere: a homogeneous atmosphere with no scattering, an absorption
+      coefficient :math:`\sigma = 1` and a thickness equal to 1.
+    - Illumination: a directional light source at the zenith with radiance
+      :math:`L_\mathrm{i} = 1.0`.
+    - Sensor: an ``mdistant`` sensor targeting (0, 0, 0) in a single direction
+      [0, 0, -1]. The ray offset is set to distant and a number of values
+      between 0 and 1.
+
+    Expected behaviour
+    ------------------
+
+    The recorded radiance is expected to be equal to
+    :math:`\frac{1}{\pi} \exp \left( - \sigma (l + \mathrm{offset}) \right)`.
+    """
+
+    sigma = 1.0
+    computed = {}
+    expected = {}
+    ls = ["distant", 0.99, 0.5, 0.01]
+
+    for l in ls:
+        computed[l] = compute(l, sigma=sigma, exp_cls=exp_cls)
+        expected[l] = np.exp(-sigma * (1.0 + (l if l != "distant" else 1.0))) / np.pi
+
+    # Plot results
+    plt.figure()
+    for l in ls:
+        computed[l].plot(ls=":", marker=".", xscale="log", label=f"{l}")
+        plt.axhline(expected[l], zorder=0, c="whitesmoke", ls="--")
+
+    plt.legend(ncol=2)
+    test_name = f"test_mdistant_insitu-{exp_cls}"
+    plt.title(test_name)
+
+    outdir = os.path.join(artefact_dir, "plots")
+    os.makedirs(outdir, exist_ok=True)
+    filename = os.path.join(outdir, f"{test_name}.png")
+    plt.savefig(filename, dpi=200, bbox_inches="tight")
+
+    plt.close()
+
+    # Actual test
+    result = np.squeeze([computed[l].isel(spp=-1) for l in ls])
+    expected = np.squeeze([expected[l] for l in ls])
+
+    assert np.allclose(
+        result, expected, rtol=1e-2
+    ), f"{result = }, {expected = }\nPlot file: '{filename}'"


### PR DESCRIPTION
# Description

This PR revives the old behaviour of the `mdistant` plugin and allows for the user to control the offset of spawned rays from the target point. This makes it possible to use this sensor to compute ground-level measures such as BOA HDRF.

To do:

- [x] Deduplicate measure kernel dict generation code
- [x] Check and fix post-processing (in-situ measures should have viewing angle coordinates but no BRF variable)
- [x] Check and fix medium (in-situ measures should produce kernel dicts where sensors are located inside the atmosphere shape)

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
