### PR TITLE
Get unit registry from application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@ Emoji marks have the following meaning:
 %
 % ### Fixed
 
+## v0.24.3 (upcoming release)
+
+### Changed
+
+* Get unit registry from application ({ghpr}`366`).
+
 ## v0.24.2 (31st August 2023)
 
 This is a fix release.

--- a/src/eradiate/units.py
+++ b/src/eradiate/units.py
@@ -10,6 +10,7 @@ __all__ = [
 ]
 
 import enum
+import logging
 import typing as t
 from functools import lru_cache
 
@@ -19,27 +20,33 @@ import xarray
 from pinttr.exceptions import UnitsError
 from pinttr.util import units_compatible
 
+logger = logging.getLogger(__name__)
+
 # -- Global data members -------------------------------------------------------
 
 #: Unit registry common to all Eradiate components. All units used in Eradiate
 #: must be created using this registry. Aliased in :mod:`eradiate`.
-unit_registry = pint.UnitRegistry()
+unit_registry = pint.get_application_registry()
 
-unit_registry.define(
-    "dobson_unit = 2.687e20 * meter^-2 " "= du = dobson = dobson_units"  # aliases
-)
-"""IUPAC. Compendium of Chemical Terminology, 2nd ed. (the "Gold Book").
-Compiled by A. D. McNaught and A. Wilkinson. Blackwell Scientific Publications,
-Oxford (1997). Online version (2019-) created by S. J. Chalk. ISBN 0-9678550-9-8.
-https://doi.org/10.1351/goldbook."""
-
-unit_registry.define(
+definitions = [
+    "dobson_unit = 2.687e20 * meter^-2 " "= du = dobson = dobson_units",
+    # IUPAC. Compendium of Chemical Terminology, 2nd ed. (the "Gold Book").
+    # Compiled by A. D. McNaught and A. Wilkinson. Blackwell Scientific
+    # Publications, Oxford (1997). Online version (2019-) created by S. J.
+    # Chalk. ISBN 0-9678550-9-8. https://doi.org/10.1351/goldbook.
     "atmo_centimeter = 1000 * dobson_unit "
-    "= atm_cm = centimeter_atmosphere = centimeter_amagat"  # aliases
-)
-"""Chapter 1 Vertical Structure of an Atmosphere. In International Geophysics,
-22:1–45. Elsevier, 1978. https://doi.org/10.1016/S0074-6142(09)60038-3.
-"""
+    "= atm_cm = centimeter_atmosphere = centimeter_amagat",
+    # Chapter 1 Vertical Structure of an Atmosphere. In International
+    # Geophysics, 22:1–45. Elsevier, 1978.
+    # https://doi.org/10.1016/S0074-6142(09)60038-3.
+]
+
+for definition in definitions:
+    try:
+        print(definition)
+        unit_registry.define(definition)
+    except pint.RedefinitionError:
+        logger.warning("unit definition '%s' already exists", definition)
 
 
 class PhysicalQuantity(enum.Enum):


### PR DESCRIPTION
# Description

Allow applications using Eradiate to define their own unit registry that Eradiate can fetch (thanks to [pint.get_application_registry](https://pint.readthedocs.io/en/stable/api/base.html#pint.get_application_registry)), modify and use.

Example 1 (the application defines a unit registry):
```python
# my application using Eradiate
import pint

ureg = pint.UnitRegistry()
ureg.define("tatami = 1.8 meter")
pint.set_application_registry()

x = 1 * ureg.tatami 

from eradiate import unit_registry  # unit_registry is the same registry as 'ureg'
y = 2 * unit_registry.meter

# since 'ureg' and 'unit_registry' are the same registries, 'x' and 'y' can be compared
print(y - x)  # 0.2 meter
```
Example 2 (the application defines a unit registry but does not set it as application registry):
```python
# my application using Eradiate
import pint

ureg = pint.UnitRegistry()
ureg.define("tatami = 1.8 meter")

x = 1 * ureg.tatami 

from eradiate import unit_registry  # 'unit_registry' is different from 'ureg'
y = 2 * unit_registry.meter

# since 'ureg' and 'unit_registry' are not the same registries, 'x' and 'y' can not be compared
print(y - x)  # raises
```

Example 3 (the application does not define a unit registry):
```python
# my application using Eradiate
from eradiate import unit_registry  # Eradiate updates pint's default unit registry with its custom units 
```


## Explanation

Eradiate will attempt to modify the application registry to add its custom units (so far, they are `dobson_unit` and `atmo_centimeter`). If the custom unit definition does not already exist, it is added; else, a warning is logged (assuming that the existing unit definition is the same as Eradiate's).
If the application does not define a unit registry, `pint.get_application_registry` is going to return the default `pint` unit registry, to which Eradiate can add its custom units.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
- [ ] update units guide