### PR TITLE
Redirect Mitsuba logs to the `mitsuba` logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ Entries marked with a  ︎⚠️ symbol require particular attention during upgr
   in Eradiate ({ghpr}`312`).
 * Added absorption and scattering bypass switches to the {class}`.ParticleLayer`
   class ({ghpr}`316`).
+* ⚠️ Moved Mitsuba logs to the `mitsuba` logger ({ghpr}`318`).
 
 ### Documentation
 

--- a/src/eradiate/experiments/_core.py
+++ b/src/eradiate/experiments/_core.py
@@ -356,7 +356,7 @@ class EarthObservationExperiment(Experiment, ABC):
             self.init()
 
         # Run Mitsuba for each context
-        logger.info("Running simulation")
+        logger.info("Launching simulation")
 
         mi_results = mi_render(
             self.mi_scene,

--- a/src/eradiate/kernel/_render.py
+++ b/src/eradiate/kernel/_render.py
@@ -280,6 +280,7 @@ def mi_render(
     """
 
     if seed_state is None:
+        logger.debug("Using default RNG seed generator")
         seed_state = root_seed_state
 
     results = {}
@@ -315,13 +316,13 @@ def mi_render(
             # Loop on sensors
             for i_sensor, mi_sensor in mi_sensors:
                 # Render sensor
-                logger.debug('Running Mitsuba for sensor "%s"', mi_sensor.id())
-                mi.render(
-                    mi_scene.obj,
-                    sensor=i_sensor,
-                    seed=int(seed_state.next()),
-                    spp=spp,
+                seed = int(seed_state.next())
+                logger.debug(
+                    'Running Mitsuba for sensor "%s" with seed value %s',
+                    mi_sensor.id(),
+                    seed,
                 )
+                mi.render(mi_scene.obj, sensor=i_sensor, seed=seed, spp=spp)
 
                 # Store result in a new Bitmap object
                 if ctx.spectral_ctx.spectral_index not in results:

--- a/src/eradiate/kernel/logging.py
+++ b/src/eradiate/kernel/logging.py
@@ -75,7 +75,7 @@ mi_log_parser = re.compile(
 mi_logger = None
 
 # Module-local logger
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("mitsuba")
 
 
 def _get_logger():


### PR DESCRIPTION
# Description

This PR redirects Mitsuba logs, originally sent to `eradiate.kernel.logging`, to the `mitsuba` logger.

> **Warning**
> Merge **after** #317.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
