### PR TITLE
Fix particle distribution out-of-bound evaluation

### DIFF
--- a/docs/src/release_notes/v0.27.x.md
+++ b/docs/src/release_notes/v0.27.x.md
@@ -45,6 +45,8 @@
   precision issues ({ghpr}`406`).
 * The SRF weighting operation is removed from monochromatic post-processing
   pipelines ({ghpr}`406`).
+* Exponential and Gaussian particle distributions now correctly evaluate to 0
+  when queried for values outside the [0, 1] interval ({ghpr}`408`).
 
 ### Internal changes
 

--- a/src/eradiate/scenes/atmosphere/_particle_layer.py
+++ b/src/eradiate/scenes/atmosphere/_particle_layer.py
@@ -1,6 +1,7 @@
 """
 Particle layers.
 """
+
 from __future__ import annotations
 
 from functools import singledispatchmethod
@@ -285,9 +286,10 @@ class ParticleLayer(AbstractHeterogeneousAtmosphere):
         # Scatter this total OT to all layers
         # TODO: Make sure that axis order is consistent with other vectorized
         #  routines
+        fractions = self.eval_fractions(zgrid)
         tau_layers = np.broadcast_to(
             np.reshape(tau, (-1, 1)), (len(wavelengths), zgrid.n_layers)
-        ) * np.reshape(self.eval_fractions(zgrid), (1, -1))
+        ) * np.reshape(fractions, (1, -1))
 
         # Compute corresponding average coefficient
         sigma_t = tau_layers / zgrid.layer_height


### PR DESCRIPTION
# Description

This PR fixes the exponential and Gaussian particle distributions and forces values outside the [0, 1] interval to 0, as expected and mentioned in the documentation of the `ParticleDistribution` abstract class.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
