### PR TITLE
Harmonise dataset converters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,8 @@ Entries marked with a  ︎⚠️ symbol require particular attention during upgr
 * Updated Mitsuba submodule to a recent post-v3.0.2 `master` ({ghpr}`277`).
   This notably fixes a
   [k-d tree creation issue](https://github.com/mitsuba-renderer/mitsuba3/issues/233).
+* Harmonise dataset converters for solar irradiance spectra, spectral response
+  function and particle radiative property datasets ({ghpr}`284`).
 
 ## v0.22.5 (17 October 2022)
 

--- a/src/eradiate/scenes/atmosphere/_particle_layer.py
+++ b/src/eradiate/scenes/atmosphere/_particle_layer.py
@@ -17,7 +17,7 @@ from ._core import AbstractHeterogeneousAtmosphere
 from ._particle_dist import ParticleDistribution, particle_distribution_factory
 from ..core import KernelDict
 from ..phase import TabulatedPhaseFunction
-from ... import converters
+from ... import converters, data
 from ..._mode import ModeFlags
 from ...attrs import documented, parse_docs
 from ...ckd import Bindex
@@ -39,7 +39,6 @@ def _particle_layer_distribution_converter(value):
             return particle_distribution_factory.convert({"type": "exponential"})
 
     return particle_distribution_factory.convert(value)
-
 
 @parse_docs
 @attrs.define
@@ -172,17 +171,25 @@ class ParticleLayer(AbstractHeterogeneousAtmosphere):
 
     dataset: xr.Dataset = documented(
         attrs.field(
-            default="spectra/particles/govaerts_2021-continental.nc",
-            converter=converters.load_dataset,
+            default="govaerts_2021-continental",
+            converter=converters.to_dataset(
+                load_from_id=lambda x: data.load_dataset(
+                    f"spectra/particles/{x}.nc",
+                )
+            ),
             validator=attrs.validators.instance_of(xr.Dataset),
         ),
-        doc="Particle radiative property data set. If a path is passed, the "
-        "converter tries to open the corresponding file on the hard drive; "
-        "if this fails, it tries to load a resource from the data store. "
-        "Refer to the data guide for the format requirements of this data set.",
+        doc="Particle radiative property data set."
+        "If a xarray.Dataset is passed, the dataset is used as is "
+        "(refer to the data guide for the format requirements of this dataset)."
+        "If a path is passed, the converter tries to open the corresponding "
+        "file on the hard drive; should that fail, it queries the Eradiate data"
+        "store with that path."
+        "If a string is passed, it is interpreted as an identifier for a "
+        "particle radiative property dataset in the Eradiate data store.",
         type="Dataset",
-        init_type="Dataset or path-like, optional",
-        default="spectra/particles/govaerts_2021-continental.nc",
+        init_type="Dataset or path-like or str, optional",
+        default="govaerts_2021-continental",
     )
 
     _phase: t.Optional[TabulatedPhaseFunction] = attrs.field(default=None, init=False)

--- a/tests/02_eradiate/01_unit/scenes/atmosphere/test_particle_layer.py
+++ b/tests/02_eradiate/01_unit/scenes/atmosphere/test_particle_layer.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from eradiate import converters
+from eradiate import data
 from eradiate import unit_registry as ureg
 from eradiate.contexts import KernelDictContext, MonoSpectralContext, SpectralContext
 from eradiate.scenes.atmosphere import ParticleLayer, UniformParticleDistribution
@@ -294,7 +294,7 @@ def test_particle_layer_eval_sigma_t_mono(
     tau = layer.eval_sigma_t_mono(wavelengths) * layer.height
 
     # data set extinction @ running and reference wavelength
-    ds = converters.load_dataset(test_dataset_path)
+    ds = data.load_dataset(test_dataset_path)
     w_units = ureg(ds.w.attrs["units"])
     sigma_t = to_quantity(ds.sigma_t.interp(w=wavelengths.m_as(w_units)))
     sigma_t_ref = to_quantity(ds.sigma_t.interp(w=w_ref.m_as(w_units)))


### PR DESCRIPTION
# Description

`ParticleLayer` and `SolarIrradianceSpectrum` take a `dataset` argument very much in the same manner as `MeasureSpectralConfig.srf`, namely, in all three instances the provided value may be:

* a path (`os.PathLike`) to a local or remote dataset
* an identifier (`str`) to a remote dataset
* or a dataset (`xarray.Dataset`).

`MeasureSpectralConfig` accepts also `Spectrum`, `dict` and `float` as init types for its `srf` attribute, but the logic for processing the other types (`os.PathLike` and `str`) is very similar to how  `ParticleLayer` and `SolarIrradianceSpectrum` (could) work.

I updated the dataset converters for `ParticleLayer` and `SolarIrradianceSpectrum` so that they share this behaviour.
Examples:

```python
from pathlib import Path

import eradiate
from eradiate.scenes.atmosphere import ParticleLayer
from eradiate.scenes.spectra import SolarIrradianceSpectrum
from eradiate.scenes.measure import MeasureSpectralConfig

eradiate.set_mode("ckd")

MeasureSpectralConfig.new(srf="sentinel_2a-msi-11")  # identifier for a dataset in the data store
MeasureSpectralConfig.new(srf="spectra/srf/sentinel_2a-msi-11.nc")  # path (remote)
MeasureSpectralConfig.new(srf=Path("./resources/data/spectra/srf/sentinel_2a-msi-11.nc"))  # path (local)

ParticleLayer(dataset="govaerts_2021-desert")  # identifier for a dataset in the data store
ParticleLayer(dataset="spectra/particles/govaerts_2021-desert.nc")  # path (remote)
ParticleLayer(dataset=Path("./resources/data/spectra/particles/govaerts_2021-desert.nc"))  # path (local)

SolarIrradianceSpectrum(dataset="meftah_2017")  # identifier for a dataset in the data store
SolarIrradianceSpectrum(dataset="spectra/solar_irradiance/meftah_2017.nc")  # path (remote)
SolarIrradianceSpectrum(dataset=Path("./resources/data/spectra/solar_irradiance/meftah_2017.nc"))  # path (local)
```

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
