### PR TITLE
MeshTreeElement: Fix behaviour when passing no units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ Entries marked with a  ︎⚠️ symbol require particular attention during upgr
 * `MeasureSpectralConfig.srf`'s converter loads the prepared SRF version first,
   by default, and falls back to the raw version if the former does not exist,
   in the case where `srf` is specified by a keyword ({ghpr}`278`).
+* Fixed the behaviour of the `MeshTreeElement` constructor when no units are 
+  specified ({ghpr}`279`).
 
 % ### Documentation
 %


### PR DESCRIPTION
This commit fixes the behaviour of the MeshTreeElement constructor when no units are specified. Now passing no units results in the documented behaviour.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
