### PR TITLE
Fix bilambertian BSDF with LLVM variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,12 +28,12 @@ Entries marked with a  ︎⚠️ symbol require particular attention during upgr
 %
 % ### Internal changes
 
-## v0.22.6 (upcoming release)
+## v0.23.1 (upcoming release)
 
 ### Deprecations and removals
 
 * The {meth}`.MultiDistantMeasure.from_viewing_angles()` constructor is
-  deprecated and will be removed in v0.23.1.
+  deprecated and will be removed in v0.23.2.
 * Removed `.EradiateConfig.data_path` ({ghpr}`292`).
 
 ### Improvements and fixes
@@ -61,6 +61,8 @@ Entries marked with a  ︎⚠️ symbol require particular attention during upgr
 * Fixed unnecessary memory allocations ({ghpr}`282`).
 * Added utility functions to `srf_tools` module ({ghpr}`283`).
 * Added {class}`.MQDiffuseBSDF` reflection model ({ghpr}`286`).
+* Fixed a bug where the `bilambertian` BSDF plugin would produce incorrect
+  results when used with LLVM Mitsuba variants ({ghpr}`297`).
 
 % ### Documentation
 

--- a/src/plugins/src/bsdfs/bilambertian.cpp
+++ b/src/plugins/src/bsdfs/bilambertian.cpp
@@ -54,6 +54,7 @@ public:
                                BSDFFlags::FrontSide | BSDFFlags::BackSide);
 
         m_flags = m_components[0] | m_components[1];
+        dr::set_attr(this, "flags", m_flags);
     }
 
     std::pair<BSDFSample3f, Spectrum>
@@ -75,9 +76,10 @@ public:
         UnpolarizedSpectrum value(0.f);
 
         // Select the lobe to be sampled
-        UnpolarizedSpectrum r              = m_reflectance->eval(si, active),
-                            t              = m_transmittance->eval(si, active);
-        Float reflection_sampling_weight   = dr::mean(r / (r + t)),
+        UnpolarizedSpectrum r = m_reflectance->eval(si, active),
+                            t = m_transmittance->eval(si, active);
+
+        Float reflection_sampling_weight = dr::mean(r / (r + t)),
               transmission_sampling_weight = 1.f - reflection_sampling_weight;
 
         // Handle case where r = t = 0
@@ -170,15 +172,16 @@ public:
         Float cos_theta_i = Frame3f::cos_theta(si.wi),
               cos_theta_o = Frame3f::cos_theta(wo);
 
-        // Ensure that uncoming direction is in upper hemisphere
+        // Ensure that incoming direction is in upper hemisphere
         Vector3f wo_flip{ wo.x(), wo.y(), dr::abs(cos_theta_o) };
 
         Float result = dr::select(
             active, warp::square_to_cosine_hemisphere_pdf(wo_flip), 0.f);
 
-        UnpolarizedSpectrum r              = m_reflectance->eval(si, active),
-                            t              = m_transmittance->eval(si, active);
-        Float reflection_sampling_weight   = dr::mean(r / (r + t)),
+        UnpolarizedSpectrum r = m_reflectance->eval(si, active),
+                            t = m_transmittance->eval(si, active);
+
+        Float reflection_sampling_weight = dr::mean(r / (r + t)),
               transmission_sampling_weight = 1.f - reflection_sampling_weight;
 
         // Handle case where r = t = 0

--- a/tests/01_plugins/bsdfs/test_bilambertian.py
+++ b/tests/01_plugins/bsdfs/test_bilambertian.py
@@ -30,38 +30,55 @@ def test_instantiation(variant_scalar_rgb):
         (0.6, 0.4),
     ],
 )
-def test_eval_pdf(variant_scalar_rgb, r, t):
-    albedo = r + t
-
-    bsdf = mi.load_dict({"type": "bilambertian", "reflectance": r, "transmittance": t})
+@pytest.mark.parametrize(
+    "wi",
+    [
+        [0, 0, 1],
+        [1, 1, 1],
+        [0, 0, -1],
+        [1, 1, -1],
+    ],
+    ids=["front", "front_oblique", "back", "back_oblique"],
+)
+def test_eval_pdf_vector(variant_llvm_ad_rgb, r, t, wi):
+    def sph_to_dir(theta, phi):
+        """Map spherical to Euclidean coordinates"""
+        st, ct = dr.sincos(theta)
+        sp, cp = dr.sincos(phi)
+        return mi.Vector3f(cp * st, sp * st, ct)
 
     ctx = mi.BSDFContext()
+    bsdf = mi.load_dict({"type": "bilambertian", "reflectance": r, "transmittance": t})
 
     si = mi.SurfaceInteraction3f()
     si.p = [0, 0, 0]
     si.n = [0, 0, 1]
+    si.wi = dr.normalize(mi.ScalarVector3f(wi))
+    si.sh_frame = mi.Frame3f(si.n)
 
-    for wi in [
-        mi.ScalarVector3f(x) for x in ([0, 0, 1], [0, 0, -1])
-    ]:  # We try from both the front and back sides
-        si.wi = wi
-        si.sh_frame = mi.Frame3f(si.n)
+    # Create grid in spherical coordinates and map it onto the sphere
+    res = 300
+    theta_o, phi_o = dr.meshgrid(
+        dr.linspace(mi.Float, 0, dr.pi, res),
+        dr.linspace(mi.Float, 0, 2 * dr.pi, 2 * res),
+    )
+    wo = sph_to_dir(theta_o, phi_o)
 
-        for i in range(20):
-            theta = i / 19.0 * dr.pi  # We cover the entire circle
+    # Evaluate BSDF
+    is_reflect = dr.eq(
+        dr.sign(dr.dot(wo, si.n)),
+        dr.sign(dr.dot(si.wi, si.n)),
+    )
+    v_eval = bsdf.eval(ctx, si, wo=wo)
+    eval_expected = dr.select(
+        is_reflect,
+        r * dr.abs(wo[2]) / dr.pi,
+        t * dr.abs(wo[2]) / dr.pi,
+    )
+    assert dr.allclose(v_eval, eval_expected)
 
-            wo = [dr.sin(theta), 0, dr.cos(theta)]
-            v_pdf = bsdf.pdf(ctx, si, wo=wo)
-            v_eval = bsdf.eval(ctx, si, wo=wo)
-
-            if dr.dot(wi, wo) > 0:
-                # reflection
-                assert dr.allclose(r * dr.abs(wo[2]) / dr.pi, v_eval)
-                assert dr.allclose(r / albedo * dr.abs(wo[2]) / dr.pi, v_pdf)
-            else:
-                # transmission
-                assert dr.allclose(t * dr.abs(wo[2]) / dr.pi, v_eval)
-                assert dr.allclose(t / albedo * dr.abs(wo[2]) / dr.pi, v_pdf)
+    v_pdf = bsdf.pdf(ctx, si, wo=wo)
+    assert dr.allclose(v_pdf, eval_expected / (r + t))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Description

This PR solves an issue where the `bilambertian` BSDF plugin would produce incorrect results when used with the LLVM variants. [This gist](https://gist.github.com/leroyvn/bc2d9630d1e47a9b4fde0236c1faa2b7) contains the notebook used to generate the plots used in this PR.

A single line was missing from the constructor (see mitsuba-renderer/mitsuba3#487):
```cpp
dr::set_attr(this, "flags", m_flags);
```

I took the opportunity to refactor the tests and vectorise them.

## Pre-fix situation

![image](https://user-images.githubusercontent.com/34740232/211615994-35be8199-f451-4cf2-abe8-e9ac22d81310.png)

## Post-fix situation

![image](https://user-images.githubusercontent.com/34740232/211616490-6cd4c8bb-88a6-43e4-ba99-fd959fc6de59.png)

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
