### PR TITLE
util.misc: Add cache_by_id()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,13 +91,13 @@ Entries marked with a  ︎⚠️ symbol require particular attention during upgr
   ({ghpr}`296`).
 * ⚠️ {class}`.Atmosphere` type hierarchy updates: altitude grid control, common
   spectral evaluation interface ({ghpr}`296`).
-* {class}`.BlendedPhaseFunction` code was transitioned from a recursive to an
+* {class}`.BlendPhaseFunction` code was transitioned from a recursive to an
   iterative loop-based implementation ({ghpr}`296`).
 * {class}`.RadProfile` evaluation on arbitrary altitude grids is now permitted
   ({ghpr}`296`).
 * Introduced the {class}`.SpotIllumination`, which points a beam of light of
-  fixed angular width ({ghpr}`302`).
-* Added a new module :mod:`eradiate.constants` to store physical constants used
+  fixed angular width at a target location ({ghpr}`302`).
+* Added a new module {mod}`eradiate.constants` to store physical constants used
   in Eradiate ({ghpr}`312`).
 
 ### Documentation
@@ -118,6 +118,8 @@ Entries marked with a  ︎⚠️ symbol require particular attention during upgr
   from double to single floating point numbers ({ghpr}`300`).
 * Added TOML formatting pre-commit hook ({ghpr}`305`).
 * Updated dependency management system to latest tooling changes ({ghpr}`306`).
+* Add {func}`.cache_by_id` to replace `@functools.lru_cache(maxsize=1)` when
+  appropriate ({ghpr}`315`).
 
 ## v0.22.5 (17 October 2022)
 

--- a/docs/rst/reference_api/scenes.rst
+++ b/docs/rst/reference_api/scenes.rst
@@ -258,6 +258,7 @@
 
    DirectionalIllumination
    ConstantIllumination
+   SpotIllumination
 
 ``eradiate.scenes.measure``
 ---------------------------

--- a/src/eradiate/radprops/_afgl1986.py
+++ b/src/eradiate/radprops/_afgl1986.py
@@ -26,6 +26,7 @@ from ..thermoprops.util import (
 )
 from ..units import to_quantity
 from ..units import unit_registry as ureg
+from ..util.misc import cache_by_id
 
 
 def _convert_thermoprops_afgl_1986(value: t.MutableMapping | xr.Dataset) -> xr.Dataset:
@@ -106,7 +107,7 @@ class AFGL1986RadProfile(RadProfile):
         # Inherit docstring
         return self._zgrid
 
-    @functools.lru_cache(maxsize=1)
+    @cache_by_id
     def _thermoprops_interp(self, zgrid: ZGrid) -> xr.Dataset:
         # Interpolate thermophysical profile on specified altitude grid
         # Note: we use a nearest neighbour scheme (so far, it doesn't seem to make a difference)

--- a/src/eradiate/radprops/_us76_approx.py
+++ b/src/eradiate/radprops/_us76_approx.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import typing as t
-from functools import lru_cache
 
 import attrs
 import numpy as np
@@ -19,6 +18,7 @@ from ..ckd import Bindex
 from ..thermoprops import us76
 from ..units import to_quantity
 from ..units import unit_registry as ureg
+from ..util.misc import cache_by_id
 
 
 def _convert_thermoprops_us76_approx(
@@ -185,7 +185,7 @@ class US76ApproxRadProfile(RadProfile):
         # Inherit docstring
         return self._zgrid
 
-    @lru_cache(maxsize=1)
+    @cache_by_id
     def _thermoprops_interp(self, zgrid: ZGrid) -> xr.Dataset:
         # Interpolate thermophysical profile on specified altitude grid
         # Note: we use a nearest neighbour scheme

--- a/src/eradiate/scenes/atmosphere/_heterogeneous.py
+++ b/src/eradiate/scenes/atmosphere/_heterogeneous.py
@@ -4,7 +4,6 @@ Heterogeneous atmospheres.
 from __future__ import annotations
 
 from collections import abc as cabc
-from functools import lru_cache
 
 import attrs
 import numpy as np
@@ -21,6 +20,7 @@ from ...contexts import KernelDictContext, SpectralContext
 from ...radprops import ZGrid
 from ...units import unit_context_config as ucc
 from ...units import unit_registry as ureg
+from ...util.misc import cache_by_id
 
 
 def _molecular_converter(value):
@@ -221,7 +221,7 @@ class HeterogeneousAtmosphere(AbstractHeterogeneousAtmosphere):
 
         return albedo * ureg.dimensionless
 
-    @lru_cache(maxsize=1)
+    @cache_by_id
     def _eval_sigma_t_impl(self, sctx: SpectralContext) -> pint.Quantity:
         result = np.zeros((len(self.components), len(self.zgrid.layers)))
         sigma_units = ucc.get("collision_coefficient")
@@ -248,7 +248,7 @@ class HeterogeneousAtmosphere(AbstractHeterogeneousAtmosphere):
             raise ValueError("zgrid must be left unset or set to self.zgrid")
         return self.eval_sigma_t(sctx) - self.eval_sigma_s(sctx)
 
-    @lru_cache(maxsize=1)
+    @cache_by_id
     def _eval_sigma_s_impl(self, sctx: SpectralContext) -> pint.Quantity:
         result = np.zeros((len(self.components), len(self.zgrid.layers)))
         sigma_units = ucc.get("collision_coefficient")

--- a/src/eradiate/scenes/phase/_blend.py
+++ b/src/eradiate/scenes/phase/_blend.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import typing as t
 from collections import abc as cabc
-from functools import lru_cache
 
 import attrs
 import mitsuba as mi
@@ -14,6 +13,7 @@ from ...attrs import documented
 from ...contexts import KernelDictContext, SpectralContext
 from ...kernel import InitParameter, UpdateParameter, map_unit_cube
 from ...units import unit_context_kernel as uck
+from ...util.misc import cache_by_id
 
 
 @attrs.define(eq=False, slots=False)
@@ -137,7 +137,7 @@ class BlendPhaseFunction(PhaseFunction):
             zmax=bbox_max[2],
         )
 
-    @lru_cache(maxsize=1)
+    @cache_by_id
     def _eval_conditional_weights_impl(self, sctx: SpectralContext) -> np.ndarray:
         """
         Memoised weight evaluation, used if weights are defined as callables.

--- a/src/eradiate/util/misc.py
+++ b/src/eradiate/util/misc.py
@@ -21,6 +21,15 @@ class cache_by_id:
     This decorator caches the value returned by the function it wraps in order
     to avoid unnecessary execution upon repeated calls with the same arguments.
 
+    Warnings
+    --------
+    The main difference with
+    :func:`functools.lru_cache(maxsize=1) <functools.lru_cache>` is that the
+    cache is referenced by positional argument IDs instead of hashes.
+    Therefore, this decorator can be used with NumPy arrays; but it's also
+    unsafe, because mutating an argument won't trigger a recompute, while it
+    actually shoud! **Use with great care!**
+
     Notes
     -----
     * Meant to be used as a decorator.

--- a/src/eradiate/util/misc.py
+++ b/src/eradiate/util/misc.py
@@ -14,6 +14,57 @@ import numpy as np
 import pint
 
 
+class cache_by_id:
+    """
+    Cache the result of a function based on the ID of its arguments.
+
+    This decorator caches the value returned by the function it wraps in order
+    to avoid unnecessary execution upon repeated calls with the same arguments.
+
+    Notes
+    -----
+    * Meant to be used as a decorator.
+    * The wrapped function may only have positional arguments.
+    * Works with functions and methods.
+
+    Examples
+    --------
+    >>> @cache_by_id
+    ... def f(x, y):
+    ...     print("Calling f")
+    ...     return x, y
+    >>> f(1, 2)
+    Calling f
+    (1, 2)
+    >>> f(1, 2)
+    (1, 2)
+    >>> f(1, 1)
+    Calling f
+    (1, 1)
+    >>> f(1, 1)
+    (1, 1)
+    """
+
+    def __init__(self, func):
+        functools.update_wrapper(self, func)
+        self.func = func
+        self._cached_value = None
+        self._cached_index = None
+
+    def __call__(self, *args):
+        index = tuple(id(arg) for arg in args)
+
+        if index != self._cached_index:
+            self._cached_index = index
+            self._cached_value = self.func(*args)
+
+        return self._cached_value
+
+    def __get__(self, instance, owner):
+        # See https://stackoverflow.com/questions/30104047 for full explanation
+        return functools.partial(self.__call__, instance)
+
+
 class LoggingContext(object):
     """
     This context manager allows for a temporary override of logger settings.

--- a/tests/02_eradiate/01_unit/util/test_misc.py
+++ b/tests/02_eradiate/01_unit/util/test_misc.py
@@ -8,6 +8,7 @@ import eradiate
 from eradiate import unit_registry as ureg
 from eradiate.util.misc import (
     Singleton,
+    cache_by_id,
     camel_to_snake,
     deduplicate,
     fullname,
@@ -96,3 +97,48 @@ def test_fullname(mode_mono):
         fullname(eradiate.scenes.spectra.Spectrum)
         == "eradiate.scenes.spectra._core.Spectrum"
     )
+
+
+def test_cache_by_id(capsys):
+    # Function
+    @cache_by_id
+    def f(x, y):
+        print("Calling f")
+        return x, y
+
+    assert f(1, 1) == (1, 1)
+    captured = capsys.readouterr()
+    assert captured.out == "Calling f\n"
+    assert f(1, 1) == (1, 1)
+    captured = capsys.readouterr()
+    assert captured.out == ""
+
+    assert f(1, 2) == (1, 2)
+    captured = capsys.readouterr()
+    assert captured.out == "Calling f\n"
+    assert f(1, 2) == (1, 2)
+    captured = capsys.readouterr()
+    assert captured.out == ""
+
+    # Class
+    class MyClass:
+        @cache_by_id
+        def f(self, x, y):
+            print("Calling f")
+            return x, y
+
+    obj = MyClass()
+
+    assert obj.f(1, 1) == (1, 1)
+    captured = capsys.readouterr()
+    assert captured.out == "Calling f\n"
+    assert obj.f(1, 1) == (1, 1)
+    captured = capsys.readouterr()
+    assert captured.out == ""
+
+    assert obj.f(1, 2) == (1, 2)
+    captured = capsys.readouterr()
+    assert captured.out == "Calling f\n"
+    assert obj.f(1, 2) == (1, 2)
+    captured = capsys.readouterr()
+    assert captured.out == ""


### PR DESCRIPTION
# Description

This commit introduces a basic per-ID caching decorator which is intended to replace `@functools.lru_cache(maxsize=1)` in the Eradiate codebase.

The main difference with `functools.lru_cache()` is that the cache is referenced by positional argument IDs instead of hashes. Therefore, `cache_by_id()` can be used with NumPy arrays; but it's also unsafe, because mutating an argument won't trigger a recompute either. Use with great care!

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
