### PR TITLE
CLI: Add eradiate data check command

### DIFF
--- a/docs/rst/data/intro.rst
+++ b/docs/rst/data/intro.rst
@@ -62,7 +62,7 @@ Downloading data
 Data download is done using the ``eradiate data fetch`` command
 (see :ref:`sec-reference_cli`). The most common way to download data is to
 reference a file list when calling ``eradiate data fetch``. Known file lists
-are displayed using the ``--list`` option:
+are displayed using the ``--list`` option, *e.g.*:
 
 .. code-block:: console
 
@@ -89,6 +89,24 @@ A specific file list can then be downloaded by simply requesting it, *e.g.*:
    ✓ found
    [/home/username/src/eradiate/.eradiate_downloads/stable/spectra/absorpti
    on/mono/komodo/metadata.json]
+
+.. note::
+
+   Some data might require ancillary files that are not part of the download
+   lists. For example, the current format of molecular absorption databases uses
+   index and spectral coverage tables, which can be missing from the download
+   list, but can be built by Eradiate automatically. While this is done
+   automatically when creating an :class:`.AbsorptionDatabase`, it can also be
+   done manually prior to running computations with Eradiate, using the
+   ``eradiate data check`` command with the ``--fix`` option, *e.g.*:
+
+   .. code-block:: console
+
+      $ eradiate data check monotropa --fix
+      [10:44:35] INFO     Opening 'monotropa'
+                 WARNING  Could not find spectral coverage table, building it
+      [10:44:37] INFO     Success!
+
 
 Accessing data (advanced users and developers)
 ----------------------------------------------

--- a/docs/src/reference_cli.md
+++ b/docs/src/reference_cli.md
@@ -42,11 +42,32 @@ $ eradiate data [OPTIONS] COMMAND [ARGS]...
 
 **Commands**:
 
+* `check`: Check data for availability and integrity,...
 * `fetch`: Fetch files from the Eradiate data store.
 * `info`: Display information about data store...
 * `make-registry`: Recursively construct a file registry from...
 * `purge-cache`: Purge the cache of online data stores.
 * `update-registries`: Update local registries for online sources.
+
+#### `eradiate data check`
+
+Check data for availability and integrity, optionally fix them.
+
+**Usage**:
+
+```console
+$ eradiate data check [OPTIONS] [KEYWORDS]...
+```
+
+**Arguments**:
+
+* `[KEYWORDS]...`: A keyword defining the datasets that are to be checked. See the `--list` option for available keywords,
+
+**Options**:
+
+* `-l, --list`: List known keywords and exit.
+* `-f, --fix`: Fix issues that can be.
+* `--help`: Show this message and exit.
 
 #### `eradiate data fetch`
 
@@ -60,7 +81,7 @@ $ eradiate data fetch [OPTIONS] [FILE_LIST]...
 
 **Arguments**:
 
-* `[FILE_LIST]...`: An arbitrary number of relative paths to files to be retrieved from the data store or file list specifications. If unset, the list of files is read from a YAML file which can be specified by using the ``--from-file`` option, if it is specified. Otherwise, it defaults to ``all`` in a production environment and ``minimal`` in a development environment.
+* `[FILE_LIST]...`: An arbitrary number of relative paths to files to be retrieved from the data store or file list specifications. A file list keyword can also be specified to download a pre-defined list of files (use the `--list` option to display) available keywords. If unset, the list of files is read from a YAML file which can be specified by using the `--from-file` option, if it is used. Otherwise, it defaults to `all` in a production environment and `minimal` in a development environment.
 
 **Options**:
 

--- a/docs/src/release_notes/v0.27.x.md
+++ b/docs/src/release_notes/v0.27.x.md
@@ -34,9 +34,11 @@ moment.
   {func}`.srf_tools.make_gaussian` function ({ghpr}`401`).
 * All `.Shape` classes now support a `to_world` member, which defines an
   arbitrary transformation of the object ({ghpr}`381`).
-* The eradiate data fetch command is extended with the possibility to fetch
+* The `eradiate data fetch` command is extended with the possibility to fetch
   groups of files (*e.g.* `eradiate data fetch monotropa`) ({ghpr}`405`).
 * Experimental validation framework based on the Cerberus library ({ghpr}`404`).
+* Added a new `eradiate data check` command to perform checks and fixes on
+  molecular absorption databases ({ghpr}`412`).
 
 ### Changed
 

--- a/src/eradiate/data/_util.py
+++ b/src/eradiate/data/_util.py
@@ -50,6 +50,9 @@ def known_file_lists() -> list[str]:
 
 
 def get_file_list(spec: str):
+    """
+    Get a list of files corresponding to a specifier (i.e. an identifier).
+    """
     try:
         return FILE_LIST_LOADERS[spec].get_file_list()
     except KeyError as e:


### PR DESCRIPTION
# Description

This commit adds a CLI subcommand to perform data integrity checks. This subcommand can run checks and, optionally, fix issues that can be.

The current implementation is limited to molecular absorption database index presence checks, but it can be extended easily to support more checks or data kinds.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
