### PR TITLE
units: Fix unit definition logic

### DIFF
--- a/docs/src/release_notes/v0.26.x.md
+++ b/docs/src/release_notes/v0.26.x.md
@@ -14,11 +14,12 @@
 
 ### Changed
 
-* Drop support of Python 3.8 ({ghpr}̀`382`).
 * Required custom Mitsuba build bumped to v0.2.0 (based on Mitsuba v3.4.1)
 
 % ### Changed
-%
-% ### Fixed
-%
+
+### Fixed
+
+* Fix unit definition bug ({ghpr}`393`).
+
 % ### Internal changes

--- a/src/eradiate/units.py
+++ b/src/eradiate/units.py
@@ -68,8 +68,12 @@ def _load_definitions(ureg: pint.UnitRegistry, definitions: list[str]) -> None:
                 # very rare cases
                 continue
             else:
-                # Definitions are different: let the user-controlled policy apply
+                # Definitions are different: attempt a redefinition and let
+                # user-controlled conflict handling policy apply
                 ureg.define(definition)
+        else:
+            # Attempt definition
+            ureg.define(definition)
 
 
 _load_definitions(unit_registry, _parse_definitions(files("eradiate") / "units.txt"))


### PR DESCRIPTION
# Description

There was a bug where a unit definition that would not already exist would not be loaded. This PR fixes it.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
