### PR TITLE
Add `MQDiffuseBSDF` interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Entries marked with a  ︎⚠️ symbol require particular attention during upgr
 * All measures can now be attached a non-default sampler ({ghpr}`280`).
 * Fixed unnecessary memory allocations ({ghpr}`282`).
 * Added utility functions to `srf_tools` module ({ghpr}`283`).
+* Added {class}`.MQDiffuseBSDF` reflection model ({ghpr}`286`).
 
 % ### Documentation
 

--- a/docs/rst/reference_api/scenes.rst
+++ b/docs/rst/reference_api/scenes.rst
@@ -167,10 +167,11 @@
 .. autosummary::
    :toctree: generated/autosummary/
 
-   LambertianBSDF
    BlackBSDF
-   RPVBSDF
    CheckerboardBSDF
+   LambertianBSDF
+   MQDiffuseBSDF
+   RPVBSDF
 
 ``eradiate.scenes.shapes``
 --------------------------

--- a/src/eradiate/kernel/__init__.pyi
+++ b/src/eradiate/kernel/__init__.pyi
@@ -1,3 +1,4 @@
 from . import logging as logging
 from . import transform as transform
 from ._bitmap import bitmap_to_dataset as bitmap_to_dataset
+from ._bsdf import eval_bsdf as eval_bsdf

--- a/src/eradiate/kernel/_bsdf.py
+++ b/src/eradiate/kernel/_bsdf.py
@@ -1,0 +1,52 @@
+import drjit as dr
+import mitsuba as mi
+import numpy as np
+import xarray as xr
+
+
+def _sph_to_dir(theta, phi):
+    """Map spherical to Euclidean coordinates"""
+    st, ct = dr.sincos(theta)
+    sp, cp = dr.sincos(phi)
+    return mi.Vector3f(cp * st, sp * st, ct)
+
+
+def _eval_bsdf_impl(plugin, theta_os, phi_os, theta_i, phi_i):
+    theta_ov, phi_ov = dr.meshgrid(theta_os, phi_os)
+    wos = _sph_to_dir(theta_ov, phi_ov)
+
+    # Evaluate BSDF
+    si = dr.zeros(mi.SurfaceInteraction3f)
+    si.wi = _sph_to_dir(theta_i, phi_i)
+    values = plugin.eval(mi.BSDFContext(), si, wos)
+    return np.reshape(values, (len(phi_os), len(theta_os))).T
+
+
+def eval_bsdf(plugin, theta_os, phi_os, theta_is, phi_is) -> xr.Dataset:
+    # Requires a JIT variant
+    if mi.Float == mi.ScalarFloat:
+        raise RuntimeError("A JIT-compiled variant is required")
+
+    result = [
+        [
+            _eval_bsdf_impl(plugin, theta_os, phi_os, theta_i, phi_i)
+            for theta_i in theta_is
+        ]
+        for phi_i in phi_is
+    ]
+
+    return xr.Dataset(
+        {
+            "bsdf": (
+                ("theta_o", "phi_o", "theta_i", "phi_i"),
+                np.transpose(result, (2, 3, 1, 0)),
+                {"units": "sr^-1"},
+            )
+        },
+        coords={
+            "theta_o": ("theta_o", theta_os, {"units": "rad"}),
+            "phi_o": ("phi_o", phi_os, {"units": "rad"}),
+            "theta_i": ("theta_i", theta_is, {"units": "rad"}),
+            "phi_i": ("phi_i", phi_is, {"units": "rad"}),
+        },
+    )

--- a/src/eradiate/scenes/bsdfs/__init__.pyi
+++ b/src/eradiate/scenes/bsdfs/__init__.pyi
@@ -3,4 +3,5 @@ from ._checkerboard import CheckerboardBSDF as CheckerboardBSDF
 from ._core import BSDF as BSDF
 from ._core import bsdf_factory as bsdf_factory
 from ._lambertian import LambertianBSDF as LambertianBSDF
+from ._mqdiffuse import MQDiffuseBSDF as MQDiffuseBSDF
 from ._rpv import RPVBSDF as RPVBSDF

--- a/src/eradiate/scenes/bsdfs/_core.py
+++ b/src/eradiate/scenes/bsdfs/_core.py
@@ -15,6 +15,7 @@ bsdf_factory.register_lazy_batch(
         ("_black.BlackBSDF", "black", {}),
         ("_checkerboard.CheckerboardBSDF", "checkerboard", {}),
         ("_lambertian.LambertianBSDF", "lambertian", {}),
+        ("_mqdiffuse.MQDiffuseBSDF", "mqdiffuse", {}),
         ("_rpv.RPVBSDF", "rpv", {}),
     ],
     cls_prefix="eradiate.scenes.bsdfs",

--- a/src/eradiate/scenes/bsdfs/_mqdiffuse.py
+++ b/src/eradiate/scenes/bsdfs/_mqdiffuse.py
@@ -1,0 +1,126 @@
+import attrs
+import mitsuba as mi
+import numpy as np
+import xarray as xr
+
+from ._core import BSDF
+from ..core import KernelDict
+from ... import converters
+from ...attrs import documented, parse_docs
+from ...contexts import KernelDictContext
+from ...units import to_quantity
+from ...units import unit_registry as ureg
+
+
+@parse_docs
+@attrs.define
+class MQDiffuseBSDF(BSDF):
+    """
+    Measured quasi-diffuse BSDF [``mqdiffuse``].
+
+    This BSDF models the reflection of light by opaque materials with a
+    behaviour close to diffuse, *i.e* with no strong scattering lobe.
+    Assumptions are as follows:
+
+    * The material is isotropic. Consequently, only the azimuth difference
+      matters.
+    * The material is gray. Consequently, no spectral dimension is used.
+
+    Notes
+    -----
+    The input is specified using an xarray dataset. It must contain a ``brdf``
+    data variable with the following dimensions (the corresponding coordinate
+    range is specified within brackets):
+
+    * ``cos_theta_o`` [0, 1]: cosine of the outgoing zenith angle;
+    * ``phi_d`` [0, 2π[: difference between the incoming and outgoing azimuth
+      angles;
+    * ``cos_theta_i`` [0, 1]: cosine of the incoming zenith angle.
+
+    Coordinates must be evenly spaced and have a `"units"` metadata field.
+
+    Warnings
+    --------
+    * Table values are not checked internally: ensuring that the data is
+      consistent (*e.g* that the corresponding reflectance is not greater than
+      1) is the user's responsibility.
+    * While this BSDF may technically represent any isotropic material, its
+      sampling routine's performance degrades as the material departs from a
+      diffuse behaviour.
+    """
+
+    data: xr.Dataset = documented(
+        attrs.field(
+            converter=converters.load_dataset,
+            kw_only=True,
+        ),
+        type="Dataset",
+        init_type="Dataset",
+        doc="Measured quasi-diffuse BRDF data formatted as an xarray dataset.",
+    )
+
+    @data.validator
+    def _data_validator(self, attribute, value):
+        # Check type
+        attrs.validators.instance_of(xr.Dataset)(self, attribute, value)
+
+        # Check data variable
+        if "brdf" not in value.data_vars:
+            raise ValueError(
+                f"while validating '{attribute.name}': missing required data "
+                "variable 'brdf'"
+            )
+
+        # Check dimensions
+        if set(value.data_vars["brdf"].dims) != {"cos_theta_o", "phi_d", "cos_theta_i"}:
+            raise ValueError(
+                f"while validating '{attribute.name}': incorrect dimension "
+                f"list (got '{set(value.dims)}', "
+                f"expected '{ {'cos_theta_o', 'phi_d', 'cos_theta_i'} }')"
+            )
+
+        # Check coordinates
+        for coord_name in ["cos_theta_o", "cos_theta_i", "phi_d"]:
+            try:
+                coord = to_quantity(value.coords[coord_name])
+            except ValueError as e:
+                if e.args[0] == "this DataArray has no 'units' metadata field":
+                    raise ValueError(
+                        f"while validating '{attribute.name}': input dataset "
+                        f"coordinate variable '{coord_name}' is missing "
+                        "'units' metadata field"
+                    ) from e
+                else:
+                    raise e
+
+            expected = (
+                np.linspace(0.0, 1.0, len(coord))
+                if coord_name.startswith("cos")
+                else (
+                    np.linspace(0.0, 2.0 * np.pi, len(coord), endpoint=False) * ureg.rad
+                )
+            )
+            if not np.allclose(coord, expected):
+                raise ValueError(
+                    f"while validating '{attribute.name}': incorrect "
+                    f"coordinate values for field '{coord_name}'; got {coord}, "
+                    f"expected {expected}"
+                )
+
+    def kernel_dict(self, ctx: KernelDictContext) -> KernelDict:
+        # Inherit docstring
+
+        values = (
+            self.data.data_vars["brdf"]
+            .transpose("cos_theta_o", "phi_d", "cos_theta_i")
+            .values
+        )
+
+        result = {
+            self.id: {
+                "type": "mqdiffuse",
+                "grid": mi.VolumeGrid(values.astype(np.float32)),
+            }
+        }
+
+        return KernelDict(result)

--- a/tests/01_plugins/bsdfs/test_mqdiffuse.py
+++ b/tests/01_plugins/bsdfs/test_mqdiffuse.py
@@ -59,10 +59,10 @@ def discretize(bsdf, n_theta_o, n_theta_i, n_phi_d):
 
 def test_construct(variant_scalar_rgb):
     grid = mi.VolumeGrid(np.ones((5, 4, 3, 1)))
-    print(grid)
+    # print(grid)
 
     mqd = mi.load_dict({"type": "mqdiffuse", "grid": grid})
-    print(mqd)
+    # print(mqd)
     assert mqd is not None
 
 

--- a/tests/02_eradiate/01_unit/scenes/bsdfs/test_mqdiffuse.py
+++ b/tests/02_eradiate/01_unit/scenes/bsdfs/test_mqdiffuse.py
@@ -1,0 +1,80 @@
+import numpy as np
+import pytest
+import xarray as xr
+
+from eradiate.contexts import KernelDictContext
+from eradiate.scenes.bsdfs import MQDiffuseBSDF
+
+ds = xr.Dataset(
+    {
+        "brdf": xr.DataArray(
+            data=np.full((3, 3, 3), 1.0 * np.pi),
+            coords=[
+                ("cos_theta_o", np.linspace(0, 1, 3), {"units": ""}),
+                (
+                    "phi_d",
+                    np.linspace(0, 2.0 * np.pi, 3, endpoint=False),
+                    {"units": "rad"},
+                ),
+                ("cos_theta_i", np.linspace(0, 1, 3), {"units": ""}),
+            ],
+        )
+    }
+)
+
+
+def test_construct():
+    # Constructing with a well-formed dataset succeeds
+    assert MQDiffuseBSDF(data=ds)
+
+    # Missing 'brdf' variable fails
+    with pytest.raises(ValueError, match="missing required data variable"):
+        MQDiffuseBSDF(data=ds.rename({"brdf": "bsdf"}))
+
+    # Incorrect dimension fails
+    with pytest.raises(ValueError, match="incorrect dimension list"):
+        MQDiffuseBSDF(data=ds.rename({"phi_d": "phi_r"}))
+
+    # Incorrect coordinate fails
+    with pytest.raises(
+        ValueError, match="incorrect coordinate values for field 'phi_d'"
+    ):
+        MQDiffuseBSDF(
+            data=ds.assign_coords(
+                {
+                    "phi_d": (
+                        "phi_d",
+                        np.linspace(0.0, 2.0 * np.pi, len(ds.phi_d)),
+                        {"units": "rad"},
+                    )
+                }
+            )
+        )
+
+    # Missing units fails
+    with pytest.raises(
+        ValueError,
+        match="input dataset coordinate variable 'phi_d' is missing 'units' "
+        "metadata field",
+    ):
+        MQDiffuseBSDF(
+            data=ds.assign_coords(
+                {
+                    "phi_d": (
+                        "phi_d",
+                        np.linspace(0.0, 2.0 * np.pi, len(ds.phi_d), endpoint=True),
+                    )
+                }
+            )
+        )
+
+
+def test_kernel_dict(mode_mono):
+    bsdf = MQDiffuseBSDF(data=ds)
+    ctx = KernelDictContext()
+
+    # Kernel dictionary generation succeeds
+    kernel_dict = bsdf.kernel_dict(ctx)
+
+    # Generated kernel dictionary can be loaded by Mitsuba
+    assert kernel_dict.load()


### PR DESCRIPTION
# Description

This PR adds an Eradiate interface to the `mqdiffuse` BSDF plugin.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
