### PR TITLE
Add Hapke BSDF support

### DIFF
--- a/docs/references.bib
+++ b/docs/references.bib
@@ -132,6 +132,18 @@
   journal      = {Space Science Reviews},
   doi          = {10.1007/BF00168069}
 }
+@article{HAPKE198441,
+  title = {Bidirectional reflectance spectroscopy: 3. Correction for macroscopic roughness},
+  journal = {Icarus},
+  volume = {59},
+  number = {1},
+  pages = {41-59},
+  year = {1984},
+  issn = {0019-1035},
+  doi = {https://doi.org/10.1016/0019-1035(84)90054-X},
+  url = {https://www.sciencedirect.com/science/article/pii/001910358490054X},
+  author = {Hapke, Bruce},
+}
 @article{Henyey1941Diffuse,
   title        = {Diffuse radiation in the galaxy},
   author       = {Henyey, L.G. and Greenstein, J.L.},

--- a/docs/src/release_notes/v0.26.x.md
+++ b/docs/src/release_notes/v0.26.x.md
@@ -4,12 +4,15 @@
 
 % ### Deprecated
 
-### Removed
+### Added
+
+* Add support for the Hapke BSDF model ({ghpr}`386`).
+
+### Changed
 
 * Drop support of Python 3.8 ({ghpr}̀`382`).
+* Required custom Mitsuba build bumped to v0.2.0 (based on Mitsuba v3.4.1)
 
-% ### Added
-%
 % ### Changed
 %
 % ### Fixed

--- a/requirements/layered.yml
+++ b/requirements/layered.yml
@@ -5,7 +5,7 @@ dependencies:
   constraints:
     - optional
   packages:
-    - "eradiate-mitsuba==0.1.1"
+    - "eradiate-mitsuba==0.2.0rc2"
 
 main:
   packages:
@@ -80,4 +80,4 @@ optional:
   includes:
     - dev
   packages:
-    - "eradiate-mitsuba==0.1.1"
+    - "eradiate-mitsuba==0.2.0rc2"

--- a/src/eradiate/kernel/_versions.py
+++ b/src/eradiate/kernel/_versions.py
@@ -5,8 +5,8 @@ Upon import, this module checks if the kernel dependencies are correctly set up.
 from importlib.metadata import PackageNotFoundError, version
 
 # Internal constants
-REQUIRED_MITSUBA_VERSION = "3.4.0"
-REQUIRED_MITSUBA_PATCH_VERSION = "0.1.1"
+REQUIRED_MITSUBA_VERSION = "3.4.1"
+REQUIRED_MITSUBA_PATCH_VERSION = "0.2.0"
 
 
 def find_drjit():

--- a/src/eradiate/scenes/bsdfs/__init__.pyi
+++ b/src/eradiate/scenes/bsdfs/__init__.pyi
@@ -7,3 +7,4 @@ from ._mqdiffuse import MQDiffuseBSDF as MQDiffuseBSDF
 from ._opacity_mask import OpacityMaskBSDF as OpacityMaskBSDF
 from ._rpv import RPVBSDF as RPVBSDF
 from ._rtls import RTLSBSDF as RTLSBSDF
+from ._hapke import HapkeBSDF as HapkeBSDF

--- a/src/eradiate/scenes/bsdfs/_hapke.py
+++ b/src/eradiate/scenes/bsdfs/_hapke.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import attrs
+import mitsuba as mi
+import pint
+import pinttr
+
+from ._core import BSDF
+from ..core import traverse
+from ..spectra import Spectrum, spectrum_factory
+from ... import validators
+from ...attrs import documented, parse_docs
+from ...kernel import TypeIdLookupStrategy, UpdateParameter
+from ...units import unit_context_config as ucc
+
+
+@parse_docs
+@attrs.define(eq=False, slots=False)
+class HapkeBSDF(BSDF):
+    """
+    Hapke BSDF [``hapke``].
+
+    This BSDF implements the Hapke surface model as described in
+    :cite:`Hapke1984BidirectionalReflectanceSpectroscopy`. This highly flexible
+    and robust surface model allows for the characterisation of a sharp
+    back-scattering hot spot. The so-called Hapke model has been adapted to
+    several different use cases in the litterature, the version with 6
+    parameters implemented here is one of the most commonly used.
+
+    See Also
+    --------
+    :ref:`plugin-bsdf-hapke`
+    """
+
+    w: Spectrum = documented(
+        attrs.field(
+            default=None,
+            converter=spectrum_factory.converter("dimensionless"),
+            validator=[
+                attrs.validators.instance_of(Spectrum),
+                validators.has_quantity("dimensionless"),
+            ],
+        ),
+        doc="Single scattering albedo 'w'. Must be in [0; 1]",
+        type=".Spectrum",
+        init_type=".Spectrum or dict or float",
+    )
+
+    b: Spectrum = documented(
+        attrs.field(
+            default=None,
+            converter=spectrum_factory.converter("dimensionless"),
+            validator=[
+                attrs.validators.instance_of(Spectrum),
+                validators.has_quantity("dimensionless"),
+            ],
+        ),
+        doc="Anisotropy parameter 'b' Must be in [0; 1]",
+        type=".Spectrum",
+        init_type=".Spectrum or dict or float",
+    )
+
+    c: Spectrum | None = documented(
+        attrs.field(
+            default=None,
+            converter=spectrum_factory.converter("dimensionless"),
+            validator=[
+                attrs.validators.instance_of(Spectrum),
+                validators.has_quantity("dimensionless"),
+            ],
+        ),
+        doc="Scattering coefficient 'c'. Must be in [0; 1]",
+        type=".Spectrum",
+        init_type=".Spectrum or dict or float",
+    )
+
+    theta: Spectrum = documented(
+        attrs.field(
+            default=0.183,
+            converter=spectrum_factory.converter("angle"),
+            validator=[
+                attrs.validators.instance_of(Spectrum),
+                validators.has_quantity("angle"),
+            ],
+        ),
+        doc="Photometric roughness 'theta'. Angle in degree. Must be in [0; 90]°",
+        type=".Spectrum",
+        init_type="quantity or float",
+    )
+
+    B_0: Spectrum = documented(
+        attrs.field(
+            default=None,
+            converter=spectrum_factory.converter("dimensionless"),
+            validator=[
+                attrs.validators.instance_of(Spectrum),
+                validators.has_quantity("dimensionless"),
+            ],
+        ),
+        doc="Shadow hiding opposition effect amplitude 'B_0'. Must be in [0; 1]",
+        type=".Spectrum",
+        init_type=".Spectrum or dict or float",
+    )
+
+    h: Spectrum = documented(
+        attrs.field(
+            default=None,
+            converter=spectrum_factory.converter("dimensionless"),
+            validator=[
+                attrs.validators.instance_of(Spectrum),
+                validators.has_quantity("dimensionless"),
+            ],
+        ),
+        doc="shadow hiding opposition effect width 'h'. Must be in [0; 1]",
+        type=".Spectrum",
+        init_type=".Spectrum or dict or float",
+    )
+
+    @property
+    def template(self) -> dict:
+        # Inherit docstring
+        objects = {
+            "w": traverse(self.w)[0],
+            "b": traverse(self.b)[0],
+            "c": traverse(self.c)[0],
+            "theta": traverse(self.theta)[0],
+            "B_0": traverse(self.B_0)[0],
+            "h": traverse(self.h)[0],
+        }
+
+        result = {
+            "type": "hapke"
+        }
+
+        for obj_key, obj_values in objects.items():
+            for key, value in obj_values.items():
+                result[f"{obj_key}.{key}"] = value
+
+        if self.id is not None:
+            result["id"] = self.id
+
+        return result
+
+    @property
+    def params(self) -> dict[str, UpdateParameter]:
+        # Inherit docstring
+        objects = {
+            "w": traverse(self.w)[1],
+            "b": traverse(self.b)[1],
+            "c": traverse(self.c)[1],
+            "theta": traverse(self.theta)[1],
+            "B_0": traverse(self.B_0)[1],
+            "h": traverse(self.h)[1],
+        }
+
+        result = {}
+        for obj_key, obj_params in objects.items():
+            for key, param in obj_params.items():
+                result[f"{obj_key}.{key}"] = attrs.evolve(
+                    param,
+                    lookup_strategy=TypeIdLookupStrategy(
+                        node_type=mi.BSDF,
+                        node_id=self.id,
+                        parameter_relpath=f"{obj_key}.{key}",
+                    )
+                    if self.id is not None
+                    else None,
+                )
+
+        return result

--- a/src/eradiate/units.py
+++ b/src/eradiate/units.py
@@ -111,6 +111,7 @@ class PhysicalQuantity(enum.Enum):
             cls.RADIANCE,
             cls.REFLECTANCE,
             cls.TRANSMITTANCE,
+            cls.ANGLE,
         )
 
 


### PR DESCRIPTION
# Description

Add the support for the Hapke BSDF 

:warning: One of the BSDF parameters, $\theta$, is an angle. I thus modeled it using a physical quantity of the `angle` nature. This means I had to modify the `PhysicalQuantity` class in order to allow for angle `Spectrum`s to be generated using its `spectrum` method. I am not particularly convinced by this approach, but could not find an alternative. :warning: 

Add the appropriate bibliography reference.

Add a few unit tests for the BSDF

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the ~`main`~ `next` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
