### PR TITLE
Summarize xarray data repr in scene elements

### DIFF
--- a/src/eradiate/radprops/_afgl1986.py
+++ b/src/eradiate/radprops/_afgl1986.py
@@ -26,7 +26,7 @@ from ..thermoprops.util import (
 )
 from ..units import to_quantity
 from ..units import unit_registry as ureg
-from ..util.misc import cache_by_id
+from ..util.misc import cache_by_id, summary_repr
 
 
 def _convert_thermoprops_afgl_1986(value: t.MutableMapping | xr.Dataset) -> xr.Dataset:
@@ -54,6 +54,7 @@ class AFGL1986RadProfile(RadProfile):
             factory=lambda: afgl_1986.make_profile(),
             converter=_convert_thermoprops_afgl_1986,
             validator=attrs.validators.instance_of(xr.Dataset),
+            repr=summary_repr,
         ),
         doc="Thermophysical properties.",
         type=":class:`~xarray.Dataset`",

--- a/src/eradiate/radprops/_us76_approx.py
+++ b/src/eradiate/radprops/_us76_approx.py
@@ -18,7 +18,7 @@ from ..ckd import Bindex
 from ..thermoprops import us76
 from ..units import to_quantity
 from ..units import unit_registry as ureg
-from ..util.misc import cache_by_id
+from ..util.misc import cache_by_id, summary_repr
 
 
 def _convert_thermoprops_us76_approx(
@@ -113,6 +113,7 @@ class US76ApproxRadProfile(RadProfile):
             factory=lambda: us76.make_profile(),
             converter=_convert_thermoprops_us76_approx,
             validator=attrs.validators.instance_of(xr.Dataset),
+            repr=summary_repr,
         ),
         doc="Thermophysical properties.",
         type=":class:`~xarray.Dataset`",

--- a/src/eradiate/scenes/atmosphere/_molecular_atmosphere.py
+++ b/src/eradiate/scenes/atmosphere/_molecular_atmosphere.py
@@ -25,6 +25,7 @@ from ...thermoprops.util import (
     rescale_concentration,
 )
 from ...units import unit_registry as ureg
+from ...util.misc import summary_repr
 
 
 @parse_docs
@@ -45,6 +46,7 @@ class MolecularAtmosphere(AbstractHeterogeneousAtmosphere):
         attrs.field(
             factory=us76.make_profile,
             validator=attrs.validators.instance_of(xr.Dataset),
+            repr=summary_repr,
         ),
         doc="Thermophysical properties.",
         type="Dataset",

--- a/src/eradiate/scenes/atmosphere/_particle_layer.py
+++ b/src/eradiate/scenes/atmosphere/_particle_layer.py
@@ -25,7 +25,7 @@ from ...radprops import ZGrid
 from ...units import to_quantity
 from ...units import unit_context_config as ucc
 from ...units import unit_registry as ureg
-from ...util.misc import cache_by_id
+from ...util.misc import cache_by_id, summary_repr
 from ...validators import is_positive
 
 
@@ -178,6 +178,7 @@ class ParticleLayer(AbstractHeterogeneousAtmosphere):
                 load_from_id=lambda x: data.load_dataset(f"spectra/particles/{x}.nc")
             ),
             validator=attrs.validators.instance_of(xr.Dataset),
+            repr=summary_repr,
         ),
         doc="Particle radiative property data set."
         "If an xarray dataset is passed, the dataset is used as is "

--- a/src/eradiate/scenes/bsdfs/_mqdiffuse.py
+++ b/src/eradiate/scenes/bsdfs/_mqdiffuse.py
@@ -11,6 +11,7 @@ from ...attrs import documented, parse_docs
 from ...kernel import InitParameter, UpdateParameter
 from ...units import to_quantity
 from ...units import unit_registry as ureg
+from ...util.misc import summary_repr
 
 
 @parse_docs
@@ -54,6 +55,7 @@ class MQDiffuseBSDF(BSDF):
         attrs.field(
             converter=converters.to_dataset(),
             kw_only=True,
+            repr=summary_repr,
         ),
         type="Dataset",
         init_type="Dataset",

--- a/src/eradiate/scenes/phase/_tabulated.py
+++ b/src/eradiate/scenes/phase/_tabulated.py
@@ -14,6 +14,7 @@ from ...contexts import SpectralContext
 from ...exceptions import UnsupportedModeError
 from ...kernel import InitParameter, UpdateParameter
 from ...units import unit_registry as ureg
+from ...util.misc import summary_repr
 
 
 def _ensure_magnitude_array(q: pint.Quantity) -> pint.Quantity:
@@ -75,6 +76,7 @@ class TabulatedPhaseFunction(PhaseFunction):
             converter=_convert_data,
             validator=[attrs.validators.instance_of(xr.DataArray), _validate_data],
             kw_only=True,
+            repr=summary_repr,
         ),
         type="DataArray",
         doc="Value table as a data array with wavelength (``w``), scattering "

--- a/src/eradiate/scenes/spectra/_solar_irradiance.py
+++ b/src/eradiate/scenes/spectra/_solar_irradiance.py
@@ -18,6 +18,7 @@ from ...units import PhysicalQuantity, to_quantity
 from ...units import unit_context_config as ucc
 from ...units import unit_context_kernel as uck
 from ...units import unit_registry as ureg
+from ...util.misc import summary_repr
 
 
 def _datetime_converter(x: t.Any):
@@ -108,6 +109,7 @@ class SolarIrradianceSpectrum(Spectrum):
                 )
             ),
             validator=attrs.validators.instance_of(xr.Dataset),
+            repr=summary_repr,
         ),
         doc="Solar irradiance spectrum dataset. "
         "If a xarray.Dataset is passed, the dataset is used as is "

--- a/src/eradiate/test_tools/regression.py
+++ b/src/eradiate/test_tools/regression.py
@@ -15,6 +15,7 @@ from .. import data
 from ..attrs import documented, parse_docs
 from ..exceptions import DataError
 from ..typing import PathLike
+from ..util.misc import summary_repr
 
 
 def regression_test_plots(
@@ -145,7 +146,10 @@ class RegressionTest(ABC):
     )
 
     value: xr.Dataset = documented(
-        attrs.field(validator=attrs.validators.instance_of(xr.Dataset)),
+        attrs.field(
+            validator=attrs.validators.instance_of(xr.Dataset),
+            repr=summary_repr,
+        ),
         doc="Simulation result. Must be specified as a dataset.",
         type=":class:`xarray.Dataset`",
         init_type=":class:`xarray.Dataset`",


### PR DESCRIPTION
# Description

This PR modifies the repr of fields containing xarray data. The resulting representation is much more compact and doesn't display unwanted data. The data can obviously still be accessed for in-depth browsing.

> **Warning**
> Merge **after** #316.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
