### PR TITLE
Implement Ubuntu-Based Dev Container for Eradiate Development Environment

### DIFF
--- a/.devcontainer/create-command.sh
+++ b/.devcontainer/create-command.sh
@@ -1,0 +1,6 @@
+conda create --name eradiate -y
+conda init bash
+. /opt/conda/etc/profile.d/conda.sh
+conda activate eradiate
+make conda-init
+make kernel

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,34 @@
+{
+    "name": "eradiate",
+    "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+    "features": {
+        "ghcr.io/devcontainers/features/git:1": {},
+        "ghcr.io/devcontainers/features/conda:1": {
+            "addCondaForge": true
+        },
+        "ghcr.io/devcontainers/features/common-utils:latest": {},
+        "ghcr.io/devcontainers-contrib/features/apt-get-packages:latest": {
+            "packages": "cmake,ninja-build,clang-11,libc++-11-dev,libc++abi-11-dev,libpng-dev,zlib1g-dev,libjpeg-dev"
+        }
+    },
+    "customizations": {
+        "vscode": {
+			"settings": {
+				"python.defaultInterpreterPath": "/opt/conda/envs/eradiate/bin/python"
+			},
+            "extensions": [
+                "donjayamanne.python-environment-manager",
+                "ms-python.black-formatter",
+                "ms-python.isort",
+                "ms-python.python",
+                "ms-python.vscode-pylance",
+                "ms-toolsai.jupyter-renderers",
+                "ms-toolsai.jupyter",
+                "ms-toolsai.vscode-jupyter-cell-tags",
+                "tamasfe.even-better-toml"
+            ]
+        }
+    },
+    "onCreateCommand": "chmod +x .devcontainer/create-command.sh && .devcontainer/create-command.sh"
+    
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -30,5 +30,4 @@
         }
     },
     "onCreateCommand": "chmod +x .devcontainer/create-command.sh && .devcontainer/create-command.sh"
-    
 }

--- a/docs/rst/developer_guide/dev_install.rst
+++ b/docs/rst/developer_guide/dev_install.rst
@@ -9,6 +9,9 @@ well as for developing on the kernel code. It requires to compile the C++ code
 of the Mitsuba renderer, using the Eradiate specific plugins and the appropriate
 variants.
 
+Additionally, an Ubuntu-based Dev Container is available for a quick setup of
+the development environment. See `Development Container`_.
+
 Prerequisites
 -------------
 
@@ -376,3 +379,34 @@ followed the installation instructions, here is a possible workflow:
 
       conda deactivate
       conda env remove --name eradiate
+
+.. _sec-developer_guide-dev_install-dev_container:
+
+Development Container
+---------------------
+
+A development container is available to quickly set up the development
+environment. To use it, you will need to first clone the repository
+as described in the section titled `Cloning the repository`_ above,
+and then follow the procedure required by your IDE.
+
+
+.. dropdown:: If you are using Visual Studio Code ...
+   :color: info
+   :icon: info
+
+
+   While not required, the development container is well-configured to work with
+   Visual Studio Code. To use it, you will need to install the
+   `Remote - Dev Containers <https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers>`_
+   extension.
+
+   Once the extension is installed, you can open the repository in a container
+   by clicking on the popup that appears in the bottom right corner of the
+   window. You can also open the command palette (``Ctrl+Shift+P``) and search
+   for the ``Remote-Containers: Reopen in Container`` command.
+
+   After a few minutes, where all the previous steps are executed automatically,
+   you should be presented with a fully configured development environment,
+   including an ``eradiate`` Conda environment with a compiled kernel and several
+   other Python-related Visual Studio Code extensions.


### PR DESCRIPTION
# Description

This pull request introduces a seamless setup for the Eradiate development environment through the use of a new Ubuntu-based Dev Container. The implementation includes the creation of a custom command script (`create-command.sh`) and a development container configuration file (`devcontainer.json`), ensuring a hassle-free initialization process for developers.

Changes include:

- A new `create-command.sh` script that automates the creation of the Eradiate conda environment and the initialization of the shell environment to activate eradiate.
- A `devcontainer.json` configuration file to define the container with the necessary features such as Git, Conda, and essential Apt packages required for the development process. Additionally, this file specifies various VS Code extensions and settings to be applied within the development container, optimizing the experience.
- Documentation updates in `dev_install.rst` to guide users through using the Development Container, including specific instructions for setting up with Visual Studio Code.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
