### PR TITLE
Improvements to `srf_tools` utilities

### DIFF
--- a/docs/rst/reference_api/srf_tools.rst
+++ b/docs/rst/reference_api/srf_tools.rst
@@ -1,5 +1,5 @@
 ``eradiate.srf_tools``
-=======================
+======================
 
 .. automodule:: eradiate.srf_tools
 
@@ -27,6 +27,8 @@ Filtering algorithms
 .. autofunction:: threshold_filter
 
 .. autofunction:: filter_srf
+
+.. autofunction:: pad_zeros
 
 Plotting
 --------

--- a/docs/src/release_notes/v0.27.x.md
+++ b/docs/src/release_notes/v0.27.x.md
@@ -151,8 +151,14 @@ This is a fix release. It fixes broken kernel version requirements.
 %
 % ### Removed
 %
-% ### Added
-%
+
+### Added
+
+* Added a new integral-based SRF filtering algorithm that enforces spectral
+  domain coverage with respect to the the SRF's mean value ({ghpr}`419`).
+* Added an SRF filter that pads an SRF dataset with leading and trailing zeros
+  ({ghpr}`419`).
+
 % ### Changed
 %
 

--- a/tests/01_unit/test_srf_tools.py
+++ b/tests/01_unit/test_srf_tools.py
@@ -116,11 +116,9 @@ def test_spectral_filter(wrange) -> None:
         assert srf_values.size == filtered.srf.size
 
 
-@pytest.mark.parametrize(
-    "percentage",
-    [50.0, 90.0, 95.0, 99.0],
-)
-def test_integral_filter(percentage) -> None:
+@pytest.mark.parametrize("percentage", [50.0, 90.0, 95.0, 99.0])
+@pytest.mark.parametrize("method, ", ["walk", "symmetry"])
+def test_integral_filter(percentage, method) -> None:
     """
     Keep only data that contribute to the integrated spectral response value
     to the amount of the specified percentage.
@@ -135,6 +133,6 @@ def test_integral_filter(percentage) -> None:
         coords={"w": ("w", w_values, {"units": "nm"})},
         attrs={"history": f"{utcnow} - data set creation"},
     )
-    filtered = integral_filter(srf=srf, percentage=percentage)
+    filtered = integral_filter(srf=srf, percentage=percentage, method=method)
 
     assert int(100 * filtered.srf.size / srf_values.size) == percentage


### PR DESCRIPTION
# Description

This PR adds two features to the `srf_tools` module. Changes are as follows:

* A new SRF filtering algorithm is added. It ensures the conservation of the mean wavelength and produces a filtered SRF support symmetrical with respect to it.

  ![image](https://github.com/eradiate/eradiate/assets/34740232/99a99006-078d-49f8-968a-c9df8d959aa9)

  *Example for MODIS band 14. The previous strategy is labelled "walk", and the new one is labelled "symmetry".*

* A new filter is added and allows to pad SRF data with leading and trailing zeros. This contributes to solving #377.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
