### PR TITLE
Add Gaussian distribution generator

### DIFF
--- a/docs/src/release_notes/v0.27.x.md
+++ b/docs/src/release_notes/v0.27.x.md
@@ -20,6 +20,8 @@
 * Eradiate can now be configured using TOML files ({ghpr}`397`).
 * The `eradiate data fetch` command-line interface now accepts keywords to
   facilitate absorption database downloads ({ghpr}`397`).
+* Gaussian SRF datasets can now be dynamically generated using the
+  :func:`.srf_tools.make_gaussian` function ({ghpr}`401`).
 
 ### Changed
 


### PR DESCRIPTION
# Description

This PR adds a helper to generate Gaussian-shaped spectral response function data from a central wavelength and full width at half maximum parametrization. The cutoff and discretization mesh can be customized with a straightforward interface:

```pycon
>>> from eradiate.srf_tools import make_gaussian
>>> make_gaussian(500, 2.5, wl_res=0.1)
<xarray.Dataset> Size: 2kB
Dimensions:  (w: 63)
Coordinates:
  * w        (w) float64 504B 496.9 497.0 497.1 497.2 ... 502.9 503.0 503.1
Data variables:
    srf      (w) float64 504B 0.009377 0.01229 0.01597 ... 0.01229 0.009377
    srf_u    (w) float64 504B nan nan nan nan nan nan ... nan nan nan nan nan
```

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
