### PR TITLE
Add retry option to online data stores

### DIFF
--- a/docs/src/release_notes/v0.26.x.md
+++ b/docs/src/release_notes/v0.26.x.md
@@ -110,3 +110,9 @@ This is a fix release.
 
 * Required custom Mitsuba build bumped to v0.2.1 (based on Mitsuba v3.4.1). This
   update contains minor fixes for the Hapke BSDF plugin.
+
+### Fixed
+
+* Fix incorrect path to the `komodo` dataset ({ghpr}`398`).
+* Online data stores now make additional attempts if a download fails
+  ({ghpr}`398`).

--- a/src/eradiate/data/downloads_all.yml
+++ b/src/eradiate/data/downloads_all.yml
@@ -370,8 +370,8 @@
 # Absorption coefficient datasets (monochromatic)
 - spectra/absorption/mono/gecko/gecko.nc
 - spectra/absorption/mono/gecko/metadata.json
+- spectra/absorption/mono/komodo/komodo.nc
 - spectra/absorption/mono/komodo/metadata.json
-- spectra/absorption/mono/komodo.nc
 # Absorption coefficient datasets (CKD): monotropa
 - spectra/absorption/ckd/monotropa/metadata.json
 - spectra/absorption/ckd/monotropa/index.csv


### PR DESCRIPTION
# Description

This PR adds a retry option to online data stores. It also fixes an incorrect path to the `komodo` dataset.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
