### PR TITLE
[Feature] Integration of the new piecewise medium and integrator into Eradiate.

### DIFF
--- a/src/eradiate/experiments/_core.py
+++ b/src/eradiate/experiments/_core.py
@@ -13,8 +13,8 @@ from hamilton.driver import Driver
 
 import eradiate
 
+from .. import converters, validators
 from .. import pipelines as pl
-from .. import validators
 from ..attrs import AUTO, documented, parse_docs
 from ..contexts import KernelContext, MultiGenerator
 from ..kernel import MitsubaObjectWrapper, mi_render, mi_traverse
@@ -27,7 +27,7 @@ from ..scenes.illumination import (
     DirectionalIllumination,
     illumination_factory,
 )
-from ..scenes.integrators import Integrator, PathIntegrator, integrator_factory
+from ..scenes.integrators import Integrator, integrator_factory
 from ..scenes.measure import (
     Measure,
     MultiDistantMeasure,
@@ -95,26 +95,23 @@ class Experiment(ABC):
         default=":class:`MultiDistantMeasure() <.MultiDistantMeasure>`",
     )
 
-    _integrator: Integrator = documented(
+    integrator: Integrator = documented(
         attrs.field(
-            factory=PathIntegrator,
-            converter=integrator_factory.convert,
-            validator=attrs.validators.instance_of(Integrator),
+            default=AUTO,
+            converter=converters.auto_or(integrator_factory.convert),
+            validator=validators.auto_or(
+                attrs.validators.instance_of(Integrator),
+            ),
         ),
         doc="Monte Carlo integration algorithm specification. "
         "This parameter can be specified as a dictionary which will be "
-        "interpreted by :data:`.integrator_factory`.",
-        type=":class:`.Integrator`",
-        init_type=":class:`.Integrator` or dict",
-        default=":class:`PathIntegrator() <.PathIntegrator>`",
+        "interpreted by :data:`.integrator_factory`."
+        "The integrator defaults to :data:`AUTO`, which will choose the appropriate "
+        "integrator depending on the experiment's configuration. ",
+        type=":class:`.Integrator` or AUTO",
+        init_type=":class:`.Integrator` or dict or AUTO",
+        default="AUTO",
     )
-
-    @property
-    def integrator(self) -> Integrator:
-        """
-        :class:`.Integrator`: Integrator used to solve the radiative transfer equation.
-        """
-        return self._integrator
 
     _results: dict[str, xr.Dataset] = attrs.field(factory=dict, repr=False)
 

--- a/src/eradiate/scenes/integrators/__init__.pyi
+++ b/src/eradiate/scenes/integrators/__init__.pyi
@@ -1,5 +1,6 @@
 from ._core import Integrator as Integrator
 from ._core import integrator_factory as integrator_factory
 from ._path_tracers import PathIntegrator as PathIntegrator
+from ._path_tracers import PiecewiseVolPathIntegrator as PiecewiseVolPathIntegrator
 from ._path_tracers import VolPathIntegrator as VolPathIntegrator
 from ._path_tracers import VolPathMISIntegrator as VolPathMISIntegrator

--- a/src/eradiate/scenes/integrators/_core.py
+++ b/src/eradiate/scenes/integrators/_core.py
@@ -14,6 +14,7 @@ integrator_factory.register_lazy_batch(
         ("_path_tracers.PathIntegrator", "path", {}),
         ("_path_tracers.VolPathIntegrator", "volpath", {}),
         ("_path_tracers.VolPathMISIntegrator", "volpathmis", {}),
+        ("_path_tracers.PiecewiseVolPathIntegrator", "piecewise_volpath", {}),
     ],
     cls_prefix="eradiate.scenes.integrators",
 )

--- a/src/eradiate/scenes/integrators/_path_tracers.py
+++ b/src/eradiate/scenes/integrators/_path_tracers.py
@@ -119,3 +119,17 @@ class VolPathMISIntegrator(MonteCarloIntegrator):
             result["use_spectral_mis"] = self.use_spectral_mis
 
         return result
+
+@parse_docs
+@attrs.define(eq=False, slots=False)
+class PiecewiseVolPathIntegrator(MonteCarloIntegrator):
+    """
+    A thin interface to the piecewise volumetric path tracer kernel plugin.
+
+    This integrator samples paths using random walks starting from the sensor.
+    It supports multiple scattering and accounts for 1D volume interactions.
+    """
+
+    @property
+    def kernel_type(self) -> str:
+        return "piecewise_volpath"


### PR DESCRIPTION
# Description

These changes integrate the new piecewise medium and piecewise volumetric integrator added to the eradiate/mitsuba3 repo into Eradiate (see eradiate/mitsuba3#9). Those changes aim to improve the performance of plane-parallel geometry simulations by doing analytical distance sampling and transmittance evaluation.

Plane-parallel geometry simulations will now use the `PiecewiseVolumetricPathIntegrator` by default. Spherical-shell geometry will revert back to the standard `VolumetricPathIntegrator`. The latter can also be enforced by specifying the integrator in the experiment, or by setting the flag `force_majorant` to true in the `Atmosphere` object:
 
```python
majorant_atmosphere = ertsc.atmosphere.MolecularAtmosphere(
    force_majorant=True, scale = 5.0
)
# or
majorant_exp = eradiate.experiments.AtmosphereExperiment(
    ...
    integrator=ertsc.integrators.VolPathIntegrator(),
)
```

The new medium and integrator were tested in various scenarios, using CKD and mono modes, with and without canopy, and over the full spectrum. The full test suite was also run.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` (`next`?) branch
- [ ] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
