### PR TITLE
ParticleLayer: Add absorption and scattering bypass switches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,8 @@ Entries marked with a  ︎⚠️ symbol require particular attention during upgr
   fixed angular width at a target location ({ghpr}`302`).
 * Added a new module {mod}`eradiate.constants` to store physical constants used
   in Eradiate ({ghpr}`312`).
+* Added absorption and scattering bypass switches to the {class}`.ParticleLayer`
+  class ({ghpr}`316`).
 
 ### Documentation
 


### PR DESCRIPTION
# Description

This PR adds long-overdue absorption and scattering bypass switches to the `ParticleLayer` class. The "theoretical" albedo and collision coefficient computation is transferred to implementation-detail methods, which use the `cache_by_id()` decorator to avoid unnecessary recomputes.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
