### PR TITLE
Allow different package specifications for Pip and Conda

### DIFF
--- a/docs/src/release_notes/v0.25.x.md
+++ b/docs/src/release_notes/v0.25.x.md
@@ -18,7 +18,10 @@
 %
 % ### Fixed
 %
-% ### Internal changes
+
+### Internal changes
+
+* Allow different package specifications for Pip and Conda ({ghpr}`385`).
 
 ## v0.25.0 (20th December 2023)
 

--- a/requirements/_utils.py
+++ b/requirements/_utils.py
@@ -1,0 +1,30 @@
+"""
+Utility functions for the Eradiate dependency management system.
+"""
+
+from copy import deepcopy
+from typing import Literal
+
+
+def resolve_package_manager(
+    layered_yml: dict, manager: Literal["pip", "conda"]
+) -> dict:
+    """
+    When relevant, filter out irrelevant dependency specifications in "packages"
+    sections of the ``layered.yml`` file depending on the selected Python package
+    manager.
+    """
+    result = {}
+
+    for key, section in layered_yml.items():
+        result[key] = deepcopy(
+            section
+        )  # We are going to mutate this, so we work on a copy
+
+        package_list = result[key].get("packages", [])
+        result[key]["packages"] = [
+            package[manager] if isinstance(package, dict) else package
+            for package in package_list
+        ]
+
+    return result

--- a/requirements/make_conda_env.py
+++ b/requirements/make_conda_env.py
@@ -4,6 +4,7 @@ from copy import deepcopy
 
 import click
 import networkx as nx
+from _utils import resolve_package_manager
 from ruamel.yaml import YAML
 from ruamel.yaml.comments import CommentedSeq as CS
 
@@ -55,7 +56,7 @@ def cli(sections, output_dir, layered_config, pip_deps, quiet, write_graphs):
     with open(os.path.join("requirements", "environment.in")) as f:
         env_yml = yaml.load(f.read())
     with open(layered_config) as f:
-        layered_yml = yaml.load(f.read())
+        layered_yml = resolve_package_manager(yaml.load(f.read()), "conda")
 
     sections = [
         (x.strip(), {"packages": set(layered_yml[x.strip()].get("packages", []))})
@@ -71,7 +72,7 @@ def cli(sections, output_dir, layered_config, pip_deps, quiet, write_graphs):
             G.add_edge(section, include)
 
     if write_graphs:
-        path = os.path.join(output_dir, f"layer_graph.dot")
+        path = os.path.join(output_dir, "layer_graph.dot")
         nx.drawing.nx_pydot.write_dot(G, path)
 
     G.add_node("default", packages=set(dep_list))

--- a/requirements/make_pip_in_files.py
+++ b/requirements/make_pip_in_files.py
@@ -1,6 +1,7 @@
 import os
 
 import click
+from _utils import resolve_package_manager
 from ruamel.yaml import YAML
 
 
@@ -34,7 +35,7 @@ def cli(sections, output_dir, layered_config, quiet):
     # Load layered dependency dependencies
     yaml = YAML(typ="safe")
     with open(layered_config) as f:
-        layered_yml = yaml.load(f.read())
+        layered_yml = resolve_package_manager(yaml.load(f.read()), "pip")
 
     for section in sections:
         if not quiet:

--- a/requirements/make_pip_txt_files.py
+++ b/requirements/make_pip_txt_files.py
@@ -1,6 +1,7 @@
 import os
 
 import click
+from _utils import resolve_package_manager
 from ruamel.yaml import YAML
 
 
@@ -34,7 +35,7 @@ def cli(sections, output_dir, layered_config, quiet):
     # Load layered dependency dependencies
     yaml = YAML(typ="safe")
     with open(layered_config) as f:
-        layered_yml = yaml.load(f.read())
+        layered_yml = resolve_package_manager(yaml.load(f.read()), "pip")
 
     for section in sections:
         if not quiet:
@@ -53,7 +54,6 @@ def cli(sections, output_dir, layered_config, quiet):
 
         # Create .txt file
         with open(os.path.join(output_dir, f"{section}.txt"), "w") as f:
-
             f.write("\n".join(packages))
             f.write("\n")
 


### PR DESCRIPTION
# Description

This commit allows different package specifications for Pip and Conda. In practice, dependencies can now be specified either this way:
```yaml
main:
  packages:
    - "attrs>=22.2"
```
or that way:
```yaml
recommended:
  packages:
    - pip: "graphviz>=0.20"
      conda: "python-graphviz>=0.20"
```
This allows using different package names for Pip and Conda.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
