### PR TITLE
Split bitmap-to-xarray converter between data array and dataset steps

### DIFF
--- a/docs/rst/reference_api/kernel.rst
+++ b/docs/rst/reference_api/kernel.rst
@@ -37,6 +37,7 @@ Other helpers
 .. autosummary::
    :toctree: generated/autosummary/
 
+   bitmap_to_dataarray
    bitmap_to_dataset
    eval_bsdf
    install_logging

--- a/docs/src/release_notes/v0.25.x.md
+++ b/docs/src/release_notes/v0.25.x.md
@@ -1,5 +1,23 @@
 # v0.25.x series (current stable)
 
+## v0.25.1 (upcoming release)
+
+% ### Deprecated
+%
+% ### Removed
+%
+
+### Added
+
+* Split bitmap-to-xarray converter between data array and dataset steps
+  ({ghpr}`383`).
+
+% ### Changed
+%
+% ### Fixed
+%
+% ### Internal changes
+
 ## v0.25.0 (20th December 2023)
 
 In this major release, we change the atmospheric profile interface for improved

--- a/src/eradiate/kernel/__init__.pyi
+++ b/src/eradiate/kernel/__init__.pyi
@@ -1,6 +1,7 @@
 from . import gridvolume as gridvolume
 from . import logging as logging
 from . import transform as transform
+from ._bitmap import bitmap_to_dataarray as bitmap_to_dataarray
 from ._bitmap import bitmap_to_dataset as bitmap_to_dataset
 from ._bsdf import eval_bsdf as eval_bsdf
 from ._kernel_dict import InitParameter as InitParameter

--- a/src/eradiate/kernel/_bitmap.py
+++ b/src/eradiate/kernel/_bitmap.py
@@ -7,9 +7,9 @@ import numpy as np
 import xarray as xr
 
 
-def bitmap_to_dataset(bmp: mi.Bitmap, dtype=float) -> xr.Dataset:
+def bitmap_to_dataarray(bmp: mi.Bitmap, dtype="float64") -> xr.DataArray:
     """
-    Format Mitsuba bitmap data as an xarray dataset.
+    Format Mitsuba bitmap data as an xarray data array.
 
     Parameters
     ----------
@@ -17,13 +17,13 @@ def bitmap_to_dataset(bmp: mi.Bitmap, dtype=float) -> xr.Dataset:
         Mitsuba bitmap to be converted to a dataset. A Numpy array can also be
         passed directly for compatibility (this feature is deprecated).
 
-    dtype : dtype
+    dtype : dtype, optional
         Data type, forwarded to :func:`numpy.array`.
 
     Returns
     -------
-    dataset : Dataset
-        Bitmap data as an xarray dataset.
+    da : DataArray
+        Bitmap data as an xarray array.
 
     Raises
     ------
@@ -59,13 +59,9 @@ def bitmap_to_dataset(bmp: mi.Bitmap, dtype=float) -> xr.Dataset:
     height = img.shape[0]
     width = img.shape[1]
 
-    result = xr.Dataset(
-        data_vars={
-            "img": (
-                ["y_index", "x_index", "channel"],
-                np.reshape(img, (height, width, -1)),
-            )
-        },
+    result = xr.DataArray(
+        data=np.reshape(img, (height, width, -1)),
+        dims=["y_index", "x_index", "channel"],
         coords={
             "y_index": (
                 "y_index",
@@ -92,3 +88,36 @@ def bitmap_to_dataset(bmp: mi.Bitmap, dtype=float) -> xr.Dataset:
     )
 
     return result
+
+
+def bitmap_to_dataset(bmp: mi.Bitmap, dtype="float64") -> xr.Dataset:
+    """
+    Format Mitsuba bitmap data as an xarray dataset.
+
+    Parameters
+    ----------
+    bmp : mitsuba.core.Bitmap or ndarray
+        Mitsuba bitmap to be converted to a dataset. A Numpy array can also be
+        passed directly for compatibility (this feature is deprecated).
+
+    dtype : dtype, optional
+        Data type, forwarded to :func:`numpy.array`.
+
+    Returns
+    -------
+    dataset : Dataset
+        Bitmap data as an xarray dataset.
+
+    See Also
+    --------
+    :func:`bitmap_to_dataarray`
+
+    Notes
+    -----
+    This function exists for backward compatibility purposes.
+    It calls :func:`bitmap_to_dataarray` and forwards its arguments to it, then
+    wraps the generated data array in a dataset with an ``img`` data variable.
+    """
+
+    da = bitmap_to_dataarray(bmp, dtype)
+    return xr.Dataset(data_vars={"img": da})


### PR DESCRIPTION
# Description

This PR splits the conversion of Mitsuba bitmaps to xarray data structures into data array and dataset steps.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
