### PR TITLE
Update Mitsuba submodule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,11 @@ Entries marked with a  ︎⚠️ symbol require particular attention during upgr
 
 % ### Documentation
 %
-% ### Internal changes
+### Internal changes
+
+* Updated Mitsuba submodule to a recent post-v3.0.2 `master` ({ghpr}`277`).
+  This notably fixes a 
+  [k-d tree creation issue](https://github.com/mitsuba-renderer/mitsuba3/issues/233).
 
 ## v0.22.5 (17 October 2022)
 


### PR DESCRIPTION
# Description

This PR advances the Mitsuba submodule to a recent `master` (post-3.0.2). It includes the important mitsuba-renderer/mitsuba3#234 fix.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
