### PR TITLE
Add Ruff linter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,11 +12,12 @@ repos:
     rev: 22.3.0
     hooks:
       - id: black
-  - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.0.220  # Ruff version
     hooks:
-      - id: isort
-        name: isort (python)
+      - id: ruff
+        # Respect `exclude` and `extend-exclude` settings.
+        args: [ "--force-exclude" ]
   - repo: https://github.com/kynan/nbstripout
     rev: 0.6.0
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ Entries marked with a  ︎⚠️ symbol require particular attention during upgr
   [k-d tree creation issue](https://github.com/mitsuba-renderer/mitsuba3/issues/233).
 * Harmonise dataset converters for solar irradiance spectra, spectral response
   function and particle radiative property datasets ({ghpr}`284`).
+* Replaced isort with [Ruff](https://github.com/charliermarsh/ruff) ({ghpr}`299`).
 
 ## v0.22.5 (17 October 2022)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,16 @@ version_scheme = "guess-next-dev" # Count commits since last tag, don't anticipa
 profile = "black"
 reverse_relative = true
 
+[tool.ruff]
+src = ["src", "tests"]
+select = [  # No selected rules for now
+  "I",
+]
+
+[tool.ruff.isort]
+relative-imports-order = "closest-to-furthest"
+
+
 [tool.coverage.run]
 omit = [
   "*/tests/*",


### PR DESCRIPTION
# Description

This PR replaces isort with [Ruff](https://github.com/charliermarsh/ruff), effectively allowing for a very simple linting setup.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
