### PR TITLE
Add timeout parameter for integrators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,8 +39,10 @@ Emoji marks have the following meaning:
 %
 % ### Removed
 %
-% ### Added
-%
+
+### Added
+
+* All {class}`.Integrator` classes now have a `timeout` parameter ({ghpr}`370`).
 
 ### Changed
 

--- a/src/eradiate/scenes/integrators/_core.py
+++ b/src/eradiate/scenes/integrators/_core.py
@@ -40,3 +40,15 @@ class Integrator(NodeSceneElement, ABC):
         init_type=get_doc(NodeSceneElement, "id", "init_type"),
         default='"integrator"',
     )
+
+    timeout: float | None = documented(
+        attrs.field(
+            default=None,
+            converter=attrs.converters.optional(float),
+        ),
+        doc="Maximum amount of time to spend during a kernel render pass in "
+        "millisecond (excluding scene parsing).",
+        type="float or None",
+        init_type="float, optional",
+        default="None",
+    )

--- a/src/eradiate/scenes/integrators/_path_tracers.py
+++ b/src/eradiate/scenes/integrators/_path_tracers.py
@@ -52,6 +52,8 @@ class MonteCarloIntegrator(Integrator):
     def template(self) -> dict:
         result = {"type": self.kernel_type}
 
+        if self.timeout is not None:
+            result["timeout"] = self.timeout
         if self.max_depth is not None:
             result["max_depth"] = self.max_depth
         if self.rr_depth is not None:


### PR DESCRIPTION
# Description

This PR adds an interface for Mitsuba's timeout feature. In practice, it allows setting a timeout for each Mitsuba render pass on the scene.

An example of usage can be found [here](https://gist.github.com/leroyvn/16d1589bec9d1c031a4c0641574d6f89).

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
