### PR TITLE
Add spherical shell geometry support to DEM components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,8 @@ Entries marked with a ︎⚠️ symbol require particular attention during upgra
 * Exposed the ``eradiate.spectral.*`` subpackage members in the
   {mod}`eradiate.spectral` namespace ({ghpr}`324`).
 * Fixed incorrect Mitsuba scene parameter drop and lookup ({ghpr}`329`).
+* Added spherical-shell geometry support to DEM components
+  {ghpr}`320`.
 
 ### Documentation
 

--- a/docs/rst/reference_api/scenes.rst
+++ b/docs/rst/reference_api/scenes.rst
@@ -174,6 +174,14 @@
 
    BasicSurface
    CentralPatchSurface
+   DEMSurface
+
+**Helpers**
+
+.. autosummary::
+   :toctree: generated/autosummary/
+
+   mesh_from_dem
 
 ``eradiate.scenes.bsdfs``
 -------------------------
@@ -202,6 +210,7 @@
    CheckerboardBSDF
    LambertianBSDF
    MQDiffuseBSDF
+   OpacityMaskBSDF
    RPVBSDF
 
 ``eradiate.scenes.shapes``
@@ -229,7 +238,9 @@
 .. autosummary::
    :toctree: generated/autosummary/
 
+   BufferMeshShape
    CuboidShape
+   FileMeshShape
    RectangleShape
    SphereShape
 

--- a/src/eradiate/converters.py
+++ b/src/eradiate/converters.py
@@ -9,6 +9,8 @@ __all__ = [
 import os
 import typing as t
 
+import mitsuba as mi
+import numpy as np
 import pint
 import xarray as xr
 
@@ -115,7 +117,6 @@ def to_dataset(
     """
 
     def converter(value: xr.Dataset | PathLike) -> xr.Dataset:
-
         if isinstance(value, xr.Dataset):
             return value
 
@@ -137,3 +138,21 @@ def to_dataset(
         raise ValueError(f"Cannot convert value '{value}'")
 
     return converter
+
+
+def to_mi_scalar_transform(value):
+    """
+    Convert an array-like value to a :class:`mitsuba.ScalarTransform4f`.
+    If `value` is a Numpy array, it is used to initialize a
+    :class:`mitsuba.ScalarTransform4f` without copy; if it is a list, a Numpy
+    array is first created from it. Otherwise, `value` is forwarded without
+    change.
+    """
+    if isinstance(value, np.ndarray):
+        return mi.ScalarTransform4f(value)
+
+    elif isinstance(value, list):
+        return mi.ScalarTransform4f(np.array(value))
+
+    else:
+        return value

--- a/src/eradiate/experiments/_atmosphere.py
+++ b/src/eradiate/experiments/_atmosphere.py
@@ -11,11 +11,7 @@ from ._helpers import (
     surface_converter,
 )
 from ..attrs import documented, get_doc, parse_docs
-from ..scenes.atmosphere import (
-    Atmosphere,
-    HomogeneousAtmosphere,
-    atmosphere_factory,
-)
+from ..scenes.atmosphere import Atmosphere, HomogeneousAtmosphere, atmosphere_factory
 from ..scenes.bsdfs import LambertianBSDF
 from ..scenes.core import SceneElement
 from ..scenes.geometry import (

--- a/src/eradiate/scenes/bsdfs/__init__.pyi
+++ b/src/eradiate/scenes/bsdfs/__init__.pyi
@@ -4,4 +4,5 @@ from ._core import BSDF as BSDF
 from ._core import bsdf_factory as bsdf_factory
 from ._lambertian import LambertianBSDF as LambertianBSDF
 from ._mqdiffuse import MQDiffuseBSDF as MQDiffuseBSDF
+from ._opacity_mask import OpacityMaskBSDF
 from ._rpv import RPVBSDF as RPVBSDF

--- a/src/eradiate/scenes/bsdfs/__init__.pyi
+++ b/src/eradiate/scenes/bsdfs/__init__.pyi
@@ -4,5 +4,5 @@ from ._core import BSDF as BSDF
 from ._core import bsdf_factory as bsdf_factory
 from ._lambertian import LambertianBSDF as LambertianBSDF
 from ._mqdiffuse import MQDiffuseBSDF as MQDiffuseBSDF
-from ._opacity_mask import OpacityMaskBSDF
+from ._opacity_mask import OpacityMaskBSDF as OpacityMaskBSDF
 from ._rpv import RPVBSDF as RPVBSDF

--- a/src/eradiate/scenes/bsdfs/_core.py
+++ b/src/eradiate/scenes/bsdfs/_core.py
@@ -15,6 +15,7 @@ bsdf_factory.register_lazy_batch(
         ("_checkerboard.CheckerboardBSDF", "checkerboard", {}),
         ("_lambertian.LambertianBSDF", "lambertian", {}),
         ("_mqdiffuse.MQDiffuseBSDF", "mqdiffuse", {}),
+        ("_opacity_mask.OpacityMaskBSDF", "opacity_mask", {}),
         ("_rpv.RPVBSDF", "rpv", {}),
     ],
     cls_prefix="eradiate.scenes.bsdfs",

--- a/src/eradiate/scenes/bsdfs/_opacity_mask.py
+++ b/src/eradiate/scenes/bsdfs/_opacity_mask.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import attrs
+import mitsuba as mi
+
+from ._core import BSDF, bsdf_factory
+from ._lambertian import LambertianBSDF
+from ..core import traverse
+from ...attrs import documented, parse_docs
+from ...kernel import TypeIdLookupStrategy, UpdateParameter
+
+
+@parse_docs
+@attrs.define(eq=False, slots=False)
+class OpacityMaskBSDF(BSDF):
+    """
+    Opacity Mask BSDF [``opacity_mask``]
+    """
+
+    opacity_bitmap: "mi.Bitmap" = documented(
+        attrs.field(kw_only=True),
+        doc="Mitsuba bitmap that specifies the opacity of the nested BSDF plugin",
+        type="mitsuba.Bitmap",
+        init_type="mitsuba.Bitmap or dict",
+    )
+
+    @opacity_bitmap.validator
+    def _opacity_bitmap_validator(self, attribute, value):
+        if value is not None:
+            if not isinstance(value, mi.Bitmap):
+                raise TypeError(
+                    f"while validating '{attribute.name}': "
+                    f"'{attribute.name}' must be a mitsuba Bitmap instance;"
+                    f"found: {type(value)}",
+                )
+
+    uv_trafo: "mi.ScalarTransform4f" = documented(
+        attrs.field(default=None),
+        doc="Transform to scale the opacity mask.",
+        type="mitsuba.ScalarTransform4f",
+        init_type="mitsuba.ScalarTransform4f or dict",
+        default="None",
+    )
+
+    @uv_trafo.validator
+    def _uv_trafo_validator(self, attribute, value):
+        if value is not None:
+            if not isinstance(value, mi.ScalarTransform4f):
+                raise TypeError(
+                    f"while validating '{attribute.name}': "
+                    f"'{attribute.name}' must be a mitsuba ScalarTransform4f instance;"
+                    f"found: {type(value)}"
+                )
+
+    nested_bsdf: BSDF = documented(
+        attrs.field(
+            factory=LambertianBSDF,
+            converter=bsdf_factory.convert,
+            validator=attrs.validators.instance_of(BSDF),
+        ),
+        doc="The reflection model attached to the surface.",
+        type=".BSDF",
+        init_type=".BSDF or dict, optional",
+        default=":class:`LambertianBSDF() <.LambertianBSDF>`",
+    )
+
+    @property
+    def template(self) -> dict:
+        # Inherit docstring
+
+        result = {
+            "type": "mask",
+            "id": self.id,
+            "opacity.type": "bitmap",
+            "opacity.bitmap": self.opacity_bitmap,
+            "opacity.filter_type": "nearest",
+            "opacity.wrap_mode": "clamp",
+        }
+
+        if self.uv_trafo is not None:
+            result["opacity.to_uv"] = self.uv_trafo
+
+        for key, value in traverse(self.nested_bsdf)[0].items():
+            result[f"nested_bsdf.{key}"] = value
+
+        return result
+
+    @property
+    def params(self) -> dict[str, UpdateParameter]:
+        # Inherit Docstring
+
+        result = {}
+
+        # improve this, by using the BSDFs own lookup strategy
+        for key, param in traverse(self.nested_bsdf)[1].items():
+            result[f"nested_bsdf.{key}"] = attrs.evolve(
+                param,
+                lookup_strategy=TypeIdLookupStrategy(
+                    node_type=mi.BSDF,
+                    node_id=self.id,
+                    parameter_relpath=f"nested_bsdf.{key}",
+                )
+                if self.id is not None
+                else None,
+            )
+
+        return result

--- a/src/eradiate/scenes/core.py
+++ b/src/eradiate/scenes/core.py
@@ -15,11 +15,7 @@ from pinttr.util import ensure_units
 from .._factory import Factory
 from ..attrs import documented, parse_docs
 from ..exceptions import TraversalError
-from ..kernel import (
-    KernelDictTemplate,
-    UpdateMapTemplate,
-    UpdateParameter,
-)
+from ..kernel import KernelDictTemplate, UpdateMapTemplate, UpdateParameter
 from ..units import unit_context_config as ucc
 from ..units import unit_registry as ureg
 

--- a/src/eradiate/scenes/shapes/_buffermesh.py
+++ b/src/eradiate/scenes/shapes/_buffermesh.py
@@ -11,8 +11,8 @@ from ..core import BoundingBox, traverse
 from ...attrs import documented, parse_docs
 from ...contexts import KernelContext
 from ...kernel import UpdateParameter
-from ...units import unit_context_kernel as uck
 from ...units import unit_context_config as ucc
+from ...units import unit_context_kernel as uck
 
 
 @parse_docs
@@ -31,8 +31,10 @@ class BufferMeshShape(ShapeInstance):
             units=ucc.deferred("length"),
             kw_only=True,
         ),
-        doc="List of vertex positions. The passed list must contain a (n, 3) list"
-        "of three dimensional points. \n\nUnit-enabled field (default: ucc['length']).",
+        doc="List of vertex coordinates, specified either as a (n, 3) NumPy "
+        "array or a list of triplets.\n"
+        "\n"
+        "Unit-enabled field (default: ucc['length']).",
         type="quantity",
         init_type="array-like",
     )
@@ -42,8 +44,8 @@ class BufferMeshShape(ShapeInstance):
             kw_only=True,
             converter=np.array,
         ),
-        doc="List of face definitions. The passed list must contain a (n, 3) list"
-        "of three vertex indices defining triangles.",
+        doc="List of face definitions. specified either as a (n, 3) NumPy "
+        "array or a list of triplets of vertex indices.",
         type="ndarray",
         init_type="array-like",
     )
@@ -93,7 +95,7 @@ class BufferMeshShape(ShapeInstance):
 
     def write_ply(self, filename: str) -> None:
         """
-        Write a ply file from the mesh data.
+        Write the mesh data to a PLY file.
 
         Parameters
         ----------
@@ -103,10 +105,12 @@ class BufferMeshShape(ShapeInstance):
 
         Notes
         -----
-        Vertices are converted into kernel units and accordingly written to file in these units.
+        Vertex coordinates are expressed in kernel units and accordingly prior
+        to writing to disk. See the documentation of
+        :data:`eradiate.unit_context_kernel` and the
+        :ref:`sec-user_guide-unit_guide_user`.
         """
-        mesh = self.instance
-        mesh.write_ply(filename)
+        self.instance.write_ply(filename)
 
     @property
     def params(self) -> dict[str, UpdateParameter] | None:

--- a/src/eradiate/scenes/shapes/_buffermesh.py
+++ b/src/eradiate/scenes/shapes/_buffermesh.py
@@ -11,8 +11,8 @@ from ..core import BoundingBox, traverse
 from ...attrs import documented, parse_docs
 from ...contexts import KernelContext
 from ...kernel import UpdateParameter
-from ...units import unit_context_config as ucc
 from ...units import unit_context_kernel as uck
+from ...units import unit_context_config as ucc
 
 
 @parse_docs
@@ -32,7 +32,7 @@ class BufferMeshShape(ShapeInstance):
             kw_only=True,
         ),
         doc="List of vertex positions. The passed list must contain a (n, 3) list"
-        "of three dimensional points.\n\nUnit-enabled field (default: ucc['length']).",
+        "of three dimensional points. \n\nUnit-enabled field (default: ucc['length']).",
         type="quantity",
         init_type="array-like",
     )
@@ -90,6 +90,23 @@ class BufferMeshShape(ShapeInstance):
         mesh_params.update()
 
         return mesh
+
+    def write_ply(self, filename: str) -> None:
+        """
+        Write a ply file from the mesh data.
+
+        Parameters
+        ----------
+        filename : str
+            Path and filename to write the mesh file into. No directories
+            are created.
+
+        Notes
+        -----
+        Vertices are converted into kernel units and accordingly written to file in these units.
+        """
+        mesh = self.instance
+        mesh.write_ply(filename)
 
     @property
     def params(self) -> dict[str, UpdateParameter] | None:

--- a/src/eradiate/scenes/shapes/_filemesh.py
+++ b/src/eradiate/scenes/shapes/_filemesh.py
@@ -15,9 +15,12 @@ class FileMeshShape(ShapeNode):
     """
     File based mesh shape [``file_mesh``].
 
-    This shape represents a triangulated mesh defined in a file
-    in either the PLY or OBJ format.
-    The vertex positions are assumed to be defined in kernel units.
+    This shape represents a triangulated mesh defined in a file. The OBJ and PLY
+    formats are supported.
+
+    Warnings
+    --------
+    Vertex coordinates are assumed to be defined in kernel units.
     """
 
     filename: Path = documented(
@@ -29,20 +32,11 @@ class FileMeshShape(ShapeNode):
 
     @filename.validator
     def _filename_validator(self, attribute, value):
-        if value.suffix not in [".obj", ".ply"]:
+        if value.suffix not in {".obj", ".ply"}:
             raise ValueError(
                 f"while validating {attribute.name}:"
                 f"Eradiate supports mesh files only in PLY or OBJ format."
             )
-
-    @property
-    def _kernel_type(self) -> str:
-        if self.filename.suffix == ".obj":
-            return "obj"
-        elif self.filename.suffix == ".ply":
-            return "ply"
-        else:
-            raise ValueError(f"unknown mesh file type '{self.filename.suffix}'")
 
     def bbox(self) -> BoundingBox:
         # Inherit docstring
@@ -51,8 +45,18 @@ class FileMeshShape(ShapeNode):
     @property
     def template(self) -> dict:
         # Inherit docstring
+
+        if self.filename.suffix == ".obj":
+            mi_plugin = "obj"
+        elif self.filename.suffix == ".ply":
+            mi_plugin = "ply"
+        else:
+            raise ValueError(
+                f"unsupported mesh file extension '{self.filename.suffix}'"
+            )
+
         return {
-            "type": self._kernel_type,
+            "type": mi_plugin,
             "filename": str(self.filename),
             "face_normals": True,
         }

--- a/src/eradiate/scenes/shapes/_sphere.py
+++ b/src/eradiate/scenes/shapes/_sphere.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import warnings
-
 import attrs
 import mitsuba as mi
 import numpy as np
@@ -12,9 +10,9 @@ from pinttr.util import ensure_units
 from ._core import ShapeNode
 from ..bsdfs import BSDF
 from ..core import BoundingBox
+from ... import converters
 from ...attrs import documented, parse_docs
 from ...constants import EARTH_RADIUS
-from ...exceptions import ConfigWarning
 from ...units import unit_context_config as ucc
 from ...units import unit_context_kernel as uck
 from ...units import unit_registry as ureg
@@ -52,16 +50,17 @@ class SphereShape(ShapeNode):
         default="1.0",
     )
 
-    to_world: mi.ScalarTransform4f = documented(
+    to_world: "mitsuba.ScalarTransform4f" = documented(
         attrs.field(
+            converter=converters.to_mi_scalar_transform,
             default=None,
         ),
         doc="Transform to scale, shift and rotate the sphere. "
-        "This transform will be prepended to the transforms derived "
-        "from the center position and radius of the sphere. If for example a "
+        "This transform will be prepended to the transform derived "
+        "from the center position and radius of the sphere. If, for example, a "
         "scaling is provided here, it will multiply the sphere's radius.",
-        type="mitsuba.ScalarTransform4f",
-        init_type="mitsuba.ScalarTransform4f or dict",
+        type="mitsuba.ScalarTransform4f or None",
+        init_type="mitsuba.ScalarTransform4f or array-like, optional",
         default=None,
     )
 
@@ -71,7 +70,7 @@ class SphereShape(ShapeNode):
             if not isinstance(value, mi.ScalarTransform4f):
                 raise TypeError(
                     f"while validating '{attribute.name}': "
-                    f"'{attribute.name}' must be a mitsuba.ScalarTransform4f;"
+                    f"'{attribute.name}' must be a mitsuba.ScalarTransform4f; "
                     f"found: {type(value)}",
                 )
 

--- a/src/eradiate/scenes/surface/__init__.pyi
+++ b/src/eradiate/scenes/surface/__init__.pyi
@@ -3,3 +3,4 @@ from ._central_patch import CentralPatchSurface as CentralPatchSurface
 from ._core import Surface as Surface
 from ._core import surface_factory as surface_factory
 from ._dem import DEMSurface as DEMSurface
+from ._dem import mesh_from_dem as mesh_from_dem

--- a/tests/02_eradiate/01_unit/experiments/test_dem.py
+++ b/tests/02_eradiate/01_unit/experiments/test_dem.py
@@ -1,5 +1,3 @@
-import os
-
 import mitsuba as mi
 import numpy as np
 import pytest
@@ -14,7 +12,6 @@ from eradiate.scenes.atmosphere import (
     HomogeneousAtmosphere,
     MolecularAtmosphere,
 )
-from eradiate.scenes.bsdfs import LambertianBSDF
 from eradiate.scenes.geometry import PlaneParallelGeometry
 from eradiate.scenes.measure import MultiDistantMeasure
 from eradiate.scenes.spectra import MultiDeltaSpectrum
@@ -224,21 +221,22 @@ def test_dem_experiment_run_detailed(modes_all):
 
 def test_dem_experiment_warn_targeting_dem(modes_all_double, tmpdir):
     """
-    Test that Eradiate raises a warning, when the measure target is a point and a DEM is defined in the scene.
+    Test that the DEMExperiment constructor raises a warning when the measure
+    target is a point and a DEM is defined in the scene.
     """
 
     da = xr.DataArray(
         data=np.zeros((10, 10)),
         dims=["x", "y"],
-        coords=dict(
-            x=(["x"], np.linspace(-10, 20, 10), dict(units="kilometer")),
-            y=(["y"], np.linspace(-30, 40, 10), dict(units="kilometer")),
-        ),
-        attrs=dict(units="meter"),
+        coords={
+            "x": (["x"], np.linspace(-10, 20, 10), {"units": "kilometer"}),
+            "y": (["y"], np.linspace(-30, 40, 10), {"units": "kilometer"}),
+        },
+        attrs={"units": "meter"},
     )
 
     mesh, lat, lon = mesh_from_dem(
-        da, geometry=PlaneParallelGeometry(), planet_radius=EARTH_RADIUS
+        da, geometry="plane_parallel", planet_radius=EARTH_RADIUS
     )
 
     with pytest.warns(UserWarning, match="uses a point target"):

--- a/tests/02_eradiate/01_unit/scenes/bsdfs/test_opacity.py
+++ b/tests/02_eradiate/01_unit/scenes/bsdfs/test_opacity.py
@@ -1,6 +1,5 @@
 import mitsuba as mi
 import numpy as np
-import pytest
 
 from eradiate.scenes.bsdfs import LambertianBSDF, OpacityMaskBSDF, bsdf_factory
 from eradiate.test_tools.types import check_scene_element
@@ -8,7 +7,7 @@ from eradiate.test_tools.types import check_scene_element
 
 def test_opacity_mask_construct(modes_all):
     assert OpacityMaskBSDF(
-        opacity_bitmap=mi.Bitmap(np.ones((3, 3))),
+        opacity_bitmap=np.ones((3, 3)),
         uv_trafo=mi.ScalarTransform4f.scale(2),
         nested_bsdf=LambertianBSDF(),
     )
@@ -18,12 +17,9 @@ def test_opacity_mask_construct_dict(modes_all):
     assert bsdf_factory.convert(
         {
             "type": "opacity_mask",
-            "opacity_bitmap": mi.Bitmap(np.ones((3, 3))),
+            "opacity_bitmap": np.ones((3, 3)),
             "uv_trafo": mi.ScalarTransform4f.scale(2),
-            "nested_bsdf": {
-                "type": "lambertian",
-                "reflectance": 0.5
-            }
+            "nested_bsdf": {"type": "lambertian", "reflectance": 0.5},
         }
     )
 

--- a/tests/02_eradiate/01_unit/scenes/bsdfs/test_opacity.py
+++ b/tests/02_eradiate/01_unit/scenes/bsdfs/test_opacity.py
@@ -1,0 +1,38 @@
+import mitsuba as mi
+import numpy as np
+import pytest
+
+from eradiate.scenes.bsdfs import LambertianBSDF, OpacityMaskBSDF, bsdf_factory
+from eradiate.test_tools.types import check_scene_element
+
+
+def test_opacity_mask_construct(modes_all):
+    assert OpacityMaskBSDF(
+        opacity_bitmap=mi.Bitmap(np.ones((3, 3))),
+        uv_trafo=mi.ScalarTransform4f.scale(2),
+        nested_bsdf=LambertianBSDF(),
+    )
+
+
+def test_opacity_mask_construct_dict(modes_all):
+    assert bsdf_factory.convert(
+        {
+            "type": "opacity_mask",
+            "opacity_bitmap": mi.Bitmap(np.ones((3, 3))),
+            "uv_trafo": mi.ScalarTransform4f.scale(2),
+            "nested_bsdf": {
+                "type": "lambertian",
+                "reflectance": 0.5
+            }
+        }
+    )
+
+
+def test_opacity_mask_kernel_dict(modes_all_double):
+    bsdf = OpacityMaskBSDF(
+        opacity_bitmap=mi.Bitmap(np.ones((3, 3))),
+        uv_trafo=mi.ScalarTransform4f.scale(2),
+        nested_bsdf=LambertianBSDF(),
+    )
+    mi_wrapper = check_scene_element(bsdf, mi.BSDF)
+    assert "nested_bsdf.reflectance.value" in mi_wrapper.parameters.keys()

--- a/tests/02_eradiate/01_unit/scenes/surface/test_dem.py
+++ b/tests/02_eradiate/01_unit/scenes/surface/test_dem.py
@@ -1,118 +1,256 @@
-import os
-import tempfile
-from copy import deepcopy
-
 import mitsuba as mi
 import numpy as np
 import pytest
 import xarray as xr
 
 from eradiate import KernelContext
+from eradiate.constants import EARTH_RADIUS
 from eradiate.scenes.core import Scene, traverse
-from eradiate.scenes.shapes import BufferMeshShape, FileMeshShape, Shape
+from eradiate.scenes.geometry import PlaneParallelGeometry, SphericalShellGeometry
+from eradiate.scenes.shapes import RectangleShape, SphereShape
 from eradiate.scenes.surface import DEMSurface
+from eradiate.scenes.surface._dem import (
+    _generate_dem_vertices,
+    _generate_face_indices,
+    _mean_coordinates,
+    _minmax_coordinates,
+    _to_uv,
+    _transform_vertices_plane_parallel,
+    _transform_vertices_spherical_shell,
+    _vertex_index,
+    mesh_from_dem,
+)
+from eradiate.test_tools.types import check_scene_element
 from eradiate.units import unit_registry as ureg
 
 
-@pytest.fixture(scope="module")
-def tempfile_obj():
-    with tempfile.TemporaryDirectory() as tmpdir:
-        filename = os.path.join(tmpdir, "tempfile_mesh.obj")
-        with open(filename, "w") as tf:
-            tf.write("v 1 0 0\n")
-            tf.write("v 0 1 0\n")
-            tf.write("v 0 0 1\n")
-            tf.write("f 1 2 3\n")
-        yield filename
+@pytest.mark.parametrize(
+    "kwargs, expected_limits",
+    [
+        (
+            {
+                "da": xr.DataArray(
+                    data=np.zeros((10, 10)),
+                    dims=["lat", "lon"],
+                    coords=dict(
+                        lat=(["lat"], np.linspace(-0.1, 0.1, 10), dict(units="degree")),
+                        lon=(["lon"], np.linspace(-0.1, 0.1, 10), dict(units="degree")),
+                    ),
+                    attrs=dict(units="meter"),
+                ),
+                "geometry": PlaneParallelGeometry(),
+                "planet_radius": EARTH_RADIUS,
+            },
+            [(-0.1, 0.1), (-0.1, 0.1)],
+        ),
+        (
+            {
+                "da": xr.DataArray(
+                    data=np.zeros((10, 10)),
+                    dims=["lat", "lon"],
+                    coords=dict(
+                        lat=(["lat"], np.linspace(-0.2, 0.3, 10), dict(units="degree")),
+                        lon=(["lon"], np.linspace(-0.4, 0.5, 10), dict(units="degree")),
+                    ),
+                    attrs=dict(units="meter"),
+                ),
+                "geometry": SphericalShellGeometry(),
+                "planet_radius": EARTH_RADIUS,
+            },
+            [(-0.2, 0.3), (-0.4, 0.5)],
+        ),
+        (
+            {
+                "da": xr.DataArray(
+                    data=np.zeros((10, 10)),
+                    dims=["x", "y"],
+                    coords=dict(
+                        x=(["x"], np.linspace(-20, 20, 10), dict(units="kilometer")),
+                        y=(["y"], np.linspace(-30, 30, 10), dict(units="kilometer")),
+                    ),
+                    attrs=dict(units="meter"),
+                ),
+                "geometry": PlaneParallelGeometry(),
+                "planet_radius": EARTH_RADIUS,
+            },
+            [(-0.179664, 0.179664), (-0.269496, 0.269496)],
+        ),
+        (
+            {
+                "da": xr.DataArray(
+                    data=np.zeros((10, 10)),
+                    dims=["x", "y"],
+                    coords=dict(
+                        x=(["x"], np.linspace(-10, 20, 10), dict(units="kilometer")),
+                        y=(["y"], np.linspace(-30, 40, 10), dict(units="kilometer")),
+                    ),
+                    attrs=dict(units="meter"),
+                ),
+                "geometry": SphericalShellGeometry(),
+                "planet_radius": EARTH_RADIUS,
+            },
+            [(-0.089832, 0.179664), (-0.269496, 0.359328)],
+        ),
+    ],
+)
+def test_mesh_from_dem(modes_all_double, kwargs, expected_limits):
+    if (
+        isinstance(kwargs["geometry"], SphericalShellGeometry)
+        and kwargs["planet_radius"] is not None
+    ):
+        with pytest.warns():
+            mesh, lat, lon = mesh_from_dem(**kwargs)
+    else:
+        mesh, lat, lon = mesh_from_dem(**kwargs)
+
+    assert len(mesh.vertices) == 100
+
+    assert np.allclose(lat.m, expected_limits[0], atol=1e-4, rtol=1e-3)
+    assert np.allclose(lon.m, expected_limits[1], atol=1e-4, rtol=1e-3)
 
 
 @pytest.mark.parametrize(
-    "constructor, kwargs, expected_shape, expected_traversal_param_keys",
+    "geometry, expected_bg, planet_radius",
     [
-        (
-            None,
-            {
-                "shape": {"type": "file_mesh", "filename": "tempfile_obj"},
-                "bsdf": {"type": "lambertian"},
-            },
-            FileMeshShape,
-            {"terrain_shape.bsdf.reflectance.value"},
-        ),
-        (
-            DEMSurface.from_dataarray,
-            {
-                "data": xr.DataArray(
-                    data=np.zeros((10, 10)),
-                    dims=["x", "y"],
-                    coords={
-                        "lat": (["x"], np.linspace(-5, 5.1, 10), {"units": "degree"}),
-                        "lon": (["y"], np.linspace(-6, 6, 10), {"units": "degree"}),
-                    },
-                ),
-                "bsdf": {"type": "lambertian"},
-            },
-            BufferMeshShape,
-            {"terrain_shape.bsdf.reflectance.value"},
-        ),
-        (
-            DEMSurface.from_analytical,
-            {
-                "elevation_function": lambda x, y: 10.0,
-                "x_length": 10 * ureg.m,
-                "y_length": 10 * ureg.m,
-                "x_steps": 100,
-                "y_steps": 100,
-                "bsdf": {"type": "lambertian"},
-            },
-            BufferMeshShape,
-            {"terrain_shape.bsdf.reflectance.value"},
-        ),
+        (PlaneParallelGeometry(), RectangleShape, EARTH_RADIUS),
+        (SphericalShellGeometry(), SphereShape, None),
     ],
-    ids=["minimal", "from_dataarray", "from_analytical"],
 )
-def test_dem_surface_construct(
-    modes_all_double,
-    constructor,
-    kwargs,
-    expected_shape,
-    expected_traversal_param_keys,
-    request,
-):
-    # Expand fixtures
-    kwargs = deepcopy(kwargs)
+def test_dem_surface_construct(modes_all_mono, geometry, expected_bg, planet_radius):
+    mesh, lat, lon = mesh_from_dem(
+        da=xr.DataArray(
+            data=np.zeros((10, 10)),
+            dims=["lat", "lon"],
+            coords=dict(
+                lat=(["lat"], np.linspace(-0.2, 0.3, 10), dict(units="degree")),
+                lon=(["lon"], np.linspace(-0.4, 0.5, 10), dict(units="degree")),
+            ),
+            attrs=dict(units="meter"),
+        ),
+        geometry=geometry,
+        planet_radius=planet_radius,
+    )
 
-    try:
-        if kwargs["shape"]["type"] == "file_mesh":
-            kwargs["shape"]["filename"] = request.getfixturevalue(
-                kwargs["shape"]["filename"]
-            )
-    except KeyError:
-        pass
+    dem = DEMSurface.from_mesh(
+        id="terrain", mesh=mesh, lat=lat, lon=lon, geometry=geometry
+    )
+    assert isinstance(dem.shape_background, expected_bg)
 
-    # Instantiate DEM surface
-    if constructor is None:
-        surface = DEMSurface(**kwargs)
-    else:
-        surface = constructor(**kwargs)
 
-    if issubclass(expected_shape, Shape):
-        assert isinstance(surface.shape, expected_shape)
-    else:
-        raise NotImplementedError
+def test_dem_surface_kernel_dict(mode_mono):
+    mesh, lat, lon = mesh_from_dem(
+        da=xr.DataArray(
+            data=np.zeros((10, 10)),
+            dims=["lat", "lon"],
+            coords=dict(
+                lat=(["lat"], np.linspace(-0.2, 0.3, 10), dict(units="degree")),
+                lon=(["lon"], np.linspace(-0.4, 0.5, 10), dict(units="degree")),
+            ),
+            attrs=dict(units="meter"),
+        ),
+        geometry=SphericalShellGeometry(),
+        planet_radius=None,
+    )
 
-    if isinstance(expected_traversal_param_keys, set):
-        template, params = traverse(surface)
+    dem = DEMSurface.from_mesh(
+        id="terrain", mesh=mesh, lat=lat, lon=lon, geometry=SphericalShellGeometry()
+    )
 
-        # Scene element is composite: template has not "type" key
-        assert "type" not in template
-        # Parameter map keys are fetched recursively
-        assert set(params.keys()) == expected_traversal_param_keys
+    check_scene_element(dem)
 
-        # When enclosed in a Scene, the surface can be traversed
-        scene = Scene(objects={"surface": surface})
-        template, params = traverse(scene)
-        kernel_dict = template.render(KernelContext())
-        assert isinstance(mi.load_dict(kernel_dict), mi.Scene)
+    # When enclosed in a Scene, the surface can be traversed
+    scene = Scene(objects={"surface": dem})
+    template, params = traverse(scene)
+    kernel_dict = template.render(KernelContext())
+    assert isinstance(mi.load_dict(kernel_dict), mi.Scene)
 
-    else:
-        raise NotImplementedError
+
+def test_generate_dem_vertices(mode_mono):
+    latitude_points = np.array([1, 2])
+    longitude_points = np.array([3, 4])
+    elevation = np.array([[1, 2], [3, 4]])
+
+    vertices = _generate_dem_vertices(latitude_points, longitude_points, elevation)
+
+    expected_vertices = [[1, 3, 1], [1, 4, 2], [2, 3, 3], [2, 4, 4]]
+
+    for exp in expected_vertices:
+        assert any([np.all(exp == v) for v in vertices])
+
+
+def test_generate_face_indices(mode_mono):
+    face_indices = _generate_face_indices(len_x=2, len_y=2)
+    print(face_indices)
+
+    expected_indices = [[3, 0, 1], [2, 0, 3]]
+
+    for exp in expected_indices:
+        assert any([np.all(exp == f) for f in face_indices])
+
+
+def test_mean_coordinates(mode_mono):
+    vertices = np.array([[1, 2, 3], [4, 5, 6]])
+
+    theta_mean, phi_mean = _mean_coordinates(vertices)
+
+    assert theta_mean == 2.5
+    assert phi_mean == 3.5
+
+
+def test_minmax_coordinates(mode_mono):
+    vertices = np.array([[-1, -2, 3], [0, 7, 4], [6, 2, 2]])
+
+    (theta_min, theta_max), (phi_min, phi_max) = _minmax_coordinates(vertices)
+
+    assert theta_min == -1
+    assert theta_max == 6
+    assert phi_min == -2
+    assert phi_max == 7
+
+
+def test_vertex_index(mode_mono):
+    assert _vertex_index(x=3, y=4, len_y=34) == 3 * 34 + 4
+
+
+def test_transform_vertices_plane_parallel(mode_mono):
+    vertices = np.array([[-1, -1, 2], [-1, 1, 2], [1, -1, 2], [1, 1, 2]])
+
+    vertices_new = _transform_vertices_plane_parallel(vertices, 2, 10)
+
+    expected_vertices = [
+        [-0.0349, -0.0349, 12],
+        [-0.0349, 0.0349, 12],
+        [0.0349, -0.0349, 12],
+        [0.0349, 0.0349, 12],
+    ]
+
+    for exp in expected_vertices:
+        assert any([np.allclose(exp, v, atol=1e-4) for v in vertices_new])
+
+
+def test_transform_vertices_spherical_shell(mode_mono):
+    vertices = np.array([[-90, 0, 2], [90, 0, 2], [0, 0, 2], [0, 180, 2]])
+
+    vertices_new = _transform_vertices_spherical_shell(vertices, 200)
+
+    expected_vertices = [[0, 0, 202], [0, 0, -202], [202, 0, 0], [-202, 0, 0]]
+
+    for exp in expected_vertices:
+        assert any([np.allclose(exp, v, atol=1e-5) for v in vertices_new])
+
+
+def test_to_uv(mode_mono):
+    lat_min = -10
+    lat_max = 10
+    lon_min = 10
+    lon_max = 30
+
+    trafo = _to_uv(lat_min, lat_max, lon_min, lon_max)
+
+    expected_trafo = mi.ScalarTransform4f.scale(
+        (6, 3, 1)
+    ) @ mi.ScalarTransform4f.translate(
+        (-0.55555555556 + (0.5 / 6.0), -0.5 + (0.5 / 3.0), 0)
+    )
+
+    assert np.allclose(trafo.matrix, expected_trafo.matrix, rtol=1e-3, atol=1e-4)


### PR DESCRIPTION
# Description

This PR updates DEM-related components to allow using a spherical shell geometry with the `DEMExperiment` class.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
