### PR TITLE
Spot illumination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,6 @@ Entries marked with a  ︎⚠️ symbol require particular attention during upgr
 * {class}`.RadProfile`: The {class}`.ArrayRadProfile` class is retired
   ({ghpr}`296`).
 
-
 ### Improvements and fixes
 
 * Added support for loading spectral response function data sets from custom
@@ -96,6 +95,7 @@ Entries marked with a  ︎⚠️ symbol require particular attention during upgr
   iterative loop-based implementation ({ghpr}`296`).
 * {class}`.RadProfile` evaluation on arbitrary altitude grids is now permitted
   ({ghpr}`296`).
+* Introduced the {class}`.SpotIllumination`, which points a beam of light of fixed angular width. ({ghpr}`302`)
 
 ### Documentation
 

--- a/src/eradiate/scenes/illumination/__init__.pyi
+++ b/src/eradiate/scenes/illumination/__init__.pyi
@@ -2,3 +2,4 @@ from ._constant import ConstantIllumination as ConstantIllumination
 from ._core import Illumination as Illumination
 from ._core import illumination_factory as illumination_factory
 from ._directional import DirectionalIllumination as DirectionalIllumination
+from ._spot import SpotIllumination as SpotIllumination

--- a/src/eradiate/scenes/illumination/_core.py
+++ b/src/eradiate/scenes/illumination/_core.py
@@ -12,6 +12,7 @@ illumination_factory.register_lazy_batch(
     [
         ("_constant.ConstantIllumination", "constant", {}),
         ("_directional.DirectionalIllumination", "directional", {}),
+        ("_spot.SpotIllumination", "spot", {}),
     ],
     cls_prefix="eradiate.scenes.illumination",
 )

--- a/src/eradiate/scenes/illumination/_spot.py
+++ b/src/eradiate/scenes/illumination/_spot.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import typing as t
+import warnings
+from pathlib import Path
+
+import attrs
+import drjit as dr
+import mitsuba as mi
+import numpy as np
+import pint
+import pinttr
+
+from ._core import Illumination
+from ..core import NodeSceneElement
+from ..spectra import Spectrum, spectrum_factory
+from ... import validators
+from ...attrs import documented, parse_docs
+from ...units import unit_context_config as ucc
+from ...units import unit_context_kernel as uck
+from ...units import unit_registry as ureg
+from ...validators import has_quantity
+
+
+@parse_docs
+@attrs.define(eq=False, slots=False)
+class SpotIllumination(Illumination):
+    """
+    Spot illumination scene element [``spot``].
+
+    Eradiate ships a beam texture that implements a gaussian beam profile with three standard deviations
+    included in the total beam width. This texture is named `gaussian_3sigma.bmp` and can be used by
+    retrieving the path to the file using `eradiate.data.data_store.fetch()`.
+    """
+
+    origin: pint.Quantity = documented(
+        pinttr.field(
+            factory=lambda: [1, 1, 1] * ureg.m,
+            validator=[validators.has_len(3), pinttr.validators.has_compatible_units],
+            units=ucc.deferred("length"),
+        ),
+        doc="A 3-vector specifying the position of the spot.\n"
+        "\n"
+        "Unit-enabled field (default: ucc['length']).",
+        type="quantity",
+        init_type="array-like",
+        default="[1, 1, 1] m",
+    )
+
+    target: pint.Quantity = documented(
+        pinttr.field(
+            factory=lambda: [0, 0, 0] * ureg.m,
+            validator=[validators.has_len(3), pinttr.validators.has_compatible_units],
+            units=ucc.deferred("length"),
+        ),
+        doc="Point location targeted by the spot.\n"
+        "\n"
+        "Unit-enabled field (default: ucc['length']).",
+        type="quantity",
+        init_type="array-like",
+        default="[0, 0, 0] m",
+    )
+
+    @target.validator
+    @origin.validator
+    def _target_origin_validator(self, attribute, value):
+        if np.allclose(self.target, self.origin):
+            raise ValueError(
+                f"While initializing {attribute}: "
+                f"Origin and target must not be equal, "
+                f"got target = {self.target}, origin = {self.origin}"
+            )
+
+    up: np.ndarray = documented(
+        attrs.field(
+            converter=np.array,
+            validator=validators.has_len(3),
+        ),
+        doc="A 3-vector specifying the up direction of the spot.\n"
+        "This vector must be different from the spots's pointing direction,\n"
+        "which is given by ``target - origin``.",
+        type="array",
+        init_type="array-like",
+        default="[0, 0, 1]",
+    )
+
+    @up.default
+    def _up_factory(self):
+        direction = dr.normalize(
+            mi.ScalarVector3f(
+                self.origin.m_as(ucc.get("length"))
+                - self.target.m_as(ucc.get("length"))
+            )
+        )
+        return mi.coordinate_system(direction)[0]
+
+    @up.validator
+    def _up_validator(self, attribute, value):
+        direction = self.target - self.origin
+        if np.allclose(np.cross(direction, value), 0):
+            raise ValueError(
+                f"While initializing '{attribute.name}': "
+                f"up direction must not be colinear with viewing direction, "
+                f"got up = {self.up}, direction = {direction}"
+            )
+
+    beam_width: pint.Quantity = documented(
+        pinttr.field(default=10.0 * ureg.deg, units=ucc.deferred("angle")),
+        doc="Spot light beam width.\n\nUnit-enabled field (default: degree).",
+        type="quantity",
+        init_type="quantity or float",
+        default="10°",
+    )
+
+    intensity: Spectrum = documented(
+        attrs.field(
+            default=1.0,
+            converter=spectrum_factory.converter("intensity"),
+            validator=[
+                attrs.validators.instance_of(Spectrum),
+                has_quantity("intensity"),
+            ],
+        ),
+        doc="Emitted power in the plane orthogonal to the illumination direction. "
+        "Must be an intensity spectrum (in W/sr/nm or compatible unit). "
+        "Can be initialised with a dictionary processed by "
+        ":meth:`.SpectrumFactory.convert`.",
+        type=":class:`~eradiate.scenes.spectra.Spectrum`",
+        init_type=":class:`~eradiate.scenes.spectra.Spectrum` or dict or float",
+        default="1.0 ucc[intensity]",
+    )
+
+    beam_profile: t.Optional[Path] = documented(
+        attrs.field(
+            default=None,
+            converter=attrs.converters.optional(Path),
+        ),
+        type="Path",
+        init_type="path-like",
+        default=None,
+        doc="Path to the file describing the beam profile. Must be a valid bitmap image file.",
+    )
+
+    @classmethod
+    def from_size_at_target(
+        cls,
+        target: np.typing.ArrayLike,
+        direction: np.typing.ArrayLike,
+        spot_radius: pint.Quantity,
+        beam_width: pint.Quantity,
+        **kwargs,
+    ) -> SpotIllumination:
+        """
+        Create a :class:`.SpotIllumination` which
+        illuminates a region of a specified size around the
+        target point.
+
+        The illuminated area is a circle defined by the
+        spot radius around the target point in the plane
+        orthogonal to the spot direction.
+        The spot origin is inferred from the spot radius
+        and a beam width value (in angle units): the
+        spot origin will be positioned closer to the target
+        point as the beam width increases and further from the
+        target point as the beam width decreases.
+
+        Parameters:
+        -----------
+
+        target : array-like
+            Target point for the spot. Unitless values are converted to ``ucc['length']``
+
+        direction : array-like
+            Pointing direction for the spot, towards target.
+
+        spot_radius : float or quantity
+            Radius of the desired spot at the target position.
+            Unitless values are converted to ``ucc['length']``
+
+        beam_width : float or quantity
+            Divergence angle of the spot.
+            Unitless values are converted to ``ucc['angle']``
+
+        **kwargs
+            Remaining keyword arguments are forwarded to the
+            :class:`.SpotIllumination` constructor.
+
+        Returns
+        -------
+        SpotIllumination
+        """
+
+        if "origin" in kwargs:
+            raise TypeError(
+                "The from_size_at_target constructor computes the origin position."
+            )
+
+        target = pinttr.util.ensure_units(target, default_units=ucc.get("length"))
+        half_angle = (
+            pinttr.util.ensure_units(beam_width, default_units=ureg.radian) / 2.0
+        )
+        tan_divergence = np.tan(half_angle)
+        distance = spot_radius / tan_divergence
+
+        origin = target - (direction * distance)
+
+        return cls(origin=origin, target=target, beam_width=beam_width, **kwargs)
+
+    @property
+    def _to_world(self) -> "mitsuba.ScalarTransform4f":
+        target = self.target.m_as(uck.get("length"))
+        origin = self.origin.m_as(uck.get("length"))
+        return mi.ScalarTransform4f.look_at(origin=origin, target=target, up=self.up)
+
+    @property
+    def template(self) -> dict:
+        retdict = {
+            "type": "spot",
+            "beam_width": self.beam_width.m_as(uck.get("angle")),
+            "cutoff_angle": self.beam_width.m_as(uck.get("angle")),
+            "to_world": self._to_world,
+        }
+
+        if self.beam_profile is not None:
+            retdict["texture"] = {
+                "type": "bitmap",
+                "filename": str(self.beam_profile),
+            }
+        return retdict
+
+    @property
+    def objects(self) -> t.Dict[str, NodeSceneElement]:
+        return {"intensity": self.intensity}

--- a/src/eradiate/units.py
+++ b/src/eradiate/units.py
@@ -49,6 +49,7 @@ class PhysicalQuantity(enum.Enum):
     ANGLE = "angle"
     COLLISION_COEFFICIENT = "collision_coefficient"
     DIMENSIONLESS = "dimensionless"
+    INTENSITY = "intensity"
     IRRADIANCE = "irradiance"
     LENGTH = "length"
     MASS = "mass"
@@ -71,6 +72,7 @@ class PhysicalQuantity(enum.Enum):
             cls.ALBEDO,
             cls.COLLISION_COEFFICIENT,
             cls.DIMENSIONLESS,
+            cls.INTENSITY,
             cls.IRRADIANCE,
             cls.RADIANCE,
             cls.REFLECTANCE,
@@ -106,6 +108,14 @@ def _make_unit_context():
     uctx.register(
         PhysicalQuantity.COLLISION_COEFFICIENT,
         pinttr.UnitGenerator(lambda: uctx.get(PhysicalQuantity.LENGTH) ** -1),
+    )
+    uctx.register(
+        PhysicalQuantity.INTENSITY,
+        pinttr.UnitGenerator(
+            lambda: unit_registry.watt
+            / unit_registry.steradian
+            / uctx.get(PhysicalQuantity.WAVELENGTH)
+        ),
     )
     uctx.register(
         PhysicalQuantity.IRRADIANCE,

--- a/tests/02_eradiate/01_unit/scenes/illumination/test_spot.py
+++ b/tests/02_eradiate/01_unit/scenes/illumination/test_spot.py
@@ -1,0 +1,84 @@
+import mitsuba as mi
+import numpy as np
+
+import eradiate.data
+from eradiate import unit_registry as ureg
+from eradiate.contexts import KernelDictContext
+from eradiate.scenes.illumination import SpotIllumination
+from eradiate.test_tools.types import check_scene_element
+
+
+def test_construct_basic(mode_mono):
+    # We need a default spectral config
+    ctx = KernelDictContext()
+
+    # Construct without parameters
+    illumination = SpotIllumination()
+    check_scene_element(illumination, mi_cls=mi.Emitter)
+
+    # Define all parameters
+    illumination = SpotIllumination(
+        target=[0, 0, 0],
+        origin=[1, 1, 1],
+        up=[1, 0, 1],
+        beam_width=10 * ureg.deg,
+        intensity=10,
+    )
+    check_scene_element(illumination, mi_cls=mi.Emitter)
+
+
+def test_construct_texture(mode_mono, tmp_path):
+    # First we set up a temporary directory with a bitmap file
+    from PIL import Image
+
+    filename = tmp_path / "texture.bmp"
+    array = np.ones((3, 3, 3))
+    im = Image.fromarray(np.uint8(array * 255))
+    im.save(filename)
+
+    # We need a default spectral config
+    ctx = KernelDictContext()
+
+    # Construct with custom beam profile filename
+    illumination = SpotIllumination(
+        target=[0, 0, 0],
+        origin=[1, 1, 1],
+        up=[1, 0, 1],
+        beam_width=10 * ureg.deg,
+        intensity=10,
+        beam_profile=str(filename),
+    )
+    check_scene_element(illumination, mi_cls=mi.Emitter)
+
+    # Construct with beam profile from data store
+    illumination = SpotIllumination(
+        target=[0, 0, 0],
+        origin=[1, 1, 1],
+        up=[1, 0, 1],
+        beam_width=10 * ureg.deg,
+        intensity=10,
+        beam_profile=eradiate.data.data_store.fetch("textures/gaussian_3sigma.bmp"),
+    )
+    check_scene_element(illumination, mi_cls=mi.Emitter)
+
+
+def test_construct_from_size(mode_mono):
+    # We need a default spectral config
+    ctx = KernelDictContext()
+
+    spot_radius = 1 * ureg.m
+    beam_angle = 3 * ureg.deg
+
+    # spot_radius / tan(beam_angle/2.)
+    expected_distance = 38.18846
+
+    illumination = SpotIllumination.from_size_at_target(
+        target=[0, 0, 0],
+        direction=[0, 0, -1],
+        spot_radius=spot_radius,
+        beam_width=beam_angle,
+    )
+
+    assert np.allclose(illumination.origin.m_as(ureg.m), [0, 0, expected_distance])
+
+    check_scene_element(illumination, mi_cls=mi.Emitter)


### PR DESCRIPTION
# Description

The SpotIllumination is rougly equivalent to a perspective camera. It is parametrized through a location, a target and a beam width.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
