### PR TITLE
MultiDistantMeasure: Refactor and fix converters and validators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@ Entries marked with a ︎⚠️ symbol require particular attention during upgra
 
 * Added {class}`.MultiDeltaSpectrum` spectrum type ({ghpr}`311`).
 * Exposed several API members in the top-level namespace ({ghpr}`324`).
-* Exposed the ``eradiate.spectral.*`` subpackage members in the
+* Exposed the `eradiate.spectral.*` subpackage members in the
   {mod}`eradiate.spectral` namespace ({ghpr}`324`).
 * Fixed incorrect Mitsuba scene parameter drop and lookup ({ghpr}`329`).
 * Added spherical-shell geometry support to DEM components
@@ -70,8 +70,9 @@ Entries marked with a ︎⚠️ symbol require particular attention during upgra
 * Fixed broken symmetry between {class}`.Spectrum` dictionary and object
   conversion protocols ({ghpr}`336`).
 * Provide an Eradiate Pypi package ({ghpr}`328`).
-* Implement the Astronomical Object Illumination, its tests and its
-  documentation ({ghpr}`331`).
+* Added {class}`.AstroObjectIllumination` illumination type ({ghpr}`331`).
+* Fixed a bug where {class}`.Layout` constructors would not raise if passed
+  invalid azimuth values (*i.e.* outside the [0, 180]° range) ({ghpr}`345`).
 
 ### Documentation
 
@@ -84,6 +85,7 @@ Entries marked with a ︎⚠️ symbol require particular attention during upgra
   its measure, its atmosphere components if applicable, and a default
   spectral set ({ghpr}`311`).
 * Rewrote the CLI using the Typer framework ({ghpr}`326`).
+* Refactored {class}`.Layout` constructor code ({ghpr}`345`).
 
 ## v0.23.1 (21 April 2023)
 

--- a/tests/01_eradiate/01_unit/scenes/measure/test_multi_distant.py
+++ b/tests/01_eradiate/01_unit/scenes/measure/test_multi_distant.py
@@ -3,7 +3,6 @@ import numpy as np
 import pytest
 
 from eradiate import unit_registry as ureg
-from eradiate.frame import AzimuthConvention
 from eradiate.scenes.measure import (
     AngleLayout,
     AzimuthRingLayout,
@@ -31,6 +30,12 @@ def test_angle_layout(mode_mono):
 
     # (2,) arrays are reshaped as (1, 2)
     assert AngleLayout([0, 0] * ureg.deg).angles.shape == (1, 2)
+
+    # Zenith values outside [0, 180]° are not allowed
+    with pytest.raises(ValueError):
+        AngleLayout([-45, 0] * ureg.deg)
+    with pytest.raises(ValueError):
+        AngleLayout([210, 0] * ureg.deg)
 
     # Regular construction pattern succeeds
     layout = AngleLayout([[0, 0], [45, 0], [45, 90], [45, 180]] * ureg.deg)
@@ -88,7 +93,7 @@ def test_direction_layout(mode_mono):
     """
     # Constructing without argument fails
     with pytest.raises(TypeError):
-        print(DirectionLayout())
+        DirectionLayout()
 
     # (3,) arrays are reshaped as (1, 3)
     assert DirectionLayout([0, 0, 1]).directions.shape == (1, 3)
@@ -237,7 +242,6 @@ def test_grid_layout_azimuth_convention(mode_mono, convention, expected):
         [0, 90] * ureg.deg,
         azimuth_convention=convention,
     )
-    print(layout.directions)
     np.testing.assert_allclose(layout.directions, expected, atol=1e-8)
 
 


### PR DESCRIPTION
# Description

This commit refactors `MultiDistantMeasure`-related constructors and validators for improved clarity.

Additionally, it fixes a bug where azimuth values outside the [0, 180]° range would not raise an exception.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
