### PR TITLE
Refactor the `Mode` type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ Entries marked with a  ︎⚠️ symbol require particular attention during upgr
 * Added {class}`.MQDiffuseBSDF` reflection model ({ghpr}`286`).
 * Fixed a bug where the `bilambertian` BSDF plugin would produce incorrect
   results when used with LLVM Mitsuba variants ({ghpr}`297`).
+* ⚠️ Refactoring of the {class}`.Mode` infrastructure ({ghpr}`298`).
 
 % ### Documentation
 

--- a/docs/rst/reference_api/eradiate_core.rst
+++ b/docs/rst/reference_api/eradiate_core.rst
@@ -32,7 +32,13 @@ Mode management
 .. autodata:: Mode
    :annotation:
 
-.. autodata:: ModeFlags
+.. autodata:: SpectralMode
+   :annotation:
+
+.. autodata:: MitsubaBackend
+   :annotation:
+
+.. autodata:: MitsubaColorMode
    :annotation:
 
 Unit management

--- a/docs/rst/reference_api/mode.rst
+++ b/docs/rst/reference_api/mode.rst
@@ -25,4 +25,6 @@ Classes
    :toctree: generated/autosummary/
 
    Mode
-   ModeFlags
+   SpectralMode
+   MitsubaBackend
+   MitsubaColorMode

--- a/src/eradiate/__init__.pyi
+++ b/src/eradiate/__init__.pyi
@@ -14,8 +14,10 @@ from . import units as units
 from . import validators as validators
 from . import xarray as xarray
 from ._config import config
+from ._mode import MitsubaBackend as MitsubaBackend
+from ._mode import MitsubaColorMode as MitsubaColorMode
 from ._mode import Mode as Mode
-from ._mode import ModeFlags as ModeFlags
+from ._mode import SpectralMode as SpectralMode
 from ._mode import mode as mode
 from ._mode import modes as modes
 from ._mode import set_mode as set_mode

--- a/src/eradiate/experiments/_atmosphere.py
+++ b/src/eradiate/experiments/_atmosphere.py
@@ -308,7 +308,7 @@ __getattr__ = substitute(
     {
         "OneDimExperiment": (
             AtmosphereExperiment,
-            {"deprecated_in": "0.22.5", "removed_in": "0.22.7"},
+            {"deprecated_in": "0.22.5", "removed_in": "0.23.2"},
         )
     }
 )

--- a/src/eradiate/experiments/_canopy.py
+++ b/src/eradiate/experiments/_canopy.py
@@ -193,7 +193,7 @@ __getattr__ = substitute(
     {
         "RamiExperiment": (
             CanopyExperiment,
-            {"deprecated_in": "0.22.5", "removed_in": "0.22.7"},
+            {"deprecated_in": "0.22.5", "removed_in": "0.23.2"},
         )
     }
 )

--- a/src/eradiate/experiments/_canopy_atmosphere.py
+++ b/src/eradiate/experiments/_canopy_atmosphere.py
@@ -324,7 +324,7 @@ __getattr__ = substitute(
     {
         "Rami4ATMExperiment": (
             CanopyAtmosphereExperiment,
-            {"deprecated_in": "0.22.5", "removed_in": "0.22.7"},
+            {"deprecated_in": "0.22.5", "removed_in": "0.23.2"},
         )
     }
 )

--- a/src/eradiate/experiments/_core.py
+++ b/src/eradiate/experiments/_core.py
@@ -15,7 +15,7 @@ import eradiate
 
 from .. import pipelines
 from .._config import ProgressLevel, config
-from .._mode import ModeFlags, supported_mode
+from .._mode import SpectralMode, supported_mode
 from ..attrs import documented, parse_docs
 from ..contexts import KernelDictContext
 from ..exceptions import KernelVariantError
@@ -325,7 +325,7 @@ class Experiment(ABC):
         """
 
         # Mode safeguard
-        supported_mode(ModeFlags.ANY_MONO | ModeFlags.ANY_CKD)
+        supported_mode(spectral_mode=SpectralMode.MONO | SpectralMode.CKD)
 
         if not measures:
             measures = self.measures

--- a/src/eradiate/pipelines/_gather.py
+++ b/src/eradiate/pipelines/_gather.py
@@ -9,7 +9,6 @@ from pinttr.util import always_iterable
 import eradiate
 
 from ._core import PipelineStep
-from .._mode import ModeFlags
 from ..attrs import documented, parse_docs
 from ..exceptions import UnsupportedModeError
 from ..kernel import bitmap_to_dataset
@@ -173,8 +172,8 @@ class Gather(PipelineStep):
         with xr.set_options(keep_attrs=True):
             result = xr.combine_by_coords(sensor_datasets)
 
-        # Drop "channel" dimension when using a mono variant
-        if eradiate.mode().has_flags(ModeFlags.MI_MONO):
+        # Drop "channel" dimension when using a monochromatic Mitsuba variant
+        if eradiate.mode().check(mi_color_mode="mono"):
             result = result.squeeze("channel", drop=True)
 
         # Apply metadata to new dimensions

--- a/src/eradiate/scenes/spectra/_air_scattering_coefficient.py
+++ b/src/eradiate/scenes/spectra/_air_scattering_coefficient.py
@@ -4,15 +4,12 @@ import attrs
 import numpy as np
 import pint
 
-import eradiate
-
 from ._core import Spectrum
 from ..core import KernelDict
-from ..._mode import ModeFlags
+from ..._mode import SpectralMode, supported_mode
 from ...attrs import parse_docs
 from ...ckd import Bindex
 from ...contexts import KernelDictContext
-from ...exceptions import UnsupportedModeError
 from ...radprops.rayleigh import compute_sigma_s_air
 from ...units import PhysicalQuantity
 from ...units import unit_context_config as ucc
@@ -93,22 +90,20 @@ class AirScatteringCoefficientSpectrum(Spectrum):
         return result * quantity_units
 
     def kernel_dict(self, ctx: KernelDictContext) -> KernelDict:
-        if eradiate.mode().has_flags(ModeFlags.ANY_MONO | ModeFlags.ANY_CKD):
-            return KernelDict(
-                {
-                    "spectrum": {
-                        "type": "uniform",
-                        "value": float(
-                            self.eval(ctx.spectral_ctx).m_as(
-                                uck.get("collision_coefficient")
-                            )
-                        ),
-                    }
-                }
-            )
+        supported_mode(spectral_mode=SpectralMode.MONO | SpectralMode.CKD)
 
-        else:
-            raise UnsupportedModeError(supported=("monochromatic", "ckd"))
+        return KernelDict(
+            {
+                "spectrum": {
+                    "type": "uniform",
+                    "value": float(
+                        self.eval(ctx.spectral_ctx).m_as(
+                            uck.get("collision_coefficient")
+                        )
+                    ),
+                }
+            }
+        )
 
     def integral(self, wmin: pint.Quantity, wmax: pint.Quantity) -> pint.Quantity:
         raise NotImplementedError

--- a/tests/02_eradiate/01_unit/scenes/test_core.py
+++ b/tests/02_eradiate/01_unit/scenes/test_core.py
@@ -14,7 +14,7 @@ def test_kernel_dict_construct():
     for mode in eradiate.modes():
         eradiate.set_mode(mode)
         kernel_dict = KernelDict({})
-        assert kernel_dict.variant == eradiate.mode().kernel_variant
+        assert kernel_dict.variant == eradiate.mode().mi_variant
 
 
 def test_kernel_dict_check(mode_mono_single):

--- a/tests/02_eradiate/01_unit/test_mode.py
+++ b/tests/02_eradiate/01_unit/test_mode.py
@@ -2,23 +2,23 @@
 import pytest
 
 import eradiate
-from eradiate import ModeFlags, supported_mode, unsupported_mode
+from eradiate import supported_mode, unsupported_mode
 from eradiate.exceptions import UnsupportedModeError
 
 
 def test_mode_mono(mode_mono):
     mode = eradiate.mode()
-    assert mode.kernel_variant == "scalar_mono_double"
+    assert mode.mi_variant == "scalar_mono_double"
 
 
 def test_mode_mono_single(mode_mono_single):
     mode = eradiate.mode()
-    assert mode.kernel_variant == "scalar_mono"
+    assert mode.mi_variant == "scalar_mono"
 
 
 def test_mode_mono_double(mode_mono_double):
     mode = eradiate.mode()
-    assert mode.kernel_variant == "scalar_mono_double"
+    assert mode.mi_variant == "scalar_mono_double"
 
 
 def test_modes():
@@ -35,20 +35,14 @@ def test_modes():
     assert mitsuba.variant() == "scalar_mono"
 
 
-def test_mode_flags():
+def test_mode_check():
     # Check flags for mono single mode
     eradiate.set_mode("mono_single")
-    assert eradiate.mode().has_flags(ModeFlags.ERT_MONO)
-    assert eradiate.mode().has_flags(ModeFlags.MI_SINGLE)
+    assert eradiate.mode().check(spectral_mode="mono", mi_double_precision=False)
 
     # Check flags for mono_double mode
     eradiate.set_mode("mono_double")
-    assert eradiate.mode().has_flags(ModeFlags.ERT_MONO)
-    assert eradiate.mode().has_flags(ModeFlags.MI_DOUBLE)
-
-    # Check if conversion of string to flags works as intended
-    eradiate.set_mode("mono_double")
-    assert eradiate.mode().has_flags("any_double")
+    assert eradiate.mode().check(spectral_mode="mono", mi_double_precision=True)
 
 
 def test_supported_mode():
@@ -56,33 +50,33 @@ def test_supported_mode():
         eradiate.set_mode(mode)
 
         with pytest.raises(UnsupportedModeError):
-            supported_mode("ANY_CKD")
+            supported_mode(spectral_mode="ckd")
 
-        supported_mode("ANY_MONO")
+        supported_mode(spectral_mode="mono")
 
     for mode in ["ckd_single", "ckd_double", "ckd"]:
         eradiate.set_mode(mode)
 
         with pytest.raises(UnsupportedModeError):
-            supported_mode("ANY_MONO")
+            supported_mode(spectral_mode="mono")
 
-        supported_mode("ANY_CKD")
+        supported_mode(spectral_mode="ckd")
 
     for mode in ["mono", "ckd"]:
         eradiate.set_mode(mode)
 
         with pytest.raises(UnsupportedModeError):
-            supported_mode("ANY_SINGLE")
+            supported_mode(mi_double_precision=False)
 
-        supported_mode("ANY_DOUBLE")
+        supported_mode(mi_double_precision=True)
 
     for mode in ["mono_double", "ckd_double"]:
         eradiate.set_mode(mode)
 
         with pytest.raises(UnsupportedModeError):
-            supported_mode("ANY_SINGLE")
+            supported_mode(mi_double_precision=False)
 
-        supported_mode("ANY_DOUBLE")
+        supported_mode(mi_double_precision=True)
 
 
 def test_unsupported_mode():
@@ -90,30 +84,30 @@ def test_unsupported_mode():
         eradiate.set_mode(mode)
 
         with pytest.raises(UnsupportedModeError):
-            unsupported_mode("ANY_MONO")
+            unsupported_mode(spectral_mode="mono")
 
-        unsupported_mode("ANY_CKD")
+        unsupported_mode(spectral_mode="ckd")
 
     for mode in ["ckd_single", "ckd_double", "ckd"]:
         eradiate.set_mode(mode)
 
         with pytest.raises(UnsupportedModeError):
-            unsupported_mode("ANY_CKD")
+            unsupported_mode(spectral_mode="ckd")
 
-        unsupported_mode("ANY_MONO")
+        unsupported_mode(spectral_mode="mono")
 
     for mode in ["mono_double", "ckd_double", "mono", "ckd"]:
         eradiate.set_mode(mode)
 
         with pytest.raises(UnsupportedModeError):
-            unsupported_mode("ANY_DOUBLE")
+            unsupported_mode(mi_double_precision=True)
 
-        unsupported_mode("ANY_SINGLE")
+        unsupported_mode(mi_double_precision=False)
 
     for mode in ["mono_single", "ckd_single"]:
         eradiate.set_mode(mode)
 
         with pytest.raises(UnsupportedModeError):
-            unsupported_mode("ANY_SINGLE")
+            unsupported_mode(mi_double_precision=False)
 
-        unsupported_mode("ANY_DOUBLE")
+        unsupported_mode(mi_double_precision=True)

--- a/tests/02_eradiate/02_system/test_basic.py
+++ b/tests/02_eradiate/02_system/test_basic.py
@@ -7,7 +7,6 @@ import pytest
 
 import eradiate
 import eradiate.scenes as ertsc
-from eradiate import ModeFlags
 from eradiate import unit_registry as ureg
 from eradiate.contexts import KernelDictContext
 from eradiate.experiments import mitsuba_run
@@ -60,7 +59,7 @@ def test_radiometric_accuracy(modes_all_mono, illumination, spp, li, ert_seed_st
 
     # Ignore warning in single precision
     with pytest.warns(UserWarning) if (
-        eradiate.mode().has_flags(ModeFlags.MI_SINGLE) and spp > 100000
+        eradiate.mode().is_single_precision and spp > 100000
     ) else nullcontext():
         measure = ertsc.measure.MultiDistantMeasure.from_viewing_angles(
             zeniths=vza, azimuths=0.0, target=[0, 0, 0], spp=spp

--- a/tests/02_eradiate/02_system/test_compare_canopy_atmosphere.py
+++ b/tests/02_eradiate/02_system/test_compare_canopy_atmosphere.py
@@ -19,12 +19,12 @@ def test_compare_canopy_atmosphere_vs_atmosphere(
 ):
     r"""
     Compare CanopyAtmosphereExperiment with AtmosphereExperiment
-    ====================================================
+    ============================================================
 
     This test compares the results of an AtmosphereExperiment with a
-    corresponding
-    CanopyAtmosphereExperiment run. To achieve that, the CanopyAtmosphereExperiment is set up
-    without an explicit canopy and a basic atmosphere.
+    corresponding CanopyAtmosphereExperiment run. To achieve that, the
+    CanopyAtmosphereExperiment is set up without an explicit canopy and a basic
+    atmosphere.
 
     Rationale
     ---------

--- a/tests/02_eradiate/02_system/test_maximum_scene_size.py
+++ b/tests/02_eradiate/02_system/test_maximum_scene_size.py
@@ -2,7 +2,6 @@ import mitsuba as mi
 import numpy as np
 
 import eradiate
-from eradiate import ModeFlags
 from eradiate.experiments import mitsuba_run
 from eradiate.scenes.core import KernelDict
 
@@ -33,7 +32,7 @@ def test_maximum_scene_size(modes_all_mono, json_metadata):
     Tolerance is set according to the defaults for :func:`numpy.allclose`.
     Metrics are reported only for the double precision version of this test.
     """
-    expected_min_size = 1e8 if eradiate.mode().has_flags(ModeFlags.MI_MONO) else 1e12
+    expected_min_size = 1e8 if eradiate.mode().is_single_precision else 1e12
     spp = 1
     rho = 0.5
     li = 1.0
@@ -93,7 +92,7 @@ def test_maximum_scene_size(modes_all_mono, json_metadata):
     # Report test metrics
     max_size = float(np.max(scene_sizes[passed])) if np.any(passed) else 0.0
 
-    if eradiate.mode().has_flags(ModeFlags.MI_DOUBLE):
+    if eradiate.mode().is_double_precision:
         json_metadata["metrics"] = {
             "test_maximum_scene_size": {
                 "name": "Maximum scene size",


### PR DESCRIPTION
# Description

This PR refactors the `Mode` class, simplifies the implementation and adds additional degrees of freedom in Mitsuba variant selection. Changes are as follows:

* The flag system was not really used and is replaced by multiple fields which use either boolean or flag values.
* The new `Mode` data class holds one field per degree of freedom in mode definition (5 at the moment).
* The `Mode.has_flags()` method is replaced by `Mode.check()`, which takes one argument per DoF field. Flag field values can be specified using enum values or strings.
* Minor code updates were done to upgrade old usage patterns.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
