### PR TITLE
Add implementation of the AstroObjectIllumination class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,8 @@ Entries marked with a ︎⚠️ symbol require particular attention during upgra
   {ghpr}`320`.
 * Fixed broken symmetry between {class}`.Spectrum` dictionary and object
   conversion protocols ({ghpr}`336`).
+* Implement the Astronomical Object Illumination, its tests and its
+  documentation ({ghpr}`331`).
 
 ### Documentation
 

--- a/src/eradiate/scenes/illumination/__init__.pyi
+++ b/src/eradiate/scenes/illumination/__init__.pyi
@@ -2,4 +2,5 @@ from ._constant import ConstantIllumination as ConstantIllumination
 from ._core import Illumination as Illumination
 from ._core import illumination_factory as illumination_factory
 from ._directional import DirectionalIllumination as DirectionalIllumination
+from . _astroobject import AstroObjectIllumination as AstroObjectIllumination
 from ._spot import SpotIllumination as SpotIllumination

--- a/src/eradiate/scenes/illumination/_astroobject.py
+++ b/src/eradiate/scenes/illumination/_astroobject.py
@@ -15,6 +15,25 @@ from ...validators import is_positive
 @attrs.define(eq=False, slots=False)
 class AstroObjectIllumination(DirectionalIllumination):
 
+    """
+    Astronomical Object Illumination scene element [``astroobject``].
+
+    This illumination represents the light coming from an astronomical object
+    (e.g. the Sun). Contrary to the ``directional`` illumination, the
+    astronomical object has a finite size and is not a point source. The
+    illumination emulates the behavior of a planet/star, being a extremely far
+    away illumination source, but still visible from the observation point.
+
+    The illumination is oriented based on the classical angular convention used
+    in Earth observation. It features a default angular diameter of 1 degree.
+    The angular diameter controls the size of the astronomical object as seen
+    from the observation point.
+
+    Rays casted by the astronomical object are not parallel, but belong to a
+    cone. The cone is defined by the angular diameter of the astronomical object
+    and the angle between the interaction point and the center of the cone cap.
+    """
+
     angular_diameter: pint.Quantity = documented(
         pinttr.field(
             default=1.0 * ureg.deg,

--- a/src/eradiate/scenes/illumination/_astroobject.py
+++ b/src/eradiate/scenes/illumination/_astroobject.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import attrs
+import pint
+import pinttr
+
+from ._directional import DirectionalIllumination
+from ...attrs import documented, parse_docs
+from ...units import unit_context_config as ucc
+from ...units import unit_registry as ureg
+from ...validators import is_positive
+
+
+@parse_docs
+@attrs.define(eq=False, slots=False)
+class AstroObjectIllumination(DirectionalIllumination):
+
+    angular_diameter: pint.Quantity = documented(
+        pinttr.field(
+            default=1.0 * ureg.deg,
+            validator=[is_positive, pinttr.validators.has_compatible_units],
+            units=ucc.deferred("angle"),
+        ),
+        doc="Angular diameter of the AstroObject, as scene from the observation point."
+            "\n\nUnit-enabled field (default units: ucc[angle]).",
+        type="quantity",
+        init_type="quantity or float",
+        default="1 deg",
+    )
+
+    @classmethod
+    def astro_object(cls, **kwargs):
+
+        return cls(**kwargs)
+
+    @property
+    def template(self) -> dict:
+        return {"type": "astroobject", "to_world": self._to_world, "angular_diameter": self.angular_diameter.m_as("degree")}

--- a/src/eradiate/scenes/illumination/_core.py
+++ b/src/eradiate/scenes/illumination/_core.py
@@ -13,6 +13,7 @@ illumination_factory.register_lazy_batch(
     [
         ("_constant.ConstantIllumination", "constant", {}),
         ("_directional.DirectionalIllumination", "directional", {}),
+        ("_astroobject.AstroObjectIllumination", "astro_object", {}),
         ("_spot.SpotIllumination", "spot", {}),
     ],
     cls_prefix="eradiate.scenes.illumination",

--- a/tests/02_eradiate/01_unit/scenes/illumination/test_astroobject.py
+++ b/tests/02_eradiate/01_unit/scenes/illumination/test_astroobject.py
@@ -1,0 +1,86 @@
+import pytest
+import numpy as np
+
+import mitsuba as mi
+
+from eradiate import unit_registry as ureg
+from eradiate.scenes.illumination import AstroObjectIllumination
+from eradiate.scenes.spectra import UniformSpectrum, SolarIrradianceSpectrum
+from eradiate.test_tools.types import check_scene_element
+
+@pytest.mark.parametrize(
+    "kwargs, expected_irradiance_type, angular_diameter",
+    [({}, SolarIrradianceSpectrum, 1.0), ({"irradiance": 1.0}, UniformSpectrum, 2.0)],
+    ids=["noargs", "from_scalar"],
+)
+def test_directional_construct(modes_all, kwargs, expected_irradiance_type, angular_diameter):
+    # Construction without argument succeeds
+    illumination = AstroObjectIllumination(**kwargs, angular_diameter=angular_diameter)
+    assert illumination
+    assert isinstance(illumination.irradiance, expected_irradiance_type)
+    assert illumination.angular_diameter == angular_diameter * ureg.deg
+
+@pytest.mark.parametrize(
+    "zenith, azimuth, direction, to_world",
+    [
+        (
+            0.0 * ureg.deg,
+            0.0 * ureg.deg,
+            [0, 0, -1],
+            [
+                [0, 1, 0, 0],
+                [1, 0, 0, 0],
+                [0, 0, -1, 0],
+                [0, 0, 0, 1],
+            ],
+        ),
+        (
+            30 * ureg.deg,
+            0.0 * ureg.deg,
+            [-0.5, 0.0, -np.sqrt(3) / 2],
+            [
+                [0.0, np.sqrt(3) / 2, -0.5, 0.0],
+                [1.0, 0.0, 0.0, 0.0],
+                [0.0, -0.5, -np.sqrt(3) / 2, 0.0],
+                [0.0, 0.0, 0.0, 1.0],
+            ],
+        ),
+    ],
+)
+def test_directional_to_world(mode_mono, zenith, azimuth, direction, to_world):
+    """
+    Direction is correctly converted to transformation matrix.
+    """
+    illumination = AstroObjectIllumination(zenith=zenith, azimuth=azimuth)
+    np.testing.assert_allclose(illumination.direction, direction)
+    np.testing.assert_allclose(illumination._to_world.matrix, to_world)
+
+def test_directional_kernel_dict(modes_all_double):
+    # The associated kernel dict is correctly formed and can be loaded
+    illumination = AstroObjectIllumination()
+    check_scene_element(illumination, mi_cls=mi.Emitter)
+
+
+COS_PI_4 = 0.5 * np.sqrt(2)
+
+
+@pytest.mark.parametrize(
+    "azimuth_convention, expected",
+    [
+        ("east_right", [0, -COS_PI_4, -COS_PI_4]),
+        ("east_left", [0, COS_PI_4, -COS_PI_4]),
+        ("north_right", [COS_PI_4, 0, -COS_PI_4]),
+        ("north_left", [-COS_PI_4, 0, -COS_PI_4]),
+        ("west_right", [0, COS_PI_4, -COS_PI_4]),
+        ("west_left", [0, -COS_PI_4, -COS_PI_4]),
+        ("south_right", [-COS_PI_4, 0, -COS_PI_4]),
+        ("south_left", [COS_PI_4, 0, -COS_PI_4]),
+    ],
+)
+def test_directional_azimuth_convention(mode_mono, azimuth_convention, expected):
+    illumination = AstroObjectIllumination(
+        zenith=45 * ureg.deg,
+        azimuth=90 * ureg.deg,
+        azimuth_convention=azimuth_convention,
+    )
+    assert np.allclose(illumination.direction, expected), illumination.direction

--- a/tests/02_eradiate/02_system/test_basic.py
+++ b/tests/02_eradiate/02_system/test_basic.py
@@ -12,7 +12,7 @@ from eradiate import unit_registry as ureg
 from eradiate.kernel import mi_render
 from eradiate.scenes.bsdfs import LambertianBSDF
 from eradiate.scenes.core import Scene
-from eradiate.scenes.illumination import ConstantIllumination, DirectionalIllumination
+from eradiate.scenes.illumination import ConstantIllumination, DirectionalIllumination, AstroObjectIllumination
 from eradiate.scenes.integrators import PathIntegrator
 from eradiate.scenes.measure import MultiDistantMeasure
 from eradiate.scenes.shapes import RectangleShape
@@ -20,7 +20,7 @@ from eradiate.scenes.surface import BasicSurface
 from eradiate.test_tools.types import check_scene_element
 
 
-@pytest.mark.parametrize("illumination, spp", [("directional", 1), ("constant", 5e5)])
+@pytest.mark.parametrize("illumination, spp", [("directional", 1), ("constant", 5e5), ("astroobject", 5e5)])
 @pytest.mark.parametrize("li", [0.1, 1.0, 10.0])
 @pytest.mark.slow
 def test_radiometric_accuracy(modes_all_mono, illumination, spp, li, ert_seed_state):
@@ -82,10 +82,17 @@ def test_radiometric_accuracy(modes_all_mono, illumination, spp, li, ert_seed_st
     if illumination == "directional":
         objects["illumination"] = DirectionalIllumination(zenith=0.0, irradiance=li)
         theoretical_solution = np.full_like(vza, rho * li / np.pi)
+        rtol=1e-3
 
     elif illumination == "constant":
         objects["illumination"] = ConstantIllumination(radiance=li)
         theoretical_solution = np.full_like(vza, rho * li)
+        rtol=1e-3
+
+    elif illumination == "astroobject":
+        objects["illumination"] = AstroObjectIllumination(zenith=0.0, irradiance=li, angular_diameter=0.03)
+        theoretical_solution = np.full_like(vza, rho * li / np.pi)
+        rtol=55e-3
 
     else:
         raise ValueError(f"unsupported illumination '{illumination}'")
@@ -94,4 +101,4 @@ def test_radiometric_accuracy(modes_all_mono, illumination, spp, li, ert_seed_st
     mi_wrapper = check_scene_element(scene, mi.Scene)
 
     result = np.squeeze(mi_render(mi_wrapper, ctxs=[KernelContext()])[550.0]["measure"])
-    np.testing.assert_allclose(result, theoretical_solution, rtol=1e-3)
+    np.testing.assert_allclose(result, theoretical_solution, rtol=rtol)


### PR DESCRIPTION
# Description

Following [the introduction of the `AstroObjectEmitter` plugin in the radiometric kernel](https://github.com/eradiate/mitsuba3/pull/3), a corresponding illumination class is required in Eradiate. This PR implements the `AstroObjectIllumination`, extending the `DirectionalIllumination` class. These two illuminations are similar adapters for the corresponging Mitsuba interfaces, since both are parameterized by an illumination direction and an irradiance spectrum. The `AstroObjectIllumination` differs by introducing a new parameter, the `angular_diameter`, defining the portion of the sky covered by the emitter, and adding it to the kernel dict. By default, the `angular_diameter` is about the average angular diameter of the sun as observed from earth.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
