### PR TITLE
Refactor and upgrade distant sensor line + a few refactoring actions

### DIFF
--- a/docs/rst/reference_api/scenes.rst
+++ b/docs/rst/reference_api/scenes.rst
@@ -3,6 +3,87 @@
 
 .. automodule:: eradiate.scenes
 
+Quick access
+------------
+
+.. grid:: 1 2 auto auto
+    :gutter: 3
+
+    .. grid-item-card:: :fas:`gear` Core
+        :link: module-eradiate.scenes.core
+        :link-type: ref
+
+        ``eradiate.scenes.core``
+
+    .. grid-item-card:: :fas:`globe` Geometry
+        :link: module-eradiate.scenes.geometry
+        :link-type: ref
+
+        ``eradiate.scenes.geometry``
+
+    .. grid-item-card:: :fas:`cloud` Atmosphere
+        :link: module-eradiate.scenes.atmosphere
+        :link-type: ref
+
+        ``eradiate.scenes.atmosphere``
+
+    .. grid-item-card:: :fas:`tree` Biosphere
+        :link: module-eradiate.scenes.biosphere
+        :link-type: ref
+
+        ``eradiate.scenes.biosphere``
+
+    .. grid-item-card:: :fas:`mountain` Surface
+        :link: module-eradiate.scenes.surface
+        :link-type: ref
+
+        ``eradiate.scenes.surface``
+
+    .. grid-item-card:: :fas:`arrow-trend-up` BSDFs
+        :link: module-eradiate.scenes.bsdfs
+        :link-type: ref
+
+        ``eradiate.scenes.bsdfs``
+
+
+    .. grid-item-card:: :fas:`cubes` Shapes
+        :link: module-eradiate.scenes.shapes
+        :link-type: ref
+
+        ``eradiate.scenes.shapes``
+
+    .. grid-item-card:: :fas:`sun` Illumination
+        :link: module-eradiate.scenes.illumination
+        :link-type: ref
+
+        ``eradiate.scenes.illumination``
+
+    .. grid-item-card:: :fas:`video` Measure
+        :link: module-eradiate.scenes.measure
+        :link-type: ref
+
+        ``eradiate.scenes.measure``
+
+    .. grid-item-card:: :fas:`arrow-trend-down` Phase functions
+        :link: module-eradiate.scenes.phase
+        :link-type: ref
+
+        ``eradiate.scenes.phase``
+
+    .. grid-item-card:: :fas:`server` Integrators
+        :link: module-eradiate.scenes.integrators
+        :link-type: ref
+
+        ``eradiate.scenes.integrators``
+
+    .. grid-item-card:: :fas:`rainbow` Spectra
+        :link: module-eradiate.scenes.spectra
+        :link-type: ref
+
+        ``eradiate.scenes.spectra``
+
+.. _module-eradiate.scenes.core:
+
 ``eradiate.scenes.core``
 ------------------------
 
@@ -43,6 +124,8 @@
 
    BoundingBox
 
+.. _module-eradiate.scenes.geometry:
+
 ``eradiate.scenes.geometry``
 ----------------------------
 
@@ -56,6 +139,8 @@
    SceneGeometry
    PlaneParallelGeometry
    SphericalShellGeometry
+
+.. _module-eradiate.scenes.atmosphere:
 
 ``eradiate.scenes.atmosphere``
 ------------------------------
@@ -98,6 +183,8 @@
    InterpolatorParticleDistribution
    GaussianParticleDistribution
    UniformParticleDistribution
+
+.. _module-eradiate.scenes.biosphere:
 
 ``eradiate.scenes.biosphere``
 -----------------------------
@@ -169,6 +256,8 @@
 
    wellington_citrus_orchard
 
+.. _module-eradiate.scenes.surface:
+
 ``eradiate.scenes.surface``
 ---------------------------
 
@@ -203,6 +292,8 @@
 
    mesh_from_dem
 
+.. _module-eradiate.scenes.bsdfs:
+
 ``eradiate.scenes.bsdfs``
 -------------------------
 
@@ -235,6 +326,8 @@
    RPVBSDF
    RTLSBSDF
 
+.. _module-eradiate.scenes.shapes:
+
 ``eradiate.scenes.shapes``
 --------------------------
 
@@ -266,6 +359,8 @@
    RectangleShape
    SphereShape
 
+.. _module-eradiate.scenes.illumination:
+
 ``eradiate.scenes.illumination``
 --------------------------------
 
@@ -295,6 +390,8 @@
    ConstantIllumination
    SpotIllumination
 
+.. _module-eradiate.scenes.measure:
+
 ``eradiate.scenes.measure``
 ---------------------------
 
@@ -319,7 +416,9 @@
 .. autosummary::
    :toctree: generated/autosummary/
 
+   DistantMeasure
    MultiDistantMeasure
+   MultiPixelDistantMeasure
    DistantFluxMeasure
    HemisphericalDistantMeasure
    RadiancemeterMeasure
@@ -347,6 +446,8 @@
    DirectionLayout
    GridLayout
    HemispherePlaneLayout
+
+.. _module-eradiate.scenes.phase:
 
 ``eradiate.scenes.phase``
 -------------------------
@@ -377,6 +478,8 @@
    BlendPhaseFunction
    TabulatedPhaseFunction
 
+.. _module-eradiate.scenes.integrators:
+
 ``eradiate.scenes.integrators``
 -------------------------------
 
@@ -403,6 +506,8 @@
    PathIntegrator
    VolPathIntegrator
    VolPathMISIntegrator
+
+.. _module-eradiate.scenes.spectra:
 
 ``eradiate.scenes.spectra``
 ---------------------------

--- a/docs/src/release_notes/v0.27.x.md
+++ b/docs/src/release_notes/v0.27.x.md
@@ -30,6 +30,9 @@ When upgrading, please check the following:
   {meth}`.AbsorptionDatabase.from_name` and {meth}`.AbsorptionDatabase.from_directory`
   constructors), as well as the
   {doc}`molecular atmosphere tutorial </tutorials/getting_started/molecular_atmosphere>`.
+* The `distant` keyword is now assigned to the {class}`.DistantMeasure` type. To
+  reference the {class}`.MultiDistantMeasure` type in dict-based constructors,
+  use the `mdistant` keyword.
 ```
 
 ### Deprecated
@@ -107,7 +110,25 @@ When upgrading, please check the following:
 
 * Update data documentation with more details on data formats and built-in data
   content ({ghpr}`415`).
+* ⚠️ The `distant` Mitsuba sensor plugin is now exposed as the `distant` measure,
+  implemented by the {class}`.DistantMeasure` class. This is a breaking change,
+  as the `distant` factory keyword was previously assigned to the
+  {class}`MultiDistantMeasure` class. This action contributes to aligning
+  measure factory keywords with their corresponding Mitsuba plugin IDs
+  ({ghpr}`416`).
+* Added the {class}`.MultiPixelDistantMeasure` class (keyword `mpdistant`)
+  ({ghpr}`416`).
+
+### Fixed
+
+* Fixed the {func}`.unstack_mdistant_grid()` after a regression due to "recent"
+  changes in xarray internals that broke multi-index-based reindexing ({ghpr}`416`).
 
 ### Internal changes
 
-* 🖥️ Generated documentation pages now use Jinja templates ({ghpr}`415`).
+* 📖 Generated documentation pages now use Jinja templates ({ghpr}`415`).
+* 🖥️ Refactored the distant measure line. The common abstract class is now named
+  {class}`.AbstractDistantMeasure` ({ghpr}`416`).
+* 🖥️ Refactored the tests for the `frame` module ({ghpr}`416`).
+* 🖥️ Added built-in conversion protocol for the {class}`.AzimuthConvention` and
+  {class}`.ProgressLevel` enums ({ghpr}`416`).

--- a/src/eradiate/experiments/_atmosphere.py
+++ b/src/eradiate/experiments/_atmosphere.py
@@ -27,7 +27,7 @@ from ..scenes.geometry import (
     SphericalShellGeometry,
 )
 from ..scenes.integrators import Integrator, VolPathIntegrator, integrator_factory
-from ..scenes.measure import DistantMeasure, Measure, TargetPoint
+from ..scenes.measure import AbstractDistantMeasure, Measure, TargetPoint
 from ..scenes.surface import BasicSurface
 from ..units import unit_context_config as ucc
 
@@ -153,7 +153,7 @@ class AtmosphereExperiment(EarthObservationExperiment):
         overridden if relevant.
         """
         for measure in self.measures:
-            if isinstance(measure, DistantMeasure) and measure.target is None:
+            if isinstance(measure, AbstractDistantMeasure) and measure.target is None:
                 if isinstance(self.geometry, PlaneParallelGeometry):
                     # Plane parallel geometry: target ground level
                     target_point = [0.0, 0.0, 0.0] * ucc.get("length")

--- a/src/eradiate/experiments/_canopy_atmosphere.py
+++ b/src/eradiate/experiments/_canopy_atmosphere.py
@@ -33,7 +33,7 @@ from ..scenes.integrators import (
     VolPathIntegrator,
     integrator_factory,
 )
-from ..scenes.measure import DistantMeasure, Measure
+from ..scenes.measure import AbstractDistantMeasure, Measure
 from ..scenes.shapes import RectangleShape
 from ..scenes.surface import BasicSurface, CentralPatchSurface
 from ..units import unit_context_config as ucc
@@ -222,7 +222,7 @@ class CanopyAtmosphereExperiment(EarthObservationExperiment):
         """
         for measure in self.measures:
             # Override ray target location if relevant
-            if isinstance(measure, DistantMeasure):
+            if isinstance(measure, AbstractDistantMeasure):
                 if measure.target is None:
                     if self.canopy is None:  # No canopy: target origin point
                         measure.target = {"type": "point", "xyz": [0, 0, 0]}

--- a/src/eradiate/experiments/_dem.py
+++ b/src/eradiate/experiments/_dem.py
@@ -27,7 +27,7 @@ from ..scenes.geometry import (
     SphericalShellGeometry,
 )
 from ..scenes.integrators import Integrator, VolPathIntegrator, integrator_factory
-from ..scenes.measure import DistantMeasure, Measure, TargetPoint
+from ..scenes.measure import AbstractDistantMeasure, Measure, TargetPoint
 from ..scenes.surface import BasicSurface, DEMSurface
 
 
@@ -161,7 +161,7 @@ class DEMExperiment(EarthObservationExperiment):
         """
         for measure in self.measures:
             # Override ray target location if relevant
-            if isinstance(measure, DistantMeasure):
+            if isinstance(measure, AbstractDistantMeasure):
                 if isinstance(self.surface, DEMSurface):
                     if measure.target is None:
                         msg = (

--- a/src/eradiate/experiments/_helpers.py
+++ b/src/eradiate/experiments/_helpers.py
@@ -4,7 +4,7 @@ from ..scenes.atmosphere import Atmosphere, MolecularAtmosphere
 from ..scenes.bsdfs import BSDF, bsdf_factory
 from ..scenes.geometry import SceneGeometry
 from ..scenes.measure import (
-    DistantMeasure,
+    AbstractDistantMeasure,
     Measure,
     MultiRadiancemeterMeasure,
     RadiancemeterMeasure,
@@ -42,7 +42,7 @@ def measure_inside_atmosphere(atmosphere: Atmosphere, measure: Measure) -> bool:
                 "atmosphere."
             )
 
-    elif isinstance(measure, DistantMeasure):
+    elif isinstance(measure, AbstractDistantMeasure):
         # Note: This will break if the user makes something weird such as using
         # a large offset value which would put some origins outside and others
         # inside the atmosphere shape

--- a/src/eradiate/frame.py
+++ b/src/eradiate/frame.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import enum
+import typing as t
 
 import aenum
 import numpy as np
@@ -27,6 +28,41 @@ class AzimuthConvention(enum.Enum):
     WEST_LEFT = (np.pi, -1)  #: West left
     SOUTH_RIGHT = (1.5 * np.pi, 1)  #: South right
     SOUTH_LEFT = (1.5 * np.pi, -1)  #: South left
+
+    @staticmethod
+    def convert(value: t.Any) -> AzimuthConvention:
+        """
+        Attempt conversion of a value to an :class:`.AzimuthConvention`
+        instance. The conversion protocol is as follows:
+
+        * If ``value`` is a string, it is converted to upper case and passed to
+          the indexing operator of :class:`.AzimuthConvention`.
+        * If ``value`` is an :class:`.AzimuthConvention` instance, it is returned
+          without change.
+        * Otherwise, the method raises an exception.
+
+        Parameters
+        ----------
+        value
+            Value to attempt conversion of.
+
+        Returns
+        -------
+        Converted value
+
+        Raises
+        ------
+        TypeError
+            If no conversion protocol exists for ``value``.
+        """
+        if isinstance(value, str):
+            return AzimuthConvention[value.upper()]
+        elif isinstance(value, AzimuthConvention):
+            return value
+        else:
+            raise TypeError(
+                f"Cannot convert a {type(value)} instance to AzimuthConvention"
+            )
 
     @classmethod
     def register(cls, name: str, value: tuple[float, float]) -> None:
@@ -132,11 +168,8 @@ def transform_azimuth(
     """
     result = angles if inplace else np.copy(angles)
 
-    if isinstance(from_convention, str):
-        from_convention = AzimuthConvention[from_convention.upper()]
-
-    if isinstance(to_convention, str):
-        to_convention = AzimuthConvention[to_convention.upper()]
+    from_convention = AzimuthConvention.convert(from_convention)
+    to_convention = AzimuthConvention.convert(to_convention)
 
     if from_convention is not to_convention:
         from_offset, from_orientation = from_convention.value

--- a/src/eradiate/scenes/measure/__init__.pyi
+++ b/src/eradiate/scenes/measure/__init__.pyi
@@ -1,5 +1,6 @@
 from ._core import Measure as Measure
 from ._core import measure_factory as measure_factory
+from ._distant import AbstractDistantMeasure as AbstractDistantMeasure
 from ._distant import DistantMeasure as DistantMeasure
 from ._distant import Target as Target
 from ._distant import TargetPoint as TargetPoint

--- a/src/eradiate/scenes/measure/__init__.pyi
+++ b/src/eradiate/scenes/measure/__init__.pyi
@@ -2,6 +2,7 @@ from ._core import Measure as Measure
 from ._core import measure_factory as measure_factory
 from ._distant import AbstractDistantMeasure as AbstractDistantMeasure
 from ._distant import DistantMeasure as DistantMeasure
+from ._distant import MultiPixelDistantMeasure as MultiPixelDistantMeasure
 from ._distant import Target as Target
 from ._distant import TargetPoint as TargetPoint
 from ._distant import TargetRectangle as TargetRectangle

--- a/src/eradiate/scenes/measure/_core.py
+++ b/src/eradiate/scenes/measure/_core.py
@@ -29,6 +29,11 @@ measure_factory = Factory()
 measure_factory.register_lazy_batch(
     [
         (
+            "_distant.DistantMeasure",
+            "distant",
+            {},
+        ),
+        (
             "_distant_flux.DistantFluxMeasure",
             "distant_flux",
             {"aliases": ["distantflux"]},
@@ -41,7 +46,7 @@ measure_factory.register_lazy_batch(
         (
             "_multi_distant.MultiDistantMeasure",
             "multi_distant",
-            {"aliases": ["mdistant", "distant"]},
+            {"aliases": ["mdistant"]},
         ),
         (
             "_multi_radiancemeter.MultiRadiancemeterMeasure",
@@ -279,14 +284,18 @@ class Measure(NodeSceneElement, ABC):
             "sampler.type": self.sampler,
             "sampler.sample_count": self.spp,
             "medium.type": InitParameter(
-                lambda ctx: "ref"
-                if f"{self.sensor_id}.atmosphere_medium_id" in ctx.kwargs
-                else InitParameter.UNUSED,
+                lambda ctx: (
+                    "ref"
+                    if f"{self.sensor_id}.atmosphere_medium_id" in ctx.kwargs
+                    else InitParameter.UNUSED
+                ),
             ),
             "medium.id": InitParameter(
-                lambda ctx: ctx.kwargs[f"{self.sensor_id}.atmosphere_medium_id"]
-                if f"{self.sensor_id}.atmosphere_medium_id" in ctx.kwargs
-                else InitParameter.UNUSED,
+                lambda ctx: (
+                    ctx.kwargs[f"{self.sensor_id}.atmosphere_medium_id"]
+                    if f"{self.sensor_id}.atmosphere_medium_id" in ctx.kwargs
+                    else InitParameter.UNUSED
+                ),
             ),
         }
 

--- a/src/eradiate/scenes/measure/_core.py
+++ b/src/eradiate/scenes/measure/_core.py
@@ -34,6 +34,11 @@ measure_factory.register_lazy_batch(
             {},
         ),
         (
+            "_distant.MultiPixelDistantMeasure",
+            "mpdistant",
+            {},
+        ),
+        (
             "_distant_flux.DistantFluxMeasure",
             "distant_flux",
             {"aliases": ["distantflux"]},

--- a/src/eradiate/scenes/measure/_distant.py
+++ b/src/eradiate/scenes/measure/_distant.py
@@ -444,3 +444,151 @@ class DistantMeasure(AbstractDistantMeasure):
             "long_name": "radiance",
             "units": symbol(uck.get("radiance")),
         }
+
+
+@parse_docs
+@attrs.define(eq=False, slots=False)
+class MultiPixelDistantMeasure(AbstractDistantMeasure):
+    """
+    Multi-pixel distant measure scene element [``mpdistant``, ``multipixel_distant``]
+
+    This scene element records radiance leaving the scene in a single direction
+    defined by its ``direction`` parameter. Most users will however find the
+    :class:`.MultiDistantMeasure` class more flexible.
+    """
+
+    # --------------------------------------------------------------------------
+    #                           Fields and properties
+    # --------------------------------------------------------------------------
+
+    azimuth_convention: frame.AzimuthConvention = documented(
+        attrs.field(
+            default=None,
+            converter=lambda x: (
+                settings.azimuth_convention
+                if x is None
+                else frame.AzimuthConvention.convert(x)
+            ),
+            validator=attrs.validators.instance_of(frame.AzimuthConvention),
+        ),
+        doc="Azimuth convention. If ``None``, the global default configuration "
+        "is used (see :ref:`sec-user_guide-config`).",
+        type=".AzimuthConvention",
+        init_type=".AzimuthConvention or str, optional",
+        default="None",
+    )
+
+    direction: np.ndarray = documented(
+        attrs.field(
+            default=[0, 0, 1],
+            converter=np.array,
+            validator=validators.is_vector3,
+        ),
+        doc="A 3-vector defining the direction observed by the sensor, pointing "
+        "outwards the target.",
+        type="ndarray",
+        init_type="array-like",
+        default="[0, 0, 1]",
+    )
+
+    _film_resolution: tuple[int, int] = documented(
+        attrs.field(
+            default=(32, 32),
+            validator=attrs.validators.deep_iterable(
+                member_validator=attrs.validators.instance_of(int),
+                iterable_validator=validators.has_len(2),
+            ),
+        ),
+        doc="Film resolution as a (width, height) 2-tuple.",
+        type="array-like",
+        default="(32, 32)",
+    )
+
+    @property
+    def film_resolution(self) -> tuple[int, int]:
+        return self._film_resolution
+
+    @property
+    def viewing_angles(self) -> pint.Quantity:
+        """
+        quantity: Viewing angles computed from stored film coordinates as a
+            (width, height, 2) array. The last dimension is ordered as
+            (zenith, azimuth).
+        """
+        angles: pint.Quantity = frame.direction_to_angles(
+            self.direction, azimuth_convention=self.azimuth_convention
+        ).squeeze()
+        shape = (*self.film_resolution, 2)
+        return np.broadcast_to(angles.m, shape) * angles.u
+
+    # --------------------------------------------------------------------------
+    #                         Additional constructors
+    # --------------------------------------------------------------------------
+
+    @classmethod
+    def from_angles(cls, angles: pint.Quantity, **kwargs) -> MultiPixelDistantMeasure:
+        """
+        Construct using a direction layout defined by explicit (zenith, azimuth)
+        pairs.
+
+        Parameters
+        ----------
+        angles : array-like
+            A (zenith, azimuth) pair, either as a quantity or a unitless
+            array-like. In the latter case, the default angle units are applied.
+
+        azimuth_convention : .AzimuthConvention or str, optional
+            The azimuth convention applying to the viewing direction layout.
+            If unset, the global default convention is used.
+
+        **kwargs
+            Remaining keyword arguments are forwarded to the
+            :class:`.DistantMeasure` constructor.
+
+        Returns
+        -------
+        DistantMeasure
+        """
+        azimuth_convention = kwargs.pop("azimuth_convention", None)
+        if azimuth_convention is None:
+            azimuth_convention = settings.azimuth_convention
+
+        angles = ensure_units(angles, default_units=ucc.get("angle")).m_as(ureg.rad)
+        direction = np.squeeze(
+            frame.angles_to_direction(
+                angles=angles, azimuth_convention=azimuth_convention
+            )
+        )
+        return cls(direction=direction, **kwargs)
+
+    # --------------------------------------------------------------------------
+    #                       Kernel dictionary generation
+    # --------------------------------------------------------------------------
+
+    @property
+    def kernel_type(self) -> str:
+        # Inherit docstring
+        return "mpdistant"
+
+    @property
+    def template(self) -> dict:
+        # Inherit docstring
+        result = super().template
+        result["direction"] = mi.ScalarVector3f(-self.direction)
+
+        if self.target is not None:
+            result["target"] = self.target.kernel_item()
+
+        if self.ray_offset is not None:
+            result["ray_offset"] = self.ray_offset.m_as(uck.get("length"))
+
+        return result
+
+    @property
+    def var(self) -> tuple[str, dict]:
+        # Inherit docstring
+        return "radiance", {
+            "standard_name": "radiance",
+            "long_name": "radiance",
+            "units": symbol(uck.get("radiance")),
+        }

--- a/src/eradiate/scenes/measure/_distant_flux.py
+++ b/src/eradiate/scenes/measure/_distant_flux.py
@@ -5,7 +5,7 @@ import mitsuba as mi
 import numpy as np
 import pint
 
-from ._distant import DistantMeasure
+from ._distant import AbstractDistantMeasure
 from ... import frame, validators
 from ...attrs import documented, parse_docs
 from ...config import settings
@@ -17,7 +17,7 @@ from ...warp import square_to_uniform_hemisphere
 
 @parse_docs
 @attrs.define(eq=False, slots=False)
-class DistantFluxMeasure(DistantMeasure):
+class DistantFluxMeasure(AbstractDistantMeasure):
     """
     Distant radiosity measure scene element [``distantflux``, ``distant_flux``].
 

--- a/src/eradiate/scenes/measure/_hemispherical_distant.py
+++ b/src/eradiate/scenes/measure/_hemispherical_distant.py
@@ -7,7 +7,7 @@ import numpy as np
 import pint
 import pinttr
 
-from ._distant import DistantMeasure
+from ._distant import AbstractDistantMeasure
 from ... import frame, validators
 from ...attrs import documented, parse_docs
 from ...config import settings
@@ -20,7 +20,7 @@ from ...warp import square_to_uniform_hemisphere
 
 @parse_docs
 @attrs.define(eq=False, slots=False)
-class HemisphericalDistantMeasure(DistantMeasure):
+class HemisphericalDistantMeasure(AbstractDistantMeasure):
     """
     Hemispherical distant radiance measure scene element
     [``hdistant``, ``hemispherical_distant``].

--- a/src/eradiate/scenes/measure/_multi_distant.py
+++ b/src/eradiate/scenes/measure/_multi_distant.py
@@ -8,7 +8,7 @@ import numpy as np
 import pint
 import pinttr
 
-from ._distant import DistantMeasure
+from ._distant import AbstractDistantMeasure
 from ... import converters, frame
 from ...attrs import documented, parse_docs
 from ...config import settings
@@ -406,7 +406,7 @@ def _extract_kwargs(kwargs: dict, keys: list[str]) -> dict:
 
 @parse_docs
 @attrs.define(eq=False, slots=False)
-class MultiDistantMeasure(DistantMeasure):
+class MultiDistantMeasure(AbstractDistantMeasure):
     """
     Multi-distant radiance measure scene element [``distant``, ``mdistant``, \
     ``multi_distant``].

--- a/src/eradiate/scenes/measure/_multi_distant.py
+++ b/src/eradiate/scenes/measure/_multi_distant.py
@@ -408,8 +408,7 @@ def _extract_kwargs(kwargs: dict, keys: list[str]) -> dict:
 @attrs.define(eq=False, slots=False)
 class MultiDistantMeasure(AbstractDistantMeasure):
     """
-    Multi-distant radiance measure scene element [``distant``, ``mdistant``, \
-    ``multi_distant``].
+    Multi-distant radiance measure scene element [``mdistant``, ``multi_distant``].
 
     This scene element creates a measure consisting of an array of
     radiancemeters positioned at an infinite distance from the scene. In

--- a/src/eradiate/scenes/measure/_multi_distant.py
+++ b/src/eradiate/scenes/measure/_multi_distant.py
@@ -36,7 +36,7 @@ class Layout(ABC):
             converter=lambda x: (
                 settings.azimuth_convention
                 if x is None
-                else (frame.AzimuthConvention[x.upper()] if isinstance(x, str) else x)
+                else frame.AzimuthConvention.convert(x)
             ),
             validator=attrs.validators.instance_of(frame.AzimuthConvention),
             kw_only=True,

--- a/src/eradiate/xarray/interp.py
+++ b/src/eradiate/xarray/interp.py
@@ -63,10 +63,8 @@ def film_to_angular(
     # Define azimuth convention
     if azimuth_convention is None:
         azimuth_convention = settings.azimuth_convention
-    elif isinstance(azimuth_convention, str):
-        azimuth_convention = frame.AzimuthConvention[azimuth_convention.upper()]
     else:
-        pass
+        azimuth_convention = frame.AzimuthConvention.convert(azimuth_convention)
 
     # Interpolate values on angular grid
     data = np.empty((len(phi), len(theta)))

--- a/tests/01_unit/experiments/test_atmosphere.py
+++ b/tests/01_unit/experiments/test_atmosphere.py
@@ -56,9 +56,9 @@ def test_atmosphere_experiment_construct_measures(modes_all_double):
 
     # Init from a dict-based measure spec
     # -- Correctly wrapped in a sequence
-    assert AtmosphereExperiment(measures=[{"type": "distant"}])
+    assert AtmosphereExperiment(measures=[{"type": "mdistant"}])
     # -- Not wrapped in a sequence
-    assert AtmosphereExperiment(measures={"type": "distant"})
+    assert AtmosphereExperiment(measures={"type": "mdistant"})
 
 
 @pytest.mark.parametrize(
@@ -91,7 +91,7 @@ def test_atmosphere_experiment_kernel_dict(mode_mono):
     exp = AtmosphereExperiment(
         geometry={"type": "plane_parallel", "width": 42.0, "width_units": "km"},
         atmosphere=HomogeneousAtmosphere(),
-        measures={"type": "distant"},
+        measures={"type": "mdistant"},
     )
     mi_wrapper = check_scene_element(
         exp.scene, mi.Scene, drop_parameters=False
@@ -112,7 +112,7 @@ def test_atmosphere_experiment_kernel_dict(mode_mono):
         atmosphere=None,
         surface={"type": "lambertian"},
         measures=[
-            {"type": "distant", "id": "distant_measure"},
+            {"type": "mdistant", "id": "mdistant_measure"},
             {"type": "radiancemeter", "origin": [1, 0, 0], "id": "radiancemeter"},
         ],
     )
@@ -143,7 +143,7 @@ def test_atmosphere_experiment_real_life(
         },
         illumination={"type": "directional", "zenith": 45.0},
         measures=[
-            {"type": "distant", "id": "distant_measure"},
+            {"type": "mdistant", "id": "mdistant_measure"},
             {"type": "radiancemeter", "origin": [1, 0, 0], "id": "radiancemeter"},
         ],
     )
@@ -173,7 +173,7 @@ def test_atmosphere_experiment_run_basic(
         },
         surface={"type": "lambertian"},
         measures={
-            "type": "distant",
+            "type": "mdistant",
             "id": "distant_measure",
             "srf": MultiDeltaSpectrum(wavelengths=550.0 * ureg.nm),
         },

--- a/tests/01_unit/experiments/test_canopy.py
+++ b/tests/01_unit/experiments/test_canopy.py
@@ -29,9 +29,9 @@ def test_canopy_experiment_construct_measures(mode_mono_double):
 
     # Init from a dict-based measure spec
     # -- Correctly wrapped in a sequence
-    assert CanopyExperiment(measures=[{"type": "distant"}])
+    assert CanopyExperiment(measures=[{"type": "mdistant"}])
     # -- Not wrapped in a sequence
-    assert CanopyExperiment(measures={"type": "distant"})
+    assert CanopyExperiment(measures={"type": "mdistant"})
 
 
 @pytest.mark.parametrize("padding", (0, 1))
@@ -96,7 +96,7 @@ def test_canopy_experiment_real_life(modes_all_double):
         },
         illumination={"type": "directional", "zenith": 45.0},
         measures={
-            "type": "distant",
+            "type": "mdistant",
             "construct": "hplane",
             "zeniths": np.arange(-60, 61, 5),
             "azimuth": 0.0,

--- a/tests/01_unit/experiments/test_canopy_atmosphere.py
+++ b/tests/01_unit/experiments/test_canopy_atmosphere.py
@@ -32,10 +32,10 @@ def test_canopy_atmosphere_experiment_construct_measures(mode_mono):
 
     # Init from a dict-based measure spec
     # -- Correctly wrapped in a sequence
-    assert CanopyAtmosphereExperiment(measures=[{"type": "distant"}])
+    assert CanopyAtmosphereExperiment(measures=[{"type": "mdistant"}])
 
     # -- Not wrapped in a sequence
-    assert CanopyAtmosphereExperiment(measures={"type": "distant"})
+    assert CanopyAtmosphereExperiment(measures={"type": "mdistant"})
 
 
 @pytest.mark.parametrize("padding", (0, 1))
@@ -96,7 +96,7 @@ def test_canopy_atmosphere_experiment_kernel_dict(mode_mono, padding):
             padding=padding,
         ),
         measures=[
-            {"type": "distant", "id": "distant_measure"},
+            {"type": "mdistant", "id": "mdistant_measure"},
             {"type": "radiancemeter", "origin": [1, 0, 0], "id": "radiancemeter"},
         ],
     )
@@ -194,7 +194,7 @@ def test_canopy_atmosphere_experiment_real_life(
         illumination={"type": "directional", "zenith": 45.0},
         measures=[
             {
-                "type": "distant",
+                "type": "mdistant",
                 "construct": "hplane",
                 "zeniths": np.arange(-60, 61, 5),
                 "azimuth": 0.0,
@@ -223,7 +223,7 @@ def test_canopy_atmosphere_experiment_run_detailed(mode_mono):
         measures=[
             {
                 "id": "toa_brf",
-                "type": "distant",
+                "type": "mdistant",
                 "construct": "hplane",
                 "zeniths": np.arange(-60, 61, 5),
                 "azimuth": 0.0,

--- a/tests/01_unit/experiments/test_dem.py
+++ b/tests/01_unit/experiments/test_dem.py
@@ -34,10 +34,10 @@ def test_dem_experiment_construct_measures(modes_all):
 
     # Init from a dict-based measure spec
     # -- Correctly wrapped in a sequence
-    assert DEMExperiment(measures=[{"type": "distant"}])
+    assert DEMExperiment(measures=[{"type": "mdistant"}])
 
     # -- Not wrapped in a sequence
-    assert DEMExperiment(measures={"type": "distant"})
+    assert DEMExperiment(measures={"type": "mdistant"})
 
 
 def test_dem_experiment_construct_normalize_measures(mode_mono):
@@ -57,7 +57,7 @@ def test_dem_experiment_ckd(mode_ckd, atmosphere_us_standard_ckd):
     exp = DEMExperiment(
         atmosphere=atmosphere_us_standard_ckd,
         surface={"type": "lambertian"},
-        measures={"type": "distant", "id": "distant_measure"},
+        measures={"type": "mdistant", "id": "mdistant_measure"},
     )
     check_scene_element(exp.scene, mi.Scene, ctx=exp.context_init)
 
@@ -72,7 +72,7 @@ def test_dem_experiment_kernel_dict(modes_all_double):
         atmosphere=None,
         surface={"type": "lambertian"},
         measures=[
-            {"type": "distant", "id": "distant_measure"},
+            {"type": "mdistant", "id": "mdistant_measure"},
             {"type": "radiancemeter", "origin": [1, 0, 0], "id": "radiancemeter"},
         ],
     )
@@ -102,7 +102,7 @@ def test_dem_experiment_real_life(mode_mono, atmosphere_us_standard_mono):
         },
         illumination={"type": "directional", "zenith": 45.0},
         measures=[
-            {"type": "distant", "id": "distant_measure"},
+            {"type": "mdistant", "id": "mdistant_measure"},
             {"type": "radiancemeter", "origin": [1, 0, 0], "id": "radiancemeter"},
         ],
     )
@@ -234,8 +234,8 @@ def test_dem_experiment_warn_targeting_dem(modes_all_double, tmpdir):
             ),
             measures=[
                 {
-                    "type": "distant",
-                    "id": "distant_measure",
+                    "type": "mdistant",
+                    "id": "mdistant_measure",
                     "target": {"type": "point", "xyz": [1, 1, 0]},
                 },
             ],

--- a/tests/01_unit/kernel/test_render.py
+++ b/tests/01_unit/kernel/test_render.py
@@ -120,7 +120,7 @@ def test_mi_render(mode_mono):
                 "bsdf": {"type": "diffuse", "id": "my_bsdf"},
             },
             "sensor": {
-                "type": "distant",
+                "type": "mdistant",
                 "film": {"type": "hdrfilm", "width": 1, "height": 1},
                 "direction": [0, 0, -1],
                 "target": [0, 0, 0],
@@ -183,13 +183,13 @@ def test_mi_render_multisensor(mode_mono):
                 "bsdf": {"type": "diffuse", "id": "my_bsdf"},
             },
             "sensor1": {
-                "type": "distant",
+                "type": "mdistant",
                 "film": {"type": "hdrfilm", "width": 1, "height": 1},
                 "direction": [0, 0, -1],
                 "target": [0, 0, 0],
             },
             "sensor2": {
-                "type": "distant",
+                "type": "mdistant",
                 "film": {"type": "hdrfilm", "width": 1, "height": 1},
                 "direction": [0, 0, -1],
                 "target": [0, 0, 0],

--- a/tests/01_unit/scenes/measure/test_distant.py
+++ b/tests/01_unit/scenes/measure/test_distant.py
@@ -1,0 +1,56 @@
+import mitsuba as mi
+import numpy as np
+import pytest
+
+import eradiate
+from eradiate.experiments import AtmosphereExperiment
+from eradiate.scenes.measure import DistantMeasure
+from eradiate.test_tools.types import check_scene_element
+
+
+def test_distant_construct(mode_mono):
+    # Constructor without arguments succeeds
+    measure = DistantMeasure()
+    check_scene_element(measure, mi.Sensor)
+
+    # The from_angles() constructor sets the direction as expected
+    measure = DistantMeasure.from_angles((45.0, 90.0))
+    d = np.array([0.0, 1.0, 1.0])
+    d /= np.linalg.norm(d)
+    np.testing.assert_allclose(measure.direction, d, atol=1e-9)
+    check_scene_element(measure, mi.Sensor)
+
+    # It also applies the azimuth convention
+    measure = DistantMeasure.from_angles(
+        angles=(45.0, 90.0), azimuth_convention="north_left"
+    )
+    d = np.array([1.0, 0.0, 1.0])
+    d /= np.linalg.norm(d)
+    np.testing.assert_allclose(measure.direction, d, atol=1e-9)
+    check_scene_element(measure, mi.Sensor)
+
+
+@pytest.mark.parametrize(
+    "direction, azimuth_convention, expected",
+    [
+        ([0, 0, 1], "east_right", [[[0, 0]]]),
+        ([0, 1, 1], "east_right", [[[45, 90]]]),
+        ([0, 1, 1], "north_left", [[[45, 0]]]),
+    ],
+)
+def test_distant_angles(mode_mono, direction, azimuth_convention, expected):
+    measure = DistantMeasure(direction=direction, azimuth_convention=azimuth_convention)
+    np.testing.assert_allclose(measure.viewing_angles.m_as("deg"), expected)
+
+
+def test_distant_full_scene(mode_mono):
+    # This is a smoke test that runs a very simple simulation to check that the
+    # full processing chain runs without crashing
+    exp = AtmosphereExperiment(
+        atmosphere=None,
+        illumination={"type": "directional", "irradiance": np.pi},
+        surface={"type": "lambertian", "reflectance": 1.0},
+        measures={"type": "distant"},
+    )
+    result = eradiate.run(exp, spp=1)
+    np.testing.assert_allclose(result.radiance.squeeze().values, 1.0)

--- a/tests/01_unit/scenes/measure/test_distant.py
+++ b/tests/01_unit/scenes/measure/test_distant.py
@@ -4,26 +4,29 @@ import pytest
 
 import eradiate
 from eradiate.experiments import AtmosphereExperiment
-from eradiate.scenes.measure import DistantMeasure
+from eradiate.scenes.measure import DistantMeasure, MultiPixelDistantMeasure
 from eradiate.test_tools.types import check_scene_element
 
 
-def test_distant_construct(mode_mono):
+@pytest.mark.parametrize(
+    "cls",
+    [DistantMeasure, MultiPixelDistantMeasure],
+    ids=["distant", "mpdistant"],
+)
+def test_distant_construct(mode_mono, cls):
     # Constructor without arguments succeeds
-    measure = DistantMeasure()
+    measure = cls()
     check_scene_element(measure, mi.Sensor)
 
     # The from_angles() constructor sets the direction as expected
-    measure = DistantMeasure.from_angles((45.0, 90.0))
+    measure = cls.from_angles((45.0, 90.0))
     d = np.array([0.0, 1.0, 1.0])
     d /= np.linalg.norm(d)
     np.testing.assert_allclose(measure.direction, d, atol=1e-9)
     check_scene_element(measure, mi.Sensor)
 
     # It also applies the azimuth convention
-    measure = DistantMeasure.from_angles(
-        angles=(45.0, 90.0), azimuth_convention="north_left"
-    )
+    measure = cls.from_angles(angles=(45.0, 90.0), azimuth_convention="north_left")
     d = np.array([1.0, 0.0, 1.0])
     d /= np.linalg.norm(d)
     np.testing.assert_allclose(measure.direction, d, atol=1e-9)
@@ -38,19 +41,47 @@ def test_distant_construct(mode_mono):
         ([0, 1, 1], "north_left", [[[45, 0]]]),
     ],
 )
-def test_distant_angles(mode_mono, direction, azimuth_convention, expected):
+def test_distant_viewing_angles(mode_mono, direction, azimuth_convention, expected):
     measure = DistantMeasure(direction=direction, azimuth_convention=azimuth_convention)
     np.testing.assert_allclose(measure.viewing_angles.m_as("deg"), expected)
 
 
-def test_distant_full_scene(mode_mono):
+@pytest.mark.parametrize(
+    "direction, azimuth_convention, expected",
+    [
+        ([0, 0, 1], "east_right", [0, 0]),
+        ([0, 1, 1], "east_right", [45, 90]),
+        ([0, 1, 1], "north_left", [45, 0]),
+    ],
+)
+def test_mpdistant_viewing_angles(mode_mono, direction, azimuth_convention, expected):
+    measure = MultiPixelDistantMeasure(
+        direction=direction,
+        film_resolution=(2, 2),
+        azimuth_convention=azimuth_convention,
+    )
+    expected = np.broadcast_to(expected, (2, 2, 2))
+    np.testing.assert_allclose(measure.viewing_angles.m_as("deg"), expected)
+
+
+@pytest.mark.parametrize(
+    "cls, film_shape",
+    [
+        ("distant", (1, 1)),
+        ("mpdistant", (32, 32)),
+    ],
+)
+def test_distant_full_scene(mode_mono, cls, film_shape):
     # This is a smoke test that runs a very simple simulation to check that the
     # full processing chain runs without crashing
     exp = AtmosphereExperiment(
         atmosphere=None,
         illumination={"type": "directional", "irradiance": np.pi},
         surface={"type": "lambertian", "reflectance": 1.0},
-        measures={"type": "distant"},
+        measures={"type": cls},
     )
     result = eradiate.run(exp, spp=1)
-    np.testing.assert_allclose(result.radiance.squeeze().values, 1.0)
+    np.testing.assert_allclose(
+        result.radiance.values.squeeze(),
+        np.full(film_shape, 1.0).squeeze(),
+    )

--- a/tests/01_unit/test_config.py
+++ b/tests/01_unit/test_config.py
@@ -1,0 +1,29 @@
+import pytest
+
+from eradiate.config import ProgressLevel, settings
+from eradiate.frame import AzimuthConvention
+
+
+def test_progress_level_conversion():
+    # Conversion from string is supported
+    assert ProgressLevel.convert("kernel") is ProgressLevel.KERNEL
+    with pytest.raises(KeyError):
+        ProgressLevel.convert("foo")
+
+    # Conversion of integer is supported
+    assert ProgressLevel.convert(2) is ProgressLevel.KERNEL
+
+    # AzimuthConvention instances pass through
+    assert ProgressLevel.convert(ProgressLevel.KERNEL) is ProgressLevel.KERNEL
+
+    # Other types raise
+    with pytest.raises(TypeError):
+        ProgressLevel.convert(1.0)
+
+
+def test_settings():
+    """
+    This test contains a few checks on settings.
+    """
+    assert isinstance(settings.azimuth_convention, AzimuthConvention)
+    assert isinstance(settings.progress, ProgressLevel)

--- a/tests/01_unit/test_frame.py
+++ b/tests/01_unit/test_frame.py
@@ -150,31 +150,20 @@ def test_angles_to_direction():
     )
 
 
-def test_direction_to_angles():
-    # Scalar call
-    assert np.allclose(direction_to_angles([0, 0, 1]), (0, 0))
-    assert np.allclose(
-        direction_to_angles([np.sqrt(2) / 2, np.sqrt(2) / 2, 0]).m_as(ureg.deg),
-        [90.0, 45.0],
-    )
-    assert np.allclose(
-        direction_to_angles([1, 1, 0]).m_as(ureg.deg),
-        [90.0, 45.0],
-    )
-    assert np.allclose(
-        direction_to_angles(
+@pytest.mark.parametrize(
+    "directions, expected",
+    [
+        # Scalar call
+        ([0, 0, 1], [[0, 0]] * ureg.deg),
+        ([np.sqrt(2) / 2, np.sqrt(2) / 2, 0], [[90.0, 45.0]] * ureg.deg),
+        ([1, 1, 0], [[90.0, 45.0]] * ureg.deg),
+        (
             [1 / np.sqrt(3), 1 / np.sqrt(3), 1 / np.sqrt(3)],
-        ).m_as(ureg.rad),
-        [np.arccos(1 / np.sqrt(3)), 0.25 * np.pi],
-    )
-    assert np.allclose(
-        direction_to_angles([1, 1, 1]).m_as(ureg.rad),
-        [np.arccos(1 / np.sqrt(3)), 0.25 * np.pi],
-    )
-
-    # Vectorized call
-    assert np.allclose(
-        direction_to_angles(
+            [[np.arccos(1 / np.sqrt(3)), 0.25 * np.pi]] * ureg.rad,
+        ),
+        ([1, 1, 1], [[np.arccos(1 / np.sqrt(3)), 0.25 * np.pi]] * ureg.rad),
+        # Vectorized call
+        (
             [
                 [0, 0, 1],
                 [1, 0, 1],
@@ -183,18 +172,32 @@ def test_direction_to_angles():
                 [0, 1, 0],
                 [1, 1, 1],
                 [0, 0, -1],
+            ],
+            [
+                [0, 0],
+                [0.25 * np.pi, 0],
+                [0.25 * np.pi, 0.5 * np.pi],
+                [0.5 * np.pi, 0],
+                [0.5 * np.pi, 0.5 * np.pi],
+                [np.arccos(1 / np.sqrt(3)), 0.25 * np.pi],
+                [np.pi, 0.0],
             ]
+            * ureg.rad,
         ),
-        [
-            [0, 0],
-            [0.25 * np.pi, 0],
-            [0.25 * np.pi, 0.5 * np.pi],
-            [0.5 * np.pi, 0],
-            [0.5 * np.pi, 0.5 * np.pi],
-            [np.arccos(1 / np.sqrt(3)), 0.25 * np.pi],
-            [np.pi, 0.0],
-        ],
-    )
+    ],
+    ids=[
+        "scalar-0",
+        "scalar-1",
+        "scalar-2",
+        "scalar-3",
+        "scalar-4",
+        "vectorized-0",
+    ],
+)
+def test_direction_to_angles(directions, expected):
+    value = direction_to_angles(directions).m_as("deg")
+    expected = expected.m_as("deg")
+    np.testing.assert_allclose(value, expected)
 
 
 def test_spherical_to_cartesian():
@@ -202,13 +205,13 @@ def test_spherical_to_cartesian():
     theta = np.deg2rad(30)
     phi = np.deg2rad(0)
     d = spherical_to_cartesian(r, theta, phi)
-    assert np.allclose(d, [1, 0, np.sqrt(3)])
+    np.testing.assert_allclose(d, [1, 0, np.sqrt(3)])
 
     r = ureg.Quantity(2.0, "km")
     theta = np.deg2rad(60)
     phi = np.deg2rad(30)
-    d = spherical_to_cartesian(r, theta, phi)
-    assert np.allclose(d, ureg.Quantity([3.0 / 2.0, np.sqrt(3) / 2.0, 1.0], "km"))
+    d = spherical_to_cartesian(r, theta, phi).m_as("km")
+    np.testing.assert_allclose(d, [3.0 / 2.0, np.sqrt(3) / 2.0, 1.0])
 
 
 @pytest.mark.parametrize(

--- a/tests/01_unit/test_frame.py
+++ b/tests/01_unit/test_frame.py
@@ -3,6 +3,7 @@ import pytest
 
 from eradiate import unit_registry as ureg
 from eradiate.frame import (
+    AzimuthConvention,
     angles_in_hplane,
     angles_to_direction,
     cos_angle_to_direction,
@@ -10,6 +11,23 @@ from eradiate.frame import (
     spherical_to_cartesian,
     transform_azimuth,
 )
+
+
+def test_azimuth_convention_conversion():
+    # Conversion from string is supported
+    assert AzimuthConvention.convert("north_left") is AzimuthConvention.NORTH_LEFT
+    with pytest.raises(KeyError):
+        AzimuthConvention.convert("south_foo")
+
+    # AzimuthConvention instances pass through
+    assert (
+        AzimuthConvention.convert(AzimuthConvention.NORTH_LEFT)
+        is AzimuthConvention.NORTH_LEFT
+    )
+
+    # Other types raise
+    with pytest.raises(TypeError):
+        AzimuthConvention.convert(1.0)
 
 
 def test_cos_angle_to_direction():
@@ -21,7 +39,7 @@ def test_cos_angle_to_direction():
         cos_angle_to_direction(-1.0, ureg.Quantity(135.0, "deg")), [0, 0, -1]
     )
 
-    # Vectorised call
+    # Vectorized call
     expected = np.array([[0, 0, 1], [1, 0, 0], [np.sqrt(3) / 2, 0, 0.5], [0, 0, -1]])
     assert np.allclose(
         cos_angle_to_direction([1.0, 0.0, 0.5, -1.0], [0, 0, 0.0, 0.75 * np.pi]),
@@ -154,7 +172,7 @@ def test_direction_to_angles():
         [np.arccos(1 / np.sqrt(3)), 0.25 * np.pi],
     )
 
-    # Vectorised call
+    # Vectorized call
     assert np.allclose(
         direction_to_angles(
             [

--- a/tests/02_system/test_compare_canopy_atmosphere.py
+++ b/tests/02_system/test_compare_canopy_atmosphere.py
@@ -85,7 +85,7 @@ def test_compare_canopy_atmosphere_vs_atmosphere(
         "molecular_atmosphere": molecular_atmosphere,
     }
     measure = {
-        "type": "distant",
+        "type": "mdistant",
         "id": "measure",
         "construct": "hplane",
         "zeniths": np.arange(-90, 91, 15),
@@ -219,7 +219,7 @@ def test_compare_canopy_atmosphere_vs_canopy(
         padding=5,
     )
     measure = {
-        "type": "distant",
+        "type": "mdistant",
         "id": "measure",
         "construct": "hplane",
         "zeniths": np.arange(-90, 91, 15),

--- a/tests/02_system/test_heterogeneous_atmosphere_expansion.py
+++ b/tests/02_system/test_heterogeneous_atmosphere_expansion.py
@@ -37,7 +37,7 @@ def test_heterogeneous_atmosphere_expansion_particle_layer(
 
     # Measure
     measure = {
-        "type": "distant",
+        "type": "mdistant",
         "id": "measure",
         "construct": "hplane",
         "zeniths": np.arange(-90, 91, 15),
@@ -113,7 +113,7 @@ def test_heterogeneous_atmosphere_expansion_molecular_atmosphere(
 
     # measure
     measure = {
-        "type": "distant",
+        "type": "mdistant",
         "id": "measure",
         "construct": "hplane",
         "zeniths": np.arange(-90, 90, 15),

--- a/tests/02_system/test_onedim_lambertian_brf.py
+++ b/tests/02_system/test_onedim_lambertian_brf.py
@@ -63,7 +63,7 @@ def test_onedim_lambertian_brf(mode_mono_double, artefact_dir):
                     "azimuth": 0.0,
                 },
                 measures={
-                    "type": "distant",
+                    "type": "mdistant",
                     "id": "toa_pplane",
                     "construct": "hplane",
                     "zeniths": np.linspace(-90, 90, n_vza),

--- a/tests/02_system/test_onedim_symmetry.py
+++ b/tests/02_system/test_onedim_symmetry.py
@@ -77,7 +77,7 @@ def test_symmetry_zenith(mode_mono_double, surface, atmosphere, artefact_dir):
         geometry={"type": "plane_parallel", "toa_altitude": 1.0e2 * ureg.km},
         illumination={"type": "directional", "zenith": 0.0, "azimuth": 0.0},
         measures={
-            "type": "distant",
+            "type": "mdistant",
             "id": "toa_pplane",
             "construct": "hplane",
             "zeniths": np.linspace(-89, 89, n_vza),


### PR DESCRIPTION
# Description

This PR extends the distant measure line and refactors several parts of the code. Changes are as follows:

- The distant measure line is refactored. The common abstract class is now named `AbstractDistantMeasure`.
- The `distant` Mitsuba sensor plugin is now exposed as the `distant` measure, implemented by the `DistantMeasure` class. This is a breaking change, as the `distant` factory keyword was previously assigned to the `MultiDistantMeasure` class. This action contributes to aligning measure factory keywords with their corresponding Mitsuba plugin IDs.
- A new `MultiPixelDistantMeasure` (keyword `mpdistant`) is added. This sensor records outgoing radiance based on a specified target. If the target is a `Shape` (the intended used case), film coordinates are mapped to the target's (u,v) coordinates. This allows recording "ortho-images" with a fixed footprint, which is sometimes easier than positioning a camera.
- The tests for the `frame` module are refactored for improved reporting, readability and maintainability.
- The `AzimuthConvention` and `ProgressLevel` enums now have a built-in conversion protocol.
- The `unstack_mdistant_grid()` helper is fixed after a regression due to "recent" changes in xarray internals broke multi-index-based reindexing.

# To do

- [x] Add API documentation
- [x] Clean up Mitsuba submodule commits

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
