### PR TITLE
Minor API updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,9 @@ Entries marked with a ︎⚠️ symbol require particular attention during upgra
 
 ### Breaking changes
 
-* Removed the docker images implementation, deployment and documentation from the
-  Eradiate repository ({ghpr}`322`).
+* Removed the Docker images implementation, deployment and documentation
+  from the Eradiate repository ({ghpr}`322`). Docker builds are no longer
+  supported for now.
 * {class}`.Measure` no longer takes a `spectral_cfg` parameter but instead a
   `srf` parameter ({ghpr}`311`).
 * In CKD modes with absorbing molecular atmospheres, the way to control the bin
@@ -44,8 +45,10 @@ Entries marked with a ︎⚠️ symbol require particular attention during upgra
 * The {meth}`.MultiDistantMeasure.from_viewing_angles` constructor is removed
   ({ghpr}`315`). Use one of the other {class}`.MultiDistantMeasure` constructors
   instead.
-
-% ### Improvements and fixes
+* The ``ertdata`` and ``ertshow`` command-line entry points are removed
+  ({ghpr}`324`). Instead, use ``eradiate data`` and ``eradiate show``.
+* The {class}`.KernelDictContext` class is renamed {class}`.KernelContext`
+  ({ghpr}`324`).
 
 ### Deprecations and removals
 
@@ -53,10 +56,14 @@ Entries marked with a ︎⚠️ symbol require particular attention during upgra
 * Removed {class}`.MeasureSpectralConfig` and subclasses ({ghpr}`311`).
 * Removed the {meth}`.MultiDistantMeasure.from_viewing_angles` constructor
   ({ghpr}`315`).
+* Removed ``ertdata`` and ``ertshow`` command-line entry points ({ghpr}`324`).
 
 ### Improvements and fixes
 
-* Added {class}`.MultiDeltaSpectrum` spectrum type ({ghpr}`311`)
+* Added {class}`.MultiDeltaSpectrum` spectrum type ({ghpr}`311`).
+* Exposed several API members in the top-level namespace ({ghpr}`324`).
+* Exposed the ``eradiate.spectral.*`` subpackage members in the
+  {mod}`eradiate.spectral` namespace ({ghpr}`324`).
 
 ### Documentation
 

--- a/docs/rst/developer_guide/radiometric_kernel_interface.rst
+++ b/docs/rst/developer_guide/radiometric_kernel_interface.rst
@@ -62,7 +62,7 @@ Basic concepts
         :term:`experiment` being processed. The context can carry any kind of
         relevant information: the current spectral coordinate, the Mitsuba ID
         of a :class:`mitsuba.Medium` object attached to a sensor, etc. The
-        kernel context is defined by a :class:`.KernelDictContext` instance.
+        kernel context is defined by a :class:`.KernelContext` instance.
 
     Kernel dictionary template
         :term:`Kernel dictionaries <kernel dictionary>` can be created from

--- a/docs/rst/reference_api/contexts.rst
+++ b/docs/rst/reference_api/contexts.rst
@@ -12,4 +12,4 @@ Classes
    :toctree: generated/autosummary/
 
    Context
-   KernelDictContext
+   KernelContext

--- a/docs/rst/reference_api/eradiate_core.rst
+++ b/docs/rst/reference_api/eradiate_core.rst
@@ -64,3 +64,6 @@ Convenience aliases
 
 .. autodata:: run
    :annotation:
+
+.. autodata:: traverse
+   :annotation:

--- a/docs/rst/reference_api/spectral.rst
+++ b/docs/rst/reference_api/spectral.rst
@@ -5,43 +5,22 @@
 
 .. py:currentmodule:: eradiate.spectral
 
-Spectral index
---------------
-
-.. automodule:: eradiate.spectral.index
-
-.. py:currentmodule:: eradiate.spectral.index
+Spectral indexes
+----------------
 
 .. autosummary::
    :toctree: generated/autosummary/
 
    SpectralIndex
-   CKDSpectralIndex
    MonoSpectralIndex
-   SPECTRAL_MODE_DISPATCH
+   CKDSpectralIndex
 
-
-BinSet
-------
-
-.. automodule:: eradiate.spectral.ckd
-
-.. py:currentmodule:: eradiate.spectral.ckd
-
-.. autosummary::
-   :toctree: generated/autosummary/
-
-   Bin
-   BinSet
-
-WavelengthSet
--------------
-
-.. automodule:: eradiate.spectral.mono
-
-.. py:currentmodule:: eradiate.spectral.mono
+Utility containers
+------------------
 
 .. autosummary::
    :toctree: generated/autosummary/
 
    WavelengthSet
+   Bin
+   BinSet

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,8 +73,6 @@ tests = [
 
 [project.scripts]
 eradiate = "eradiate.cli:main"
-ertdata = "eradiate.cli:data"
-ertshow = "eradiate.cli:show"
 
 [project.urls]
 changelog = "https://github.com/eradiate/eradiate/CHANGELOG.md"

--- a/src/eradiate/__init__.pyi
+++ b/src/eradiate/__init__.pyi
@@ -26,6 +26,7 @@ from ._mode import supported_mode as supported_mode
 from ._mode import unsupported_mode as unsupported_mode
 from .experiments import run as run
 from .notebook import load_ipython_extension as load_ipython_extension
+from .scenes.core import traverse as traverse
 from .units import unit_context_config as unit_context_config
 from .units import unit_context_kernel as unit_context_kernel
 from .units import unit_registry as unit_registry

--- a/src/eradiate/__init__.pyi
+++ b/src/eradiate/__init__.pyi
@@ -24,6 +24,7 @@ from ._mode import modes as modes
 from ._mode import set_mode as set_mode
 from ._mode import supported_mode as supported_mode
 from ._mode import unsupported_mode as unsupported_mode
+from .contexts import KernelContext as KernelContext
 from .experiments import run as run
 from .notebook import load_ipython_extension as load_ipython_extension
 from .scenes.core import traverse as traverse

--- a/src/eradiate/contexts.py
+++ b/src/eradiate/contexts.py
@@ -6,8 +6,6 @@ import attrs
 
 from .attrs import documented, parse_docs
 from .spectral import SpectralIndex
-from .units import unit_context_config as ucc
-from .units import unit_registry as ureg
 
 # ------------------------------------------------------------------------------
 #                                      ABC
@@ -42,12 +40,12 @@ class Context:
 
 @parse_docs
 @attrs.define
-class KernelDictContext(Context):
+class KernelContext(Context):
     """
-    Kernel dictionary evaluation context data structure. This class is used
-    *e.g.* to store information about the spectral configuration to apply
-    when generating kernel dictionaries associated with a :class:`.SceneElement`
-    instance.
+    Kernel evaluation context data structure. This class is used *e.g.* to store
+    information about the spectral configuration to apply when generating kernel
+    dictionaries or update parameter maps associated with a
+    :class:`.SceneElement` instance.
     """
 
     si: SpectralIndex = documented(

--- a/src/eradiate/contexts.py
+++ b/src/eradiate/contexts.py
@@ -5,7 +5,7 @@ import typing as t
 import attrs
 
 from .attrs import documented, parse_docs
-from .spectral.index import SpectralIndex
+from .spectral import SpectralIndex
 from .units import unit_context_config as ucc
 from .units import unit_registry as ureg
 

--- a/src/eradiate/experiments/_core.py
+++ b/src/eradiate/experiments/_core.py
@@ -14,7 +14,7 @@ import eradiate
 
 from .. import pipelines, validators
 from ..attrs import AUTO, documented, parse_docs
-from ..contexts import KernelDictContext
+from ..contexts import KernelContext
 from ..exceptions import UnsupportedModeError
 from ..kernel import MitsubaObjectWrapper, mi_render, mi_traverse
 from ..pipelines import Pipeline
@@ -248,7 +248,7 @@ class Experiment(ABC):
 
     @property
     @abstractmethod
-    def context_init(self) -> KernelDictContext:
+    def context_init(self) -> KernelContext:
         """
         Return a single context used for scene initialization.
         """
@@ -256,7 +256,7 @@ class Experiment(ABC):
 
     @property
     @abstractmethod
-    def contexts(self) -> list[KernelDictContext]:
+    def contexts(self) -> list[KernelContext]:
         """
         Return a list of contexts used for processing.
         """
@@ -379,14 +379,14 @@ class EarthObservationExperiment(Experiment, ABC):
         pass
 
     @property
-    def context_init(self) -> KernelDictContext:
-        return KernelDictContext(
+    def context_init(self) -> KernelContext:
+        return KernelContext(
             si=SpectralIndex.new(),
             kwargs=self._context_kwargs,
         )
 
     @property
-    def contexts(self) -> list[KernelDictContext]:
+    def contexts(self) -> list[KernelContext]:
         # Inherit docstring
 
         # Collect contexts from all measures
@@ -407,7 +407,7 @@ class EarthObservationExperiment(Experiment, ABC):
         )
         kwargs = self._context_kwargs
 
-        return [KernelDictContext(si, kwargs=kwargs) for si in sis]
+        return [KernelContext(si, kwargs=kwargs) for si in sis]
 
     @property
     @abstractmethod

--- a/src/eradiate/kernel/_kernel_dict.py
+++ b/src/eradiate/kernel/_kernel_dict.py
@@ -13,7 +13,7 @@ import attrs
 import mitsuba as mi
 
 from ..attrs import documented, parse_docs
-from ..contexts import KernelDictContext
+from ..contexts import KernelContext
 from ..util.misc import nest
 
 
@@ -32,11 +32,11 @@ class InitParameter:
     evaluator: t.Callable = documented(
         attrs.field(validator=attrs.validators.is_callable()),
         doc="A callable that returns the value of the parameter for a given "
-        "context, with signature ``f(ctx: KernelDictContext) -> Any``.",
+        "context, with signature ``f(ctx: KernelContext) -> Any``.",
         type="callable",
     )
 
-    def __call__(self, ctx: KernelDictContext) -> t.Any:
+    def __call__(self, ctx: KernelContext) -> t.Any:
         return self.evaluator(ctx)
 
 
@@ -50,7 +50,7 @@ class UpdateParameter:
 
     See Also
     --------
-    :class:`.KernelDictContext`, :class:`.TypeIdLookupStrategy`
+    :class:`.KernelContext`, :class:`.TypeIdLookupStrategy`
     """
 
     #: Sentinel value indicating that a parameter is not used
@@ -69,7 +69,7 @@ class UpdateParameter:
     evaluator: t.Callable = documented(
         attrs.field(validator=attrs.validators.is_callable()),
         doc="A callable that returns the value of the parameter for a given "
-        "context, with signature ``f(ctx: KernelDictContext) -> Any``.",
+        "context, with signature ``f(ctx: KernelContext) -> Any``.",
         type="callable",
     )
 
@@ -98,7 +98,7 @@ class UpdateParameter:
         init_type="str, optional",
     )
 
-    def __call__(self, ctx: KernelDictContext) -> t.Any:
+    def __call__(self, ctx: KernelContext) -> t.Any:
         return self.evaluator(ctx)
 
 
@@ -120,7 +120,7 @@ class KernelDictTemplate(UserDict):
     data: dict[str, InitParameter] = attrs.field(factory=dict)
 
     def render(
-        self, ctx: KernelDictContext, nested: bool = True, drop: bool = True
+        self, ctx: KernelContext, nested: bool = True, drop: bool = True
     ) -> dict:
         """
         Render the template as a nested dictionary using a parameter map to fill
@@ -128,7 +128,7 @@ class KernelDictTemplate(UserDict):
 
         Parameters
         ----------
-        ctx : :class:`.KernelDictContext`
+        ctx : :class:`.KernelContext`
             A kernel dictionary context.
 
         nested : bool, optional
@@ -218,7 +218,7 @@ class UpdateMapTemplate(UserDict):
 
     def render(
         self,
-        ctx: KernelDictContext,
+        ctx: KernelContext,
         flags: UpdateParameter.Flags = UpdateParameter.Flags.ALL,
         drop: bool = False,
     ) -> dict:
@@ -227,7 +227,7 @@ class UpdateMapTemplate(UserDict):
 
         Parameters
         ----------
-        ctx : :class:`.KernelDictContext`
+        ctx : :class:`.KernelContext`
             A kernel dictionary context.
 
         flags : :class:`.ParamFlags`

--- a/src/eradiate/kernel/_render.py
+++ b/src/eradiate/kernel/_render.py
@@ -10,7 +10,7 @@ from tqdm.auto import tqdm
 from ._kernel_dict import UpdateMapTemplate
 from .._config import ProgressLevel, config
 from ..attrs import documented, parse_docs
-from ..contexts import KernelDictContext
+from ..contexts import KernelContext
 from ..rng import SeedState, root_seed_state
 
 logger = logging.getLogger(__name__)
@@ -238,7 +238,7 @@ def mi_traverse(
 
 def mi_render(
     mi_scene: MitsubaObjectWrapper,
-    ctxs: list[KernelDictContext],
+    ctxs: list[KernelContext],
     sensors: None | int | list[int] = None,
     spp: int = 0,
     seed_state: SeedState | None = None,
@@ -252,7 +252,7 @@ def mi_render(
     mi_scene : .MitsubaObjectWrapper
         Mitsuba scene to render.
 
-    ctxs : list of :class:`.KernelDictContext`
+    ctxs : list of :class:`.KernelContext`
         List of contexts used to generate the parameter update table at each
         iteration.
 

--- a/src/eradiate/scenes/atmosphere/_core.py
+++ b/src/eradiate/scenes/atmosphere/_core.py
@@ -18,7 +18,7 @@ from ..phase import PhaseFunction
 from ..shapes import Shape
 from ..._factory import Factory
 from ...attrs import documented, get_doc, parse_docs
-from ...contexts import KernelDictContext
+from ...contexts import KernelContext
 from ...kernel import (
     InitParameter,
     TypeIdLookupStrategy,
@@ -163,7 +163,7 @@ class Atmosphere(CompositeSceneElement, ABC):
     # --------------------------------------------------------------------------
 
     @abstractmethod
-    def eval_mfp(self, ctx: KernelDictContext) -> pint.Quantity:
+    def eval_mfp(self, ctx: KernelContext) -> pint.Quantity:
         """
         Compute a typical scattering mean free path. This rough estimate can be
         used *e.g.* to compute a distance guaranteeing that the medium can be
@@ -171,7 +171,7 @@ class Atmosphere(CompositeSceneElement, ABC):
 
         Parameters
         ----------
-        ctx : :class:`.KernelDictContext`
+        ctx : :class:`.KernelContext`
             A context data structure containing parameters relevant for kernel
             dictionary generation.
 

--- a/src/eradiate/scenes/atmosphere/_heterogeneous.py
+++ b/src/eradiate/scenes/atmosphere/_heterogeneous.py
@@ -9,7 +9,6 @@ import attrs
 import mitsuba as mi
 import numpy as np
 import pint
-import xarray as xr
 
 from ._core import AbstractHeterogeneousAtmosphere, atmosphere_factory
 from ._molecular_atmosphere import MolecularAtmosphere
@@ -17,7 +16,7 @@ from ._particle_layer import ParticleLayer
 from ..core import traverse
 from ..phase import BlendPhaseFunction, PhaseFunction
 from ...attrs import documented, parse_docs
-from ...contexts import KernelDictContext
+from ...contexts import KernelContext
 from ...kernel import TypeIdLookupStrategy
 from ...radprops import ZGrid
 from ...spectral.ckd import BinSet
@@ -197,7 +196,7 @@ class HeterogeneousAtmosphere(AbstractHeterogeneousAtmosphere):
         # Fall back
         return None
 
-    def eval_mfp(self, ctx: KernelDictContext) -> pint.Quantity:
+    def eval_mfp(self, ctx: KernelContext) -> pint.Quantity:
         # Inherit docstring
         mfp = [component.eval_mfp(ctx=ctx) for component in self.components]
         return max(mfp)

--- a/src/eradiate/scenes/atmosphere/_homogeneous.py
+++ b/src/eradiate/scenes/atmosphere/_homogeneous.py
@@ -8,7 +8,7 @@ from ..core import traverse
 from ..phase import PhaseFunction, RayleighPhaseFunction, phase_function_factory
 from ..spectra import AirScatteringCoefficientSpectrum, Spectrum, spectrum_factory
 from ...attrs import documented, parse_docs
-from ...contexts import KernelDictContext
+from ...contexts import KernelContext
 from ...kernel import InitParameter, UpdateParameter
 from ...spectral.ckd import BinSet
 from ...spectral.index import SpectralIndex
@@ -112,7 +112,7 @@ class HomogeneousAtmosphere(Atmosphere):
     #                           Evaluation methods
     # --------------------------------------------------------------------------
 
-    def eval_mfp(self, ctx: KernelDictContext) -> pint.Quantity:
+    def eval_mfp(self, ctx: KernelContext) -> pint.Quantity:
         # Inherit docstring
         return (
             1.0 / self.eval_sigma_s(ctx.si)

--- a/src/eradiate/scenes/atmosphere/_molecular_atmosphere.py
+++ b/src/eradiate/scenes/atmosphere/_molecular_atmosphere.py
@@ -19,7 +19,7 @@ from ..core import traverse
 from ..phase import PhaseFunction, RayleighPhaseFunction, phase_function_factory
 from ... import converters
 from ...attrs import documented, parse_docs
-from ...contexts import KernelDictContext
+from ...contexts import KernelContext
 from ...quad import Quad
 from ...radprops import AFGL1986RadProfile, RadProfile, US76ApproxRadProfile, ZGrid
 from ...spectral.ckd import BinSet
@@ -177,7 +177,7 @@ class MolecularAtmosphere(AbstractHeterogeneousAtmosphere):
         # Inherit docstring
         return self._thermoprops
 
-    def eval_mfp(self, ctx: KernelDictContext) -> pint.Quantity:
+    def eval_mfp(self, ctx: KernelContext) -> pint.Quantity:
         # Inherit docstring
         min_sigma_s = self.radprops_profile.eval_sigma_s(ctx.si).min()
         return np.divide(

--- a/src/eradiate/scenes/atmosphere/_particle_layer.py
+++ b/src/eradiate/scenes/atmosphere/_particle_layer.py
@@ -18,7 +18,7 @@ from ..core import traverse
 from ..phase import TabulatedPhaseFunction
 from ... import converters, data
 from ...attrs import documented, parse_docs
-from ...contexts import KernelDictContext
+from ...contexts import KernelContext
 from ...kernel import UpdateParameter
 from ...radprops import ZGrid
 from ...spectral.ckd import BinSet
@@ -247,7 +247,7 @@ class ParticleLayer(AbstractHeterogeneousAtmosphere):
         fractions /= np.sum(fractions)
         return fractions
 
-    def eval_mfp(self, ctx: KernelDictContext) -> pint.Quantity:
+    def eval_mfp(self, ctx: KernelContext) -> pint.Quantity:
         min_sigma_s = self.eval_sigma_s(ctx.si).min()
         return 1.0 / min_sigma_s if min_sigma_s != 0.0 else np.inf * ureg.m
 

--- a/src/eradiate/scenes/core.py
+++ b/src/eradiate/scenes/core.py
@@ -385,7 +385,7 @@ class SceneTraversal:
 def traverse(node: NodeSceneElement) -> tuple[KernelDictTemplate, UpdateMapTemplate]:
     """
     Traverse a scene element tree and collect kernel dictionary template and
-     parameter update table data.
+    parameter update table data.
 
     Parameters
     ----------

--- a/src/eradiate/scenes/phase/_blend.py
+++ b/src/eradiate/scenes/phase/_blend.py
@@ -11,7 +11,7 @@ from ._core import PhaseFunction, phase_function_factory
 from ..core import traverse
 from ..geometry import PlaneParallelGeometry, SceneGeometry, SphericalShellGeometry
 from ...attrs import documented
-from ...contexts import KernelDictContext
+from ...contexts import KernelContext
 from ...kernel import InitParameter, UpdateParameter, map_unit_cube
 from ...spectral.index import SpectralIndex
 from ...units import unit_context_kernel as uck
@@ -49,9 +49,7 @@ class BlendPhaseFunction(PhaseFunction):
                 "have at least two components"
             )
 
-    weights: (
-        np.ndarray | list[t.Callable[[KernelDictContext], np.ndarray]]
-    ) = documented(
+    weights: (np.ndarray | list[t.Callable[[KernelContext], np.ndarray]]) = documented(
         attrs.field(
             converter=lambda x: x if callable(x[0]) else np.array(x, dtype=np.float64),
             kw_only=True,
@@ -62,7 +60,7 @@ class BlendPhaseFunction(PhaseFunction):
         "numerical values; in that case, they ust be of shape (n,) or (n, m), "
         "where n is the number of components and m the number of cells along "
         "the atmosphere's vertical axis. Alternatively, weights may be "
-        "callables that take a :class:`.KernelDictContext` as argument and "
+        "callables that take a :class:`.KernelContext` as argument and "
         "return an array of shape (n, m). "
         "This parameter is required and has no default.",
     )
@@ -209,7 +207,7 @@ class BlendPhaseFunction(PhaseFunction):
                 # Note: This defines a partial and evaluates the component index.
                 # Passing i as the kwarg default value is essential to force the
                 # dereferencing of the loop variable.
-                def eval_conditional_weights(ctx: KernelDictContext, n_component=i):
+                def eval_conditional_weights(ctx: KernelContext, n_component=i):
                     return mi.VolumeGrid(
                         np.reshape(
                             self.eval_conditional_weights(ctx.si, n_component),
@@ -227,7 +225,7 @@ class BlendPhaseFunction(PhaseFunction):
 
             elif isinstance(self.geometry, SphericalShellGeometry):
                 # Same comment as above
-                def eval_conditional_weights(ctx: KernelDictContext, n_component=i):
+                def eval_conditional_weights(ctx: KernelContext, n_component=i):
                     return mi.VolumeGrid(
                         np.reshape(
                             self.eval_conditional_weights(ctx.si, n_component),
@@ -277,7 +275,7 @@ class BlendPhaseFunction(PhaseFunction):
                 # Note: This defines a partial and evaluates the component index.
                 # Passing i as the kwarg default value is essential to force the
                 # dereferencing of the loop variable.
-                def eval_conditional_weights(ctx: KernelDictContext, n_component=i):
+                def eval_conditional_weights(ctx: KernelContext, n_component=i):
                     return np.reshape(
                         self.eval_conditional_weights(ctx.si, n_component),
                         (-1, 1, 1, 1),  # Mind dim ordering! (C-style, i.e. zyxc)
@@ -291,7 +289,7 @@ class BlendPhaseFunction(PhaseFunction):
 
             elif isinstance(self.geometry, SphericalShellGeometry):
                 # Same comment as above
-                def eval_conditional_weights(ctx: KernelDictContext, n_component=i):
+                def eval_conditional_weights(ctx: KernelContext, n_component=i):
                     return np.reshape(
                         self.eval_conditional_weights(ctx.si, n_component),
                         (1, 1, -1, 1),  # Mind dim ordering! (C-style, i.e. zyxc)

--- a/src/eradiate/scenes/shapes/_buffermesh.py
+++ b/src/eradiate/scenes/shapes/_buffermesh.py
@@ -9,7 +9,7 @@ import pinttr
 from ._core import ShapeInstance
 from ..core import BoundingBox, traverse
 from ...attrs import documented, parse_docs
-from ...contexts import KernelDictContext
+from ...contexts import KernelContext
 from ...kernel import UpdateParameter
 from ...units import unit_context_config as ucc
 from ...units import unit_context_kernel as uck
@@ -65,7 +65,7 @@ class BufferMeshShape(ShapeInstance):
     def instance(self) -> mi.Object:
         if self.bsdf is not None:
             template, _ = traverse(self.bsdf)
-            bsdf = mi.load_dict(template.render(ctx=KernelDictContext()))
+            bsdf = mi.load_dict(template.render(ctx=KernelContext()))
         else:
             bsdf = None
 

--- a/src/eradiate/scenes/shapes/_cuboid.py
+++ b/src/eradiate/scenes/shapes/_cuboid.py
@@ -13,7 +13,7 @@ from ._core import ShapeNode
 from ..bsdfs import BSDF
 from ..core import BoundingBox
 from ...attrs import documented, parse_docs
-from ...contexts import KernelDictContext
+from ...contexts import KernelContext
 from ...units import unit_context_config as ucc
 from ...units import unit_context_kernel as uck
 from ...units import unit_registry as ureg
@@ -107,9 +107,7 @@ class CuboidShape(ShapeNode):
         )
         return np.all(cmp, axis=1)
 
-    def eval_to_world(
-        self, ctx: KernelDictContext | None = None
-    ) -> mi.ScalarTransform4f:
+    def eval_to_world(self, ctx: KernelContext | None = None) -> mi.ScalarTransform4f:
         kwargs = ctx.kwargs.get(self.id, {}) if ctx is not None else {}
 
         if "to_world" in kwargs:

--- a/src/eradiate/spectral/__init__.py
+++ b/src/eradiate/spectral/__init__.py
@@ -1,11 +1,5 @@
-"""Data structures for working along the spectral dimension.
-
-This includes in particular:
-
-* :class:`.SpectralIndex`: a data structure used to evaluate spectral quantities
-* :class:`.WavelengthSet`: a set of wavelength values at which an experiment is
-  run
-* :class:`.BinSet`: a set of wavelength bins at which an experiment is run
+"""
+Data structures for working along the spectral dimension.
 """
 import lazy_loader
 

--- a/src/eradiate/spectral/__init__.pyi
+++ b/src/eradiate/spectral/__init__.pyi
@@ -1,3 +1,6 @@
-from . import ckd as ckd
-from . import index as index
-from . import mono as mono
+from .ckd import Bin as Bin
+from .ckd import BinSet as BinSet
+from .index import CKDSpectralIndex as CKDSpectralIndex
+from .index import MonoSpectralIndex as MonoSpectralIndex
+from .index import SpectralIndex as SpectralIndex
+from .mono import WavelengthSet as WavelengthSet

--- a/src/eradiate/spectral/ckd.py
+++ b/src/eradiate/spectral/ckd.py
@@ -151,7 +151,7 @@ class BinSet:
 
     See Also
     --------
-    :class:`~.mono.WavelengthSet`
+    :class:`.WavelengthSet`
     """
 
     bins: list[Bin] = documented(

--- a/src/eradiate/spectral/index.py
+++ b/src/eradiate/spectral/index.py
@@ -7,21 +7,22 @@ spectral quantities. The simplest example is provided by
 Each SpectralIndex subclass is specific to an Eradiate spectral mode.
 For example, :class:`MonoSpectralIndex` is used in monochromatic mode.
 
-Note to maintainers
--------------------
-All methods that evaluate spectral quantities, conventionally named ``eval_*``,
-should accept a ``si: SpectralIndex`` parameter.
+.. admonition:: Note to maintainers
+   :class: note
 
-If a new spectral mode is added, you need to:
+   All methods that evaluate spectral quantities, conventionally named ``eval_*``,
+   should accept a ``si: SpectralIndex`` parameter.
 
-* add a new :class:`.SpectralIndex` subclass
-* add it to the :attr:`.SPECTRAL_MODE_DISPATCH` dictionary, which maps
-  spectral mode enum values to the corresponding spectral index type
+   If a new spectral mode is added, you need to:
 
-For experiments to support the newly added spectral mode, you will also need to
-update the eradiate/src/experiment package, in particular the
-`_normalize_spectral()` post-init method of the
-:class:`~eradiate.experiments.EarthObservationExperiment`.
+   * add a new :class:`.SpectralIndex` subclass
+   * add it to the :data:`.SPECTRAL_MODE_DISPATCH` dictionary, which maps
+     spectral mode enum values to the corresponding spectral index type
+
+   For experiments to support the newly added spectral mode, you will also need to
+   update the ``eradiate/src/experiment`` package, in particular the
+   ``_normalize_spectral()`` post-init method of the
+   :class:`.EarthObservationExperiment`.
 """
 from __future__ import annotations
 
@@ -162,7 +163,6 @@ class MonoSpectralIndex(SpectralIndex):
 
     @w.validator
     def _w_validator(self, attribute, value):
-
         # wavelength must be a scalar quantity
         validators.on_quantity(validators.is_scalar)(self, attribute, value)
 
@@ -219,7 +219,6 @@ class CKDSpectralIndex(SpectralIndex):
 
     @w.validator
     def _w_validator(self, attribute, value):
-
         # wavelength must be a scalar quantity
         validators.on_quantity(validators.is_scalar)(self, attribute, value)
 

--- a/src/eradiate/spectral/mono.py
+++ b/src/eradiate/spectral/mono.py
@@ -27,13 +27,13 @@ class WavelengthSet:
 
     See Also
     --------
-    :class:`~.ckd.BinSet`
+    :class:`~.BinSet`
 
     Notes
     -----
     This is class is a simple container for an array of wavelengths at which
     a monochromatic experiment is to be performed.
-    Its design is inspired by :class:`~.ckd.BinSet`.
+    Its design is inspired by :class:`~.BinSet`.
     """
 
     wavelengths: pint.Quantity = documented(

--- a/src/eradiate/test_tools/types.py
+++ b/src/eradiate/test_tools/types.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import mitsuba as mi
 import pytest
 
-from ..contexts import KernelDictContext
+from ..contexts import KernelContext
 from ..kernel import MitsubaObjectWrapper, mi_traverse
 from ..scenes.core import CompositeSceneElement, NodeSceneElement, Scene, traverse
 
@@ -11,7 +11,7 @@ from ..scenes.core import CompositeSceneElement, NodeSceneElement, Scene, traver
 def check_scene_element(
     instance: NodeSceneElement | CompositeSceneElement,
     mi_cls=None,
-    ctx: KernelDictContext = None,
+    ctx: KernelContext = None,
 ) -> MitsubaObjectWrapper:
     """
     Perform kernel dictionary checks on a scene element.
@@ -31,7 +31,7 @@ def check_scene_element(
         Mitsuba class the node scene element expands to. Must be set if
         `instance` is a :class:`.NodeSceneElement`; ignored otherwise.
 
-    ctx : .KernelDictContext, optional
+    ctx : .KernelContext, optional
         If provided, the kernel dictionary context to use. Otherwise, a default
         context is created.
 
@@ -65,7 +65,7 @@ def check_scene_element(
         raise RuntimeError(f"Cannot test type '{instance.__class__}'")
 
     # Check if the template can be instantiated
-    ctx = KernelDictContext() if ctx is None else ctx
+    ctx = KernelContext() if ctx is None else ctx
     kernel_dict = kdict_template.render(ctx)
 
     try:

--- a/tests/02_eradiate/01_unit/kernel/test_render.py
+++ b/tests/02_eradiate/01_unit/kernel/test_render.py
@@ -4,7 +4,7 @@ import attrs
 import mitsuba as mi
 import numpy as np
 
-from eradiate.contexts import KernelDictContext
+from eradiate.contexts import KernelContext
 from eradiate.kernel import (
     MitsubaObjectWrapper,
     TypeIdLookupStrategy,
@@ -157,7 +157,7 @@ def test_mi_render(mode_mono):
     result = mi_render(
         mi_wrapper,
         ctxs=[
-            KernelDictContext(si=SpectralIndex.new(w=w), kwargs={"r": r})
+            KernelContext(si=SpectralIndex.new(w=w), kwargs={"r": r})
             for (r, w) in zip(reflectances, wavelengths)
         ],
     )
@@ -226,7 +226,7 @@ def test_mi_render_multisensor(mode_mono):
     result = mi_render(
         mi_wrapper,
         ctxs=[
-            KernelDictContext(si=SpectralIndex.new(w=w), kwargs={"r": r})
+            KernelContext(si=SpectralIndex.new(w=w), kwargs={"r": r})
             for (r, w) in zip(reflectances, wavelengths)
         ],
     )

--- a/tests/02_eradiate/01_unit/kernel/test_render.py
+++ b/tests/02_eradiate/01_unit/kernel/test_render.py
@@ -1,10 +1,9 @@
 from itertools import product
 
-import attrs
 import mitsuba as mi
 import numpy as np
 
-from eradiate.contexts import KernelContext
+from eradiate import KernelContext
 from eradiate.kernel import (
     MitsubaObjectWrapper,
     TypeIdLookupStrategy,

--- a/tests/02_eradiate/01_unit/scenes/atmosphere/test_heterogeneous.py
+++ b/tests/02_eradiate/01_unit/scenes/atmosphere/test_heterogeneous.py
@@ -3,9 +3,9 @@ import numpy as np
 import pytest
 
 import eradiate
+from eradiate import KernelContext
 from eradiate import unit_context_config as ucc
 from eradiate import unit_registry as ureg
-from eradiate.contexts import KernelContext
 from eradiate.radprops import ZGrid
 from eradiate.scenes.atmosphere import (
     HeterogeneousAtmosphere,

--- a/tests/02_eradiate/01_unit/scenes/atmosphere/test_heterogeneous.py
+++ b/tests/02_eradiate/01_unit/scenes/atmosphere/test_heterogeneous.py
@@ -5,7 +5,7 @@ import pytest
 import eradiate
 from eradiate import unit_context_config as ucc
 from eradiate import unit_registry as ureg
-from eradiate.contexts import KernelDictContext
+from eradiate.contexts import KernelContext
 from eradiate.radprops import ZGrid
 from eradiate.scenes.atmosphere import (
     HeterogeneousAtmosphere,
@@ -54,7 +54,7 @@ def test_heterogeneous_single_mono(
         )
 
     # The scene element produces valid kernel dictionary specifications
-    check_scene_element(atmosphere, KernelDictContext())
+    check_scene_element(atmosphere, KernelContext())
 
 
 @pytest.mark.parametrize("geometry", ["plane_parallel", "spherical_shell"])
@@ -79,7 +79,7 @@ def test_heterogeneous_single_ckd(mode_ckd, geometry, component, bin_set):
         )
 
     # The scene element produces valid kernel dictionary specifications
-    check_scene_element(atmosphere, KernelDictContext())
+    check_scene_element(atmosphere, KernelContext())
 
 
 @pytest.mark.parametrize("geometry", ["plane_parallel", "spherical_shell"])
@@ -99,7 +99,7 @@ def test_heterogeneous_multi_mono(mode_mono, geometry, path_to_ussa76_approx_dat
     )
 
     # The scene element produces valid kernel dictionary specifications
-    check_scene_element(atmosphere, KernelDictContext())
+    check_scene_element(atmosphere, KernelContext())
 
 
 @pytest.mark.parametrize("geometry", ["plane_parallel", "spherical_shell"])
@@ -118,7 +118,7 @@ def test_heterogeneous_multi_ckd(mode_ckd, geometry, bin_set):
     )
 
     # The scene element produces valid kernel dictionary specifications
-    check_scene_element(atmosphere, KernelDictContext())
+    check_scene_element(atmosphere, KernelContext())
 
 
 @pytest.mark.parametrize("field", ["sigma_a", "sigma_t"])
@@ -139,7 +139,7 @@ def test_heterogeneous_mix_collision_coefficients(modes_all_double, field):
         },
         particle_layers=[component_1, component_2, component_3],
     )
-    ctx = KernelDictContext()
+    ctx = KernelContext()
     zgrid = mixed.geometry.zgrid
 
     # Evaluate all profiles on the container's altitude grid
@@ -192,7 +192,7 @@ def test_heterogeneous_mix_weights(modes_all_double):
     """
     Check that component weights are correctly computed.
     """
-    ctx = KernelDictContext()
+    ctx = KernelContext()
     geometry = SceneGeometry.convert(
         {
             "type": "plane_parallel",
@@ -306,7 +306,7 @@ def test_heterogeneous_scale(mode_mono, path_to_ussa76_approx_data):
     assert template["medium_atmosphere.scale"] == 2.0
 
     # The scene element produces valid kernel dictionary specifications
-    check_scene_element(atmosphere, KernelDictContext())
+    check_scene_element(atmosphere, KernelContext())
 
 
 def test_heterogeneous_blend_switches(mode_mono):

--- a/tests/02_eradiate/01_unit/scenes/atmosphere/test_molecular_atmosphere.py
+++ b/tests/02_eradiate/01_unit/scenes/atmosphere/test_molecular_atmosphere.py
@@ -4,8 +4,8 @@ import mitsuba as mi
 import numpy.testing as npt
 import pytest
 
+from eradiate import KernelContext
 from eradiate import unit_registry as ureg
-from eradiate.contexts import KernelContext
 from eradiate.data import data_store
 from eradiate.scenes.atmosphere import MolecularAtmosphere
 from eradiate.scenes.core import Scene, traverse

--- a/tests/02_eradiate/01_unit/scenes/atmosphere/test_particle_layer.py
+++ b/tests/02_eradiate/01_unit/scenes/atmosphere/test_particle_layer.py
@@ -2,9 +2,8 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from eradiate import data
+from eradiate import KernelContext, data
 from eradiate import unit_registry as ureg
-from eradiate.contexts import KernelContext
 from eradiate.radprops import ZGrid
 from eradiate.scenes.atmosphere import ParticleLayer, UniformParticleDistribution
 from eradiate.scenes.core import traverse

--- a/tests/02_eradiate/01_unit/scenes/atmosphere/test_particle_layer.py
+++ b/tests/02_eradiate/01_unit/scenes/atmosphere/test_particle_layer.py
@@ -4,7 +4,7 @@ import xarray as xr
 
 from eradiate import data
 from eradiate import unit_registry as ureg
-from eradiate.contexts import KernelDictContext
+from eradiate.contexts import KernelContext
 from eradiate.radprops import ZGrid
 from eradiate.scenes.atmosphere import ParticleLayer, UniformParticleDistribution
 from eradiate.scenes.core import traverse
@@ -57,7 +57,7 @@ def test_particle_layer_eval_mono_absorbing_only(mode_mono, absorbing_only, w):
     assert np.allclose(layer.eval_sigma_a(si), 0.2 / ureg.km)
     assert np.allclose(layer.eval_albedo(si).m, 0.0)
 
-    ctx = KernelDictContext(si=si)
+    ctx = KernelContext(si=si)
     assert layer.eval_mfp(ctx).magnitude == np.inf
 
 
@@ -81,7 +81,7 @@ def test_particle_layer_eval_mono_scattering_only(mode_mono, scattering_only, w)
     assert np.allclose(layer.eval_sigma_a(si), 0.0 / ureg.km)
     assert np.allclose(layer.eval_albedo(si).m, 1.0)
 
-    ctx = KernelDictContext(si=si)
+    ctx = KernelContext(si=si)
     assert np.isclose(layer.eval_mfp(ctx), 5.0 * ureg.km)
 
 
@@ -109,7 +109,7 @@ def test_particle_layer_eval_mono(mode_mono, test_particles_dataset, w):
     assert np.allclose(layer.eval_sigma_a(si), 0.2 / ureg.km)
     assert np.allclose(layer.eval_albedo(si).m, 0.8)
 
-    ctx = KernelDictContext(si=si)
+    ctx = KernelContext(si=si)
     assert np.isclose(layer.eval_mfp(ctx), 1.25 * ureg.km)
 
 
@@ -133,7 +133,7 @@ def test_particle_layer_eval_ckd_absorbing_only(mode_ckd, absorbing_only, w):
     assert np.allclose(layer.eval_sigma_a(si), 0.2 / ureg.km)
     assert np.allclose(layer.eval_albedo(si).m, 0.0)
 
-    ctx = KernelDictContext(si=si)
+    ctx = KernelContext(si=si)
     assert layer.eval_mfp(ctx).magnitude > 0.0
 
 
@@ -157,7 +157,7 @@ def test_particle_layer_eval_ckd_scattering_only(mode_ckd, scattering_only, w):
     assert np.allclose(layer.eval_sigma_a(si).m, 0.0)
     assert np.allclose(layer.eval_albedo(si).m, 1.0)
 
-    ctx = KernelDictContext(si=si)
+    ctx = KernelContext(si=si)
     assert layer.eval_mfp(ctx).magnitude > 0.0
 
 
@@ -183,7 +183,7 @@ def test_particle_layer_eval_ckd(mode_ckd, test_particles_dataset, w):
     assert np.allclose(layer.eval_sigma_a(si), 0.2 / ureg.km)
     assert np.allclose(layer.eval_albedo(si).m, 0.8)
 
-    ctx = KernelDictContext(si=si)
+    ctx = KernelContext(si=si)
     assert layer.eval_mfp(ctx) == 1.25 * ureg.km
 
 

--- a/tests/02_eradiate/01_unit/scenes/biosphere/test_leaf_cloud.py
+++ b/tests/02_eradiate/01_unit/scenes/biosphere/test_leaf_cloud.py
@@ -5,8 +5,8 @@ import attr
 import numpy as np
 import pytest
 
+from eradiate import KernelContext
 from eradiate import unit_registry as ureg
-from eradiate.contexts import KernelContext
 from eradiate.scenes.biosphere._leaf_cloud import (
     LeafCloud,
     _leaf_cloud_orientations,

--- a/tests/02_eradiate/01_unit/scenes/biosphere/test_leaf_cloud.py
+++ b/tests/02_eradiate/01_unit/scenes/biosphere/test_leaf_cloud.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 
 from eradiate import unit_registry as ureg
-from eradiate.contexts import KernelDictContext
+from eradiate.contexts import KernelContext
 from eradiate.scenes.biosphere._leaf_cloud import (
     LeafCloud,
     _leaf_cloud_orientations,
@@ -309,7 +309,7 @@ def test_leaf_cloud_kernel_dict(mode_mono):
     template, params = traverse(leaf_cloud)
 
     # The BSDF is bilambertian with the parameters we initially set
-    kernel_dict = template.render(ctx=KernelDictContext())
+    kernel_dict = template.render(ctx=KernelContext())
     assert kernel_dict[f"bsdf_{leaf_cloud_id}"] == {
         "type": "bilambertian",
         "reflectance": {"type": "uniform", "value": 0.5},

--- a/tests/02_eradiate/01_unit/scenes/biosphere/test_tree_abstract.py
+++ b/tests/02_eradiate/01_unit/scenes/biosphere/test_tree_abstract.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 
 from eradiate import unit_registry as ureg
-from eradiate.contexts import KernelDictContext
+from eradiate.contexts import KernelContext
 from eradiate.scenes.biosphere import AbstractTree, LeafCloud
 from eradiate.scenes.core import traverse
 from eradiate.test_tools.types import check_scene_element
@@ -132,7 +132,7 @@ def test_abstract_tree_kernel_dict(mode_mono):
     )
 
     template = traverse(tree)[0]
-    kdict = template.render(ctx=KernelDictContext())
+    kdict = template.render(ctx=KernelContext())
 
     # The BSDF is bilambertian with the parameters we initially set
     assert kdict[f"bsdf_{cloud_id}"] == {

--- a/tests/02_eradiate/01_unit/scenes/biosphere/test_tree_abstract.py
+++ b/tests/02_eradiate/01_unit/scenes/biosphere/test_tree_abstract.py
@@ -4,8 +4,8 @@ import tempfile
 import numpy as np
 import pytest
 
+from eradiate import KernelContext
 from eradiate import unit_registry as ureg
-from eradiate.contexts import KernelContext
 from eradiate.scenes.biosphere import AbstractTree, LeafCloud
 from eradiate.scenes.core import traverse
 from eradiate.test_tools.types import check_scene_element

--- a/tests/02_eradiate/01_unit/scenes/biosphere/test_tree_mesh.py
+++ b/tests/02_eradiate/01_unit/scenes/biosphere/test_tree_mesh.py
@@ -4,8 +4,8 @@ import tempfile
 import mitsuba as mi
 import pytest
 
+from eradiate import KernelContext
 from eradiate import unit_registry as ureg
-from eradiate.contexts import KernelContext
 from eradiate.kernel._kernel_dict import KernelDictTemplate
 from eradiate.scenes.biosphere import MeshTree, MeshTreeElement
 from eradiate.scenes.core import traverse

--- a/tests/02_eradiate/01_unit/scenes/biosphere/test_tree_mesh.py
+++ b/tests/02_eradiate/01_unit/scenes/biosphere/test_tree_mesh.py
@@ -5,7 +5,7 @@ import mitsuba as mi
 import pytest
 
 from eradiate import unit_registry as ureg
-from eradiate.contexts import KernelDictContext
+from eradiate.contexts import KernelContext
 from eradiate.kernel._kernel_dict import KernelDictTemplate
 from eradiate.scenes.biosphere import MeshTree, MeshTreeElement
 from eradiate.scenes.core import traverse
@@ -181,7 +181,7 @@ def test_mesh_tree_element_load(mode_mono, tmp_file, request):
     )
 
     # Check that the template successfully expands to a valid Mitsuba scene
-    mi_scene = mi.load_dict(template.render(KernelDictContext()))
+    mi_scene = mi.load_dict(template.render(KernelContext()))
     assert isinstance(mi_scene, mi.Scene)
 
 

--- a/tests/02_eradiate/01_unit/scenes/illumination/test_spot.py
+++ b/tests/02_eradiate/01_unit/scenes/illumination/test_spot.py
@@ -3,14 +3,14 @@ import numpy as np
 
 import eradiate.data
 from eradiate import unit_registry as ureg
-from eradiate.contexts import KernelDictContext
+from eradiate.contexts import KernelContext
 from eradiate.scenes.illumination import SpotIllumination
 from eradiate.test_tools.types import check_scene_element
 
 
 def test_construct_basic(mode_mono):
     # We need a default spectral config
-    ctx = KernelDictContext()
+    ctx = KernelContext()
 
     # Construct without parameters
     illumination = SpotIllumination()
@@ -37,7 +37,7 @@ def test_construct_texture(mode_mono, tmp_path):
     im.save(filename)
 
     # We need a default spectral config
-    ctx = KernelDictContext()
+    ctx = KernelContext()
 
     # Construct with custom beam profile filename
     illumination = SpotIllumination(
@@ -64,7 +64,7 @@ def test_construct_texture(mode_mono, tmp_path):
 
 def test_construct_from_size(mode_mono):
     # We need a default spectral config
-    ctx = KernelDictContext()
+    ctx = KernelContext()
 
     spot_radius = 1 * ureg.m
     beam_angle = 3 * ureg.deg

--- a/tests/02_eradiate/01_unit/scenes/illumination/test_spot.py
+++ b/tests/02_eradiate/01_unit/scenes/illumination/test_spot.py
@@ -2,8 +2,8 @@ import mitsuba as mi
 import numpy as np
 
 import eradiate.data
+from eradiate import KernelContext
 from eradiate import unit_registry as ureg
-from eradiate.contexts import KernelContext
 from eradiate.scenes.illumination import SpotIllumination
 from eradiate.test_tools.types import check_scene_element
 

--- a/tests/02_eradiate/01_unit/scenes/measure/test_multi_radiancemeter.py
+++ b/tests/02_eradiate/01_unit/scenes/measure/test_multi_radiancemeter.py
@@ -1,7 +1,7 @@
 import mitsuba as mi
 import pytest
 
-from eradiate.contexts import KernelDictContext
+from eradiate.contexts import KernelContext
 from eradiate.scenes.core import traverse
 from eradiate.scenes.measure import MultiRadiancemeterMeasure
 from eradiate.test_tools.types import check_scene_element
@@ -24,12 +24,10 @@ def test_multi_radiancemeter_medium(mode_mono):
     measure = MultiRadiancemeterMeasure()
     template, _ = traverse(measure)
 
-    kdict = template.render(ctx=KernelDictContext())
+    kdict = template.render(ctx=KernelContext())
     assert "medium" not in kdict
 
     kdict = template.render(
-        ctx=KernelDictContext(
-            kwargs={"measure.atmosphere_medium_id": "test_atmosphere"}
-        )
+        ctx=KernelContext(kwargs={"measure.atmosphere_medium_id": "test_atmosphere"})
     )
     assert kdict["medium"] == {"type": "ref", "id": "test_atmosphere"}

--- a/tests/02_eradiate/01_unit/scenes/measure/test_multi_radiancemeter.py
+++ b/tests/02_eradiate/01_unit/scenes/measure/test_multi_radiancemeter.py
@@ -1,7 +1,7 @@
 import mitsuba as mi
 import pytest
 
-from eradiate.contexts import KernelContext
+from eradiate import KernelContext
 from eradiate.scenes.core import traverse
 from eradiate.scenes.measure import MultiRadiancemeterMeasure
 from eradiate.test_tools.types import check_scene_element

--- a/tests/02_eradiate/01_unit/scenes/measure/test_perspective.py
+++ b/tests/02_eradiate/01_unit/scenes/measure/test_perspective.py
@@ -1,7 +1,7 @@
 import mitsuba as mi
 import pytest
 
-from eradiate.contexts import KernelDictContext
+from eradiate.contexts import KernelContext
 from eradiate.scenes.core import traverse
 from eradiate.scenes.measure import PerspectiveCameraMeasure
 from eradiate.test_tools.types import check_scene_element
@@ -54,12 +54,10 @@ def test_perspective_medium(mode_mono):
     measure = PerspectiveCameraMeasure()
     template, _ = traverse(measure)
 
-    kdict = template.render(ctx=KernelDictContext())
+    kdict = template.render(ctx=KernelContext())
     assert "medium" not in kdict
 
     kdict = template.render(
-        ctx=KernelDictContext(
-            kwargs={"measure.atmosphere_medium_id": "test_atmosphere"}
-        )
+        ctx=KernelContext(kwargs={"measure.atmosphere_medium_id": "test_atmosphere"})
     )
     assert kdict["medium"] == {"type": "ref", "id": "test_atmosphere"}

--- a/tests/02_eradiate/01_unit/scenes/measure/test_perspective.py
+++ b/tests/02_eradiate/01_unit/scenes/measure/test_perspective.py
@@ -1,7 +1,7 @@
 import mitsuba as mi
 import pytest
 
-from eradiate.contexts import KernelContext
+from eradiate import KernelContext
 from eradiate.scenes.core import traverse
 from eradiate.scenes.measure import PerspectiveCameraMeasure
 from eradiate.test_tools.types import check_scene_element

--- a/tests/02_eradiate/01_unit/scenes/measure/test_radiancemeter.py
+++ b/tests/02_eradiate/01_unit/scenes/measure/test_radiancemeter.py
@@ -1,6 +1,6 @@
 import mitsuba as mi
 
-from eradiate.contexts import KernelContext
+from eradiate import KernelContext
 from eradiate.scenes.core import traverse
 from eradiate.scenes.measure import RadiancemeterMeasure
 from eradiate.test_tools.types import check_scene_element

--- a/tests/02_eradiate/01_unit/scenes/measure/test_radiancemeter.py
+++ b/tests/02_eradiate/01_unit/scenes/measure/test_radiancemeter.py
@@ -1,6 +1,6 @@
 import mitsuba as mi
 
-from eradiate.contexts import KernelDictContext
+from eradiate.contexts import KernelContext
 from eradiate.scenes.core import traverse
 from eradiate.scenes.measure import RadiancemeterMeasure
 from eradiate.test_tools.types import check_scene_element
@@ -15,15 +15,13 @@ def test_radiancemeter_medium(mode_mono):
     measure = RadiancemeterMeasure()
     template, _ = traverse(measure)
 
-    ctx1 = KernelDictContext()
-    ctx2 = KernelDictContext(kwargs={"measure.atmosphere_medium_id": "test_atmosphere"})
+    ctx1 = KernelContext()
+    ctx2 = KernelContext(kwargs={"measure.atmosphere_medium_id": "test_atmosphere"})
 
-    kdict = template.render(ctx=KernelDictContext())
+    kdict = template.render(ctx=KernelContext())
     assert "medium" not in kdict
 
     kdict = template.render(
-        ctx=KernelDictContext(
-            kwargs={"measure.atmosphere_medium_id": "test_atmosphere"}
-        )
+        ctx=KernelContext(kwargs={"measure.atmosphere_medium_id": "test_atmosphere"})
     )
     assert kdict["medium"] == {"type": "ref", "id": "test_atmosphere"}

--- a/tests/02_eradiate/01_unit/scenes/phase/test_blend.py
+++ b/tests/02_eradiate/01_unit/scenes/phase/test_blend.py
@@ -3,7 +3,7 @@ import numpy as np
 import pytest
 
 from eradiate import unit_registry as ureg
-from eradiate.contexts import KernelDictContext
+from eradiate.contexts import KernelContext
 from eradiate.scenes.core import traverse
 from eradiate.scenes.geometry import SceneGeometry
 from eradiate.scenes.phase import BlendPhaseFunction
@@ -233,7 +233,7 @@ def test_blend_phase_kernel_dict_2_components(mode_mono, kwargs):
     check_scene_element(phase, mi.PhaseFunction)
 
     template, params = traverse(phase)
-    ctx = KernelDictContext()
+    ctx = KernelContext()
     kernel_dict = mi_to_numpy(template.render(ctx, nested=False))
 
     # Check that the kernel dict is correct
@@ -310,7 +310,7 @@ def test_blend_phase_kernel_dict_3_components(mode_mono, kwargs, expected_mi_wei
     check_scene_element(phase, mi.PhaseFunction)
 
     template, params = traverse(phase)
-    kernel_dict = mi_to_numpy(template.render(KernelDictContext(), nested=False))
+    kernel_dict = mi_to_numpy(template.render(KernelContext(), nested=False))
 
     # Array weights
     expected = {

--- a/tests/02_eradiate/01_unit/scenes/phase/test_blend.py
+++ b/tests/02_eradiate/01_unit/scenes/phase/test_blend.py
@@ -2,8 +2,8 @@ import mitsuba as mi
 import numpy as np
 import pytest
 
+from eradiate import KernelContext
 from eradiate import unit_registry as ureg
-from eradiate.contexts import KernelContext
 from eradiate.scenes.core import traverse
 from eradiate.scenes.geometry import SceneGeometry
 from eradiate.scenes.phase import BlendPhaseFunction

--- a/tests/02_eradiate/01_unit/scenes/phase/test_tabulated.py
+++ b/tests/02_eradiate/01_unit/scenes/phase/test_tabulated.py
@@ -5,7 +5,7 @@ import xarray as xr
 
 import eradiate
 from eradiate.scenes.phase import TabulatedPhaseFunction
-from eradiate.spectral.index import SpectralIndex
+from eradiate.spectral import SpectralIndex
 from eradiate.test_tools.types import check_scene_element
 
 

--- a/tests/02_eradiate/01_unit/scenes/shapes/test_cuboid.py
+++ b/tests/02_eradiate/01_unit/scenes/shapes/test_cuboid.py
@@ -6,7 +6,7 @@ import pytest
 from eradiate import unit_context_config as ucc
 from eradiate import unit_context_kernel as uck
 from eradiate import unit_registry as ureg
-from eradiate.contexts import KernelDictContext
+from eradiate.contexts import KernelContext
 from eradiate.scenes.core import BoundingBox, traverse
 from eradiate.scenes.shapes import CuboidShape
 from eradiate.test_tools.types import check_scene_element
@@ -44,7 +44,7 @@ def test_cuboid_params(mode_mono_double, kwargs, expected_transform):
     # Set edges
     cuboid = CuboidShape(**kwargs)
     template, _ = traverse(cuboid)
-    kernel_dict = template.render(ctx=KernelDictContext())
+    kernel_dict = template.render(ctx=KernelContext())
     to_world = kernel_dict["to_world"]
     assert dr.allclose(
         to_world.transform_affine(mi.Point3f(-1, -1, -1)), expected_transform[0]
@@ -67,7 +67,7 @@ def test_cuboid_atmosphere(mode_mono_double):
 
     with uck.override(length="m"):
         template, _ = traverse(cuboid)
-        kernel_dict = template.render(ctx=KernelDictContext())
+        kernel_dict = template.render(ctx=KernelContext())
         bbox = mi.load_dict(kernel_dict).bbox()
         assert dr.allclose(bbox.min, [-500, -500, -500])
         assert dr.allclose(bbox.max, [500, 500, 1000])

--- a/tests/02_eradiate/01_unit/scenes/shapes/test_cuboid.py
+++ b/tests/02_eradiate/01_unit/scenes/shapes/test_cuboid.py
@@ -3,11 +3,11 @@ import mitsuba as mi
 import numpy as np
 import pytest
 
+from eradiate import KernelContext
 from eradiate import unit_context_config as ucc
 from eradiate import unit_context_kernel as uck
 from eradiate import unit_registry as ureg
-from eradiate.contexts import KernelContext
-from eradiate.scenes.core import BoundingBox, traverse
+from eradiate.scenes.core import traverse
 from eradiate.scenes.shapes import CuboidShape
 from eradiate.test_tools.types import check_scene_element
 

--- a/tests/02_eradiate/01_unit/scenes/shapes/test_rectangle.py
+++ b/tests/02_eradiate/01_unit/scenes/shapes/test_rectangle.py
@@ -5,7 +5,7 @@ import pytest
 
 from eradiate import unit_context_config as ucc
 from eradiate import unit_registry as ureg
-from eradiate.contexts import KernelDictContext
+from eradiate.contexts import KernelContext
 from eradiate.scenes.core import traverse
 from eradiate.scenes.shapes import RectangleShape
 from eradiate.test_tools.types import check_scene_element
@@ -59,7 +59,7 @@ def test_rectangle_params(mode_mono_double, kwargs, expected_transform):
     # Set edges
     rectangle = RectangleShape(**kwargs)
     template, _ = traverse(rectangle)
-    kernel_dict = template.render(ctx=KernelDictContext())
+    kernel_dict = template.render(ctx=KernelContext())
     to_world = kernel_dict["to_world"]
     assert dr.allclose(
         to_world.transform_affine(mi.Point3f(-1, -1, 0)), expected_transform[0]

--- a/tests/02_eradiate/01_unit/scenes/shapes/test_rectangle.py
+++ b/tests/02_eradiate/01_unit/scenes/shapes/test_rectangle.py
@@ -3,9 +3,9 @@ import mitsuba as mi
 import numpy as np
 import pytest
 
+from eradiate import KernelContext
 from eradiate import unit_context_config as ucc
 from eradiate import unit_registry as ureg
-from eradiate.contexts import KernelContext
 from eradiate.scenes.core import traverse
 from eradiate.scenes.shapes import RectangleShape
 from eradiate.test_tools.types import check_scene_element

--- a/tests/02_eradiate/01_unit/scenes/spectra/test_air_scattering_coefficient.py
+++ b/tests/02_eradiate/01_unit/scenes/spectra/test_air_scattering_coefficient.py
@@ -4,7 +4,7 @@ import numpy as np
 import eradiate
 from eradiate import unit_context_kernel as uck
 from eradiate import unit_registry as ureg
-from eradiate.contexts import KernelDictContext
+from eradiate.contexts import KernelContext
 from eradiate.scenes.spectra import AirScatteringCoefficientSpectrum
 from eradiate.test_tools.types import check_scene_element
 
@@ -20,7 +20,7 @@ def test_air_scattering_coefficient_eval(modes_all_double):
     expected = 0.0114934 / ureg.km  # value at 550 nm (default wavelength)
 
     s = AirScatteringCoefficientSpectrum()
-    ctx = KernelDictContext()
+    ctx = KernelContext()
 
     value = s.eval(ctx.si)
     assert np.allclose(value, expected)

--- a/tests/02_eradiate/01_unit/scenes/spectra/test_air_scattering_coefficient.py
+++ b/tests/02_eradiate/01_unit/scenes/spectra/test_air_scattering_coefficient.py
@@ -2,9 +2,9 @@ import mitsuba as mi
 import numpy as np
 
 import eradiate
+from eradiate import KernelContext
 from eradiate import unit_context_kernel as uck
 from eradiate import unit_registry as ureg
-from eradiate.contexts import KernelContext
 from eradiate.scenes.spectra import AirScatteringCoefficientSpectrum
 from eradiate.test_tools.types import check_scene_element
 

--- a/tests/02_eradiate/01_unit/scenes/surface/test_basic.py
+++ b/tests/02_eradiate/01_unit/scenes/surface/test_basic.py
@@ -1,7 +1,7 @@
 import mitsuba as mi
 import pytest
 
-from eradiate.contexts import KernelContext
+from eradiate import KernelContext
 from eradiate.exceptions import TraversalError
 from eradiate.scenes.core import Scene, traverse
 from eradiate.scenes.shapes import RectangleShape, Shape

--- a/tests/02_eradiate/01_unit/scenes/surface/test_basic.py
+++ b/tests/02_eradiate/01_unit/scenes/surface/test_basic.py
@@ -1,7 +1,7 @@
 import mitsuba as mi
 import pytest
 
-from eradiate.contexts import KernelDictContext
+from eradiate.contexts import KernelContext
 from eradiate.exceptions import TraversalError
 from eradiate.scenes.core import Scene, traverse
 from eradiate.scenes.shapes import RectangleShape, Shape
@@ -47,7 +47,7 @@ def test_basic_surface_construct(
         # When enclosed in a Scene, the surface can be traversed
         scene = Scene(objects={"surface": surface})
         template, params = traverse(scene)
-        kernel_dict = template.render(KernelDictContext())
+        kernel_dict = template.render(KernelContext())
         assert isinstance(mi.load_dict(kernel_dict), mi.Scene)
 
     elif isinstance(expected_traversal_param_keys, type) and issubclass(

--- a/tests/02_eradiate/01_unit/scenes/surface/test_central_patch.py
+++ b/tests/02_eradiate/01_unit/scenes/surface/test_central_patch.py
@@ -3,7 +3,7 @@ import mitsuba as mi
 import numpy as np
 import pytest
 
-from eradiate.contexts import KernelDictContext
+from eradiate.contexts import KernelContext
 from eradiate.exceptions import TraversalError
 from eradiate.scenes.core import Ref, Scene, traverse
 from eradiate.scenes.shapes import RectangleShape, Shape
@@ -63,7 +63,7 @@ def test_central_patch_construct_new(
         # When enclosed in a Scene, the surface can be traversed
         scene = Scene(objects={"surface": surface})
         template, params = traverse(scene)
-        kernel_dict = template.render(KernelDictContext())
+        kernel_dict = template.render(KernelContext())
         assert isinstance(mi.load_dict(kernel_dict), mi.Scene)
 
     elif isinstance(expected_traversal_param_keys, type) and issubclass(
@@ -99,7 +99,7 @@ def test_central_patch_scale_kernel_dict(mode_mono):
     )
 
     template, params = traverse(surface)
-    kernel_dict = template.render(ctx=KernelDictContext())
+    kernel_dict = template.render(ctx=KernelContext())
     result = kernel_dict["surface_bsdf"]["weight"]["to_uv"].matrix
     expected = (
         mi.ScalarTransform4f.scale([10, 10, 1])

--- a/tests/02_eradiate/01_unit/scenes/surface/test_central_patch.py
+++ b/tests/02_eradiate/01_unit/scenes/surface/test_central_patch.py
@@ -3,7 +3,7 @@ import mitsuba as mi
 import numpy as np
 import pytest
 
-from eradiate.contexts import KernelContext
+from eradiate import KernelContext
 from eradiate.exceptions import TraversalError
 from eradiate.scenes.core import Ref, Scene, traverse
 from eradiate.scenes.shapes import RectangleShape, Shape

--- a/tests/02_eradiate/01_unit/scenes/surface/test_dem.py
+++ b/tests/02_eradiate/01_unit/scenes/surface/test_dem.py
@@ -7,7 +7,7 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from eradiate.contexts import KernelDictContext
+from eradiate.contexts import KernelContext
 from eradiate.scenes.core import Scene, traverse
 from eradiate.scenes.shapes import BufferMeshShape, FileMeshShape, Shape
 from eradiate.scenes.surface import DEMSurface
@@ -111,7 +111,7 @@ def test_dem_surface_construct(
         # When enclosed in a Scene, the surface can be traversed
         scene = Scene(objects={"surface": surface})
         template, params = traverse(scene)
-        kernel_dict = template.render(KernelDictContext())
+        kernel_dict = template.render(KernelContext())
         assert isinstance(mi.load_dict(kernel_dict), mi.Scene)
 
     else:

--- a/tests/02_eradiate/01_unit/scenes/surface/test_dem.py
+++ b/tests/02_eradiate/01_unit/scenes/surface/test_dem.py
@@ -7,7 +7,7 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from eradiate.contexts import KernelContext
+from eradiate import KernelContext
 from eradiate.scenes.core import Scene, traverse
 from eradiate.scenes.shapes import BufferMeshShape, FileMeshShape, Shape
 from eradiate.scenes.surface import DEMSurface

--- a/tests/02_eradiate/01_unit/spectral/test_ckd.py
+++ b/tests/02_eradiate/01_unit/spectral/test_ckd.py
@@ -4,7 +4,7 @@ import pytest
 from eradiate import unit_registry as ureg
 from eradiate.quad import Quad
 from eradiate.scenes.spectra import InterpolatedSpectrum, MultiDeltaSpectrum
-from eradiate.spectral.ckd import Bin, BinSet
+from eradiate.spectral import Bin, BinSet
 
 
 def test_ckd_bin():
@@ -26,7 +26,7 @@ def test_ckd_bin():
 
 def test_select_with_multi_delta_1():
     """
-    Unit tests for :meth:`eradiate.ckd.BinSet.select_with`.
+    Unit tests for :meth:`.BinSet.select_with`.
     """
     binset = BinSet.arange(
         start=280.0 * ureg.nm,
@@ -45,7 +45,7 @@ def test_select_with_multi_delta_1():
 
 def test_select_with_multi_delta_2():
     """
-    Unit tests for :meth:`eradiate.ckd.BinSet.select_with`.
+    Unit tests for :meth:`.BinSet.select_with`.
     """
     binset = BinSet.arange(
         start=280.0 * ureg.nm,
@@ -64,7 +64,7 @@ def test_select_with_multi_delta_2():
 
 def test_select_from_connex_interpolated_spectrum_1():
     """
-    Unit tests for :meth:`eradiate.ckd.BinSet.select_from_srf`.
+    Unit tests for :meth:`.BinSet.select_from_srf`.
     """
     binset = BinSet.arange(
         start=280.0 * ureg.nm,
@@ -87,7 +87,7 @@ def test_select_from_connex_interpolated_spectrum_1():
 
 def test_select_from_connex_interpolated_spectrum_2():
     """
-    Unit tests for :meth:`eradiate.ckd.BinSet.select_from_srf`.
+    Unit tests for :meth:`.BinSet.select_from_srf`.
     """
     binset = BinSet.arange(
         start=280.0 * ureg.nm,
@@ -116,7 +116,7 @@ def test_select_from_connex_interpolated_spectrum_2():
 
 def test_select_from_connex_interpolated_spectrum_3():
     """
-    Unit tests for :meth:`eradiate.ckd.BinSet.select_from_srf`.
+    Unit tests for :meth:`.BinSet.select_from_srf`.
     """
     binset = BinSet.arange(
         start=280.0 * ureg.nm,
@@ -145,7 +145,7 @@ def test_select_from_connex_interpolated_spectrum_3():
 
 def test_select_from_non_connex_interpolated_spectrum_1():
     """
-    Unit tests for :meth:`eradiate.ckd.BinSet.select_from_srf`.
+    Unit tests for :meth:`.BinSet.select_from_srf`.
     """
     binset = BinSet.arange(
         start=280.0 * ureg.nm,
@@ -175,7 +175,7 @@ def test_select_from_non_connex_interpolated_spectrum_1():
 
 def test_select_from_non_connex_interpolated_spectrum_2():
     """
-    Unit tests for :meth:`eradiate.ckd.BinSet.select_from_srf`.
+    Unit tests for :meth:`.BinSet.select_from_srf`.
     """
     binset = BinSet.arange(
         start=280.0 * ureg.nm,
@@ -204,7 +204,7 @@ def test_select_from_non_connex_interpolated_spectrum_2():
 
 def test_select_from_connex_interpolated_spectrum_misaligned():
     """
-    Unit tests for :meth:`eradiate.ckd.BinSet.select_from_srf`.
+    Unit tests for :meth:`.BinSet.select_from_srf`.
     """
     binset = BinSet.arange(
         start=280.0 * ureg.nm,

--- a/tests/02_eradiate/01_unit/spectral/test_mono.py
+++ b/tests/02_eradiate/01_unit/spectral/test_mono.py
@@ -8,7 +8,7 @@ from eradiate.units import unit_registry as ureg
 
 def test_select_with_multi_delta():
     """
-    Unit tests for :meth:`eradiate.mono.WavelengthSet.select_with_srf`.
+    Unit tests for :meth:`.WavelengthSet.select_with_srf`.
     """
 
     wset = WavelengthSet(wavelengths=np.arange(280.0, 2400.0, 1.0) * ureg.nm)

--- a/tests/02_eradiate/01_unit/util/test_misc.py
+++ b/tests/02_eradiate/01_unit/util/test_misc.py
@@ -82,11 +82,11 @@ def test_fullname(mode_mono):
     assert fullname(path.is_file) == "pathlib.Path.is_file"
     # -- Class method from class definition
     assert (
-        fullname(eradiate.spectral.index.SpectralIndex.new)
+        fullname(eradiate.spectral.SpectralIndex.new)
         == "eradiate.spectral.index.SpectralIndex.new"
     )
     assert (
-        fullname(eradiate.spectral.index.SpectralIndex.new().new)
+        fullname(eradiate.spectral.SpectralIndex.new().new)
         == "eradiate.spectral.index.SpectralIndex.new"
     )
 

--- a/tests/02_eradiate/02_system/test_basic.py
+++ b/tests/02_eradiate/02_system/test_basic.py
@@ -8,7 +8,7 @@ import pytest
 
 import eradiate
 from eradiate import unit_registry as ureg
-from eradiate.contexts import KernelDictContext
+from eradiate.contexts import KernelContext
 from eradiate.kernel import mi_render
 from eradiate.scenes.bsdfs import LambertianBSDF
 from eradiate.scenes.core import Scene
@@ -93,7 +93,5 @@ def test_radiometric_accuracy(modes_all_mono, illumination, spp, li, ert_seed_st
     scene = Scene(objects=objects)
     mi_wrapper = check_scene_element(scene, mi.Scene)
 
-    result = np.squeeze(
-        mi_render(mi_wrapper, ctxs=[KernelDictContext()])[550.0]["measure"]
-    )
+    result = np.squeeze(mi_render(mi_wrapper, ctxs=[KernelContext()])[550.0]["measure"])
     np.testing.assert_allclose(result, theoretical_solution, rtol=1e-3)

--- a/tests/02_eradiate/02_system/test_basic.py
+++ b/tests/02_eradiate/02_system/test_basic.py
@@ -7,8 +7,8 @@ import numpy as np
 import pytest
 
 import eradiate
+from eradiate import KernelContext
 from eradiate import unit_registry as ureg
-from eradiate.contexts import KernelContext
 from eradiate.kernel import mi_render
 from eradiate.scenes.bsdfs import LambertianBSDF
 from eradiate.scenes.core import Scene

--- a/tests/02_eradiate/02_system/test_kernel_render_benchmark.py
+++ b/tests/02_eradiate/02_system/test_kernel_render_benchmark.py
@@ -2,8 +2,8 @@ import mitsuba as mi
 import numpy as np
 import pytest
 
+from eradiate import KernelContext
 from eradiate import unit_registry as ureg
-from eradiate.contexts import KernelContext
 from eradiate.kernel import mi_render, mi_traverse
 from eradiate.scenes.biosphere import LeafCloud
 from eradiate.scenes.core import Scene, traverse

--- a/tests/02_eradiate/02_system/test_kernel_render_benchmark.py
+++ b/tests/02_eradiate/02_system/test_kernel_render_benchmark.py
@@ -3,7 +3,7 @@ import numpy as np
 import pytest
 
 from eradiate import unit_registry as ureg
-from eradiate.contexts import KernelDictContext
+from eradiate.contexts import KernelContext
 from eradiate.kernel import mi_render, mi_traverse
 from eradiate.scenes.biosphere import LeafCloud
 from eradiate.scenes.core import Scene, traverse
@@ -41,8 +41,8 @@ def test_mi_render(mode_mono):
     and stores results as expected.
     """
     template, params = traverse(make_scene())
-    mi_scene = mi_traverse(mi.load_dict(template.render(ctx=KernelDictContext())))
-    contexts = [KernelDictContext(si={"w": w}) for w in wavelengths]
+    mi_scene = mi_traverse(mi.load_dict(template.render(ctx=KernelContext())))
+    contexts = [KernelContext(si={"w": w}) for w in wavelengths]
     result = mi_render(mi_scene, contexts, spp=spp)
 
     # We store film values and SPPs
@@ -58,12 +58,12 @@ def test_mi_render_rebuild(mode_mono):
     previous.
     """
     template, params = traverse(make_scene())
-    kdict = template.render(ctx=KernelDictContext(), drop=True)
+    kdict = template.render(ctx=KernelContext(), drop=True)
 
     for w in wavelengths:
         mi_scene = mi_traverse(mi.load_dict(kdict))
         mi_render(
             mi_scene,
-            [KernelDictContext(si={"w": w})],
+            [KernelContext(si={"w": w})],
             spp=spp,
         )

--- a/tests/02_eradiate/02_system/test_maximum_scene_size.py
+++ b/tests/02_eradiate/02_system/test_maximum_scene_size.py
@@ -2,7 +2,7 @@ import mitsuba as mi
 import numpy as np
 
 import eradiate
-from eradiate.contexts import KernelDictContext
+from eradiate.contexts import KernelContext
 from eradiate.kernel import mi_render, mi_traverse
 
 
@@ -89,7 +89,7 @@ def test_maximum_scene_size(modes_all_mono, json_metadata):
         )
 
         result = np.squeeze(
-            mi_render(mi_wrapper, ctxs=[KernelDictContext()])[550.0]["measure"]
+            mi_render(mi_wrapper, ctxs=[KernelContext()])[550.0]["measure"]
         )
         passed[i] = np.allclose(result, expected)
 

--- a/tests/02_eradiate/02_system/test_maximum_scene_size.py
+++ b/tests/02_eradiate/02_system/test_maximum_scene_size.py
@@ -2,7 +2,7 @@ import mitsuba as mi
 import numpy as np
 
 import eradiate
-from eradiate.contexts import KernelContext
+from eradiate import KernelContext
 from eradiate.kernel import mi_render, mi_traverse
 
 


### PR DESCRIPTION
# Description

*This is a draft PR providing a few convenience API updates*.

Changes are as follows:

* The `traverse()` function is exposed up in the `eradiate` namespace.
* The `spectral.*` members are exposed up in the `eradiate.spectral` namespace.
* The `KernelDictContext` class is renamed `KernelContext` and exposed in the `eradiate` namespace.
* The deprecated CLI entry points `ertdata` and `ertshow` are removed.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
