### PR TITLE
illumination: Add common interface for directional-like illuminants

### DIFF
--- a/docs/rst/reference_api/scenes.rst
+++ b/docs/rst/reference_api/scenes.rst
@@ -279,6 +279,7 @@
    :toctree: generated/autosummary/
 
    Illumination
+   AbstractDirectionalIllumination
 
 **Factories**
 

--- a/docs/src/release_notes/v0.27.x.md
+++ b/docs/src/release_notes/v0.27.x.md
@@ -33,6 +33,8 @@
   ({ghpr}`397`).
 * 📖 The Data documentation content is extracted from the user guide and moved
   to its own section ({ghpr}`405`).
+* Illumination azimuth values out of the [0°, 360°[ range are now allowed and
+  issue a warning instead of raising an exception ({ghpr}`409`).
 
 ### Fixed
 

--- a/src/eradiate/scenes/illumination/__init__.pyi
+++ b/src/eradiate/scenes/illumination/__init__.pyi
@@ -1,5 +1,6 @@
 from ._astro_object import AstroObjectIllumination as AstroObjectIllumination
 from ._constant import ConstantIllumination as ConstantIllumination
+from ._core import AbstractDirectionalIllumination as AbstractDirectionalIllumination
 from ._core import Illumination as Illumination
 from ._core import illumination_factory as illumination_factory
 from ._directional import DirectionalIllumination as DirectionalIllumination

--- a/src/eradiate/scenes/illumination/_astro_object.py
+++ b/src/eradiate/scenes/illumination/_astro_object.py
@@ -5,7 +5,7 @@ import numpy as np
 import pint
 import pinttr
 
-from ._directional import DirectionalIllumination
+from ._core import AbstractDirectionalIllumination
 from ...attrs import documented, parse_docs
 from ...frame import angles_to_direction
 from ...units import unit_context_config as ucc
@@ -15,7 +15,7 @@ from ...validators import is_positive
 
 @parse_docs
 @attrs.define(eq=False, slots=False)
-class AstroObjectIllumination(DirectionalIllumination):
+class AstroObjectIllumination(AbstractDirectionalIllumination):
     """
     Astronomical Object Illumination scene element [``astro_object``].
 

--- a/src/eradiate/scenes/illumination/_core.py
+++ b/src/eradiate/scenes/illumination/_core.py
@@ -1,12 +1,24 @@
 from __future__ import annotations
 
+import warnings
 from abc import ABC
 
 import attrs
+import drjit as dr
+import mitsuba as mi
+import numpy as np
+import pint
+import pinttrs
 
 from ..core import NodeSceneElement
+from ..spectra import SolarIrradianceSpectrum, Spectrum, spectrum_factory
+from ... import unit_context_config as ucc
+from ... import unit_registry as ureg
 from ..._factory import Factory
 from ...attrs import documented, get_doc, parse_docs
+from ...config import settings
+from ...frame import AzimuthConvention, angles_to_direction
+from ...validators import has_quantity, is_positive
 
 illumination_factory = Factory()
 illumination_factory.register_lazy_batch(
@@ -41,3 +53,103 @@ class Illumination(NodeSceneElement, ABC):
         init_type=get_doc(NodeSceneElement, "id", "init_type"),
         default='"illumination"',
     )
+
+
+def _azimuth_converter(value):
+    if not 0.0 <= value.m_as("deg") < 360.0:
+        warnings.warn(
+            "Illumination azimuth values should be in the [0°, 360°[ interval. "
+            "Applying modulo operation."
+        )
+        return value % (360.0 * ureg.deg)
+    else:
+        return value
+
+
+@parse_docs
+@attrs.define(eq=False, slots=False)
+class AbstractDirectionalIllumination(Illumination):
+    """
+    Abstract interface to directional-like illuminants.
+    """
+
+    zenith: pint.Quantity = documented(
+        pinttrs.field(
+            default=0.0 * ureg.deg,
+            validator=[is_positive, pinttrs.validators.has_compatible_units],
+            units=ucc.deferred("angle"),
+        ),
+        doc="Zenith angle.\n\nUnit-enabled field (default units: ucc['angle']).",
+        type="quantity",
+        init_type="quantity or float",
+        default="0.0 deg",
+    )
+
+    azimuth: pint.Quantity = documented(
+        pinttrs.field(
+            default=0.0 * ureg.deg,
+            converter=[
+                pinttrs.converters.to_units(ucc.deferred("angle")),
+                _azimuth_converter,
+            ],
+            units=ucc.deferred("angle"),
+        ),
+        doc="Azimuth angle value.\n"
+        "\n"
+        "Unit-enabled field (default units: ucc['angle']).",
+        type="quantity",
+        init_type="quantity or float",
+        default="0.0 deg",
+    )
+
+    azimuth_convention: AzimuthConvention = documented(
+        attrs.field(
+            default=None,
+            converter=lambda x: (
+                settings.azimuth_convention
+                if x is None
+                else (AzimuthConvention[x.upper()] if isinstance(x, str) else x)
+            ),
+            validator=attrs.validators.instance_of(AzimuthConvention),
+        ),
+        doc="Azimuth convention. If ``None``, the global default configuration "
+        "is used (see :ref:`sec-user_guide-config`).",
+        type=".AzimuthConvention",
+        init_type=".AzimuthConvention or str, optional",
+        default="None",
+    )
+
+    irradiance: Spectrum = documented(
+        attrs.field(
+            factory=SolarIrradianceSpectrum,
+            converter=spectrum_factory.converter("irradiance"),
+            validator=[
+                attrs.validators.instance_of(Spectrum),
+                has_quantity("irradiance"),
+            ],
+        ),
+        doc="Emitted power flux in the plane orthogonal to the illumination direction. "
+        "Must be an irradiance spectrum (in W/m²/nm or compatible unit). "
+        "Can be initialised with a dictionary processed by "
+        ":meth:`.SpectrumFactory.convert`.",
+        type=":class:`~eradiate.scenes.spectra.Spectrum`",
+        init_type=":class:`~eradiate.scenes.spectra.Spectrum` or dict or float",
+        default=":class:`SolarIrradianceSpectrum() <.SolarIrradianceSpectrum>`",
+    )
+
+    @property
+    def _to_world(self) -> mi.ScalarTransorm4f:
+        direction = dr.normalize(mi.ScalarVector3f(self.direction))
+        up, _ = mi.coordinate_system(direction)
+        return mi.ScalarTransform4f.look_at(origin=0.0, target=direction, up=up)
+
+    @property
+    def direction(self) -> np.ndarray:
+        """
+        Illumination direction as an array of shape (3,), pointing inwards.
+        """
+        return angles_to_direction(
+            [self.zenith.m_as(ureg.rad), self.azimuth.m_as(ureg.rad)],
+            azimuth_convention=self.azimuth_convention,
+            flip=True,
+        ).reshape((3,))

--- a/src/eradiate/scenes/illumination/_directional.py
+++ b/src/eradiate/scenes/illumination/_directional.py
@@ -1,110 +1,21 @@
 from __future__ import annotations
 
 import attrs
-import drjit as dr
-import mitsuba as mi
-import numpy as np
-import pint
-import pinttr
 
-from ._core import Illumination
+from ._core import AbstractDirectionalIllumination
 from ..core import NodeSceneElement
-from ..spectra import SolarIrradianceSpectrum, Spectrum, spectrum_factory
-from ...attrs import documented, parse_docs
-from ...config import settings
-from ...frame import AzimuthConvention, angles_to_direction
-from ...units import unit_context_config as ucc
-from ...units import unit_registry as ureg
-from ...validators import has_quantity, is_positive
+from ...attrs import parse_docs
 
 
 @parse_docs
 @attrs.define(eq=False, slots=False)
-class DirectionalIllumination(Illumination):
+class DirectionalIllumination(AbstractDirectionalIllumination):
     """
     Directional illumination scene element [``directional``].
 
     The illumination is oriented based on the classical angular convention used
     in Earth observation.
     """
-
-    zenith: pint.Quantity = documented(
-        pinttr.field(
-            default=0.0 * ureg.deg,
-            validator=[is_positive, pinttr.validators.has_compatible_units],
-            units=ucc.deferred("angle"),
-        ),
-        doc="Zenith angle.\n\nUnit-enabled field (default units: ucc[angle]).",
-        type="quantity",
-        init_type="quantity or float",
-        default="0.0 deg",
-    )
-
-    azimuth: pint.Quantity = documented(
-        pinttr.field(
-            default=0.0 * ureg.deg,
-            validator=[is_positive, pinttr.validators.has_compatible_units],
-            units=ucc.deferred("angle"),
-        ),
-        doc="Azimuth angle value.\n"
-        "\n"
-        "Unit-enabled field (default units: ucc[angle]).",
-        type="quantity",
-        init_type="quantity or float",
-        default="0.0 deg",
-    )
-
-    azimuth_convention: AzimuthConvention = documented(
-        attrs.field(
-            default=None,
-            converter=lambda x: (
-                settings.azimuth_convention
-                if x is None
-                else (AzimuthConvention[x.upper()] if isinstance(x, str) else x)
-            ),
-            validator=attrs.validators.instance_of(AzimuthConvention),
-        ),
-        doc="Azimuth convention. If ``None``, the global default configuration "
-        "is used (see :class:`.EradiateConfig`).",
-        type=".AzimuthConvention",
-        init_type=".AzimuthConvention or str, optional",
-        default="None",
-    )
-
-    irradiance: Spectrum = documented(
-        attrs.field(
-            factory=SolarIrradianceSpectrum,
-            converter=spectrum_factory.converter("irradiance"),
-            validator=[
-                attrs.validators.instance_of(Spectrum),
-                has_quantity("irradiance"),
-            ],
-        ),
-        doc="Emitted power flux in the plane orthogonal to the illumination direction. "
-        "Must be an irradiance spectrum (in W/m²/nm or compatible unit). "
-        "Can be initialised with a dictionary processed by "
-        ":meth:`.SpectrumFactory.convert`.",
-        type=":class:`~eradiate.scenes.spectra.Spectrum`",
-        init_type=":class:`~eradiate.scenes.spectra.Spectrum` or dict or float",
-        default=":class:`SolarIrradianceSpectrum() <.SolarIrradianceSpectrum>`",
-    )
-
-    @property
-    def direction(self) -> np.ndarray:
-        """
-        Illumination direction as an array of shape (3,), pointing inwards.
-        """
-        return angles_to_direction(
-            [self.zenith.m_as(ureg.rad), self.azimuth.m_as(ureg.rad)],
-            azimuth_convention=self.azimuth_convention,
-            flip=True,
-        ).reshape((3,))
-
-    @property
-    def _to_world(self) -> mi.ScalarTransorm4f:
-        direction = dr.normalize(mi.ScalarVector3f(self.direction))
-        up, _ = mi.coordinate_system(direction)
-        return mi.ScalarTransform4f.look_at(origin=0.0, target=direction, up=up)
 
     @property
     def template(self) -> dict:

--- a/tests/01_unit/scenes/illumination/test_astro_object.py
+++ b/tests/01_unit/scenes/illumination/test_astro_object.py
@@ -80,6 +80,16 @@ COS_PI_4 = 0.5 * np.sqrt(2)
         ("south_right", [COS_PI_4, 0, COS_PI_4]),
         ("south_left", [-COS_PI_4, 0, COS_PI_4]),
     ],
+    ids=[
+        "east_right",
+        "east_left",
+        "north_right",
+        "north_left",
+        "west_right",
+        "west_left",
+        "south_right",
+        "south_left",
+    ],
 )
 def test_astro_object_azimuth_convention(mode_mono, azimuth_convention, expected):
     illumination = AstroObjectIllumination(
@@ -88,3 +98,14 @@ def test_astro_object_azimuth_convention(mode_mono, azimuth_convention, expected
         azimuth_convention=azimuth_convention,
     )
     assert np.allclose(illumination.direction, expected), illumination.direction
+
+
+@pytest.mark.parametrize(
+    "azimuth", [-90.0 * ureg.deg, -np.pi / 2 * ureg.rad], ids=["-90 deg", "-pi/2 rad"]
+)
+def test_astro_object_azimuth_negative_values(mode_mono, azimuth):
+    with pytest.warns(UserWarning):
+        illumination = AstroObjectIllumination(
+            azimuth=ureg.Quantity(azimuth), zenith=0.0 * ureg.deg
+        )
+        np.testing.assert_allclose(illumination.azimuth.m_as("deg"), 270.0)

--- a/tests/01_unit/scenes/illumination/test_directional.py
+++ b/tests/01_unit/scenes/illumination/test_directional.py
@@ -77,6 +77,16 @@ COS_PI_4 = 0.5 * np.sqrt(2)
         ("south_right", [-COS_PI_4, 0, -COS_PI_4]),
         ("south_left", [COS_PI_4, 0, -COS_PI_4]),
     ],
+    ids=[
+        "east_right",
+        "east_left",
+        "north_right",
+        "north_left",
+        "west_right",
+        "west_left",
+        "south_right",
+        "south_left",
+    ],
 )
 def test_directional_azimuth_convention(mode_mono, azimuth_convention, expected):
     illumination = DirectionalIllumination(
@@ -85,3 +95,14 @@ def test_directional_azimuth_convention(mode_mono, azimuth_convention, expected)
         azimuth_convention=azimuth_convention,
     )
     assert np.allclose(illumination.direction, expected), illumination.direction
+
+
+@pytest.mark.parametrize(
+    "azimuth", [-90.0 * ureg.deg, -np.pi / 2 * ureg.rad], ids=["-90 deg", "-pi/2 rad"]
+)
+def test_directional_azimuth_negative_values(mode_mono, azimuth):
+    with pytest.warns(UserWarning):
+        illumination = DirectionalIllumination(
+            azimuth=ureg.Quantity(azimuth), zenith=0.0 * ureg.deg
+        )
+        np.testing.assert_allclose(illumination.azimuth.m_as("deg"), 270.0)


### PR DESCRIPTION
# Description

This PR adds a common interface for the `DirectionalIllumination` and `AstroObjectIllumination` classes. This makes sense, since it is strange to say that "an `AstroObjectIllumination` is a `DirectionalIllumination`".

In addition, we fix the azimuth field init sequence to allow all values and warn if the user inputs something out of the expected range. The idea is to still force values within a known range, but still to avoid modifying user input without notice.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
