### PR TITLE
Clearer aerosol optical thickness algorithm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,7 @@ Entries marked with a  ︎⚠️ symbol require particular attention during upgr
 * Updated dependency management system to latest tooling changes ({ghpr}`306`).
 * Add {func}`.cache_by_id` to replace `@functools.lru_cache(maxsize=1)` when
   appropriate ({ghpr}`315`).
+* Clarify particle layer optical thickness computation ({ghpr}`321`).
 
 ## v0.22.5 (17 October 2022)
 


### PR DESCRIPTION
# Description

This PR clarifies the formulation of the AOT computation made by the `ParticleLayer` class. The logic is now more obvious: the layer AOT at the active wavelength is inferred from the value at the reference wavelength (typically 550 nm) provided as input, based on the ratio of the extinction coefficient at the active wavelength and at the reference wavelength.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
