### PR TITLE
DocFlags: Change field init type from str to int

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ Entries marked with a ︎⚠️ symbol require particular attention during upgra
   {class}`.HomogeneousAtmosphere` ({ghpr}`352`).
 * Fixed a bug where the kernel dictionary emitted by the {class}`.MQDiffuseBSDF`
   wrapper would miss a data point on the azimuth dimension ({ghpr}`353`).
+* Fixed a bug where an incorrect flag field init type would raise a `TypeError`
+  on Python 3.11 ({ghpr}`358`).
 
 % ### Documentation
 

--- a/src/eradiate/attrs.py
+++ b/src/eradiate/attrs.py
@@ -64,7 +64,7 @@ class DocFlags(enum.Flag):
     Extra flags used to pass information about docs.
     """
 
-    NOINIT = "noinit"
+    NOINIT = 0
 
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
# Description

Closes #356.

This PR fixes an issue where an incorrect flag field type would raise a `TypeError` on Python 3.11.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
