### PR TITLE
Fix atmospheric property setup and update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,11 @@ Entries marked with a  ︎⚠️ symbol require particular attention during upgr
 * Added absorption and scattering bypass switches to the {class}`.ParticleLayer`
   class ({ghpr}`316`).
 * ⚠️ Moved Mitsuba logs to the `mitsuba` logger ({ghpr}`318`).
+* ⚠️ Centralized geometric information to `SceneGeometry` ({ghpr}`319`).
+* ⚠️ Made {class}`Atmosphere`'s `_params_*` properties abstract for improved
+  safety ({ghpr}`319`).
+* Fixed a major issue in volume definitions and parameter updates of
+  {class}`BlendPhaseFunction` ({ghpr}`319`).
 
 ### Documentation
 

--- a/src/eradiate/experiments/_atmosphere.py
+++ b/src/eradiate/experiments/_atmosphere.py
@@ -55,7 +55,10 @@ class AtmosphereExperiment(EarthObservationExperiment):
                 (PlaneParallelGeometry, SphericalShellGeometry)
             ),
         ),
-        doc="Problem geometry.",
+        doc="Problem geometry. Can be specified as a simple string "
+        '(``"plane_parallel" or "spherical_shell"``), a dictionary interpreted '
+        "by :meth:`.SceneGeometry.convert`, or a :class:`.SceneGeometry` "
+        "instance.",
         type=".PlaneParallelGeometry or .SphericalShellGeometry",
         init_type="str or dict or .SceneGeometry",
         default='"plane_parallel"',
@@ -180,7 +183,7 @@ class AtmosphereExperiment(EarthObservationExperiment):
             if isinstance(self.geometry, PlaneParallelGeometry):
                 width = self.geometry.width
                 altitude = (
-                    self.atmosphere.bottom
+                    self.atmosphere.bottom_altitude
                     if self.atmosphere is not None
                     else 0.0 * ureg.km
                 )
@@ -192,7 +195,7 @@ class AtmosphereExperiment(EarthObservationExperiment):
 
             elif isinstance(self.geometry, SphericalShellGeometry):
                 altitude = (
-                    self.atmosphere.bottom
+                    self.atmosphere.bottom_altitude
                     if self.atmosphere is not None
                     else 0.0 * ureg.km
                 )

--- a/src/eradiate/experiments/_canopy_atmosphere.py
+++ b/src/eradiate/experiments/_canopy_atmosphere.py
@@ -280,7 +280,9 @@ class CanopyAtmosphereExperiment(EarthObservationExperiment):
 
         # Pre-process surface
         if self.surface is not None:
-            altitude = atmosphere.bottom if atmosphere is not None else 0.0 * ureg.km
+            altitude = (
+                atmosphere.bottom_altitude if atmosphere is not None else 0.0 * ureg.km
+            )
             surface = attrs.evolve(
                 self.surface,
                 shape=RectangleShape.surface(altitude=altitude, width=surface_width),

--- a/src/eradiate/experiments/_dem.py
+++ b/src/eradiate/experiments/_dem.py
@@ -198,7 +198,7 @@ class DEMExperiment(EarthObservationExperiment):
         if self.surface is not None:
             if self.atmosphere is not None:
                 surface_width = self.atmosphere.geometry.width
-                surface_altitude = self.atmosphere.bottom
+                surface_altitude = self.atmosphere.bottom_altitude
             else:
                 surface_width = self._default_surface_width
                 surface_altitude = 0.0 * ureg.km

--- a/src/eradiate/scenes/atmosphere/_core.py
+++ b/src/eradiate/scenes/atmosphere/_core.py
@@ -718,7 +718,7 @@ class AbstractHeterogeneousAtmosphere(Atmosphere, ABC):
 
         elif isinstance(self.geometry, SphericalShellGeometry):
             return {
-                "albedo.data": UpdateParameter(
+                "albedo.volume.data": UpdateParameter(
                     lambda ctx: np.reshape(
                         self.eval_albedo(ctx.spectral_ctx).m_as(ureg.dimensionless),
                         (1, 1, -1, 1),
@@ -730,7 +730,7 @@ class AbstractHeterogeneousAtmosphere(Atmosphere, ABC):
                         parameter_relpath=f"albedo.volume.data",
                     ),
                 ),
-                "sigma_t.data": UpdateParameter(
+                "sigma_t.volume.data": UpdateParameter(
                     lambda ctx: np.reshape(
                         self.eval_sigma_t(ctx.spectral_ctx).m_as(
                             uck.get("collision_coefficient")

--- a/src/eradiate/scenes/atmosphere/_homogeneous.py
+++ b/src/eradiate/scenes/atmosphere/_homogeneous.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import attrs
 import pint
-import pinttr
 
 from ._core import Atmosphere
 from ..core import traverse
@@ -11,9 +10,7 @@ from ..spectra import AirScatteringCoefficientSpectrum, Spectrum, spectrum_facto
 from ...attrs import documented, parse_docs
 from ...contexts import KernelDictContext, SpectralContext
 from ...kernel import InitParameter, UpdateParameter
-from ...units import unit_context_config as ucc
 from ...units import unit_context_kernel as uck
-from ...units import unit_registry as ureg
 from ...validators import has_quantity
 
 
@@ -26,38 +23,6 @@ class HomogeneousAtmosphere(Atmosphere):
     This class builds an atmosphere consisting of a homogeneous medium with
     customizable collision coefficients and phase function.
     """
-
-    _bottom: pint.Quantity = documented(
-        pinttr.field(
-            default=ureg.Quantity(0.0, ureg.km),
-            units=ucc.deferred("length"),
-        ),
-        doc="Atmosphere's bottom altitude.\n"
-        "\n"
-        "Unit-enabled field (default: ucc['length']).",
-        type="quantity",
-        init_type="quantity or float",
-        default="0 km",
-    )
-
-    _top: pint.Quantity = documented(
-        pinttr.field(
-            default=ureg.Quantity(10.0, ureg.km),
-            units=ucc.deferred("length"),
-        ),
-        doc="Atmosphere's top altitude.\n"
-        "\n"
-        "Unit-enabled field (default: ucc['length']).",
-        type="quantity",
-        init_type="quantity or float",
-        default="10 km",
-    )
-
-    @_bottom.validator
-    @_top.validator
-    def _validate_bottom_and_top(self, attribute, value):
-        if self.bottom >= self.top:
-            raise ValueError("bottom altitude must be lower than top altitude")
 
     sigma_s: Spectrum = documented(
         attrs.field(
@@ -119,16 +84,6 @@ class HomogeneousAtmosphere(Atmosphere):
     # --------------------------------------------------------------------------
     #                               Properties
     # --------------------------------------------------------------------------
-
-    @property
-    def bottom(self) -> pint.Quantity:
-        # Inherit docstring
-        return self._bottom
-
-    @property
-    def top(self) -> pint.Quantity:
-        # Inherit docstring
-        return self._top
 
     @property
     def phase(self) -> PhaseFunction:

--- a/src/eradiate/scenes/atmosphere/_molecular_atmosphere.py
+++ b/src/eradiate/scenes/atmosphere/_molecular_atmosphere.py
@@ -124,7 +124,6 @@ class MolecularAtmosphere(AbstractHeterogeneousAtmosphere):
 
     def update(self) -> None:
         # Inherit docstring
-        super().update()
 
         self.phase.id = self.phase_id
 
@@ -154,21 +153,6 @@ class MolecularAtmosphere(AbstractHeterogeneousAtmosphere):
     # --------------------------------------------------------------------------
     #              Spatial extension and thermophysical properties
     # --------------------------------------------------------------------------
-
-    @property
-    def zgrid(self) -> ZGrid:
-        # Inherit docstring
-        return self.radprops_profile.zgrid
-
-    @property
-    def bottom(self) -> pint.Quantity:
-        # Inherit docstring
-        return self.zgrid.levels.min()
-
-    @property
-    def top(self) -> pint.Quantity:
-        # Inherit docstring
-        return self.zgrid.levels.max()
 
     @property
     def thermoprops(self) -> xr.Dataset:
@@ -205,7 +189,7 @@ class MolecularAtmosphere(AbstractHeterogeneousAtmosphere):
         # Inherit docstring
         return self.radprops_profile.eval_albedo(
             sctx,
-            self.zgrid if zgrid is None else zgrid,
+            self.geometry.zgrid if zgrid is None else zgrid,
         )
 
     def eval_sigma_t(
@@ -214,7 +198,7 @@ class MolecularAtmosphere(AbstractHeterogeneousAtmosphere):
         # Inherit docstring
         return self.radprops_profile.eval_sigma_t(
             sctx,
-            self.zgrid if zgrid is None else zgrid,
+            self.geometry.zgrid if zgrid is None else zgrid,
         )
 
     def eval_sigma_a(
@@ -223,7 +207,7 @@ class MolecularAtmosphere(AbstractHeterogeneousAtmosphere):
         # Inherit docstring
         return self.radprops_profile.eval_sigma_a(
             sctx,
-            self.zgrid if zgrid is None else zgrid,
+            self.geometry.zgrid if zgrid is None else zgrid,
         )
 
     def eval_sigma_s(
@@ -232,7 +216,7 @@ class MolecularAtmosphere(AbstractHeterogeneousAtmosphere):
         # Inherit docstring
         return self.radprops_profile.eval_sigma_s(
             sctx,
-            self.zgrid if zgrid is None else zgrid,
+            self.geometry.zgrid if zgrid is None else zgrid,
         )
 
     # --------------------------------------------------------------------------

--- a/src/eradiate/scenes/geometry.py
+++ b/src/eradiate/scenes/geometry.py
@@ -150,7 +150,7 @@ class SceneGeometry(ABC):
 
     @property
     @abstractmethod
-    def atmosphere_gridvolume_to_world(self) -> mi.ScalarTransform4f:
+    def atmosphere_volume_to_world(self) -> mi.ScalarTransform4f:
         """
         :class:`mi.ScalarTransform4f` : Mitsuba transform mapping volume texture
             coordinates to world coordinates for heterogeneous atmosphere
@@ -195,7 +195,7 @@ class PlaneParallelGeometry(SceneGeometry):
         )
 
     @property
-    def atmosphere_gridvolume_to_world(self) -> mi.ScalarTransform4f:
+    def atmosphere_volume_to_world(self) -> mi.ScalarTransform4f:
         length_units = uck.get("length")
         shape = self.atmosphere_shape
 
@@ -240,7 +240,7 @@ class SphericalShellGeometry(SceneGeometry):
         )
 
     @property
-    def atmosphere_gridvolume_to_world(self) -> mi.ScalarTransform4f:
+    def atmosphere_volume_to_world(self) -> mi.ScalarTransform4f:
         length_units = ucc.get("length")
 
         # The bounding box corresponds to the vertices of the bounding box
@@ -249,6 +249,16 @@ class SphericalShellGeometry(SceneGeometry):
         xmax, ymax, zmax = bbox.max.m_as(length_units)
 
         return map_cube(xmin, xmax, ymin, ymax, zmin, zmax)
+
+    @property
+    def atmosphere_volume_rmin(self) -> float:
+        """
+        Value for the ``rmin`` parameter of the ``sphericalcoordsvolume`` plugin
+        describing the volume data in the spherical shell geometry.
+        """
+        return (self.planet_radius / (self.planet_radius + self.toa_altitude)).m_as(
+            ureg.dimensionless
+        )
 
     @property
     def surface_shape(self) -> Shape:

--- a/src/eradiate/scenes/geometry.py
+++ b/src/eradiate/scenes/geometry.py
@@ -1,24 +1,100 @@
 from __future__ import annotations
 
-import abc
 import typing as t
+from abc import ABC, abstractmethod
 
 import attrs
+import mitsuba as mi
+import numpy as np
 import pint
 import pinttr
 
+from .shapes import CuboidShape, RectangleShape, Shape, SphereShape
 from ..attrs import documented, parse_docs
 from ..constants import EARTH_RADIUS
+from ..kernel import map_cube, map_unit_cube
+from ..radprops import ZGrid
 from ..units import unit_context_config as ucc
+from ..units import unit_context_kernel as uck
 from ..units import unit_registry as ureg
 
 
 @parse_docs
 @attrs.define
-class SceneGeometry(abc.ABC):
+class SceneGeometry(ABC):
     """
     Abstract base class defining a scene geometry.
+
+    Warnings
+    --------
+     If a ``zgrid`` value is passed to the constructor (instead of letting
+     the constructor set it automatically), its extent must be
+     [``ground_altitude``, ``toa_altitude``]. The constructor will raise
+     a :class:`ValueError` otherwise.
     """
+
+    toa_altitude: pint.Quantity = documented(
+        pinttr.field(default=120.0 * ureg.km, units=ucc.deferred("length")),
+        doc="Top-of-atmosphere level altitude. "
+        'Unit-enabled field (default: ``ucc["length"]``).',
+        default="120 km",
+        type="pint.Quantity",
+        init_type="float or quantity",
+    )
+
+    ground_altitude: pint.Quantity = documented(
+        pinttr.field(default=0.0 * ureg.km, units=ucc.deferred("length")),
+        doc="Baseline ground altitude. "
+        'Unit-enabled field (default: ``ucc["length"]``).',
+        default="0 km",
+        type="pint.Quantity",
+        init_type="float or quantity",
+    )
+
+    zgrid: ZGrid = documented(
+        attrs.field(
+            default=None,
+            converter=attrs.converters.optional(
+                lambda x: ZGrid(x) if not isinstance(x, ZGrid) else x
+            ),
+            validator=attrs.validators.optional(attrs.validators.instance_of(ZGrid)),
+        ),
+        doc="The altitude mesh on which the radiative properties of "
+        "heterogeneous atmosphere components are evaluated. "
+        "If unset, a default grid with one layer per 100 m (or 10 layers if "
+        "the atmosphere object height is less than 100 m) is used.",
+        type=".ZGrid",
+        init_type=".ZGrid, quantity or ndarray, optional",
+    )
+
+    def __attrs_post_init__(self) -> None:
+        # Set altitude grid
+        if self.zgrid is None:
+            bottom = self.ground_altitude.m_as(ureg.m)
+            top = self.toa_altitude.m_as(ureg.m)
+            step = min(100.0, (top - bottom) / 10.0)
+            self.zgrid = ZGrid(
+                ureg.convert(
+                    np.arange(bottom, top + step * 0.1, step),
+                    ureg.m,
+                    ucc.get("length"),
+                )
+            )
+
+        else:
+            grid_bottom = self.zgrid.levels[0]
+            if not np.isclose(grid_bottom, self.ground_altitude):
+                raise ValueError(
+                    "zgrid bottom must match ground_altitude; "
+                    f"expected {self.ground_altitude}, got {grid_bottom}"
+                )
+
+            grid_top = self.zgrid.levels[-1]
+            if not np.isclose(grid_top, self.toa_altitude):
+                raise ValueError(
+                    "zgrid top must match toa_altitude; "
+                    f"expected {self.toa_altitude}, got {grid_top}"
+                )
 
     @classmethod
     def convert(cls, value: t.Any) -> t.Any:
@@ -64,6 +140,32 @@ class SceneGeometry(abc.ABC):
 
         return value
 
+    @property
+    @abstractmethod
+    def atmosphere_shape(self) -> Shape:
+        """
+        :class:`.Shape`: Stencil of the participating medium representing the atmosphere.
+        """
+        pass
+
+    @property
+    @abstractmethod
+    def atmosphere_gridvolume_to_world(self) -> mi.ScalarTransform4f:
+        """
+        :class:`mi.ScalarTransform4f` : Mitsuba transform mapping volume texture
+            coordinates to world coordinates for heterogeneous atmosphere
+            components.
+        """
+        pass
+
+    @property
+    @abstractmethod
+    def surface_shape(self) -> Shape:
+        """
+        :class:`.Shape` : Shape representing the surface.
+        """
+        pass
+
 
 @parse_docs
 @attrs.define
@@ -83,8 +185,33 @@ class PlaneParallelGeometry(SceneGeometry):
         doc="Cuboid shape width.",
         type="quantity",
         init_type="quantity or float",
-        default="1.000.000 km",
+        default="1,000,000 km",
     )
+
+    @property
+    def atmosphere_shape(self) -> CuboidShape:
+        return CuboidShape.atmosphere(
+            top=self.toa_altitude, bottom=0.0 * ureg.km, width=self.width
+        )
+
+    @property
+    def atmosphere_gridvolume_to_world(self) -> mi.ScalarTransform4f:
+        length_units = uck.get("length")
+        shape = self.atmosphere_shape
+
+        # The bounding box corresponds to the vertices of the cuboid
+        center = shape.center.m_as(length_units)
+        edges = shape.edges.m_as(length_units)
+        xmin, ymin = center[0:2] - edges[0:2] * 0.5
+        xmax, ymax = center[0:2] + edges[0:2] * 0.5
+        zmin = self.ground_altitude.m_as(length_units)
+        zmax = self.toa_altitude.m_as(length_units)
+
+        return map_unit_cube(xmin, xmax, ymin, ymax, zmin, zmax)
+
+    @property
+    def surface_shape(self) -> RectangleShape:
+        return RectangleShape.surface(altitude=self.ground_altitude, width=self.width)
 
 
 @parse_docs
@@ -105,3 +232,26 @@ class SphericalShellGeometry(SceneGeometry):
         init_type="quantity or float",
         default=":data:`.EARTH_RADIUS`",
     )
+
+    @property
+    def atmosphere_shape(self) -> SphereShape:
+        return SphereShape.atmosphere(
+            top=self.toa_altitude, planet_radius=self.planet_radius
+        )
+
+    @property
+    def atmosphere_gridvolume_to_world(self) -> mi.ScalarTransform4f:
+        length_units = ucc.get("length")
+
+        # The bounding box corresponds to the vertices of the bounding box
+        bbox = self.atmosphere_shape.bbox
+        xmin, ymin, zmin = bbox.min.m_as(length_units)
+        xmax, ymax, zmax = bbox.max.m_as(length_units)
+
+        return map_cube(xmin, xmax, ymin, ymax, zmin, zmax)
+
+    @property
+    def surface_shape(self) -> Shape:
+        return SphereShape.surface(
+            altitude=self.ground_altitude, planet_radius=self.planet_radius
+        )

--- a/src/eradiate/scenes/shapes/_buffermesh.py
+++ b/src/eradiate/scenes/shapes/_buffermesh.py
@@ -7,7 +7,7 @@ import pint
 import pinttr
 
 from ._core import ShapeInstance
-from ..core import traverse
+from ..core import BoundingBox, traverse
 from ...attrs import documented, parse_docs
 from ...contexts import KernelDictContext
 from ...kernel import UpdateParameter
@@ -56,6 +56,10 @@ class BufferMeshShape(ShapeInstance):
                 f"while validating {attribute.name}, must be an array of shape "
                 f"(n, 3), got {value.shape}"
             )
+
+    def bbox(self) -> BoundingBox:
+        # Inherit docstring
+        raise NotImplementedError
 
     @property
     def instance(self) -> mi.Object:

--- a/src/eradiate/scenes/shapes/_core.py
+++ b/src/eradiate/scenes/shapes/_core.py
@@ -5,7 +5,7 @@ from abc import ABC
 import attrs
 
 from ..bsdfs import BSDF, bsdf_factory
-from ..core import InstanceSceneElement, NodeSceneElement, Ref
+from ..core import BoundingBox, InstanceSceneElement, NodeSceneElement, Ref
 from ..._factory import Factory
 from ...attrs import documented, get_doc, parse_docs
 
@@ -67,8 +67,18 @@ class Shape:
 
     def update(self) -> None:
         # Inherit docstring
+
+        # Normalize child BSDF ID
         if isinstance(self.bsdf, BSDF):
             self.bsdf.id = self._bsdf_id
+
+    @property
+    def bbox(self) -> BoundingBox:
+        """
+        :class:`.BoundingBox` : Shape bounding box. Default implementation
+            raises a :class:`NotImplementedError`.
+        """
+        raise NotImplementedError
 
     @property
     def _bsdf_id(self) -> str:

--- a/src/eradiate/scenes/shapes/_cuboid.py
+++ b/src/eradiate/scenes/shapes/_cuboid.py
@@ -11,6 +11,7 @@ from pinttr.util import ensure_units
 
 from ._core import ShapeNode
 from ..bsdfs import BSDF
+from ..core import BoundingBox
 from ...attrs import documented, parse_docs
 from ...contexts import KernelDictContext
 from ...units import unit_context_config as ucc
@@ -64,6 +65,14 @@ class CuboidShape(ShapeNode):
         init_type="quantity or array-like",
         default="[1, 1, 1]",
     )
+
+    @property
+    def bbox(self) -> BoundingBox:
+        # Inherit docstring
+
+        return BoundingBox(
+            self.center - 0.5 * self.edges, self.center + 0.5 * self.edges
+        )
 
     def contains(
         self, p: np.typing.ArrayLike, strict: bool = False

--- a/src/eradiate/scenes/shapes/_filemesh.py
+++ b/src/eradiate/scenes/shapes/_filemesh.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import attrs
 
 from ._core import ShapeNode
+from ..core import BoundingBox
 from ...attrs import documented, parse_docs
 
 
@@ -42,6 +43,10 @@ class FileMeshShape(ShapeNode):
             return "ply"
         else:
             raise ValueError(f"unknown mesh file type '{self.filename.suffix}'")
+
+    def bbox(self) -> BoundingBox:
+        # Inherit docstring
+        raise NotImplementedError
 
     @property
     def template(self) -> dict:

--- a/src/eradiate/scenes/shapes/_rectangle.py
+++ b/src/eradiate/scenes/shapes/_rectangle.py
@@ -8,6 +8,7 @@ import pinttr
 
 from ._core import ShapeNode
 from ..bsdfs import BSDF
+from ..core import BoundingBox
 from ... import validators
 from ...attrs import documented, parse_docs
 from ...units import unit_context_config as ucc
@@ -93,6 +94,10 @@ class RectangleShape(ShapeNode):
         init_type="array-like, optional",
         default="[0, 1, 0]",
     )
+
+    def bbox(self) -> BoundingBox:
+        # Inherit docstring
+        raise NotImplementedError
 
     @property
     def template(self) -> dict:

--- a/src/eradiate/scenes/shapes/_sphere.py
+++ b/src/eradiate/scenes/shapes/_sphere.py
@@ -8,6 +8,7 @@ from pinttr.util import ensure_units
 
 from ._core import ShapeNode
 from ..bsdfs import BSDF
+from ..core import BoundingBox
 from ...attrs import documented, parse_docs
 from ...constants import EARTH_RADIUS
 from ...units import unit_context_config as ucc
@@ -46,6 +47,14 @@ class SphereShape(ShapeNode):
         init_type="quantity or float, optional",
         default="1.0",
     )
+
+    @property
+    def bbox(self) -> BoundingBox:
+        length_units = ucc.get("length")
+        offset = (
+            np.full_like(self.center, self.radius.m_as(length_units)) * length_units
+        )
+        return BoundingBox(self.center - offset, self.center + offset)
 
     @property
     def template(self) -> dict:

--- a/tests/02_eradiate/01_unit/experiments/test_dem.py
+++ b/tests/02_eradiate/01_unit/experiments/test_dem.py
@@ -46,7 +46,7 @@ def test_dem_experiment_construct_normalize_measures(mode_mono):
     assert np.allclose(exp.measures[0].target.xyz, [0, 0, 0] * ureg.m)
 
     # When atmosphere is set, measure target is at ground level
-    exp = DEMExperiment(atmosphere=HomogeneousAtmosphere(top=100.0 * ureg.km))
+    exp = DEMExperiment(atmosphere=HomogeneousAtmosphere())
     assert np.allclose(exp.measures[0].target.xyz, [0, 0, 0] * ureg.m)
 
 

--- a/tests/02_eradiate/01_unit/scenes/atmosphere/test_heterogeneous.py
+++ b/tests/02_eradiate/01_unit/scenes/atmosphere/test_heterogeneous.py
@@ -351,7 +351,7 @@ def test_heterogeneous_absorbing_mol_atm(mode_ckd, particle_radprops, request):
 
     # Collect phase function weights
     mi_wrapper = check_scene_element(atmosphere.phase, mi.PhaseFunction)
-    weights = np.squeeze(mi_wrapper.parameters["weight.data"])
+    weights = np.squeeze(mi_wrapper.parameters["weight.volume.data"])
 
     # Extract phase function weights
     inside_particle_layer = (atmosphere.geometry.zgrid.layers >= pl_bottom) & (

--- a/tests/02_eradiate/01_unit/scenes/atmosphere/test_homogeneous.py
+++ b/tests/02_eradiate/01_unit/scenes/atmosphere/test_homogeneous.py
@@ -13,14 +13,12 @@ from eradiate.test_tools.types import check_scene_element
         {},
         {"phase": {"type": "isotropic"}},
         {"phase": {"type": "hg"}},
-        {"bottom": 1.0 * ureg.km, "top": 8.0 * ureg.km},
         {"geometry": "spherical_shell"},
     ],
     ids=[
         "noargs",
         "phase_isotropic",
         "phase_hg",
-        "bottom_top",
         "geometry_spherical_shell",
     ],
 )
@@ -54,9 +52,12 @@ def test_homogeneous_atmosphere_params(mode_mono):
     [
         (
             {
-                "geometry": {"type": "plane_parallel", "width": 1.0 * ureg.km},
-                "bottom": 0.0 * ureg.km,
-                "top": 1.0 * ureg.km,
+                "geometry": {
+                    "type": "plane_parallel",
+                    "width": 1.0 * ureg.km,
+                    "ground_altitude": 0.0 * ureg.km,
+                    "toa_altitude": 1.0 * ureg.km,
+                }
             },
             {
                 "bbox_min": [-500.0, -500.0, -10.0],
@@ -66,9 +67,12 @@ def test_homogeneous_atmosphere_params(mode_mono):
         ),
         (
             {
-                "geometry": {"type": "spherical_shell", "planet_radius": 1.0 * ureg.km},
-                "bottom": 0.0 * ureg.km,
-                "top": 1.0 * ureg.km,
+                "geometry": {
+                    "type": "spherical_shell",
+                    "planet_radius": 1.0 * ureg.km,
+                    "ground_altitude": 0.0 * ureg.km,
+                    "toa_altitude": 1.0 * ureg.km,
+                },
             },
             {
                 "bbox_min": [-2000.0, -2000.0, -2000.0],
@@ -91,5 +95,7 @@ def test_homogeneous_atmosphere_geometry(mode_mono, kwargs, expected):
     assert mi_shape_type_name == expected["atmosphere_shape_type_name"]
 
     # Check scene bounding box
-    assert dr.allclose(mi_wrapper.obj.bbox().min, expected["bbox_min"])
-    assert dr.allclose(mi_wrapper.obj.bbox().max, expected["bbox_max"])
+    bbmin = mi_wrapper.obj.bbox().min
+    bbmax = mi_wrapper.obj.bbox().max
+    assert dr.allclose(bbmin, expected["bbox_min"])
+    assert dr.allclose(bbmax, expected["bbox_max"])

--- a/tests/02_eradiate/01_unit/scenes/atmosphere/test_particle_layer.py
+++ b/tests/02_eradiate/01_unit/scenes/atmosphere/test_particle_layer.py
@@ -39,7 +39,18 @@ def test_particle_layer_kernel_dict(mode_mono, geometry):
 @pytest.mark.parametrize("wavelength", [280.0, 550.0, 1600.0, 2400.0])
 def test_particle_layer_eval_mono_absorbing_only(mode_mono, absorbing_only, wavelength):
     """eval methods return expected values for an absorbing-only layer."""
-    layer = ParticleLayer(dataset=absorbing_only)
+    bottom = 0.0 * ureg.km
+    top = 1.0 * ureg.km
+    layer = ParticleLayer(
+        geometry={
+            "type": "plane_parallel",
+            "ground_altitude": bottom,
+            "toa_altitude": top,
+        },
+        dataset=absorbing_only,
+        bottom=bottom,
+        top=top,
+    )
     spectral_ctx = SpectralContext.new(wavelength=wavelength)
     assert np.allclose(layer.eval_sigma_s(spectral_ctx), 0.0 / ureg.km)
     assert np.allclose(layer.eval_sigma_a(spectral_ctx), 0.2 / ureg.km)
@@ -54,14 +65,25 @@ def test_particle_layer_eval_mono_scattering_only(
     mode_mono, scattering_only, wavelength
 ):
     """eval methods return expected values for a scattering-only layer."""
-    layer = ParticleLayer(dataset=scattering_only)
+    bottom = 0.0 * ureg.km
+    top = 1.0 * ureg.km
+    layer = ParticleLayer(
+        geometry={
+            "type": "plane_parallel",
+            "ground_altitude": bottom,
+            "toa_altitude": top,
+        },
+        dataset=scattering_only,
+        bottom=bottom,
+        top=top,
+    )
     spectral_ctx = SpectralContext.new(wavelength=wavelength)
     assert np.allclose(layer.eval_sigma_s(spectral_ctx), 0.2 / ureg.km)
     assert np.allclose(layer.eval_sigma_a(spectral_ctx), 0.0 / ureg.km)
     assert np.allclose(layer.eval_albedo(spectral_ctx).m, 1.0)
 
     ctx = KernelDictContext(spectral_ctx=spectral_ctx)
-    assert layer.eval_mfp(ctx) == 5.0 * ureg.km
+    assert np.isclose(layer.eval_mfp(ctx), 5.0 * ureg.km)
 
 
 @pytest.mark.parametrize("wavelength", [280.0, 550.0, 1600.0, 2400.0])
@@ -69,27 +91,45 @@ def test_particle_layer_eval_mono(mode_mono, test_particles_dataset, wavelength)
     """
     eval_* methods return expected values for a scattering and absorbing layer.
     """
+    bottom = 0.0 * ureg.km
+    top = 1.0 * ureg.km
     layer = ParticleLayer(
+        geometry={
+            "type": "plane_parallel",
+            "ground_altitude": bottom,
+            "toa_altitude": top,
+        },
         dataset=test_particles_dataset,
-        n_layers=1,
         tau_ref=1.0,
-        bottom=0.0 * ureg.km,
-        top=1.0 * ureg.km,
+        bottom=bottom,
+        top=top,
     )
     spectral_ctx = SpectralContext.new(wavelength=wavelength)
+    print(layer.eval_sigma_t(spectral_ctx))
     assert np.allclose(layer.eval_sigma_t(spectral_ctx), 1.0 / ureg.km)
     assert np.allclose(layer.eval_sigma_s(spectral_ctx), 0.8 / ureg.km)
     assert np.allclose(layer.eval_sigma_a(spectral_ctx), 0.2 / ureg.km)
     assert np.allclose(layer.eval_albedo(spectral_ctx).m, 0.8)
 
     ctx = KernelDictContext(spectral_ctx=spectral_ctx)
-    assert layer.eval_mfp(ctx) == 1.25 * ureg.km
+    assert np.isclose(layer.eval_mfp(ctx), 1.25 * ureg.km)
 
 
 @pytest.mark.parametrize("ckd_bin", ["280", "550", "1600", "2400"])
 def test_particle_layer_eval_ckd_absorbing_only(mode_ckd, absorbing_only, ckd_bin):
     """eval methods return expected values for an absorbing-only layer."""
-    layer = ParticleLayer(dataset=absorbing_only)
+    bottom = 0.0 * ureg.km
+    top = 1.0 * ureg.km
+    layer = ParticleLayer(
+        geometry={
+            "type": "plane_parallel",
+            "ground_altitude": bottom,
+            "toa_altitude": top,
+        },
+        dataset=absorbing_only,
+        bottom=bottom,
+        top=top,
+    )
     spectral_config = MeasureSpectralConfig.new(bin_set="10nm", bins=ckd_bin)
     spectral_ctx = spectral_config.spectral_ctxs()[0]
     assert np.allclose(layer.eval_sigma_s(spectral_ctx), 0.0 / ureg.km)
@@ -103,12 +143,23 @@ def test_particle_layer_eval_ckd_absorbing_only(mode_ckd, absorbing_only, ckd_bi
 @pytest.mark.parametrize("bins", ["280", "550", "1600", "2400"])
 def test_particle_layer_eval_ckd_scattering_only(mode_ckd, scattering_only, bins):
     """eval methods return expected values for a scattering-only layer."""
-    layer = ParticleLayer(dataset=scattering_only)
+    bottom = 0.0 * ureg.km
+    top = 1.0 * ureg.km
+    layer = ParticleLayer(
+        geometry={
+            "type": "plane_parallel",
+            "ground_altitude": bottom,
+            "toa_altitude": top,
+        },
+        dataset=scattering_only,
+        bottom=bottom,
+        top=top,
+    )
     spectral_config = MeasureSpectralConfig.new(bin_set="10nm", bins=bins)
     spectral_ctx = spectral_config.spectral_ctxs()[0]
-    assert np.all(layer.eval_sigma_s(spectral_ctx) == 0.2 / ureg.km)
-    assert np.all(layer.eval_sigma_a(spectral_ctx).m == 0.0)
-    assert np.all(layer.eval_albedo(spectral_ctx).m == 1.0)
+    assert np.allclose(layer.eval_sigma_s(spectral_ctx), 0.2 / ureg.km)
+    assert np.allclose(layer.eval_sigma_a(spectral_ctx).m, 0.0)
+    assert np.allclose(layer.eval_albedo(spectral_ctx).m, 1.0)
 
     ctx = KernelDictContext(spectral_ctx=spectral_ctx)
     assert layer.eval_mfp(ctx).magnitude > 0.0
@@ -117,19 +168,25 @@ def test_particle_layer_eval_ckd_scattering_only(mode_ckd, scattering_only, bins
 @pytest.mark.parametrize("bins", ["280", "550", "1600", "2400"])
 def test_particle_layer_eval_ckd(mode_ckd, test_particles_dataset, bins):
     """eval methods return expected values for a scattering-only layer."""
+    bottom = 0.0 * ureg.km
+    top = 1.0 * ureg.km
     layer = ParticleLayer(
+        geometry={
+            "type": "plane_parallel",
+            "ground_altitude": bottom,
+            "toa_altitude": top,
+        },
         dataset=test_particles_dataset,
-        n_layers=1,
         tau_ref=1.0,
-        bottom=0.0 * ureg.km,
-        top=1.0 * ureg.km,
+        bottom=bottom,
+        top=top,
     )
     spectral_config = MeasureSpectralConfig.new(bin_set="10nm", bins=bins)
     spectral_ctx = spectral_config.spectral_ctxs()[0]
-    assert np.isclose(layer.eval_sigma_t(spectral_ctx), 1.0 / ureg.km)
-    assert np.isclose(layer.eval_sigma_s(spectral_ctx), 0.8 / ureg.km)
-    assert np.isclose(layer.eval_sigma_a(spectral_ctx), 0.2 / ureg.km)
-    assert np.isclose(layer.eval_albedo(spectral_ctx).m, 0.8)
+    assert np.allclose(layer.eval_sigma_t(spectral_ctx), 1.0 / ureg.km)
+    assert np.allclose(layer.eval_sigma_s(spectral_ctx), 0.8 / ureg.km)
+    assert np.allclose(layer.eval_sigma_a(spectral_ctx), 0.2 / ureg.km)
+    assert np.allclose(layer.eval_albedo(spectral_ctx).m, 0.8)
 
     ctx = KernelDictContext(spectral_ctx=spectral_ctx)
     assert layer.eval_mfp(ctx) == 1.25 * ureg.km
@@ -137,7 +194,7 @@ def test_particle_layer_eval_ckd(mode_ckd, test_particles_dataset, bins):
 
 def test_particle_layer_construct_basic():
     """Construction succeeds with basic parameters."""
-    assert ParticleLayer(n_layers=9)
+    assert ParticleLayer()
 
 
 def test_particle_layer_scale(modes_all_single):
@@ -153,18 +210,21 @@ def test_particle_layer_construct_attrs(test_dataset_path):
     top = ureg.Quantity(1.8, "km")
     tau_ref = ureg.Quantity(0.3, "dimensionless")
     layer = ParticleLayer(
+        geometry={
+            "type": "plane_parallel",
+            "ground_altitude": bottom,
+            "toa_altitude": top,
+        },
         bottom=bottom,
         top=top,
         distribution=UniformParticleDistribution(),
         tau_ref=tau_ref,
-        n_layers=9,
         dataset=test_dataset_path,
     )
-    assert layer.bottom == bottom
-    assert layer.top == top
+    assert layer.bottom_altitude == bottom
+    assert layer.top_altitude == top
     assert isinstance(layer.distribution, UniformParticleDistribution)
     assert layer.tau_ref == tau_ref
-    assert layer.n_layers == 9
     assert isinstance(layer.dataset, xr.Dataset)
 
 
@@ -216,31 +276,15 @@ def test_particle_layer_eval_radprops(mode_mono, test_dataset_path, tau_ref):
         bottom=0.5 * ureg.km,  # arbitrary
         top=3.0 * ureg.km,  # arbitrary
         distribution={"type": "uniform"},
-        n_layers=1,
         tau_ref=tau_ref,
     )
-
-    # compute optical thickness at reference wavelength from layer's radprops
-    # and check it matches the input tau_ref
-    spectral_ctx = SpectralContext.new(wavelength=layer.w_ref)
-    radprops = layer.eval_radprops(spectral_ctx)
-    delta_z = layer.height / layer.n_layers
-
-    with xr.set_options(keep_attrs=True):
-        tau = to_quantity(radprops.sigma_t.sum()) * delta_z
-
-    assert np.isclose(tau, tau_ref)
 
 
 @pytest.mark.parametrize(
     "tau_ref",
     np.array([0.1, 0.5, 1.0, 2.0, 5.0]) * ureg.dimensionless,
 )
-def test_particle_layer_eval_sigma_t_mono(
-    mode_mono,
-    tau_ref,
-    test_dataset_path,
-):
+def test_particle_layer_eval_sigma_t_mono(mode_mono, tau_ref, test_dataset_path):
     r"""
     Spectral dependency of extinction is accounted for.
 
@@ -258,19 +302,28 @@ def test_particle_layer_eval_sigma_t_mono(
     which is what we assert in this test.
     """
     w_ref = 550 * ureg.nm
+    bottom = 0.5 * ureg.km  # arbitrary
+    top = 3.0 * ureg.km  # arbitrary
+
     layer = ParticleLayer(
+        geometry=dict(
+            type="plane_parallel",
+            ground_altitude=bottom,
+            toa_altitude=top,
+            zgrid=[bottom.m, top.m] * top.u,
+        ),
         dataset=test_dataset_path,
-        bottom=0.5 * ureg.km,  # arbitrary
-        top=3.0 * ureg.km,  # arbitrary
+        bottom=bottom,
+        top=top,
         distribution={"type": "uniform"},
-        n_layers=1,
         w_ref=w_ref,
         tau_ref=tau_ref,
     )
 
     # layer optical thickness @ current wavelength
     wavelengths = np.linspace(500.0, 1500.0, 101) * ureg.nm
-    tau = layer.eval_sigma_t_mono(wavelengths, layer.zgrid) * layer.height
+    tau = layer.eval_sigma_t_mono(wavelengths, layer.geometry.zgrid) * layer.height
+    print(tau.shape)
 
     # data set extinction @ running and reference wavelength
     ds = data.load_dataset(test_dataset_path)
@@ -321,14 +374,19 @@ def test_particle_layer_eval_sigma_t_mono(
 )
 def test_particle_layer_switches(mode_mono, has_absorption, has_scattering, expected):
     try:
+        bottom = 0.0 * ureg.km
+        top = 1.0 * ureg.km
         particle_layer = ParticleLayer(
-            bottom=0.0 * ureg.km,
-            top=1.0 * ureg.km,
+            geometry={
+                "type": "plane_parallel",
+                "ground_altitude": bottom,
+                "toa_altitude": top,
+            },
             tau_ref=1.0,
             has_absorption=has_absorption,
             has_scattering=has_scattering,
         )
-        zgrid = particle_layer.zgrid
+        zgrid = particle_layer.geometry.zgrid
         w = 550.0 * ureg.nm
 
         np.testing.assert_allclose(

--- a/tests/02_eradiate/01_unit/scenes/phase/test_blend.py
+++ b/tests/02_eradiate/01_unit/scenes/phase/test_blend.py
@@ -162,15 +162,16 @@ def test_blend_phase_geometry(mode_mono, geometry):
 
     # Appropriate geometry setup works
     geometry = SceneGeometry.convert(geometry)
-    expected = np.array(geometry.atmosphere_gridvolume_to_world.matrix)
+    expected = np.array(geometry.atmosphere_volume_to_world.matrix)
     phase = BlendPhaseFunction(
         components=[{"type": "isotropic"}, {"type": "rayleigh"}, {"type": "hg"}],
         weights=[0.25, 0.25, 0.5],
         geometry=geometry,
     )
-    template = traverse(phase)[0].render(KernelDictContext())
-    to_world = np.array(template["weight"]["to_world"].matrix)
+    template = traverse(phase)[0]
+    to_world = np.array(template["weight.to_world"].matrix)
     np.testing.assert_allclose(to_world, expected)
+    check_scene_element(phase, mi.PhaseFunction)
 
     # Nested BlendPhaseFunction objects must have the same geometry
     phase = BlendPhaseFunction(
@@ -188,9 +189,11 @@ def test_blend_phase_geometry(mode_mono, geometry):
 
     for comp in phase.components:
         if isinstance(comp, BlendPhaseFunction):
-            template = traverse(comp)[0].render(KernelDictContext())
-            to_world = np.array(template["weight"]["to_world"].matrix)
+            template = traverse(comp)[0]
+            to_world = np.array(template["weight.to_world"].matrix)
             np.testing.assert_allclose(to_world, expected)
+
+    check_scene_element(phase, mi.PhaseFunction)
 
 
 @pytest.mark.parametrize(
@@ -245,7 +248,7 @@ def test_blend_phase_kernel_dict_2_components(mode_mono, kwargs):
     if "geometry" in kwargs:
         geometry = SceneGeometry.convert(kwargs["geometry"])
         expected["weight.to_world"] = np.array(
-            geometry.atmosphere_gridvolume_to_world.matrix
+            geometry.atmosphere_volume_to_world.matrix
         )
     assert_cmp_dict(kernel_dict, expected)
 
@@ -328,7 +331,7 @@ def test_blend_phase_kernel_dict_3_components(mode_mono, kwargs, expected_mi_wei
     if "geometry" in kwargs:
         geometry = SceneGeometry.convert(kwargs["geometry"])
         expected["weight.to_world"] = np.array(
-            geometry.atmosphere_gridvolume_to_world.matrix
+            geometry.atmosphere_volume_to_world.matrix
         )
         expected["phase_1.weight.to_world"] = expected["weight.to_world"].copy()
 

--- a/tests/02_eradiate/01_unit/scenes/shapes/test_cuboid.py
+++ b/tests/02_eradiate/01_unit/scenes/shapes/test_cuboid.py
@@ -7,7 +7,7 @@ from eradiate import unit_context_config as ucc
 from eradiate import unit_context_kernel as uck
 from eradiate import unit_registry as ureg
 from eradiate.contexts import KernelDictContext
-from eradiate.scenes.core import traverse
+from eradiate.scenes.core import BoundingBox, traverse
 from eradiate.scenes.shapes import CuboidShape
 from eradiate.test_tools.types import check_scene_element
 
@@ -83,3 +83,10 @@ def test_cuboid_contains():
 
     # Works with multiple points
     assert np.all(cuboid.contains([[0.5, 0.5, 0.5], [0.5, -0.5, 0.5]]) == [True, False])
+
+
+def test_cuboid_bbox():
+    cuboid = CuboidShape(center=[0.5, 0.5, 0.5], edges=[1, 1, 1])
+    bbox = cuboid.bbox
+    np.testing.assert_array_equal(bbox.min.m_as(ureg.m), [0, 0, 0])
+    np.testing.assert_array_equal(bbox.max.m_as(ureg.m), [1, 1, 1])

--- a/tests/02_eradiate/01_unit/scenes/shapes/test_sphere.py
+++ b/tests/02_eradiate/01_unit/scenes/shapes/test_sphere.py
@@ -47,3 +47,10 @@ def test_sphere_contains():
 
     # Works with multiple points
     assert np.all(sphere.contains([[1.5, 1.5, 1.5], [1.5, 2.0, -2.0]]) == [True, False])
+
+
+def test_sphere_bbox():
+    sphere = SphereShape(center=[1, 1, 1], radius=2.0)
+    bbox = sphere.bbox
+    np.testing.assert_array_equal(bbox.min.m_as(ureg.m), [-1, -1, -1])
+    np.testing.assert_array_equal(bbox.max.m_as(ureg.m), [3, 3, 3])

--- a/tests/02_eradiate/02_system/test_heterogeneous_atmosphere_expansion.py
+++ b/tests/02_eradiate/02_system/test_heterogeneous_atmosphere_expansion.py
@@ -50,10 +50,19 @@ def test_heterogeneous_atmosphere_expansion_particle_layer(
     # Particle layer only
     bottom = bottom * ureg.km
     top = bottom + 1.0 * ureg.km
-    layer = eradiate.scenes.atmosphere.ParticleLayer(
-        bottom=bottom, top=top, tau_ref=tau_ref, n_layers=16
-    )
+    geometry = {
+        "type": "plane_parallel",
+        "ground_altitude": bottom,
+        "toa_altitude": top,
+    }
+    layer = {
+        "type": "particle_layer",
+        "bottom": bottom,
+        "top": top,
+        "tau_ref": tau_ref,
+    }
     exp1 = eradiate.experiments.AtmosphereExperiment(
+        geometry=geometry,
         atmosphere=layer,
         measures=[measure],
     )
@@ -63,10 +72,10 @@ def test_heterogeneous_atmosphere_expansion_particle_layer(
 
     # Heterogeneous atmosphere with a particle layer
     exp2 = eradiate.experiments.AtmosphereExperiment(
+        geometry=geometry,
         atmosphere={
             "type": "heterogeneous",
             "particle_layers": [layer],
-            "zgrid": layer.zgrid,
         },
         measures=[measure],
     )
@@ -131,7 +140,6 @@ def test_heterogeneous_atmosphere_expansion_molecular_atmosphere(
         atmosphere={
             "type": "heterogeneous",
             "molecular_atmosphere": {"type": "molecular", "has_absorption": False},
-            "zgrid": exp1.atmosphere.zgrid,
         },
         measures=[measure],
     )

--- a/tests/02_eradiate/02_system/test_heterogeneous_atmosphere_parameter_id_lookup.py
+++ b/tests/02_eradiate/02_system/test_heterogeneous_atmosphere_parameter_id_lookup.py
@@ -30,7 +30,7 @@ def test_heterogeneous_parameter_lookup(modes_all_double, geometry):
     # Medium is resolved, regardless the fact that it is first encountered as
     # a member of the "dflux" sensor
     assert (
-        exp.mi_scene.umap_template["medium_atmosphere.albedo.data"].parameter_id
+        exp.mi_scene.umap_template["medium_atmosphere.albedo.volume.data"].parameter_id
         == "dflux.medium.albedo.volume.data"
         if geometry == "spherical_shell"
         else "dflux.medium.albedo.data"

--- a/tests/02_eradiate/02_system/test_mdistant_insitu.py
+++ b/tests/02_eradiate/02_system/test_mdistant_insitu.py
@@ -16,11 +16,11 @@ def compute(l="distant", sigma=1.0, rho=1.0, exp_cls="AtmosphereExperiment"):
 
     for spp in spps:
         exp = getattr(eradiate.experiments, exp_cls)(
+            geometry={"type": "plane_parallel", "toa_altitude": 1.0 * ureg.m},
             atmosphere={
                 "type": "homogeneous",
                 "sigma_a": sigma * ureg("m^-1"),
                 "sigma_s": 0.0,
-                "top": 1.0 * ureg.m,
             },
             illumination={"type": "directional", "irradiance": 1.0},
             surface={"type": "lambertian", "reflectance": rho},

--- a/tests/02_eradiate/02_system/test_onedim_phase.py
+++ b/tests/02_eradiate/02_system/test_onedim_phase.py
@@ -88,6 +88,11 @@ def test(mode_mono_double, rayleigh_tab_phase, artefact_dir, ert_seed_state, req
         assert eradiate.mode().id == "mono_double"
 
         return AtmosphereExperiment(
+            geometry={
+                "type": "plane_parallel",
+                "ground_altitude": bottom,
+                "toa_altitude": top,
+            },
             measures={
                 "type": "mdistant",
                 "construct": "from_viewing_angles",
@@ -103,8 +108,6 @@ def test(mode_mono_double, rayleigh_tab_phase, artefact_dir, ert_seed_state, req
             },
             atmosphere={
                 "type": "homogeneous",
-                "bottom": bottom,
-                "top": top,
                 "sigma_a": sigma_a,
                 "sigma_s": sigma_s,
                 "phase": phase,

--- a/tests/02_eradiate/02_system/test_onedim_symmetry.py
+++ b/tests/02_eradiate/02_system/test_onedim_symmetry.py
@@ -69,6 +69,7 @@ def test_symmetry_zenith(mode_mono_double, surface, atmosphere, artefact_dir):
 
     # Run simulation
     exp = eradiate.experiments.AtmosphereExperiment(
+        geometry={"type": "plane_parallel", "toa_altitude": 1.0e2 * ureg.km},
         illumination={"type": "directional", "zenith": 0.0, "azimuth": 0.0},
         measures={
             "type": "distant",
@@ -84,11 +85,7 @@ def test_symmetry_zenith(mode_mono_double, surface, atmosphere, artefact_dir):
         }[surface],
         atmosphere={
             "none": None,
-            "homogeneous": {
-                "type": "homogeneous",
-                "sigma_s": 1.0e-2 * ureg.km**-1,
-                "top": 1.0e2 * ureg.km,
-            },
+            "homogeneous": {"type": "homogeneous", "sigma_s": 1.0e-2 * ureg.km**-1},
         }[atmosphere],
     )
     results = eradiate.run(exp)


### PR DESCRIPTION
# Description

This PR mainly fixes incorrect volume texture transforms with spherical shell geometries. This required substantial modifications to the geometric description.

The key point is that `BlendPhaseFunction`, when emitting its a kernel dict template, has to set volume textures. The initial interface simply foresaw the plane parallel case and required only an axis-aligned bounding box for a correct setup; the spherical shell geometry, however, requires to set the min and max radii of the `sphericalcoordsvolume` plugins, which goes beyond what a `BoundingBox` can do. Clearly, more geometric information had to be passed to `BlendPhaseFunction`.

I therefore decided to centralize the geometric information in the `SceneGeometry` objects: I added the `SceneGeometry.ground_altitude` and `SceneGeometry.toa_altitude` members and removed the corresponding information from the `Atmosphere` line. This simplifies the setup of the `zgrid` of heterogeneous atmospheres, which now always match the scene geometry.

A consequence, however, is that atmospheric radiative properties are now always evaluated on a grid which is primarily set after the scene geometry, and not the atmospheric components' radiative properties like it used to be. For molecular atmospheres and the heterogeneous container, users should barely notice anything, except maybe that the `zgrid` no longer has to be adapted when switching between the USSA and AFGL profiles. When dealing with particle layers, however, things change significantly: a layer with an extent [0, 1] km will be evaluated on the `zgrid` which, by default, has 1201 levels between 0 and 120 km. The radiative property profile therefore contains a bunch of zeros outside of the extent of the particle layer. This disrupted greatly the testing suite of the particle layer class—which needs now a complete retrofit.

As I was going through this work and further testing the spherical shell configuration, I realized that providing a default implementation for `Atmosphere._params_phase` was a mistake: failing to provide an implementation, although critically wrong, would just go unnoticed silently. I made this property abstract and provided a missing implementation for `HeterogeneousAtmosphere`.

# Detailed change log

* `Shape`: all shapes can optionally emit their AABB on their own. Only the ones for which the AABB is actually used provide an implementation for now.
* `SceneGeometry`: added atmosphere bounds (`ground_altitude` and `toa_altitude` fields). Geometries now emit their own surface and atmosphere shapes (`surface_shape` and `atmosphere_shape` properties), as well as appropriate volume data transforms (`atmosphere_volume_to_world` property).
* `SceneGeometry`: transferred zgrid data to a `zgrid` field. Instead of syncing both the `geometry` and `zgrid` fields of all heterogeneous atmosphere components, we resort to syncing only the former.
* `Atmosphere`: `zgrid` is transferred to the `SceneGeometry` container. It is now defined as the altitude grid on which volume data is discretized when setting up the experiment, and it must be common to all atmospheric components.
* `Atmosphere`: the `bottom` and `top` properties are renamed `bottom_altitude` and `top_altitude` respectively. They are kept for convenience, but all they do now is forward the underlying geometry's `ground_altitude` and `toa_altitude`.
* `Atmosphere`: `_params_*` properties are now abstract for improved safety.
* `HeterogeneousAtmosphere`: added missing `_params_phase` implementation (this was a critical bug).
* `ParticleLayer`: the `n_layers` field is dropped.
* `BlendPhaseFunction`: the `bbox` field is replaced by a `geometry` field which references the full scene geometry. This grants the phase function access to atmosphere bounds (ground and TOA altitudes), required to set up the volume data transforms in the spherical shell geometry. Support for all scene geometries was added and fixed (this was a critical bug).

# To do

- [x] Fix `BlendPhaseFunction`
- [x] Clean up messed up tests
- [x] ~~Optional: simplify the `HeterogeneousAtmosphere` class and replace its `molecular_atmosphere` and `particle_layers` fields with a single `components` one~~

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
