### PR TITLE
Fix Mitsuba scene parameter drop and lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ Entries marked with a ︎⚠️ symbol require particular attention during upgra
 * Exposed several API members in the top-level namespace ({ghpr}`324`).
 * Exposed the ``eradiate.spectral.*`` subpackage members in the
   {mod}`eradiate.spectral` namespace ({ghpr}`324`).
+* Fixed incorrect Mitsuba scene parameter drop ({ghpr}`329`).
 
 ### Documentation
 


### PR DESCRIPTION
# Description

This PR fixes the Mitsuba scene parameter drop system and updates it to make mistakes easier to detect. This, in turn, fixes incorrect scene parameter updates during the spectral loop.

It also fixes BSDF parameter lookups which would fail because BSDF IDs were unset.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
