### PR TITLE
Experimental dataset validation infrastructure

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include src/eradiate/config/*.toml
 include src/eradiate/data/downloads_all.yml
 include src/eradiate/data/downloads_minimal.yml
+include src/eradiate/data/schemas/*.yml
 include src/eradiate/units.txt

--- a/docs/src/release_notes/v0.27.x.md
+++ b/docs/src/release_notes/v0.27.x.md
@@ -26,6 +26,7 @@
   arbitrary transformation of the object ({ghpr}`381`).
 * The eradiate data fetch command is extended with the possibility to fetch
   groups of files (*e.g.* `eradiate data fetch monotropa`) ({ghpr}`405`).
+* Experimental validation framework based on the Cerberus library ({ghpr}`404`).
 
 ### Changed
 

--- a/requirements/layered.yml
+++ b/requirements/layered.yml
@@ -12,6 +12,7 @@ main:
     - "aenum"
     - "attrs>=22.2"
     - "cachetools>=5.3"
+    - "cerberus>=1.3"
     - "click"
     - "dessinemoi>=23.1.0"
     - "dynaconf>=3.2"

--- a/src/eradiate/data/_validation.py
+++ b/src/eradiate/data/_validation.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import glob
+import importlib.resources
+from pathlib import Path
+
+import cerberus
+import xarray as xr
+from ruamel.yaml import YAML
+
+from eradiate.units import unit_registry as ureg
+from eradiate.units import units_compatible
+
+
+def _load_rules():
+    cerberus.rules_set_registry.extend([("integer", {"type": "integer"})])
+    cerberus.rules_set_registry.extend([("string", {"type": "string"})])
+
+
+def _load_schemas() -> None:
+    schema_paths = sorted(
+        Path(x)
+        for x in glob.glob(
+            str(importlib.resources.files("eradiate.data.schemas").joinpath("*.yml"))
+        )
+    )  # TODO: check if that would work on Windows
+
+    yaml = YAML(typ="safe")
+    for path in schema_paths:
+        name = path.stem
+        schema = yaml.load(open(path))
+        cerberus.schema_registry.add(name, schema)
+
+
+_load_rules()
+_load_schemas()
+
+
+class DatasetValidator(cerberus.Validator):
+    """
+    This class implements xarray dataset validation. In addition to providing
+    a simple interface to validate the structure of a dataset against a Cerberus
+    schema, it provides validation rules
+    """
+
+    def _validate_equal_list(self, constraint, field, value):
+        """
+        Check if the value is equal to a specific list.
+
+        The rule's arguments are validated against this schema:
+        {"type": "list"}
+        """
+        if list(value) != list(constraint):
+            self._error(field, f"Must be equal to {constraint}")
+
+    def _validate_units_compatible(self, constraint, field, value):
+        """
+        Check if a 'units' attribute field has a value that is compatible with
+        specific units. The underlying implementation uses
+        :func:`.units_compatible` and will consequently not return a false
+        positive if validating angle units against dimensionless quantities.
+
+        The rule's arguments are validated against this schema:
+        {"type": "string"}
+        """
+        u_value = ureg.Unit(value)
+        u_constraint = ureg.Unit(constraint)
+        if not units_compatible(u_constraint, u_value):
+            self._error(field, f"Must be units compatible with {constraint}")
+
+    def validate(self, document, schema=None, update=False, normalize=True):
+        # Inherit docstring
+        if isinstance(document, xr.Dataset):
+            document = document.to_dict(data=False)
+        super().validate(document, schema=schema, update=update, normalize=normalize)
+
+
+def list_schemas() -> list[str]:
+    """
+    List currently registered Cerberus schemas.
+    """
+    return sorted(cerberus.schema_registry._storage.keys())

--- a/src/eradiate/data/schemas/particle_dataset_v1.yml
+++ b/src/eradiate/data/schemas/particle_dataset_v1.yml
@@ -1,0 +1,121 @@
+dims:
+  type: dict
+  allow_unknown: false
+  schema:
+    w: integer
+    mu: integer
+    i: integer
+    j: integer
+coords:
+  type: dict
+  allow_unknown: true
+  schema:
+    w:
+      required: true
+      type: dict
+      schema:
+        dims:
+          equal_list: [ w ]
+        dtype:
+          allowed: [ float64 ]
+        attrs:
+          type: dict
+          schema:
+            standard_name: string
+            long_name: string
+            units:
+              units_compatible: nm
+    i:
+      required: true
+      type: dict
+      schema:
+        dims:
+          equal_list: [ i ]
+        dtype:
+          allowed: [ int64 ]
+        attrs:
+          type: dict
+          schema:
+            standard_name: string
+            long_name: string
+            units:
+              units_compatible: dimensionless
+    j:
+      required: true
+      type: dict
+      schema:
+        dims:
+          equal_list: [ j ]
+        dtype:
+          allowed: [ int64 ]
+        attrs:
+          type: dict
+          schema:
+            standard_name: string
+            long_name: string
+            units:
+              units_compatible: dimensionless
+    mu:
+      required: true
+      type: dict
+      schema:
+        dims:
+          equal_list: [ mu ]
+        dtype:
+          allowed: [ float64 ]
+        attrs:
+          type: dict
+          schema:
+            standard_name: string
+            long_name: string
+            units:
+              units_compatible: dimensionless
+data_vars:
+  type: dict
+  allow_unknown: true
+  schema:
+    sigma_t:
+      required: true
+      type: dict
+      schema:
+        dims:
+          equal_list: [ w ]
+        dtype:
+          allowed: [ float64 ]
+        attrs:
+          type: dict
+          schema:
+            standard_name: string
+            long_name: string
+            units:
+              units_compatible: dimensionless  # TODO: check (documentation mismatch)
+    albedo:
+      required: true
+      type: dict
+      schema:
+        dims:
+          equal_list: [ w ]
+        dtype:
+          allowed: [ float64 ]
+        attrs:
+          type: dict
+          schema:
+            standard_name: string
+            long_name: string
+            units:
+              units_compatible: dimensionless
+    phase:
+      required: true
+      type: dict
+      schema:
+        dims:
+          equal_list: [ w, mu, i, j ]
+        dtype:
+          allowed: [ float64 ]
+        attrs:
+          type: dict
+          schema:
+            standard_name: string
+            long_name: string
+            units:
+              units_compatible: dimensionless  # TODO: check (documentation mismatch)


### PR DESCRIPTION
# Description

This PR introduces an experimental data validation framework. This is a best-effort solution since specialized validation frameworks are not mature enough for production use.

## What is this for?

This work started during a subsequent documentation update. I realized that we have so far documented our data formats, but nothing exists in our code base to help users verify if their data are correct and, if not, how to fix them.

With this framework, the user can validate a dataset against a registered schema and, in case of a failure, get a full diagnostic of errors.

## How does it work?

This PR provides a simple interface that wraps around the [Cerberus library](https://docs.python-cerberus.org/) (new dependency), which performs validation on a dict-based document extracted from an xarray dataset.

Schemas are saved and versioned alongside the code. They are automatically discovered by the validator.

## How can I use it?

Instantiate a validator:

```python
from eradiate.data._validation import DatasetValidator

v = DatasetValidator()
```

then validate a dataset:

```python
v.validate(ds, schema="particle_dataset_v1")
```

In case of a failure, the `v.errors` member should explain well what is wrong.

## Any issues or caveats?

* This is experimental, we can change the infrastructure at any moment.
* I wish I could use Pandera for this ([xarray integration is planned](https://github.com/unionai-oss/pandera/issues/705), but doesn't seem to progress).
* This system can only validate the dataset schema and metadata, not the data themselves
* Cerberus's rule system is a bit complicated and thorough testing is required.
* The only schema that is registered at the moment is likely incomplete and might give a pass to files that will not work.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
