### PR TITLE
spectral: Minor refactoring and fixes to the QuadSpec line

### DIFF
--- a/docs/src/release_notes/v0.27.x.md
+++ b/docs/src/release_notes/v0.27.x.md
@@ -144,3 +144,22 @@ data for several instruments.
 ## v0.27.2 (21st June 2024)
 
 This is a fix release. It fixes broken kernel version requirements.
+
+## v0.27.3 (upcoming release)
+
+% ### Deprecated
+%
+% ### Removed
+%
+% ### Added
+%
+% ### Changed
+%
+
+### Fixed
+
+* Fallback for unimplemented spectral quadrature specifications is now correctly
+  behaved: if no value for the maximum number of *g*-points is supplied, a
+  consistent default is used ({ghpr}`419`).
+
+% ### Internal changes


### PR DESCRIPTION
# Description

*Closes #418.*

This PR refactors and fixes the `QuadSpec` class and its subclasses. Changes are as follows:

* The number of *g*-points of the default spectral quadrature rule is now held by a constant that can be used in other parts of the code.
* Some class method constructors are turned into static methods for consistency across all `QuadSpec` subclasses.
* Fallback for unimplemented quad specs is now correctly behaved: if no value for the maximum number of *g*-points is supplied, a consistent default is used.
* The interface bug reported in #418 is fixed.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
