### PR TITLE
Spectrum: Allow assigning `None` to the `quantity` field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,8 @@ Entries marked with a ︎⚠️ symbol require particular attention during upgra
 * Fixed incorrect Mitsuba scene parameter drop and lookup ({ghpr}`329`).
 * Added spherical-shell geometry support to DEM components
   {ghpr}`320`.
+* Fixed broken symmetry between {class}`.Spectrum` dictionary and object
+  conversion protocols ({ghpr}`336`).
 
 ### Documentation
 


### PR DESCRIPTION
This PR closes #333.

# Description

This commit allows leaving the `Spectrum.quantity` field unset. This is required to allow for incomplete `Spectrum` object initialization, which is, in turn, required to allow for the deferred application of a default `quantity` field by a converter.

The policy is as follows:

* if `quantity` is set, unitless spectrum values are applied appropriate units and validators check if spectrum values have consistent units;
* if `quantity` is `None`, unitless spectrum values are allowed and validators do not check spectrum value units, which can be anything.

Integral computations will consider unitless fields as dimensionless.

# How does it work, in practice?

I refactored the `Spectrum` constructors to apply units, if relevant, prior to initialization. For example with `UniformSpectrum`:

* if `quantity` is set and `value` is assigned a quantity, the validator makes a consistency check;
* if `quantity` is set and `value` is assigned a unitless value, `value` is attached units, then the validator makes a consistency check;
* if `quantity` is unset nothing happens.

If one instantiates a `UniformSpectrum` with unset `quantity`, it is possible to:

* apply arbitrary units to the `value` field;
* assign a value to the `quantity` field.

Both should be done with `attrs.evolve()` to make sure that validation occurs.

# The whole point of it

The `SpectrumFactory.converter()` method is also updated to allow for consistent initialization of `Spectrum` objects in situations where a missing quantity field can be inferred from the context.

In practice, these fixes enforce symmetry between spectrum dictionary and constructor syntaxes:
```python
import eradiate.scenes as ertsc

# 1
ground_bsdf_dict = ertsc.bsdfs.LambertianBSDF(
    reflectance = {
        "type": "interpolated",
        "wavelengths": [440, 550, 620],
        "values": [0.067269, 0.096786, 0.125058]
    }
)

# 2
ground_bsdf_obj = ertsc.bsdfs.LambertianBSDF(
    reflectance=ertsc.spectra.InterpolatedSpectrum(
        wavelengths=[440, 550, 620], 
        values=[0.067269, 0.096786, 0.125058]
    )
)
```
In snippet 1, the conversion protocol completes the dictionary with a `"quantity"` entry, then used to instantiate a well-formed `InterpolatedSpectrum`. In snippet 2, an incomplete `InterpolatedSpectrum` instance is created; the converter then evolves it into a new object for which the `quantity` field is specified; all unitless fields are then converted and validated.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
