### PR TITLE
Pull `***Experiment.contexts` one level up

### DIFF
--- a/src/eradiate/experiments/_atmosphere.py
+++ b/src/eradiate/experiments/_atmosphere.py
@@ -171,40 +171,6 @@ class AtmosphereExperiment(EarthObservationExperiment):
         return kwargs
 
     @property
-    def contexts(self) -> list[KernelDictContext]:
-        # Inherit docstring
-
-        # Collect contexts from all measures
-        sctxs = []
-
-        for measure in self.measures:
-            sctxs.extend(measure.spectral_cfg.spectral_ctxs())
-
-        # Sort and remove duplicates
-        key = {
-            MonoSpectralContext: lambda sctx: sctx.wavelength.m,
-            CKDSpectralContext: lambda sctx: (
-                sctx.bindex.bin.wcenter.m,
-                sctx.bindex.index,
-            ),
-        }[type(sctxs[0])]
-
-        sctxs = deduplicate_sorted(
-            sorted(sctxs, key=key), cmp=lambda x, y: key(x) == key(y)
-        )
-        kwargs = self._context_kwargs
-
-        return [KernelDictContext(spectral_ctx=sctx, kwargs=kwargs) for sctx in sctxs]
-
-    @property
-    def context_init(self) -> KernelDictContext:
-        # Inherit docstring
-
-        return KernelDictContext(
-            spectral_ctx=SpectralContext.new(), kwargs=self._context_kwargs
-        )
-
-    @property
     def scene_objects(self) -> dict[str, SceneElement]:
         # Inherit docstring
 

--- a/src/eradiate/experiments/_canopy.py
+++ b/src/eradiate/experiments/_canopy.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import typing as t
+
 import attrs
 
 from ._core import EarthObservationExperiment, Experiment
@@ -134,35 +136,8 @@ class CanopyExperiment(EarthObservationExperiment):
         return result
 
     @property
-    def contexts(self) -> list[KernelDictContext]:
-        # Inherit docstring
-
-        # Collect contexts from all measures
-        sctxs = []
-
-        for measure in self.measures:
-            sctxs.extend(measure.spectral_cfg.spectral_ctxs())
-
-        # Sort and remove duplicates
-        key = {
-            MonoSpectralContext: lambda sctx: sctx.wavelength.m,
-            CKDSpectralContext: lambda sctx: (
-                sctx.bindex.bin.wcenter.m,
-                sctx.bindex.index,
-            ),
-        }[type(sctxs[0])]
-
-        sctxs = deduplicate_sorted(
-            sorted(sctxs, key=key), cmp=lambda x, y: key(x) == key(y)
-        )
-
-        return [KernelDictContext(spectral_ctx=sctx) for sctx in sctxs]
-
-    @property
-    def context_init(self) -> KernelDictContext:
-        # Inherit docstring
-
-        return KernelDictContext(spectral_ctx=SpectralContext.new())
+    def _context_kwargs(self) -> dict[str, t.Any]:
+        return {}
 
     @property
     def scene_objects(self) -> dict[str, SceneElement]:

--- a/src/eradiate/experiments/_canopy_atmosphere.py
+++ b/src/eradiate/experiments/_canopy_atmosphere.py
@@ -234,40 +234,6 @@ class CanopyAtmosphereExperiment(EarthObservationExperiment):
         return kwargs
 
     @property
-    def contexts(self) -> list[KernelDictContext]:
-        # Inherit docstring
-
-        # Collect contexts from all measures
-        sctxs = []
-
-        for measure in self.measures:
-            sctxs.extend(measure.spectral_cfg.spectral_ctxs())
-
-        # Sort and remove duplicates
-        key = {
-            MonoSpectralContext: lambda sctx: sctx.wavelength.m,
-            CKDSpectralContext: lambda sctx: (
-                sctx.bindex.bin.wcenter.m,
-                sctx.bindex.index,
-            ),
-        }[type(sctxs[0])]
-
-        sctxs = deduplicate_sorted(
-            sorted(sctxs, key=key), cmp=lambda x, y: key(x) == key(y)
-        )
-        kwargs = self._context_kwargs
-
-        return [KernelDictContext(spectral_ctx=sctx, kwargs=kwargs) for sctx in sctxs]
-
-    @property
-    def context_init(self) -> KernelDictContext:
-        # Inherit docstring
-
-        return KernelDictContext(
-            spectral_ctx=SpectralContext.new(), kwargs=self._context_kwargs
-        )
-
-    @property
     def _default_surface_width(self):
         return 10.0 * ucc.get("length")
 


### PR DESCRIPTION
# Description

`AtmosphereExperiment`, `CanopyExperiment` and `CanopyAtmosphereExperiment` each implement almost identical `contexts`, `_contexts_kwargs` and `context_init` properties. This pull request suggest that we move them one level up, to `EarthObservationExperiment`. This would facilitate the ongoing work on spectral refactoring.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] ~~I updated the change log if relevant~~
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
