### PR TITLE
Minor fixes to the `spectral` module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,21 @@ Emoji marks have the following meaning:
 % ### Fixed
 %
 
+## v0.25.0 (upcoming release)
+
+% ### Deprecated
+
+% ### Removed
+
+% ### Added
+
+% ### Changed
+
+% ### Fixed
+
+* Set default units of the `*SpectralIndex.w` field to `ucc['wavelength']`
+  ({ghpr}`362`).
+
 ## v0.24.0 (7th August 2023)
 
 Release highlights:

--- a/src/eradiate/spectral/index.py
+++ b/src/eradiate/spectral/index.py
@@ -152,10 +152,10 @@ class MonoSpectralIndex(SpectralIndex):
     w: pint.Quantity = documented(
         pinttr.field(
             default=550.0 * ureg.nm,
-            units=ucc.deferred("length"),
+            units=ucc.deferred("wavelength"),
             on_setattr=None,
         ),
-        doc="Wavelength.\n\nUnit-enabled field (default: ucc[length]).",
+        doc="Wavelength.\n\nUnit-enabled field (default: ucc[wavelength]).",
         type="quantity",
         init_type="quantity or float",
         default="550.0 nm",
@@ -208,10 +208,10 @@ class CKDSpectralIndex(SpectralIndex):
     w: pint.Quantity = documented(
         pinttr.field(
             default=550.0 * ureg.nm,
-            units=ucc.deferred("length"),
+            units=ucc.deferred("wavelength"),
             on_setattr=None,
         ),
-        doc="Bin center wavelength.\n\nUnit-enabled field (default: ucc[length]).",
+        doc="Bin center wavelength.\n\nUnit-enabled field (default: ucc[wavelength]).",
         type="quantity",
         init_type="quantity or float",
         default="550.0 nm",

--- a/src/eradiate/spectral/index.py
+++ b/src/eradiate/spectral/index.py
@@ -134,16 +134,6 @@ class MonoSpectralIndex(SpectralIndex):
     """
     Monochromatic spectral index.
 
-    Parameters
-    ----------
-    wavelength : quantity
-        Wavelength.
-
-    Attributes
-    ----------
-    wavelength : quantity
-        Wavelength.
-
     See Also
     --------
     :class:`CKDSpectralIndex`
@@ -183,22 +173,6 @@ class MonoSpectralIndex(SpectralIndex):
 class CKDSpectralIndex(SpectralIndex):
     """
     CKD spectral index.
-
-    Parameters
-    ----------
-    w : quantity
-        Bin center wavelength.
-
-    g : float
-        g value.
-
-    Attributes
-    ----------
-    w : quantity
-        Bin center wavelength.
-
-    g : float
-        g value.
 
     See Also
     --------


### PR DESCRIPTION
# Description

This is a minor fix patch. It removes redundant docs content and fixes the default units of the `SpectralIndex.w` fields.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
