### PR TITLE
Fix

### DIFF
--- a/docs/src/release_notes/v0.26.x.md
+++ b/docs/src/release_notes/v0.26.x.md
@@ -82,3 +82,22 @@ This is a major release. This is a summary of the most important changes:
   file related to the parent class ({ghpr}`387`).
 * 🖥️ The {class}`.MultiDeltaSpectrum` code was refactored for improved
   maintainability ({ghpr}`387`).
+
+## v0.26.2 (15th March 2024)
+
+This is a fix release.
+
+### Changed
+
+* The `repr` of some fields of the {class}`.AtmosphereRadProfile` and
+  {class}`.MultiDeltaSpectrum` classes was modified for improved readability
+  ({ghpr}`395`).
+* The `extra_objects` field of the {class}`EarthObservationExperiment` subclasses
+  can now be initialized with `None` ({ghpr}`395`).
+
+### Fixed
+
+* When opening a molecular absorption coefficient database, bins are sorted by
+  ascending lower bound values ({ghpr}`395`).
+* Fix a bug in post-processing pipelines where radiosity node would not appear
+  for in situ sensors ({ghpr}`395`).

--- a/src/eradiate/converters.py
+++ b/src/eradiate/converters.py
@@ -247,7 +247,12 @@ def convert_absorption_data(
             wavelength_range=wavelength_range,
         )
         datasets = [xr.load_dataset(path) for path in paths]
-        return {wrange(ds): ds for ds in datasets}
+
+        # Sort entries by ascending lower bound
+        entries = [(wrange(ds), ds) for ds in datasets]
+        entries.sort(key=lambda x: x[0][0])
+
+        return dict(entries)
 
     # Dataset: compute wavelength range
     elif isinstance(value, xr.Dataset):

--- a/src/eradiate/experiments/_core.py
+++ b/src/eradiate/experiments/_core.py
@@ -266,7 +266,10 @@ class Experiment(ABC):
         pass
 
 
-def _extra_objects_converter(value):
+def _extra_objects_converter(value: dict | None) -> dict:
+    if not value:
+        return {}
+
     result = {}
 
     for key, element_spec in value.items():
@@ -292,7 +295,7 @@ class EarthObservationExperiment(Experiment, ABC):
 
     extra_objects: dict[str, SceneElement] = documented(
         attrs.field(
-            factory=dict,
+            default=None,
             converter=_extra_objects_converter,
             validator=attrs.validators.deep_mapping(
                 key_validator=attrs.validators.instance_of(str),
@@ -303,7 +306,8 @@ class EarthObservationExperiment(Experiment, ABC):
         "The keys of this dictionary are used to identify the objects "
         "in the kernel dictionary.",
         type="dict",
-        default="{}",
+        init_type="dict or None",
+        default="None",
     )
 
     illumination: DirectionalIllumination | ConstantIllumination = documented(

--- a/src/eradiate/pipelines/definitions.py
+++ b/src/eradiate/pipelines/definitions.py
@@ -168,7 +168,7 @@ def gather_bitmaps(
 
 
 @tag(**{"final": "true", "kind": "data"})
-@config.when(measure_distant=True, var_name="sector_radiosity")
+@config.when(var_name="sector_radiosity")
 def radiosity(sector_radiosity: xr.DataArray) -> xr.DataArray:
     return logic.radiosity(sector_radiosity)
 

--- a/src/eradiate/radprops/_atmosphere.py
+++ b/src/eradiate/radprops/_atmosphere.py
@@ -40,7 +40,25 @@ def _absorption_data_repr(
         """Representation for values which are absorption dataset"""
         return summary_repr(value)
 
-    return "\n".join([repr_k(k) + ": " + repr_v(v) for k, v in value.items()])
+    if len(value) < 10:
+        lines = [f"{repr_k(k)}: {repr_v(v)}" for k, v in value.items()]
+
+    else:
+        lines = []
+
+        for i, (k, v) in enumerate(value.items()):
+            if i > 4:
+                break
+            lines.append(f"{repr_k(k)}: {repr_v(v)}")
+
+        lines.append("...")
+
+        for i, (k, v) in enumerate(reversed(value.items())):
+            if i > 4:
+                break
+            lines.append(f"{repr_k(k)}: {repr_v(v)}")
+
+    return "\n".join(lines)
 
 
 @parse_docs

--- a/src/eradiate/scenes/spectra/_multi_delta.py
+++ b/src/eradiate/scenes/spectra/_multi_delta.py
@@ -11,6 +11,7 @@ from ...attrs import documented, parse_docs
 from ...spectral.ckd import BinSet
 from ...spectral.mono import WavelengthSet
 from ...units import unit_context_kernel as uck
+from ...util.misc import summary_repr_vector
 
 
 @parse_docs
@@ -35,6 +36,7 @@ class MultiDeltaSpectrum(Spectrum):
                 lambda x: np.unique(x.m) * x.units,
             ],
             validator=validators.all_strictly_positive,
+            repr=lambda x: f"{summary_repr_vector(x.m)} {x.u:~}",
         ),
         doc="An array of wavelengths specifying the translation wavelength of each "
         "Dirac delta. Wavelength values are positive and unique. "

--- a/src/eradiate/util/misc.py
+++ b/src/eradiate/util/misc.py
@@ -1,6 +1,7 @@
 """
 A collection of tools which don't really fit anywhere else.
 """
+
 from __future__ import annotations
 
 import functools
@@ -508,6 +509,21 @@ def _(da: xr.DataArray):
         desc = " | " + desc
 
     return f"<xarray.DataArray{desc}>"
+
+
+def summary_repr_vector(a: np.ndarray, edgeitems: int = 4):
+    """
+    Return a brief summary representation of a Numpy vector.
+    """
+    size = len(a)
+    if size > edgeitems * 2 + 1:
+        return (
+            f"[{np.array2string(a[:edgeitems]).strip('[]')}"
+            " ... "
+            f"{np.array2string(a[size-edgeitems:]).strip('[]')}]"
+        )
+    else:
+        return np.array2string(a)
 
 
 def find_runs(


### PR DESCRIPTION
# Description

This PR contains a few bug fixes and quality-of-life improvements. Changes are as follows:

* Fix: `converters`: When opening a molecular absorption coefficient database, bins are sorted by ascending lower bound values.
* Fix: `pipelines`: Fix a bug where radiosity node would not appear for in situ sensors.
* `AtmosphereRadProfile`: The absorption data `repr` was modified for improved readability.
* `EarthObservationExperiment`: The `extra_objects` field can now be initialized with `None`.
* `MultiDeltaSpectrum`: The wavelength field `repr` was modified for improved readability.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
