### PR TITLE
Bugfix dem spherical shell

### DIFF
--- a/docs/src/release_notes/v0.27.x.md
+++ b/docs/src/release_notes/v0.27.x.md
@@ -34,6 +34,7 @@
 
 * Large absorption databases are now handled with little to no performance
   penalty ({ghpr}`397`).
+* DEM Surfaces would not behave correctly when used with a {class}`.SphericalShellGeometry` ({ghpr}`402`).
 
 ### Internal changes
 

--- a/tests/01_eradiate/01_unit/scenes/surface/test_dem.py
+++ b/tests/01_eradiate/01_unit/scenes/surface/test_dem.py
@@ -127,21 +127,39 @@ def make_dataarray(data: pint.Quantity, coords: dict):
             },
             [(-0.089832, 0.179664), (-0.269496, 0.359328)],
         ),
+        (
+            {
+                "da": make_dataarray(
+                    data=np.zeros((10, 10)) * ureg.m,
+                    coords={
+                        "x": np.linspace(-10, 20, 10) * ureg.km,
+                        "y": np.linspace(-30, 40, 10) * ureg.km,
+                    },
+                ),
+                "geometry": "invalidgeometry",
+                "planet_radius": EARTH_RADIUS,
+            },
+            [(-0.089832, 0.179664), (-0.269496, 0.359328)],
+        ),
     ],
 )
 def test_mesh_from_dem(modes_all_double, kwargs, expected_limits):
-    if (kwargs["geometry"] == "spherical_shell") and kwargs[
-        "planet_radius"
-    ] is not None:
-        with pytest.warns():
-            mesh, lat, lon = mesh_from_dem(**kwargs)
+    if kwargs["geometry"] not in ["spherical_shell", "plane_parallel"]:
+        with pytest.raises(ValueError):
+            mesh_from_dem(**kwargs)
     else:
-        mesh, lat, lon = mesh_from_dem(**kwargs)
+        if (kwargs["geometry"] == "spherical_shell") and kwargs[
+            "planet_radius"
+        ] is not None:
+            with pytest.warns():
+                mesh, lat, lon = mesh_from_dem(**kwargs)
+        else:
+            mesh, lat, lon = mesh_from_dem(**kwargs)
 
-    assert len(mesh.vertices) == 100
+        assert len(mesh.vertices) == 100
 
-    assert np.allclose(lat.m, expected_limits[0], atol=1e-4, rtol=1e-3)
-    assert np.allclose(lon.m, expected_limits[1], atol=1e-4, rtol=1e-3)
+        assert np.allclose(lat.m, expected_limits[0], atol=1e-4, rtol=1e-3)
+        assert np.allclose(lon.m, expected_limits[1], atol=1e-4, rtol=1e-3)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Description

The DEM surface would not work properly on spherical shell geometries, when the geometry was specified with a string.
The string was not properly converted into a scene geometry object in the `from_mesh` constructor method of the `DEMSurface` class.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `next` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
