### PR TITLE
Measure: Allow sampler selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,6 @@ Entries marked with a  ︎⚠️ symbol require particular attention during upgr
 %
 % ### Internal changes
 
-
 ## v0.22.6 (upcoming release)
 
 ### Deprecations and removals
@@ -56,10 +55,11 @@ Entries marked with a  ︎⚠️ symbol require particular attention during upgr
 * Extended the distant measure line with the possibility to control the
   distance between ray origins and the target ({ghpr}`275`). The default 
   behaviour is unchanged, effectively positioning ray origins at an infinite 
-  distance from the target.   
+  distance from the target.
+* All measures can now be attached a non-default sampler ({ghpr}`280`).
 
 % ### Documentation
-%
+
 ### Internal changes
 
 * Updated Mitsuba submodule to a recent post-v3.0.2 `master` ({ghpr}`277`).

--- a/src/eradiate/scenes/measure/_core.py
+++ b/src/eradiate/scenes/measure/_core.py
@@ -589,6 +589,20 @@ class Measure(SceneElement, ABC):
         default=":meth:`MeasureSpectralConfig.new() <.MeasureSpectralConfig.new>`",
     )
 
+    sampler: str = documented(
+        attrs.field(
+            default="independent",
+            validator=attrs.validators.in_(
+                {"independent", "stratified", "multijitter", "orthogonal", "ldsampler"}
+            ),
+        ),
+        doc="Mitsuba sampler used to generate pseudo-random number sequences.",
+        type="str",
+        init_type='{"independent", "stratified", "multijitter", "orthogonal", '
+        '"ldsampler"}',
+        default='"independent"',
+    )
+
     spp: int = documented(
         attrs.field(default=1000, converter=int, validator=validators.is_positive),
         doc="Number of samples per pixel.",

--- a/src/eradiate/scenes/measure/_distant_flux.py
+++ b/src/eradiate/scenes/measure/_distant_flux.py
@@ -137,7 +137,7 @@ class DistantFluxMeasure(DistantMeasure):
                 up=up,
             ),
             "sampler": {
-                "type": "independent",
+                "type": self.sampler,
                 "sample_count": spp,
             },
             "film": {

--- a/src/eradiate/scenes/measure/_hemispherical_distant.py
+++ b/src/eradiate/scenes/measure/_hemispherical_distant.py
@@ -164,7 +164,7 @@ class HemisphericalDistantMeasure(DistantMeasure):
                 origin=[0.0, 0.0, 0.0], target=self.direction, up=up
             ),
             "sampler": {
-                "type": "independent",
+                "type": self.sampler,
                 "sample_count": spp,
             },
             "film": {

--- a/src/eradiate/scenes/measure/_multi_distant.py
+++ b/src/eradiate/scenes/measure/_multi_distant.py
@@ -684,7 +684,7 @@ class MultiDistantMeasure(DistantMeasure):
                 map(str, -self.direction_layout.directions.ravel(order="C"))
             ),
             "sampler": {
-                "type": "independent",
+                "type": self.sampler,
                 "sample_count": spp,
             },
             "film": {

--- a/src/eradiate/scenes/measure/_multi_radiancemeter.py
+++ b/src/eradiate/scenes/measure/_multi_radiancemeter.py
@@ -91,7 +91,7 @@ class MultiRadiancemeterMeasure(Measure):
             "origins": ",".join(map(str, origins.ravel(order="C"))),
             "directions": ",".join(map(str, directions.ravel(order="C"))),
             "sampler": {
-                "type": "independent",
+                "type": self.sampler,
                 "sample_count": spp,
             },
             "film": {

--- a/src/eradiate/scenes/measure/_perspective.py
+++ b/src/eradiate/scenes/measure/_perspective.py
@@ -157,7 +157,7 @@ class PerspectiveCameraMeasure(Measure):
                 origin=origin, target=target, up=self.up
             ),
             "sampler": {
-                "type": "independent",
+                "type": self.sampler,
                 "sample_count": spp,
             },
             "film": {

--- a/src/eradiate/scenes/measure/_radiancemeter.py
+++ b/src/eradiate/scenes/measure/_radiancemeter.py
@@ -88,7 +88,7 @@ class RadiancemeterMeasure(Measure):
             "origin": origin,
             "direction": direction,
             "sampler": {
-                "type": "independent",
+                "type": self.sampler,
                 "sample_count": spp,
             },
             "film": {


### PR DESCRIPTION
# Description

This PR adds sampler selection support to all `Measure` scene elements. This allows to select pseudo-random number generation algorithm used during ray tracing. All Mitsuba samplers are now accessible.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
