### PR TITLE
experiments: Fix incorrect type check on illumination in `EarthObservationExperiment`

### DIFF
--- a/docs/src/release_notes/v0.27.x.md
+++ b/docs/src/release_notes/v0.27.x.md
@@ -155,7 +155,7 @@ This is a fix release. It fixes broken kernel version requirements.
 ### Added
 
 * Added a new integral-based SRF filtering algorithm that enforces spectral
-  domain coverage with respect to the the SRF's mean value ({ghpr}`419`).
+  domain coverage with respect to the SRF's mean value ({ghpr}`419`).
 * Added an SRF filter that pads an SRF dataset with leading and trailing zeros
   ({ghpr}`419`).
 
@@ -167,5 +167,8 @@ This is a fix release. It fixes broken kernel version requirements.
 * Fallback for unimplemented spectral quadrature specifications is now correctly
   behaved: if no value for the maximum number of *g*-points is supplied, a
   consistent default is used ({ghpr}`419`).
+* Fixed incorrect type checks performed upon initialization of all
+  {class}`.EarthObservationExperiment` child classes and in post-processing
+  pipeline logic ({ghpr}`422`).
 
 % ### Internal changes

--- a/src/eradiate/experiments/_core.py
+++ b/src/eradiate/experiments/_core.py
@@ -22,6 +22,7 @@ from ..rng import SeedState
 from ..scenes.atmosphere import AbstractHeterogeneousAtmosphere
 from ..scenes.core import Scene, SceneElement, get_factory, traverse
 from ..scenes.illumination import (
+    AbstractDirectionalIllumination,
     ConstantIllumination,
     DirectionalIllumination,
     illumination_factory,
@@ -310,19 +311,21 @@ class EarthObservationExperiment(Experiment, ABC):
         default="None",
     )
 
-    illumination: DirectionalIllumination | ConstantIllumination = documented(
+    illumination: AbstractDirectionalIllumination | ConstantIllumination = documented(
         attrs.field(
             factory=DirectionalIllumination,
             converter=illumination_factory.convert,
             validator=attrs.validators.instance_of(
-                (DirectionalIllumination, ConstantIllumination)
+                (AbstractDirectionalIllumination, ConstantIllumination)
             ),
         ),
         doc="Illumination specification. "
         "This parameter can be specified as a dictionary which will be "
         "interpreted by :data:`.illumination_factory`.",
-        type=":class:`.DirectionalIllumination`",
-        init_type=":class:`.DirectionalIllumination` or dict",
+        type=":class:`.AbstractDirectionalIllumination` or "
+        ":class:`.ConstantIllumination`",
+        init_type=":class:`.DirectionalIllumination` or "
+        ":class:`.ConstantIllumination` or dict",
         default=":class:`DirectionalIllumination() <.DirectionalIllumination>`",
     )
 

--- a/src/eradiate/pipelines/logic.py
+++ b/src/eradiate/pipelines/logic.py
@@ -14,7 +14,7 @@ from ..exceptions import UnsupportedModeError
 from ..kernel import bitmap_to_dataarray
 from ..scenes.illumination import (
     ConstantIllumination,
-    DirectionalIllumination,
+    AbstractDirectionalIllumination,
     Illumination,
 )
 from ..scenes.spectra import InterpolatedSpectrum, Spectrum, UniformSpectrum
@@ -453,7 +453,7 @@ def extract_irradiance(
             }
         )
 
-    if isinstance(illumination, DirectionalIllumination):
+    if isinstance(illumination, AbstractDirectionalIllumination):
         # Collect illumination angular data
         saa = illumination.azimuth.m_as(ureg.deg)
         sza = illumination.zenith.m_as(ureg.deg)

--- a/tests/01_unit/experiments/test_atmosphere.py
+++ b/tests/01_unit/experiments/test_atmosphere.py
@@ -27,6 +27,15 @@ def test_atmosphere_experiment_construct_default(modes_all_double):
     assert exp.atmosphere.geometry is exp.geometry
 
 
+@pytest.mark.parametrize("illumination", ["directional", "astro_object"])
+def test_atmosphere_experiment_construct_illuminations(modes_all_double, illumination):
+    """
+    AtmosphereExperiment initializes successfully with different illumination
+    types.
+    """
+    assert AtmosphereExperiment(illumination={"type": illumination})
+
+
 def test_atmosphere_experiment_extra_objects(mode_mono):
     """
     Extra objects can be added to the scene.


### PR DESCRIPTION
# Description

This PR fixes an incorrect type check performed upon initialization of all `EarthObservationExperiment` child classes. This would notably prevent using the `astro_object` illuminant.

It also fixes incorrect type checks in the post-processing pipeline logic.

These bugs were introduced during the refactoring of the `DirectionalIllumination` class hierarchy (see #409).

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
