### PR TITLE
Change the data folder path to src/data in the CLI

### DIFF
--- a/src/eradiate/cli/data.py
+++ b/src/eradiate/cli/data.py
@@ -143,10 +143,10 @@ def fetch(
         if from_file is None:
             # TODO: fetch this list from online
             if eradiate.config.source_dir is None:
-                from_file = files("eradiate") / "data" / "downloads.yml"
+                from_file = files("eradiate") / "src" / "eradiate" / "data" / "downloads.yml"
             else:
                 from_file = (
-                    eradiate.config.source_dir / "data" / "downloads_development.yml"
+                    eradiate.config.source_dir / "src" / "eradiate" / "data" / "downloads_development.yml"
                 )
         console.print(f"Reading file list from '{from_file}'")
         yaml = YAML()


### PR DESCRIPTION
# Description

It seems a path was incorrect in the CLI for data fetch. It may come from a mistake I made when rewriting the CLI.
This PR fixes this problem.

Step to reproduce: in a clean installation of Eradiate, perform the command "eradiate data fetch"

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
