### PR TITLE
Data: Look for prepared then raw SRF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@ Entries marked with a  ︎⚠️ symbol require particular attention during upgr
 * Added a helper to grid against VZA and VAA the results obtained with a 
   `MultiDistantMeasure` with a grid layout ({ghpr}`274`). See 
   {meth}`~eradiate.xarray.unstack_mdistant_grid`.
+* `MeasureSpectralConfig.srf`'s converter loads the prepared SRF version first,
+  by default, and falls back to the raw version if the former does not exist,
+  in the case where `srf` is specified by a keyword ({ghpr}`278`).
 
 % ### Documentation
 %


### PR DESCRIPTION
# Description

Resolves eradiate/eradiate-issues#180

The code generates a new warning (see below).

## New usage/behaviour of `MeasureSpectralConfig`'s `srf` parameter for data store SRFs

See also [spectra/srf/README.md](https://github.com/eradiate/eradiate-data/blob/master/spectra/srf/README.md) for the difference between *prepared* and *raw* SRF versions.

A *prepared* version of the SRF for band 8 of the MSI instrument onboard Sentinel-2A exists, therefore it is used:
```python
from eradiate.scenes.measure import MeasureSpectralConfig

spectral_cfg=MeasureSpectralConfig.new(
       srf="sentinel_2a-msi-8",
)
```

To specifically ask the raw version to be used, add the `-raw` suffix:

```python
spectral_cfg=MeasureSpectralConfig.new(
       srf="sentinel_2a-msi-8-raw",
)
```

No prepared version of the SRF for Sentinel-2B MSI's band 8 exists, therefore the *raw* SRF version is used
```python
spectral_cfg=MeasureSpectralConfig.new(
       srf="sentinel_2b-msi-8",
)
```
In that case, the following warning is provided:

```shell
UserWarning: Could not serve SRF 'sentinel_2b-msi-8' from the data store. Trying to serve 'sentinel_2b-msi-8-raw' instead.
```
# Checklist

- [x] The code follows the relevant coding guidelines
- [x] ~~The code generates no new warnings~~
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
