### PR TITLE
`CheckerboardBSDF`: Add missing scaling parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,10 @@ Emoji marks have the following meaning:
 * The `eradiate show` command-line diagnostic tool now reports on dependency
   versions.
 
-% ### Fixed
+### Fixed
+
+* The {class}`.CheckerboardBSDF` class's `scale_pattern` parameter now
+  behaves as intended ({ghpr}`372`).
 
 ## v0.24.3 (18th September 2023)
 

--- a/src/eradiate/scenes/bsdfs/_checkerboard.py
+++ b/src/eradiate/scenes/bsdfs/_checkerboard.py
@@ -54,13 +54,15 @@ class CheckerboardBSDF(BSDF):
 
     scale_pattern: float = documented(
         attrs.field(
-            default=2.0, converter=float, validator=attrs.validators.instance_of(float)
+            default=None,
+            converter=attrs.converters.optional(float),
+            validator=attrs.validators.optional(attrs.validators.instance_of(float)),
         ),
         doc="Scaling factor for the checkerboard pattern. The higher the value, "
         "the more checkerboard patterns will fit on the surface to which this "
         "reflection model is attached.",
-        type="float",
-        default="2.0",
+        type="float or None",
+        init_type="float, optional",
     )
 
     @property
@@ -71,6 +73,9 @@ class CheckerboardBSDF(BSDF):
 
         if self.id is not None:
             result["id"] = self.id
+
+        if self.scale_pattern is not None:
+            result["reflectance.to_uv"] = mi.ScalarTransform4f.scale(self.scale_pattern)
 
         for obj_key, obj_values in {
             "color0": traverse(self.reflectance_a)[0],


### PR DESCRIPTION
# Description

This PR fixes the `scale_pattern` parameter of the `CheckerboardBSDF` class to make it behave as intended.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
