### PR TITLE
`HomogeneousAtmosphere`: Add missing lookup strategy for participating medium parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,19 @@ Entries marked with a ︎⚠️ symbol require particular attention during upgra
 %
 % ### Internal changes
 
+## v0.24.0 (upcoming release)
+
+% ### Deprecations and removals
+
+### Improvements and fixes
+
+* Added missing lookup strategy for participating medium parameters of the
+  {class}`.HomogeneousAtmosphere` ({ghpr}`352`).
+
+% ### Documentation
+
+% ### Internal changes
+
 ## v0.23.2 (8th July 2023)
 
 Release highlights:

--- a/src/eradiate/scenes/atmosphere/_homogeneous.py
+++ b/src/eradiate/scenes/atmosphere/_homogeneous.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import attrs
+import mitsuba as mi
 import pint
 
 from ._core import Atmosphere
@@ -9,11 +10,10 @@ from ..phase import PhaseFunction, RayleighPhaseFunction, phase_function_factory
 from ..spectra import AirScatteringCoefficientSpectrum, Spectrum, spectrum_factory
 from ...attrs import documented, parse_docs
 from ...contexts import KernelContext
-from ...kernel import InitParameter, UpdateParameter
+from ...kernel import InitParameter, TypeIdLookupStrategy, UpdateParameter
 from ...spectral.ckd import BinSet
 from ...spectral.index import SpectralIndex
 from ...spectral.mono import WavelengthSet
-from ...units import unit_context_config as ucc
 from ...units import unit_context_kernel as uck
 from ...validators import has_quantity
 
@@ -222,10 +222,20 @@ class HomogeneousAtmosphere(Atmosphere):
                     uck.get("collision_coefficient")
                 ),
                 UpdateParameter.Flags.SPECTRAL,
+                lookup_strategy=TypeIdLookupStrategy(
+                    node_type=mi.Medium,
+                    node_id=self.medium_id,
+                    parameter_relpath="sigma_t.value.value",
+                ),
             ),
             "albedo.value.value": UpdateParameter(
                 lambda ctx: self.eval_albedo(ctx.si).m_as(uck.get("albedo")),
                 UpdateParameter.Flags.SPECTRAL,
+                lookup_strategy=TypeIdLookupStrategy(
+                    node_type=mi.Medium,
+                    node_id=self.medium_id,
+                    parameter_relpath="albedo.value.value",
+                ),
             ),
         }
 

--- a/tests/01_eradiate/01_unit/scenes/atmosphere/test_homogeneous.py
+++ b/tests/01_eradiate/01_unit/scenes/atmosphere/test_homogeneous.py
@@ -39,12 +39,15 @@ def test_homogeneous_atmosphere_params(mode_mono):
         }
     )
 
-    # Phase function parameters are exposed at highest level
     _, umap_template = traverse(atmosphere)
-    assert "medium_atmosphere.phase_function.g" in umap_template
-
     mi_wrapper = check_scene_element(atmosphere)
+
+    # Phase function parameters are exposed at highest level
+    assert "medium_atmosphere.phase_function.g" in umap_template
     assert "medium_atmosphere.phase_function.g" in mi_wrapper.parameters.keys()
+    # Volume data source parameters are exposed at highest level
+    assert "medium_atmosphere.sigma_t.value.value" in umap_template
+    assert "medium_atmosphere.albedo.value.value" in umap_template
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Description

This commit adds missing lookup strategy for participating medium parameters in the `HomogeneousAtmosphere` class. This missing strategy would notably prevent parameter retrieval when using an in situ measure, which would result in atmospheric optical properties not being updated by the spectral loop.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
