### PR TITLE
Fix a bug where geometry vs atmosphere extent check would not work as intended

### DIFF
--- a/docs/src/release_notes/v0.27.x.md
+++ b/docs/src/release_notes/v0.27.x.md
@@ -47,6 +47,8 @@
   pipelines ({ghpr}`406`).
 * Exponential and Gaussian particle distributions now correctly evaluate to 0
   when queried for values outside the [0, 1] interval ({ghpr}`408`).
+* Fixed a bug where geometry vs atmosphere extent check would not work as
+  intended ({ghpr}`407`).
 
 ### Internal changes
 

--- a/tests/01_unit/experiments/test_experiment_common.py
+++ b/tests/01_unit/experiments/test_experiment_common.py
@@ -1,0 +1,55 @@
+"""
+Tests for behaviour common to multiple experiment classes.
+"""
+
+import pytest
+
+from eradiate import unit_registry as ureg
+from eradiate.experiments import (
+    AtmosphereExperiment,
+    CanopyAtmosphereExperiment,
+    DEMExperiment,
+)
+
+
+@pytest.mark.parametrize(
+    "cls",
+    [
+        AtmosphereExperiment,
+        CanopyAtmosphereExperiment,
+        DEMExperiment,
+    ],
+    ids=[
+        "atmosphere",
+        "canopy_atmosphere",
+        "dem",
+    ],
+)
+@pytest.mark.parametrize(
+    "ground_altitude, toa_altitude, expected",
+    [
+        (0, 120, "pass"),
+        (-1, 120, "raises"),
+        (0, 121, "raises"),
+        (-1, 121, "raises"),
+    ],
+)
+def test_atmosphere_experiment_geometry_bounds(
+    mode_mono, cls, ground_altitude, toa_altitude, expected
+):
+    """
+    Incompatible geometry bounds and atmosphere extent raise an exception.
+    """
+    kwargs = {
+        "atmosphere": {"type": "molecular"},
+        "geometry": {
+            "type": "plane_parallel",
+            "ground_altitude": ground_altitude * ureg.km,
+            "toa_altitude": toa_altitude * ureg.km,
+        },
+    }
+    if expected == "raises":
+        with pytest.raises(ValueError):
+            cls(**kwargs)
+    else:
+        cls(**kwargs)


### PR DESCRIPTION
# Description

This commit fixes a bug where, for some experiment classes, the check of scene geometry parameters against molecular atmosphere extent would unexpectedly pass or fail.

The code performing this check is refactored to reduce the amount of duplicates.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
