### PR TITLE
Fix missing data point in `MQDiffuseBSDF` data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ Entries marked with a ︎⚠️ symbol require particular attention during upgra
 
 * Added missing lookup strategy for participating medium parameters of the
   {class}`.HomogeneousAtmosphere` ({ghpr}`352`).
+* Fixed a bug where the kernel dictionary emitted by the {class}`.MQDiffuseBSDF`
+  wrapper would miss a data point on the azimuth dimension ({ghpr}`353`).
 
 % ### Documentation
 

--- a/src/eradiate/scenes/bsdfs/_mqdiffuse.py
+++ b/src/eradiate/scenes/bsdfs/_mqdiffuse.py
@@ -116,6 +116,8 @@ class MQDiffuseBSDF(BSDF):
             .transpose("cos_theta_o", "phi_d", "cos_theta_i")
             .values
         )
+        # Add an extra row with φ_d = 0° data to ensure azimuthal periodicity
+        values = np.concatenate((values, values[:, [0], :]), axis=1)
         return mi.VolumeGrid(values.astype(np.float32))
 
     @property


### PR DESCRIPTION
# Description

This PR fixes a bug where the kernel dictionary emitted by the `MQDiffuseBSDF` wrapper would miss a data point on the azimuth dimension.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
