### PR TITLE
Fix excessive memory usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Entries marked with a  ︎⚠️ symbol require particular attention during upgr
   behaviour is unchanged, effectively positioning ray origins at an infinite
   distance from the target.
 * All measures can now be attached a non-default sampler ({ghpr}`280`).
+* Fixed unnecessary memory allocations ({ghpr}`282`).
 
 % ### Documentation
 

--- a/src/eradiate/pipelines/_gather.py
+++ b/src/eradiate/pipelines/_gather.py
@@ -171,7 +171,7 @@ class Gather(PipelineStep):
 
         # Combine all the data
         with xr.set_options(keep_attrs=True):
-            result = xr.merge(sensor_datasets)
+            result = xr.combine_by_coords(sensor_datasets)
 
         # Drop "channel" dimension when using a mono variant
         if eradiate.mode().has_flags(ModeFlags.MI_MONO):

--- a/src/eradiate/scenes/spectra/_solar_irradiance.py
+++ b/src/eradiate/scenes/spectra/_solar_irradiance.py
@@ -96,6 +96,8 @@ class SolarIrradianceSpectrum(Spectrum):
       to account for the seasonal variations of the Earth-Sun distance using the
       ephemeris of :func:`astropy.coordinates.get_sun`.
       The dataset is assumed to be normalised to an Earth-Sun distance of 1 AU.
+      This will trigger the import of :mod:`astropy.coordinates` and consume a
+      significant amount of memory (150 MiB with astropy v5.1).
 
     * The ``scale`` field can be used to apply additional arbitrary scaling.
       It is mostly used for debugging purposes. It can also be used to rescale
@@ -170,16 +172,19 @@ class SolarIrradianceSpectrum(Spectrum):
         Compute scaling factor applied to the irradiance spectrum based on the
         Earth-Sun distance.
         """
-        import astropy.coordinates
-        import astropy.time
-        import astropy.units
-
         # Note: We assume that the loaded dataset is for a reference
         # Earth-Sun distance of 1 AU
         if self.datetime is None:
             return 1.0
 
         else:
+            # Note: astropy.coordinates consumes a significant amount of memory
+            # (150 MiB with astropy v5.1). The import is therefore optional for
+            # performance.
+            import astropy.coordinates
+            import astropy.time
+            import astropy.units
+
             # The irradiance scales as the inverse of d**2, where d is the
             # Earth-Sun distance divided by the AU (reference distance for all
             # Solar irradiance spectra in Eradiate).


### PR DESCRIPTION
# Description

This PR fixes mistakes significantly increasing RAM usage:

* The `astropy.coordinates` package is now imported only when relevant. In other words, if the user does not specify a date when setting up the Solar irradiance spectrum, the module is not imported. This saves around 150 MB according to the Memray flame graph.
* The `pipelines.Gather` pipeline step now merges datasets using the [`xarray.combine_by_coords()`]() function, [as recommended by the xarray documentation](https://docs.xarray.dev/en/stable/user-guide/combining.html#combining-along-multiple-dimensions). The previous implementation used `xarray.merge()`, which could result in several tens of GB being temporarily allocated when merging result datasets.

# Details

The following code was profiled using [Memray](https://github.com/bloomberg/memray):

<details>
<summary><tt>scratch.py</tt></summary>

```python
import numpy as np


def run():
    import eradiate

    eradiate.kernel.logging.install_logging()
    eradiate.config.progress = "spectral_loop"
    eradiate.set_mode("ckd")

    exp = eradiate.experiments.AtmosphereExperiment(
        surface={"reflectance": 1.0, "type": "lambertian"},
        atmosphere={
            "molecular_atmosphere": {
                "has_absorption": False,
                "has_scattering": True,
                "absorption_data_sets": {},
                "type": "molecular",
                "construct": "afgl_1986",
                "model": "us_standard",
            },
            "particle_layers": [],
            "type": "heterogeneous",
        },
        illumination={"zenith": 30.0, "azimuth": 0.0, "type": "directional"},
        measures=[
            {
                "spectral_cfg": {"srf": "sentinel_2a-msi-2", "bin_set": "10nm"},
                "spp": 100,
                "id": "distant_toa_measure",
                "type": "mdistant",
                "direction_layout": {
                    "type": "hplane",
                    "azimuth": 0.0,
                    "zeniths": np.arange(-75, 76, 1),
                },
            },
            {
                "spectral_cfg": {"srf": "sentinel_2a-msi-2", "bin_set": "10nm"},
                "spp": 100,
                "id": "distant_toa_flux",
                "type": "distant_flux",
                "azimuth_convention": "NORTH_LEFT",
            },
        ],
    )

    eradiate.run(exp, 0)
    eradiate.run(exp, 1)


if __name__ == "__main__":
    run()
```

</details>

Memory profile before the fix (0be6c2c541bb6f50281def72b7e23e2ba1dfc566):
![memory_before](https://user-images.githubusercontent.com/34740232/202454747-48eb2483-36b2-47c5-af92-a2c770410c82.png)

Memory profile after the fix:
![memory_after](https://user-images.githubusercontent.com/34740232/202454722-a79a4f27-f9b5-4021-ac16-141ab5ef9a03.png)

I'm not entirely sure what the difference between the heap size and resident size is (I have limited knowledge of Memray), but it's still a clear improvement.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
