### PR TITLE
[Feature] New benchmark test suite.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,9 @@ htmlcov/
 # Default data storage
 .eradiate_downloads/
 .scenarios/*
+
+# Airspeed Velocity (benchmarking infrastructure)
+benchmarks/env/
+benchmarks/eradiate/
+benchmarks/html/
+benchmarks/results/

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -1,0 +1,40 @@
+{
+    // see https://github.com/airspeed-velocity/asv/blob/main/asv/template/asv.conf.json
+    // for comments on various configs.
+
+    "version": 1,
+
+    "project": "eradiate",
+
+    "project_url": "https://www.eradiate.eu/site/",
+
+    "repo": "https://github.com/eradiate/eradiate.git",
+
+    "build_command": [
+        "pip install --editable . --no-deps",
+        "cmake -S ext/mitsuba -B ext/mitsuba/build -DCMAKE_BUILD_TYPE=Release -GNinja -DMI_ENABLE_EMBREE=OFF -DMI_DEFAULT_VARIANTS='scalar_rgb;scalar_mono_double' -DPYTHONPATH=./ext/mitsuba/build/python:$ASV_PYTHONPATH",
+	    "ninja -C ext/mitsuba/build"
+    ],
+
+    // skip install step with a padding command (cannot be empty)
+    "install_command": ["python --version"],
+
+    "branches": ["main", "next"], 
+    "dvcs": "git",
+    "environment_type": "conda",
+
+    "show_commit_url": "http://github.com/eradiate/eradiate/commits/",
+    "conda_environment_file": "../requirements/conda/environment-tests.yml",
+    "matrix": {
+        "req":{
+            "make":[],
+            "cmake":[],
+            "ninja":[]
+        }
+    },
+
+    "benchmark_dir": "benchmarks",
+    "env_dir": "env",
+    "results_dir": "results",
+    "html_dir": "html"
+}

--- a/benchmarks/benchmarks/__init__.py
+++ b/benchmarks/benchmarks/__init__.py
@@ -1,0 +1,13 @@
+import sys
+import os
+
+if "ASV" in os.environ:
+    asv_env_dir = os.environ["ASV_ENV_DIR"]
+
+    os.environ["ERADIATE_SOURCE_DIR"] = os.environ["ASV_ENV_DIR"]+"/project"
+    eradiate_source_dir = os.environ["ERADIATE_SOURCE_DIR"]
+
+    sys.path.insert(0, eradiate_source_dir+"/ext/mitsuba/build/python")
+
+    print("INIT SYS PATH:")
+    print(sys.path)

--- a/benchmarks/benchmarks/bench_atmosphere.py
+++ b/benchmarks/benchmarks/bench_atmosphere.py
@@ -1,0 +1,44 @@
+import eradiate
+from eradiate.test_tools.test_cases.atmospheres import (
+    absorption_database_error_handler_config,
+    create_rpv_afgl1986_brfpp,
+    create_rpv_afgl1986_continental_brfpp,
+)
+from eradiate.test_tools.util import append_doc
+
+
+class BenchmarkAtmosphere:
+    error_handler_config = None
+
+    def setup(self):
+        eradiate.set_mode("ckd")
+        self.error_handler_config = absorption_database_error_handler_config()
+
+    @append_doc(create_rpv_afgl1986_continental_brfpp)
+    def time_rpv_afgl1986_continental_brfpp(self):
+        r"""
+        RPV AFGL1986 Aerosol benchmark test
+        ====================================
+
+        This is a benchmark test, which records the time taken for the
+        experiment to run. The test is done multiple times to get a s
+        statistical result
+
+        """
+
+        exp = create_rpv_afgl1986_continental_brfpp(self.error_handler_config)
+        eradiate.run(exp, spp=1000)
+
+    @append_doc(create_rpv_afgl1986_brfpp)
+    def time_rpv_afgl1986_brfpp(self):
+        r"""
+        RPV AFGL1986 benchmark test
+        ===========================
+
+        This is a benchmark test, which records the time taken for the
+        experiment to run. The test is done multiple times to get a
+        statistical result
+
+        """
+        exp = create_rpv_afgl1986_brfpp(self.error_handler_config)
+        eradiate.run(exp, spp=1000)

--- a/benchmarks/benchmarks/bench_rami4atm.py
+++ b/benchmarks/benchmarks/bench_rami4atm.py
@@ -1,0 +1,25 @@
+import eradiate
+from eradiate.test_tools.test_cases.rami4atm import (
+    create_rami4atm_hom00_bla_sd2s_m03_z30a000_brfpp,
+)
+from eradiate.test_tools.util import append_doc
+
+
+class BenchmarkRami4ATM:
+    def setup(self):
+        eradiate.set_mode("ckd")
+
+    @append_doc(create_rami4atm_hom00_bla_sd2s_m03_z30a000_brfpp)
+    def time_rami4atm_hom00_bla_sd2s_m03_z30a000_brfpp(self):
+        r"""
+        RAMI4ATM HOM00_BLA_SD2S_M03 benchmark test
+        ==========================================
+
+        This is a benchmark test, which records the time taken for the
+        experiment to run. The test is done multiple times to get a
+        statistical result
+
+        """
+
+        exp = create_rami4atm_hom00_bla_sd2s_m03_z30a000_brfpp()
+        eradiate.run(exp)

--- a/benchmarks/benchmarks/bench_romc.py
+++ b/benchmarks/benchmarks/bench_romc.py
@@ -1,0 +1,30 @@
+import eradiate
+from eradiate.test_tools.test_cases.romc import (
+    create_het06_brfpp,
+    fetch_het06_brfpp,
+)
+from eradiate.test_tools.util import append_doc
+
+
+class BenchmarkROMC:
+    data = None
+
+    def setup(self):
+        eradiate.set_mode("ckd")
+        self.data = fetch_het06_brfpp()
+
+    @append_doc(create_het06_brfpp)
+    def time_het06_brfpp(self):
+        r"""
+        Coniferous forest (HET06) benchmark test
+        ========================================
+
+        This is a benchmark test, which records the time taken for the
+        experiment to run. The test is done multiple times to get a
+        statistical result
+
+        """
+
+        exp = create_het06_brfpp(self.data)
+        eradiate.run(exp)
+   

--- a/benchmarks/eradiate.toml
+++ b/benchmarks/eradiate.toml
@@ -1,0 +1,49 @@
+## This is the default configuration file for Eradiate.
+## All settings below can be set using environment variables with the
+## `ERADIATE_` prefix (e.g. the `download_dir` can be set with the
+## `ERADIATE_DOWNLOAD_DIR` variable).
+##
+## The configuration module will look for a file named `eradiate.toml`
+## in the current working directory, then walk up the file system until it finds
+## one.
+
+## -----------------------------------------------------------------------------
+##                           CONFIGURATION STARTS HERE
+## -----------------------------------------------------------------------------
+
+## Default azimuth convention
+## (see https://eradiate.readthedocs.io/en/stable/rst/user_guide/conventions.html#azimuth-definition-conventions)
+azimuth_convention = "east_right"
+
+## Progress information display
+## (from least to most verbose: none, spectral_loop or kernel)
+progress = "spectral_loop"
+
+## -----------------------------------------------------------------------------
+##                           Data store configuration
+## -----------------------------------------------------------------------------
+
+## Path where data files are downloaded, unset by default. Default behaviour is
+## as follows:
+## * If ERADIATE_SOURCE_DIR is defined, the default is $ERADIATE_SOURCE_DIR/.eradiate_downloads/
+## * If ERADIATE_SOURCE_DIR is not defined, the default is $PWD/.eradiate_downloads/
+download_dir = "../.eradiate_downloads"
+
+## Path to the large file repository
+data_store_url = "https://eradiate.eu/data/store/"
+
+## Path to the small file repository registry
+small_files_registry_url = "https://raw.githubusercontent.com/eradiate/eradiate-data"
+small_files_registry_revision = "master"
+
+## Offline mode switch: if true, data download attempts will be suppressed
+offline = false
+
+[absorption_database.error_handling]
+# This default configuration ignores bound errors on pressure and temperature
+# variables because this usually occurs at high altitude, where the absorption
+# coefficient is very low and can be safely forced to 0.
+p = {missing = "raise", scalar = "raise", bounds = "ignore"}
+t = {missing = "raise", scalar = "raise", bounds = "ignore"}
+# Ignore missing molecule coordinates, raise on bound error.
+x = {missing = "ignore", scalar = "ignore", bounds = "raise"}

--- a/docs/rst/developer_guide/benchmark.rst
+++ b/docs/rst/developer_guide/benchmark.rst
@@ -1,0 +1,54 @@
+Benchmarking
+============
+
+Run Benchmarks
+--------------
+Eradiate's benchmarking suite is based on the ASV package which enables
+tracking a project's performance over time.
+To run the benchmark suite:
+
+.. code:: bash
+
+    conda activate <env name>
+    cd benchmarks
+    python -m eradiate.test_tools.benchmark.benchmark
+
+By default, it will run the benchmark using the currently active environment.
+For dev environments, this means that you need an operational version
+of eradiate. Note that environments that use production versions prior
+to v0.28.xx cannot be benchmarked as they do no include changes required
+for the benchmark.
+
+If you want to archive results to a separate **asv database**, add the
+``--archive-dir=<dir>`` argument. The path should point to the root
+of the database, where the asv.conf.json exists.
+
+ASV also offers the possibility to run benchmarks on previous commits
+and branches. It will clone and build the project in a new environment
+and run the benchmarks on those. To use this, specify the ``--git-ref=<range>``
+as a range, e.g. ``main^!`` for the last commit of the ``main`` branch:
+
+.. code:: bash
+
+    pyhton -m eradiate.test_tools.benchmark --git-ref=main^!
+
+The benchmark results are stored in the ``results`` folder. Those can be
+publish to an html page and viewed by running:
+
+.. code:: bash
+
+    # publish results to html page
+    asv publish
+    # start a server to view results
+    asv preview
+
+ASV commands are also available, for custom use of ASV, please refer
+to `the package documentation <https://asv.readthedocs.io/en/v0.6.1/>`_.
+
+Write Benchmarks
+----------------
+
+Benchmarks are in the ``benchmarks`` folder. They follow the
+`ASV syntax <https://asv.readthedocs.io/en/v0.6.1/writing_benchmarks.html>`_.
+The test cases that are benchmarks are often also used for regression test.
+For this reason, they are stored in ``src/eradiate/test_tools/test_cases/``.

--- a/docs/rst/developer_guide/benchmark.rst
+++ b/docs/rst/developer_guide/benchmark.rst
@@ -3,25 +3,26 @@ Benchmarking
 
 Run Benchmarks
 --------------
-Eradiate's benchmarking suite is based on the ASV package which enables
-tracking a project's performance over time.
-To run the benchmark suite:
+
+Eradiate's benchmarking suite is based on the
+`Airspeed Velocity (ASV) <https://github.com/airspeed-velocity/asv>`_
+package which enables tracking a project's performance over time. To run the benchmark suite:
 
 .. code:: bash
 
     conda activate <env name>
     cd benchmarks
-    python -m eradiate.test_tools.benchmark.benchmark
+    python -m eradiate.test_tools.benchmark.cli
 
 By default, it will run the benchmark using the currently active environment.
 For dev environments, this means that you need an operational version
-of eradiate. Note that environments that use production versions prior
-to v0.28.xx cannot be benchmarked as they do no include changes required
+of Eradiate. Note that environments that use production versions prior
+to v0.28.0 cannot be benchmarked as they do no include changes required
 for the benchmark.
 
 If you want to archive results to a separate **asv database**, add the
 ``--archive-dir=<dir>`` argument. The path should point to the root
-of the database, where the asv.conf.json exists.
+of the database, where the ``asv.conf.json`` file exists.
 
 ASV also offers the possibility to run benchmarks on previous commits
 and branches. It will clone and build the project in a new environment
@@ -30,7 +31,7 @@ as a range, e.g. ``main^!`` for the last commit of the ``main`` branch:
 
 .. code:: bash
 
-    pyhton -m eradiate.test_tools.benchmark --git-ref=main^!
+    python -m eradiate.test_tools.benchmark.cli --git-ref=main^!
 
 The benchmark results are stored in the ``results`` folder. Those can be
 publish to an html page and viewed by running:

--- a/docs/rst/developer_guide/index.rst
+++ b/docs/rst/developer_guide/index.rst
@@ -15,3 +15,4 @@ Hereafter is a collection of detailed guides for developers.
    lazy_loading
    radiometric_kernel_interface
    design_atmosphere
+   benchmark

--- a/docs/rst/user_guide/atmosphere/molecular.rst
+++ b/docs/rst/user_guide/atmosphere/molecular.rst
@@ -13,7 +13,7 @@ Thermophysical properties
 -------------------------
 
 Molecular atmosphere objects are created from a
-:ref:`thermophysical properties data set <sec-user_guide-data-thermoprops>`.
+:ref:`thermophysical properties data set <sec-data-thermoprops>`.
 
 .. _sec-molecular-atmosphere-thermophysical-properties-pre-defined:
 

--- a/requirements/layered.yml
+++ b/requirements/layered.yml
@@ -68,6 +68,7 @@ tests:
   packages:
     - "pytest"
     - "pytest-json-report"
+    - "asv=0.6.*"
 
 dev:
   includes:

--- a/src/eradiate/test_tools/benchmark/asvdb.py
+++ b/src/eradiate/test_tools/benchmark/asvdb.py
@@ -1,0 +1,1345 @@
+# This is a vendored and updated copy of the asvdb project (https://github.com/rapidsai/asvdb).
+
+import glob
+import json
+import os
+import random
+import stat
+import tempfile
+import time
+from os import path
+from pathlib import Path
+from urllib.parse import urlparse
+
+BenchmarkInfoKeys = set(
+    [
+        "machineName",
+        "cudaVer",
+        "osType",
+        "pythonVer",
+        "commitHash",
+        "commitTime",
+        "branch",
+        "gpuType",
+        "cpuType",
+        "num_cpu",
+        "arch",
+        "ram",
+        "gpuRam",
+        "requirements",
+        "env_vars",
+    ]
+)
+
+BenchmarkResultKeys = set(
+    [
+        "funcName",
+        "result",
+        "argNameValuePairs",
+        "unit",
+    ]
+)
+
+
+class BenchmarkInfo:
+    """
+    Meta-data describing the environment for a benchmark or set of benchmarks.
+    """
+
+    def __init__(
+        self,
+        machineName="",
+        cudaVer="",
+        osType="",
+        pythonVer="",
+        commitHash="",
+        commitTime=0,
+        branch="",
+        envName="",
+        gpuType="",
+        cpuType="",
+        numCpu="",
+        arch="",
+        ram="",
+        gpuRam="",
+        requirements=None,
+        envVar=None,
+        resultColumns=None,
+    ):
+        self.machineName = machineName
+        self.cudaVer = cudaVer
+        self.osType = osType
+        self.gpuType = gpuType
+        self.cpuType = cpuType
+        self.numCpu = numCpu
+        self.arch = arch
+        self.ram = ram
+        self.gpuRam = gpuRam
+
+        self.pythonVer = pythonVer
+        self.commitHash = commitHash
+        self.commitTime = int(commitTime)
+        self.branch = branch
+        self.envName = envName
+
+        self.requirements = requirements or {}
+        self.envVar = envVar or {}
+
+        self.resultColumns = resultColumns or []
+
+    def __repr__(self):
+        return (
+            f"{self.__class__.__name__}(machineName='{self.machineName}'\n"
+            f", cudaVer='{self.cudaVer}'\n"
+            f", osType='{self.osType}'\n"
+            f", pythonVer='{self.pythonVer}'\n"
+            f", commitHash='{self.commitHash}'\n"
+            f", commitTime={self.commitTime}\n"
+            f", branch={self.branch}\n"
+            f", envName={self.envName}\n"
+            f", gpuType='{self.gpuType}'\n"
+            f", cpuType='{self.cpuType}'\n"
+            f", numCpu='{self.numCpu}'\n"
+            f", arch='{self.arch}'\n"
+            f", ram={repr(self.ram)}\n"
+            f", gpuRam={repr(self.gpuRam)}\n"
+            f", requirements={repr(self.requirements)}\n"
+            f", envVar={repr(self.envVar)}\n"
+            f", resultColumns={repr(self.resultColumns)}\n"
+            ")"
+        )
+
+    def __eq__(self, other):
+        return (
+            (self.machineName == other.machineName)
+            and (self.cudaVer == other.cudaVer)
+            and (self.osType == other.osType)
+            and (self.pythonVer == other.pythonVer)
+            and (self.commitHash == other.commitHash)
+            and (self.commitTime == other.commitTime)
+            and (self.branch == other.branch)
+            and (self.envName == other.envName)
+            and (self.gpuType == other.gpuType)
+            and (self.cpuType == other.cpuType)
+            and (self.numCpu == other.numCpu)
+            and (self.arch == other.arch)
+            and (self.ram == other.ram)
+            and (self.gpuRam == other.gpuRam)
+            and (self.requirements == other.requirements)
+            and (self.envVar == other.envVar)
+            and (self.resultColumns == other.resultColumns)
+        )
+
+
+class BenchmarkResult:
+    """
+    The result of a benchmark run for a particular benchmark function, given
+    specific args.
+    """
+
+    def __init__(
+        self,
+        funcName,
+        results,
+        paramNames=None,
+        param=None,
+        argNameValuePairs=None,
+        unit=None,
+        benchType=None,
+        code=None,
+        version=None,
+        minRunCount=2,
+        number=0,
+        repeat=0,
+        rounds=2,
+        sampleTime=0.01,
+        warmupTime=-1,
+    ):
+        self.funcName = funcName
+        self.argNameValuePairs = self.__sanitizeArgNameValues(argNameValuePairs)
+
+        self.benchType = benchType or "time"
+        self.unit = unit or "seconds"
+        self.code = code or funcName
+
+        if type(results) is not list:
+            results = [results]
+
+        self.paramNames = paramNames or []
+        self.param = param or []
+        self.version = version or "2"
+
+        self.minRunCount = minRunCount
+        self.number = number
+        self.repeat = repeat
+        self.rounds = rounds
+        self.sampleTime = sampleTime
+        self.warmupTime = warmupTime
+
+        self.results = results
+
+    def __sanitizeArgNameValues(self, argNameValuePairs):
+        if argNameValuePairs is None:
+            return []
+        return [(n, str(v if v is not None else "NaN")) for (n, v) in argNameValuePairs]
+
+    def __repr__(self):
+        return (
+            f"{self.__class__.__name__}(funcName='{self.funcName}'\n"
+            f", results={repr(self.results)}\n"
+            f", argNameValuePairs={repr(self.argNameValuePairs)}\n"
+            f", unit='{self.unit}'\n"
+            f", type='{self.benchType}'\n"
+            f", param='{self.param}'\n"
+            f", paramNames='{self.paramNames}'\n"
+            f", version='{self.version}'\n"
+            f", minRunCount='{self.minRunCount}'\n"
+            f", number='{self.number}'\n"
+            f", repeat='{self.repeat}'\n"
+            f", rounds='{self.rounds}'\n"
+            f", sampleTime='{self.sampleTime}'\n"
+            f", warmupTime='{self.warmupTime}'\n"
+            f", results='{self.results}'\n"
+            ")"
+        )
+
+    def __eq__(self, other):
+        return (
+            (self.funcName == other.funcName)
+            and (self.argNameValuePairs == other.argNameValuePairs)
+            and (self.results == other.result)
+            and (self.unit == other.unit)
+            and (self.code == other.code)
+            and (self.param == other.param)
+            and (self.paramNames == other.paramNames)
+            and (self.version == other.version)
+            and (self.minRunCount == other.minRunCount)
+            and (self.number == other.number)
+            and (self.repeat == other.repeat)
+            and (self.rounds == other.rounds)
+            and (self.sampleTime == other.sampleTime)
+            and (self.warmupTime == other.warmupTime)
+            and (self.results == other.results)
+        )
+
+
+class ASVDb:
+    """
+    A "database" of benchmark results consumable by ASV.
+    https://asv.readthedocs.io/en/stable/dev.html?highlight=%24results_dir#benchmark-suite-layout-and-file-formats
+    """
+
+    confFileName = "asv.conf.json"
+    defaultResultsDirName = "results"
+    defaultHtmlDirName = "html"
+    defaultConfVersion = 1
+    benchmarksFileName = "benchmarks.json"
+    machineFileName = "machine.json"
+    lockfilePrefix = ".asvdbLOCK"
+
+    def __init__(
+        self, dbDir, repo=None, branches=None, projectName=None, commitUrl=None
+    ):
+        """
+        dbDir - directory containing the ASV results, config file, etc.
+        repo - the repo associated with all reasults in the DB.
+        branches - https://asv.readthedocs.io/en/stable/asv.conf.json.html#branches
+        projectName - the name of the project to display in ASV reports
+        commitUrl - the URL ASV will use in reports to redirect users to when
+                    they click on a data point. This is typically a Github
+                    project URL that shows the contents of a commit.
+        """
+        self.dbDir = dbDir
+        self.repo = repo
+        self.branches = branches
+        self.projectName = projectName
+        self.commitUrl = commitUrl
+
+        self.machineFileExt = path.join(
+            self.defaultResultsDirName, "*", self.machineFileName
+        )
+        self.confFileExt = self.confFileName
+        self.confFilePath = path.join(self.dbDir, self.confFileName)
+        self.confVersion = self.defaultConfVersion
+        self.resultsDirName = self.defaultResultsDirName
+        self.resultsDirPath = path.join(self.dbDir, self.resultsDirName)
+        self.htmlDirName = self.defaultHtmlDirName
+        self.benchmarksFileExt = path.join(
+            self.defaultResultsDirName, self.benchmarksFileName
+        )
+        self.benchmarksFilePath = path.join(
+            self.resultsDirPath, self.benchmarksFileName
+        )
+
+        # Each ASVDb instance must have a unique lockfile name to identify other
+        # instances that may be setting locks.
+        self.lockfileName = "%s-%s-%s" % (self.lockfilePrefix, os.getpid(), time.time())
+        self.lockfileTimeout = 5  # seconds
+
+        # S3-related attributes
+        if self.__isS3URL(dbDir):
+            self.s3Resource = None  # boto3.resource("s3")
+            self.bucketName = urlparse(self.dbDir, allow_fragments=False).netloc
+            self.bucketKey = urlparse(self.dbDir, allow_fragments=False).path.lstrip(
+                "/"
+            )
+
+        ########################################
+        # Testing and debug members
+        self.debugPrint = False
+        # adds a delay during write operations to easily test write collision
+        # handling.
+        self.writeDelay = 0
+        # To "cancel" write operations that are being delayed.
+        self.cancelWrite = False
+
+    ###########################################################################
+    # Public API
+    ###########################################################################
+    def loadConfFile(self):
+        """
+        Read the ASV conf file on disk and set - or possibly overwrite - the
+        member variables with the contents of the file.
+        """
+        self.__assertDbDirExists()
+        try:
+            self.__getLock(self.dbDir)
+            # FIXME: check if confFile exists
+            self.__downloadIfS3()
+
+            d = self.__loadJsonDictFromFile(self.confFilePath)
+            self.resultsDirName = d.get("results_dir", self.resultsDirName)
+            self.resultsDirPath = path.join(self.dbDir, self.resultsDirName)
+            self.benchmarksFilePath = path.join(
+                self.resultsDirPath, self.benchmarksFileName
+            )
+            self.htmlDirName = d.get("html_dir", self.htmlDirName)
+            self.repo = d.get("repo")
+            self.branches = d.get("branches", [])
+            self.projectName = d.get("project")
+            self.commitUrl = d.get("show_commit_url")
+
+            self.__uploadIfS3()
+
+        finally:
+            self.__releaseLock(self.dbDir)
+            self.__removeLocalS3Copy()
+
+    def updateConfFile(self):
+        """
+        Update the ASV conf file with the values passed in to the CTOR. This
+        also ensures the object is up-to-date with any changes to the conf file
+        that may have been done by other ASVDb instances.
+        """
+        self.__ensureDbDirExists()
+        try:
+            self.__getLock(self.dbDir)
+            self.__downloadIfS3()
+
+            if self.__waitForWrite():
+                self.__updateConfFile()
+
+            self.__uploadIfS3()
+
+        finally:
+            self.__releaseLock(self.dbDir)
+            self.__removeLocalS3Copy()
+
+    def addResult(self, benchmarkInfo, benchmarkResult):
+        """
+        Add the benchmarkResult associated with the benchmarkInfo to the DB.
+        This will also update the conf file with the CTOR args if not done
+        already.
+        """
+        self.__ensureDbDirExists()
+        try:
+            self.__getLock(self.dbDir)
+            self.__downloadIfS3(bInfo=benchmarkInfo)
+            if self.__waitForWrite():
+                self.__updateFilesForInfo(benchmarkInfo)
+                self.__updateFilesForResult(benchmarkInfo, benchmarkResult)
+
+            self.__uploadIfS3()
+
+        finally:
+            self.__releaseLock(self.dbDir)
+            self.__removeLocalS3Copy()
+
+    def addResults(self, benchmarkInfo, benchmarkResultList):
+        """
+        Add each benchmarkResult obj in benchmarkResultList associated with
+        benchmarkInfo to the DB.  This will also update the conf file with the
+        CTOR args if not done already.
+        """
+        self.__ensureDbDirExists()
+        try:
+            self.__getLock(self.dbDir)
+            self.__downloadIfS3(bInfo=benchmarkInfo)
+
+            if self.__waitForWrite():
+                self.__updateFilesForInfo(benchmarkInfo)
+                for resultObj in benchmarkResultList:
+                    self.__updateFilesForResult(benchmarkInfo, resultObj)
+
+            self.__uploadIfS3()
+
+        finally:
+            self.__releaseLock(self.dbDir)
+            self.__removeLocalS3Copy()
+
+    def getInfo(self):
+        """
+        Return a list of BenchmarkInfo objs from reading the db files on disk.
+        """
+        self.__assertDbDirExists()
+        try:
+            self.__getLock(self.dbDir)
+            self.__downloadIfS3()
+            retList = self.__readResults(infoOnly=True)
+
+        finally:
+            self.__releaseLock(self.dbDir)
+            self.__removeLocalS3Copy()
+
+        return retList
+
+    def getResults(self, filterInfoObjList=None):
+        """
+        Return a list of (BenchmarkInfo obj, [BenchmarkResult obj, ...]) tuples
+        from reading the db files on disk.  filterInfoObjList is expected to be
+        a list of BenchmarkInfo objs, and if provided will be used to return
+        results for only those BenchmarkInfo objs.
+        """
+        self.__assertDbDirExists()
+        try:
+            self.__getLock(self.dbDir)
+            self.__downloadIfS3(results=True)
+            retList = self.__readResults(filterByInfoObjs=filterInfoObjList)
+
+        finally:
+            self.__releaseLock(self.dbDir)
+            self.__removeLocalS3Copy()
+
+        return retList
+
+    ###########################################################################
+    # Private methods. These should not be called by clients. Among other
+    # things, public methods use proper locking to ensure atomic operations
+    # and these do not.
+    ###########################################################################
+    def __readResults(self, infoOnly=False, filterByInfoObjs=None):
+        """
+        Main "read" method responsible for reading ASV JSON files and creating
+        BenchmarkInfo and BenchmarkResult objs.
+
+        If infoOnly==True, returns a list of only BenchmarkInfo objs, otherwise
+        returns a list of tuples containing (BenchmarkInfo obj, [BenchmarkResult
+        obj, ...]) to represent each BenchmarkInfo object and all the
+        BenchmarkResult objs associated with it.
+
+        filterByInfoObjs can be set to only return BenchmarkInfo objs and their
+        results that match at least one of the BenchmarkInfo objs in the
+        filterByInfoObjs list (the list is treated as ORd).
+        """
+        retList = []
+
+        resultsPath = Path(self.resultsDirPath)
+
+        # benchmarks.json containes meta-data about the individual benchmarks,
+        # which is only needed for returning results.
+        if not (infoOnly):
+            benchmarksJsonFile = resultsPath / self.benchmarksFileName
+            if benchmarksJsonFile.exists():
+                bDict = self.__loadJsonDictFromFile(benchmarksJsonFile.as_posix())
+            else:
+                # FIXME: test
+                raise FileNotFoundError(f"{benchmarksJsonFile.as_posix()}")
+
+        for machineDir in resultsPath.iterdir():
+            # Each subdir under the results dir contains all results for a
+            # individual machine. The only non-dir (file) that may need to be
+            # read in the results dir is benchmarks.json, which would have been
+            # read above.
+            if machineDir.is_dir():
+                # Inside the individual machine dir, ;ook for and read
+                # machine.json first.  Assume this is not a valid results dir if
+                # no machine file and skip.
+                machineJsonFile = machineDir / self.machineFileName
+                if machineJsonFile.exists():
+                    mDict = self.__loadJsonDictFromFile(machineJsonFile.as_posix())
+                else:
+                    continue
+
+                # Read each results file and populate the machineResults list.
+                # This will contain either BenchmarkInfo objs or tuples of
+                # (BenchmarkInfo, [BenchmarkResult objs, ...]) based on infoOnly
+                machineResults = []
+                for resultsFile in machineDir.iterdir():
+                    if resultsFile == machineJsonFile:
+                        continue
+                    rDict = self.__loadJsonDictFromFile(resultsFile.as_posix())
+
+                    resultsParams = rDict.get("params", {})
+                    # Each results file has a single BenchmarkInfo obj
+                    # describing it.
+                    bi = BenchmarkInfo(
+                        machineName=mDict.get("machine", ""),
+                        cudaVer=resultsParams.get("cuda", ""),
+                        osType=resultsParams.get("os", ""),
+                        pythonVer=resultsParams.get("python", ""),
+                        commitHash=rDict.get("commit_hash", ""),
+                        commitTime=rDict.get("date", ""),
+                        branch=rDict.get("branch", ""),
+                        envName=rDict.get("env_name", ""),
+                        gpuType=mDict.get("gpu", ""),
+                        cpuType=mDict.get("cpu", ""),
+                        numCpu=mDict.get("num_cpu", ""),
+                        arch=mDict.get("arch", ""),
+                        ram=mDict.get("ram", ""),
+                        gpuRam=mDict.get("gpuRam", ""),
+                        requirements=rDict.get("requirements", {}),
+                        envVar=rDict.get("env_vars", {}),
+                        resultColumns=rDict.get("result_columns", None),
+                    )
+
+                    # If a filter was specified, at least one EXACT MATCH to the
+                    # BenchmarkInfo obj must be present.
+                    if filterByInfoObjs and bi not in filterByInfoObjs:
+                        continue
+
+                    if infoOnly:
+                        machineResults.append(bi)
+                    else:
+                        # FIXME: if results not in rDict, throw better error
+                        resultsDict = rDict["results"]
+                        # Populate the list of BenchmarkResult objs associated
+                        # with the BenchmarkInfo obj
+                        resultObjs = []
+                        for benchmarkName in resultsDict:
+                            # benchmarkSpec is the entry in benchmarks.json,
+                            # which is needed for the param names
+                            if benchmarkName not in bDict:
+                                print(
+                                    "WARNING: Encountered benchmark name "
+                                    "that is not in "
+                                    f"{self.benchmarksFileName}: "
+                                    f"file: {resultsFile.as_posix()} "
+                                    f'invalid name"{benchmarkName}", skipping.'
+                                )
+                                continue
+
+                            # the number of result columns should always be the same as the number of results
+                            # not true for because samples and profile only exist if the benchmark is run with profile mode
+                            # assert len(bi.resultColumns) == len(resultsDict[benchmarkName])
+
+                            benchmarkSpec = bDict[benchmarkName]
+                            # benchmarkResults is the entry in this particular
+                            # result file for this benchmark
+                            # benchmarkResults = dict(zip(rDict["result_columns"],resultsDict[benchmarkName]))
+
+                            # dropping the parameter picking. we will just overwrite
+                            br = BenchmarkResult(
+                                funcName=benchmarkName,
+                                results=resultsDict[benchmarkName],
+                                paramNames=benchmarkSpec["param_names"],
+                                param=benchmarkSpec["params"],
+                                code=benchmarkSpec["code"],
+                                version=benchmarkSpec["version"],
+                                benchType=benchmarkSpec["type"],
+                                unit=benchmarkSpec["unit"],
+                                minRunCount=benchmarkSpec["min_run_count"],
+                                number=benchmarkSpec["number"],
+                                repeat=benchmarkSpec["repeat"],
+                                rounds=benchmarkSpec["rounds"],
+                                sampleTime=benchmarkSpec["sample_time"],
+                                warmupTime=benchmarkSpec["warmup_time"],
+                            )
+                            unit = benchmarkSpec.get("unit")
+                            code = benchmarkSpec.get("code")
+                            if unit is not None:
+                                br.unit = unit
+                            if code is not None:
+                                br.code = code
+                            resultObjs.append(br)
+
+                            # NM 18/07/2024: Disabled parameter expansion
+                            # -------------------------------------------
+
+                            # Inverse of the write operation described in
+                            # self.__updateResultJson()
+                            # paramsCartProd = list(itertools.product(*paramValues))
+                            # for (paramValueCombo, result) in zip(paramsCartProd, results):
+                            # br = BenchmarkResult(
+                            # funcName=benchmarkName,
+                            # argNameValuePairs=zip(paramNames, paramValueCombo),
+                            # result=result)
+                            #     unit = benchmarkSpec.get("unit")
+                            #     if unit is not None:
+                            #         br.unit = unit
+                            #     resultObjs.append(br)
+                        machineResults.append((bi, resultObjs))
+
+                retList += machineResults
+
+        return retList
+
+    def __updateFilesForInfo(self, benchmarkInfo):
+        """
+        Updates all the db files that are affected by a new BenchmarkInfo obj.
+        """
+        # special case: if the benchmarkInfo has a new branch specified,
+        # update self.branches so the conf files includes the new branch
+        # name.
+        newBranch = benchmarkInfo.branch
+        if newBranch and newBranch not in self.branches:
+            self.branches.append(newBranch)
+
+        # The comments below assume default dirname values (mainly
+        # "results"), which can be changed in the asv.conf.json file.
+        #
+        # <self.dbDir>/asv.conf.json
+        self.__updateConfFile()
+        # <self.dbDir>/results/<machine dir>/machine.json
+        self.__updateMachineJson(benchmarkInfo)
+
+    def __updateFilesForResult(self, benchmarkInfo, benchmarkResult):
+        """
+        Updates all the db files that are affected by a new BenchmarkResult
+        obj. This also requires the corresponding BenchmarkInfo obj since some
+        results files also include info data.
+        """
+        # <self.dbDir>/results/benchmarks.json
+        self.__updateBenchmarkJson(benchmarkResult)
+        # <self.dbDir>/results/<machine dir>/<result file name>.json
+        self.__updateResultJson(benchmarkResult, benchmarkInfo)
+
+    def __assertDbDirExists(self):
+        # FIXME: update for support S3 - this method should return True if
+        # self.dbDir is a valid S3 URL or a valid path on disk.
+        if self.__isS3URL(self.dbDir):
+            self.s3Resource.Bucket(self.bucketName).objects
+        else:
+            if not (path.isdir(self.dbDir)):
+                raise FileNotFoundError(
+                    f"{self.dbDir} does not exist or is " "not a directory"
+                )
+
+    def __ensureDbDirExists(self):
+        # FIXME: for S3 support, if self.dbDir is a S3 URL then simply check if
+        # it's valid and exists, but don't try to create it (raise an exception
+        # if it does not exist).  For a local file path, create it if it does
+        # not exist, like already being done below.
+        if self.__isS3URL(self.dbDir):
+            self.s3Resource.Bucket(self.bucketName).objects
+        else:
+            if not (path.exists(self.dbDir)):
+                os.mkdir(self.dbDir)
+                # Hack: os.mkdir() seems to return before the filesystem catches up,
+                # so pause before returning to help ensure the dir actually exists
+                time.sleep(0.1)
+
+    def __updateConfFile(self):
+        """
+        Update the conf file with the settings in this ASVDb instance.
+        """
+        if self.repo is None:
+            raise AttributeError(
+                "repo must be set to non-None before " f"writing {self.confFilePath}"
+            )
+
+        d = self.__loadJsonDictFromFile(self.confFilePath)
+        # ASVDb is git-only for now, so ensure .git extension
+        d["repo"] = self.repo + (".git" if not self.repo.endswith(".git") else "")
+        currentBranches = d.get("branches", [])
+        d["branches"] = currentBranches + [
+            b for b in (self.branches or []) if b not in currentBranches
+        ]
+        d["version"] = self.confVersion
+        d["project"] = self.projectName or self.repo.replace(".git", "").split("/")[-1]
+        d["show_commit_url"] = self.commitUrl or (
+            self.repo.replace(".git", "")
+            + ("/" if not self.repo.endswith("/") else "")
+            + "commit/"
+        )
+
+        self.__writeJsonDictToFile(d, self.confFilePath)
+
+    def __updateBenchmarkJson(self, benchmarkResult):
+        # The following is an example of the schema ASV expects for
+        # `benchmarks.json`.  If param names are A, B, and C
+        #
+        # {
+        #     "<algo name>": {
+        #         "code": "",
+        #         "name": "<algo name>",
+        #         "param_names": [
+        #             "A", "B", "C"
+        #         ],
+        #     "params": [
+        #                [<value1 for A>,
+        #                 <value2 for A>,
+        #                ],
+        #                [<value1 for B>,
+        #                 <value2 for B>,
+        #                ],
+        #                [<value1 for C>,
+        #                 <value2 for C>,
+        #                ],
+        #               ],
+        #         "timeout": 60,
+        #         "type": "time",
+        #         "unit": "seconds",
+        #         "version": 1,
+        #     }
+        # }
+
+        newParamNames = []
+        newParamValues = []
+        for n, v in benchmarkResult.argNameValuePairs:
+            newParamNames.append(n)
+            newParamValues.append(v)
+
+        d = self.__loadJsonDictFromFile(self.benchmarksFilePath)
+
+        benchDict = d.setdefault(
+            benchmarkResult.funcName,
+            self.__getDefaultBenchmarkDescrDict(
+                benchmarkResult.funcName, newParamNames
+            ),
+        )
+        benchDict["unit"] = benchmarkResult.unit
+        benchDict["type"] = benchmarkResult.benchType
+        benchDict["code"] = benchmarkResult.code
+        benchDict["version"] = benchmarkResult.version
+
+        benchDict["param_names"] = benchmarkResult.paramNames
+        benchDict["params"] = benchmarkResult.param
+
+        benchDict["min_run_count"] = benchmarkResult.minRunCount
+        benchDict["number"] = benchmarkResult.number
+        benchDict["repeat"] = benchmarkResult.repeat
+        benchDict["rounds"] = benchmarkResult.rounds
+        benchDict["sample_time"] = benchmarkResult.sampleTime
+        benchDict["warmup_time"] = benchmarkResult.warmupTime
+
+        # NM 18/07/2024: Disabled parameter expansion
+        # -------------------------------------------
+
+        # existingParamNames = benchDict["param_names"]
+        # existingParamValues = benchDict["params"]
+
+        # numExistingParams = len(existingParamNames)
+        # numExistingParamValues = len(existingParamValues)
+        # numNewParams = len(newParamNames)
+
+        # # Check for the case where a result came in for the function, but it has
+        # # a different number of args vs. what was saved previously
+        # if numExistingParams != numNewParams:
+        #     raise ValueError("result for %s had %d params in benchmarks.json, "
+        #                      "but new result has %d params" \
+        #                      % (benchmarkResult.funcName, numExistingParams,
+        #                         numNewParams))
+        # numParams = numNewParams
+
+        # cartProd = list(itertools.product(*existingParamValues))
+        # if tuple(newParamValues) not in cartProd:
+        #     if numExistingParamValues == 0:
+        #         for newVal in newParamValues:
+        #             existingParamValues.append([newVal])
+        #     else:
+        #         for i in range(numParams):
+        #             if newParamValues[i] not in existingParamValues[i]:
+        #                 existingParamValues[i].append(newParamValues[i])
+
+        d[benchmarkResult.funcName] = benchDict
+
+        # a version key must always be present in self.benchmarksFilePath,
+        # "current" ASV version requires this to be 2 (or higher?)
+        # d["version"] = benchmarkResult["version"]
+        d["version"] = 2
+        self.__writeJsonDictToFile(d, self.benchmarksFilePath)
+
+    def __updateMachineJson(self, benchmarkInfo):
+        # The following is an example of the schema ASV expects for
+        # `machine.json`.
+        # {
+        #     "arch": "x86_64",
+        #     "cpu": "Intel, ...",
+        #     "machine": "sm01",
+        #     "os": "Linux ...",
+        #     "ram": "123456",
+        #     "version": 1,
+        # }
+
+        machineFilePath = path.join(
+            self.resultsDirPath, benchmarkInfo.machineName, self.machineFileName
+        )
+        d = self.__loadJsonDictFromFile(machineFilePath)
+        d["arch"] = benchmarkInfo.arch
+        d["cpu"] = benchmarkInfo.cpuType
+        d["gpu"] = benchmarkInfo.gpuType
+        # d["cuda"] = benchmarkInfo.cudaVer
+        d["machine"] = benchmarkInfo.machineName
+        # d["os"] = benchmarkInfo.osType
+        d["ram"] = benchmarkInfo.ram
+        d["gpuRam"] = benchmarkInfo.gpuRam
+        d["version"] = 1
+        self.__writeJsonDictToFile(d, machineFilePath)
+
+    def __updateResultJson(self, benchmarkResult, benchmarkInfo):
+        # The following is an example of the schema ASV expects for
+        # '<machine>-<commit_hash>.json'. If param names are A, B, and C
+        #
+        # {
+        #     "params": {
+        #         "cuda": "9.2",
+        #         "gpu": "Tesla ...",
+        #         "machine": "sm01",
+        #         "os": "Linux ...",
+        #         "python": "3.7",
+        #     },
+        #     "requirements": {},
+        #     "result_columns":["result", "params", "version", "started_at", "duration", "stats_ci_99_a", "stats_ci_99_b", "stats_q_25", "stats_q_75", "stats_number", "stats_repeat", "samples", "profile"]
+        #     "results": {
+        #         "<algo name>": {
+        #              [[<result1>,<result2>,],[<param1>, <param2>],"<version>",...]
+        #     },
+        #     "commit_hash": "321e321321eaf",
+        #     "date": 12345678,
+        #     "python": "3.7",
+        #     "version": 1,
+        # }
+
+        resultsFilePath = self.__getResultsFilePath(benchmarkInfo)
+        d = self.__loadJsonDictFromFile(resultsFilePath)
+
+        d["commit_hash"] = benchmarkInfo.commitHash
+        d["env_name"] = benchmarkInfo.envName
+        d["date"] = int(benchmarkInfo.commitTime)
+        d["python"] = benchmarkInfo.pythonVer
+        d["params"] = {
+            "arch": benchmarkInfo.arch,
+            "cpu": benchmarkInfo.cpuType,
+            "num_cpu": benchmarkInfo.numCpu,
+            "machine": benchmarkInfo.machineName,
+            "os": benchmarkInfo.osType,
+            "python": benchmarkInfo.pythonVer,
+        }
+        d["requirements"] = benchmarkInfo.requirements
+        d["env_vars"] = benchmarkInfo.envVar
+        d["result_columns"] = benchmarkInfo.resultColumns
+
+        allResultsDict = d.setdefault("results", {})
+        allResultsDict[benchmarkResult.funcName] = benchmarkResult.results
+        d["version"] = 2
+
+        # NM 18/07/2024: Disabled parameter expansion
+        # -------------------------------------------
+
+        # resultDict = allResultsDict.setdefault(benchmarkResult.funcName, {})
+
+        # existingParamValuesList = benchmarkInfo.params
+        # existingResultValueList = resultDict.setdefault("result", [])
+
+        # ASV uses the cartesian product of the param values for looking up the
+        # result for a particular combination of param values.  For example:
+        # "params": [["a"], ["b", "c"], ["d", "e"]] results in: [("a", "b",
+        # "d"), ("a", "b", "e"), ("a", "c", "d"), ("a", "c", "e")] and each
+        # combination of param values has a result, with the results for the
+        # corresponding param values in the same order.  If a result for a set
+        # of param values DNE, use None.
+
+        # store existing results in map based on cartesian product of all
+        # current params.
+        # paramsCartProd = list(itertools.product(*existingParamValuesList))
+        # Assume there is an equal number of results for cartProd values
+        # (some will be None)
+        # paramsResultMap = dict(zip(paramsCartProd, existingResultValueList))
+
+        # FIXME: dont assume these are ordered properly (ie. the same way as
+        # defined in benchmarks.json)
+        # newResultParamValues = tuple(v for (_, v) in benchmarkResult.argNameValuePairs)
+
+        # Update the "params" lists with the new param settings for the new result.
+        # Only add values that are not already present
+        # numExistingParamValues = len(existingParamValuesList)
+        # if numExistingParamValues == 0:
+        #     for newParamValue in newResultParamValues:
+        #         existingParamValuesList.append([newParamValue])
+        #     results = [benchmarkResult.results]
+
+        # else:
+        #     for i in range(numExistingParamValues):
+        #         if newResultParamValues[i] not in existingParamValuesList[i]:
+        #             existingParamValuesList[i].append(newResultParamValues[i])
+
+        #     # Add the new result
+        #     paramsResultMap[newResultParamValues] = benchmarkResult.results
+
+        #     # Re-compute the cartesian product of all param values now that the
+        #     # new values are added. Use this to determine where to place the new
+        #     # result in the result list.
+        #     results = []
+        #     for paramVals in itertools.product(*existingParamValuesList):
+        #         results.append(paramsResultMap.get(paramVals))
+
+        # resultDict["params"] = existingParamValuesList
+        # resultDict["results"] = benchmarkResult.results
+
+        self.__writeJsonDictToFile(d, resultsFilePath)
+
+    def __getDefaultBenchmarkDescrDict(self, funcName, paramNames):
+        return {
+            "code": funcName,
+            "min_run_count": 2,
+            "name": funcName,
+            "number": 0,
+            "param_names": paramNames,
+            "params": [],
+            "repeat": 0,
+            "rounds": 1,
+            "sample_time": 0.01,
+            "type": "time",
+            "unit": "seconds",
+            "version": 2,
+            "warmup_time": -1,
+        }
+
+    def __getResultsFilePath(self, benchmarkInfo):
+        # The path to the resultsFile will be based on additional params present
+        # in the benchmarkInfo obj.
+        assert (
+            len(benchmarkInfo.commitHash[:8]) >= 8
+        ), "commit hash needs to be at leas 8 characters long"
+
+        fileNameParts = [
+            benchmarkInfo.commitHash[:8],
+            benchmarkInfo.envName,
+        ]
+        fileName = "-".join(fileNameParts) + ".json"
+        return path.join(self.resultsDirPath, benchmarkInfo.machineName, fileName)
+
+    def __loadJsonDictFromFile(self, jsonFile):
+        """
+        Return a dictionary representing the contents of jsonFile by
+        either reading in the existing file or returning {}
+        """
+        if path.exists(jsonFile):
+            with open(jsonFile) as fobj:
+                # FIXME: ideally this could use flock(), but some situations do
+                # not allow grabbing a file lock (NFS?)
+                # fcntl.flock(fobj, fcntl.LOCK_EX)
+                # FIXME: error checking
+                return json.load(fobj)
+
+        return {}
+
+    def __writeJsonDictToFile(self, jsonDict, filePath):
+        # FIXME: error checking
+        dirPath = path.dirname(filePath)
+        if not path.isdir(dirPath):
+            os.makedirs(dirPath)
+
+        with open(filePath, "w") as fobj:
+            # FIXME: ideally this could use flock(), but some situations do not
+            # allow grabbing a file lock (NFS?)
+            # fcntl.flock(fobj, fcntl.LOCK_EX)
+            json.dump(jsonDict, fobj, indent=2)
+
+    ###########################################################################
+    # ASVDb private locking methods
+    ###########################################################################
+    def __getLock(self, dirPath):
+        if self.__isS3URL(dirPath):
+            self.__getS3Lock()
+        else:
+            self.__getLocalFileLock(dirPath)
+
+    def __getLocalFileLock(self, dirPath):
+        """
+        Gets a lock on dirPath against other ASVDb instances (in other
+        processes, possibily on other machines) using the following technique:
+
+        * Check for other locks and clear them if they've been seen for longer
+          than self.lockfileTimeout (do this to help cleanup after others that
+          may have died prematurely)
+
+        * Once all locks are clear - either by their owner because they
+          finished their read/write, or by removing them because they're
+          presumed dead - create a lock for this instance
+
+        * If a race condition was detected, probably because multiple ASVDbs
+          saw all locks were cleared at the same time and created their locks
+          at the same time, remove this lock, and wait a random amount of time
+          before trying again.  The random time prevents yet another race.
+        """
+        otherLockfileTimes = {}
+        thisLockfile = path.join(dirPath, self.lockfileName)
+        # FIXME: This shouldn't be needed? But if so, be smarter about
+        # preventing an infintite loop?
+        i = 0
+        while i < 1000:
+            # Keep checking for other locks to clear
+            self.__updateOtherLockfileTimes(dirPath, otherLockfileTimes)
+            # FIXME: potential infintite loop due to starvation?
+            otherLocks = list(otherLockfileTimes.keys())
+            while otherLocks:
+                if self.debugPrint:
+                    print(
+                        f"This lock file will be {thisLockfile} but other "
+                        f"locks present: {otherLocks}, waiting to try to "
+                        "lock again..."
+                    )
+                time.sleep(0.2)
+                self.__updateOtherLockfileTimes(dirPath, otherLockfileTimes)
+                otherLocks = list(otherLockfileTimes.keys())
+
+            # All clear, create lock
+            if self.debugPrint:
+                print(f"All clear, setting lock {thisLockfile}")
+            self.__createLockfile(dirPath)
+
+            # Check for a race condition where another lock could have been created
+            # while creating the lock for this instance.
+            self.__updateOtherLockfileTimes(dirPath, otherLockfileTimes)
+
+            # If another lock snuck in while this instance was creating its
+            # lock, remove this lock and wait a random amount of time before
+            # trying again (random time to prevent another race condition with
+            # the competing instance, this way someone will clearly get there
+            # first)
+            if otherLockfileTimes:
+                self.__releaseLock(dirPath)
+                randTime = (int(5 * random.random()) + 1) + random.random()
+                if self.debugPrint:
+                    print(
+                        f"Collision - waiting {randTime} seconds before "
+                        "trying to lock again."
+                    )
+                time.sleep(randTime)
+            else:
+                break
+
+            i += 1
+
+    def __releaseLock(self, dirPath):
+        if self.__isS3URL(dirPath):
+            self.__releaseS3Lock()
+        else:
+            self.__releaseLocalFileLock(dirPath)
+
+    def __releaseLocalFileLock(self, dirPath):
+        thisLockfile = path.join(dirPath, self.lockfileName)
+        if self.debugPrint:
+            print(f"Removing lock {thisLockfile}")
+        self.__removeFiles([thisLockfile])
+
+    def __updateOtherLockfileTimes(self, dirPath, lockfileTimes):
+        """
+        Return a list of lockfiles that have "timed out", probably because their
+        process was killed. This will never include the lockfile for this
+        instance.  Update the lockfileTimes dict as a side effect with the
+        discovery time of any new lockfiles and remove any lockfiles that are no
+        longer present.
+        """
+        thisLockfile = path.join(dirPath, self.lockfileName)
+        now = time.time()
+        expired = []
+
+        allLockfiles = glob.glob(path.join(dirPath, self.lockfilePrefix) + "*")
+
+        if self.debugPrint:
+            print(
+                f"   This lockfile is {thisLockfile}, allLockfiles is "
+                f"{allLockfiles}, lockfileTimes is {lockfileTimes}"
+            )
+        # Remove lockfiles from the lockfileTimes dict that are no longer
+        # present on disk
+        lockfilesToRemove = set(lockfileTimes.keys()) - set(allLockfiles)
+        for removedLockfile in lockfilesToRemove:
+            lockfileTimes.pop(removedLockfile)
+
+        # check for expired lockfiles while also setting the discovery time on
+        # new lockfiles in the lockfileTimes dict.
+        for lockfile in allLockfiles:
+            if lockfile == thisLockfile:
+                continue
+            if (now - lockfileTimes.setdefault(lockfile, now)) > self.lockfileTimeout:
+                expired.append(lockfile)
+
+        if self.debugPrint:
+            print(
+                f"   This lockfile is {thisLockfile}, lockfileTimes is "
+                f"{lockfileTimes}, now is {now}, expired is {expired}"
+            )
+        self.__removeFiles(expired)
+
+    def __createLockfile(self, dirPath):
+        """
+        low-level lockfile creation - consider calling __getLock() instead.
+        """
+        thisLockfile = path.join(dirPath, self.lockfileName)
+        open(thisLockfile, "w").close()
+        # Make the lockfile read/write to all so others can remove it if this
+        # process dies prematurely
+        os.chmod(
+            thisLockfile,
+            (
+                stat.S_IRUSR
+                | stat.S_IWUSR
+                | stat.S_IRGRP
+                | stat.S_IWGRP
+                | stat.S_IROTH
+                | stat.S_IWOTH
+            ),
+        )
+
+    ###########################################################################
+    # S3 Locking methods
+    ###########################################################################
+    def __getS3Lock(self):
+        thisLockfile = path.join(self.bucketKey, self.lockfileName)
+        # FIXME: This shouldn't be needed? But if so, be smarter about
+        # preventing an infintite loop?
+        i = 0
+
+        # otherLockfileTimes is a tuple representing (<List of lockfiles>, <Length of List>)
+        otherLockfileTimes = ([], 0)
+        while i < 1000:
+            otherLockfileTimes = self.__updateS3LockfileTimes()
+            debugCounter = 0
+
+            while otherLockfileTimes[1] != 0:
+                if self.debugPrint:
+                    lockfileList = []
+                    for each in otherLockfileTimes[0]:
+                        lockfileList.append(each.key)
+
+                    print(
+                        f"This lock file will be {thisLockfile} but other "
+                        f"locks present: {lockfileList}, waiting to try to "
+                        "lock again..."
+                    )
+
+                time.sleep(1)
+                otherLockfileTimes = self.__updateS3LockfileTimes()
+
+            # All clear, create lock
+            if self.debugPrint:
+                print(f"All clear, setting lock {thisLockfile}")
+            self.s3Resource.Object(self.bucketName, thisLockfile).put()
+
+            # Give S3 time to see the new lock
+            time.sleep(1)
+
+            # Check for a race condition where another lock could have been created
+            # while creating the lock for this instance.
+            otherLockfileTimes = self.__updateS3LockfileTimes()
+
+            if otherLockfileTimes[1] != 0:
+                self.__releaseS3Lock()
+                randTime = (int(30 * random.random()) + 5) + random.random()
+                if self.debugPrint:
+                    print(
+                        f"Collision - waiting {randTime} seconds before "
+                        "trying to lock again."
+                    )
+                time.sleep(randTime)
+            else:
+                break
+
+            i += 1
+
+    def __updateS3LockfileTimes(self):
+        # Find lockfiles in S3 Bucket
+        response = self.s3Resource.Bucket(self.bucketName).objects.filter(
+            Prefix=path.join(self.bucketKey, self.lockfilePrefix)
+        )
+
+        length = 0
+        for lockfile in response:
+            length += 1
+            if self.lockfileName in lockfile.key:
+                lockfile.delete()
+                length -= 1
+
+        return (response, length)
+
+    def __releaseS3Lock(self):
+        thisLockfile = path.join(self.bucketKey, self.lockfileName)
+        if self.debugPrint:
+            print(f"Removing lock {thisLockfile}")
+        self.s3Resource.Object(self.bucketName, thisLockfile).delete()
+
+    ###########################################################################
+    # S3 utilities
+    ###########################################################################
+    def __downloadIfS3(self, bInfo=BenchmarkInfo(), results=False):
+        def downloadS3(bucket, ext):
+            bucket.download_file(
+                path.join(self.bucketKey, ext), path.join(self.localS3Copy.name, ext)
+            )
+
+        if not self.__isS3URL(self.dbDir):
+            return
+
+        self.localS3Copy = tempfile.TemporaryDirectory()
+        os.makedirs(path.join(self.localS3Copy.name, self.defaultResultsDirName))
+        bucket = self.s3Resource.Bucket(self.bucketName)
+        # If results isn't set, only download key files, else download key files and results
+        if results == False:
+            keyFileExts = [
+                self.confFileExt,
+                self.machineFileExt,
+                self.benchmarksFileExt,
+            ]
+            # Use Try/Except to catch file Not Found errors and continue, avoids additional API calls
+            for fileExt in keyFileExts:
+                try:
+                    downloadS3(bucket, fileExt)
+                except Exception as e:
+                    err = "Not Found"
+                    if err not in e.response["Error"]["Message"]:
+                        raise
+
+            # Download specific result file for updating results if BenchmarkInfo is sent
+            try:
+                if bInfo.machineName != "":
+                    commitHash, pyVer, cuVer, osType = (
+                        bInfo.commitHash,
+                        bInfo.pythonVer,
+                        bInfo.cudaVer,
+                        bInfo.osType,
+                    )
+                    filename = f"{commitHash}-python{pyVer}-cuda{cuVer}-{osType}.json"
+                    os.makedirs(
+                        path.join(
+                            self.localS3Copy.name,
+                            self.defaultResultsDirName,
+                            bInfo.machineName,
+                        ),
+                        exist_ok=True,
+                    )
+                    resultFileExt = path.join(
+                        self.defaultResultsDirName, bInfo.machineName, filename
+                    )
+                    downloadS3(bucket, resultFileExt)
+
+            except Exception as e:
+                err = "Not Found"
+                if err not in e.response["Error"]["Message"]:
+                    raise
+
+        else:
+            try:
+                downloadS3(bucket, self.confFileExt)
+            except Exception as e:
+                err = "Not Found"
+                if err not in e.response["Error"]["Message"]:
+                    raise
+
+            try:
+                resultsBucketPath = path.join(
+                    self.bucketKey, self.defaultResultsDirName
+                )
+                resultsLocalPath = path.join(
+                    self.localS3Copy.name, self.defaultResultsDirName
+                )
+
+                # Loop over ASV results folder and download everything.
+                # objectExt represents the file extension starting from the base resultsBucketPath
+                # For example: resultsBucketPath = "asvdb/results"
+                #            : objectKey = "asvdb/results/machine_name/results.json
+                #            : objectExt = "machine_name/results.json"
+                for bucketObj in bucket.objects.filter(Prefix=resultsBucketPath):
+                    objectExt = bucketObj.key.replace(resultsBucketPath + "/", "")
+                    if len(objectExt.split("/")) > 1:
+                        os.makedirs(
+                            path.join(resultsLocalPath, objectExt.split("/")[0]),
+                            exist_ok=True,
+                        )
+                    bucket.download_file(
+                        bucketObj.key, path.join(resultsLocalPath, objectExt)
+                    )
+
+            except Exception as e:
+                err = "Not Found"
+                if err not in e.response["Error"]["Message"]:
+                    raise e
+
+        # Set all the internal locations to point to the downloaded files:
+        self.confFilePath = path.join(self.localS3Copy.name, self.confFileName)
+        self.resultsDirPath = path.join(self.localS3Copy.name, self.resultsDirName)
+        self.benchmarksFilePath = path.join(
+            self.resultsDirPath, self.benchmarksFileName
+        )
+
+    def __uploadIfS3(self):
+        def recursiveUpload(base, ext=""):
+            root, dirs, files = next(os.walk(path.join(base, ext), topdown=True))
+
+            # Upload files in this folder
+            for name in files:
+                self.s3Resource.Bucket(self.bucketName).upload_file(
+                    path.join(base, ext, name), path.join(self.bucketKey, ext, name)
+                )
+
+            # Call upload again for each folder
+            if len(dirs) != 0:
+                for folder in dirs:
+                    ext = path.join(ext, folder)
+                    recursiveUpload(base, ext)
+
+        if self.__isS3URL(self.dbDir):
+            recursiveUpload(self.localS3Copy.name)
+            # Give S3 time to see the new uploads before releasing lock
+            time.sleep(1)
+
+    def __removeLocalS3Copy(self):
+        if not self.__isS3URL(self.dbDir):
+            return
+
+        self.localS3Copy.cleanup()
+        self.localS3Copy = None
+
+        self.confFilePath = path.join(self.dbDir, self.confFileName)
+        self.resultsDirPath = path.join(self.dbDir, self.resultsDirName)
+        self.benchmarksFilePath = path.join(
+            self.resultsDirPath, self.benchmarksFileName
+        )
+
+    ###########################################################################
+    def __removeFiles(self, fileList):
+        for f in fileList:
+            try:
+                os.remove(f)
+            except FileNotFoundError:
+                pass
+
+    def __isS3URL(self, url):
+        """
+        Returns True if url is a S3 URL, False otherwise.
+        """
+        if url.startswith("s3:"):
+            return True
+
+        return False
+
+    def __waitForWrite(self):
+        """
+        Testing helper: pause for self.writeDelay seconds, or until
+        self.cancelWrite turns True. Always set self.cancelWrite back to False
+        so future writes can take place by default.
+
+        Return True to indicate a write operation should take place, False to
+        cancel the write operation, based on if the write was cancelled or not.
+        """
+        if not (self.cancelWrite):
+            st = now = time.time()
+            while ((now - st) < self.writeDelay) and not (self.cancelWrite):
+                time.sleep(0.01)
+                now = time.time()
+
+        retVal = not (self.cancelWrite)
+        self.cancelWrite = False
+        return retVal

--- a/src/eradiate/test_tools/benchmark/benchmark.py
+++ b/src/eradiate/test_tools/benchmark/benchmark.py
@@ -1,0 +1,187 @@
+import os
+import platform
+import subprocess
+
+import click
+import json5
+
+import eradiate
+
+from . import utils
+from .asvdb import ASVDb
+
+
+@click.command
+@click.option(
+    "--set-commit-hash",
+    default=None,
+    help="Set the commit hash to use when recording benchmark results. "
+    "By default, will use the currently checked out environment for dev environments "
+    "and the eradiate version tag's commit for prod environment. Note also "
+    "that if git-ref is specified, this will overwrite it when recording the results.",
+)
+@click.option(
+    "--archive-dir",
+    default=None,
+    help="Specify the directory to another ASV database in which the result should be archived. "
+    "The path should point to the root of the database (where the asv.conf.json lives).",
+)
+@click.option(
+    "--git-ref",
+    default=None,
+    help="Specifies a range at which benchmarks should be run. Note that this will run using ASV's "
+    "contained environments and clone and build the project at each commit in the range.",
+)
+@click.option("-v", "--verbose", is_flag=True, help="increase verbosity")
+@click.option(
+    "-e",
+    "--show-stderr",
+    is_flag=True,
+    help="Display the stderr output from the benchmarks.",
+)
+@click.option(
+    "-q",
+    "--quick",
+    is_flag=True,
+    help="Do a 'quick' run, where each benchmark function is run only once. "
+    "This is useful to find basic errors in the benchmark "
+    "functions faster. The results are unlikely to be useful, "
+    "and thus are not saved.",
+)
+@click.option(
+    "-m",
+    "--machine",
+    default=None,
+    help="Use the given name to retrieve machine information. If not provided, "
+    "the hostname is used. If no entry with that name is found, and there "
+    "is only one entry in ~/.asv-machine.json, that one entry will be used.",
+)
+def benchmark(
+    set_commit_hash, archive_dir, git_ref, verbose, show_stderr, quick, machine
+):
+    """
+    Benchmark test suite based on ASV. By default, runs the test suite on the current
+    environment. Specify a git-ref range to run the benchmark on cloned projects (ASV's default).
+
+    Warning!
+    --------
+    Prod environment cannot be tested yet because no packaged versions contain
+    those changes yet.
+    """
+
+    # get current benchmark directory
+    eradiate_dir = os.environ.get("ERADIATE_SOURCE_DIR")
+    benchmark_dir = os.path.join(eradiate_dir, "benchmarks")
+    conf_path = os.path.join(benchmark_dir, "asv.conf.json")
+    branches = []
+    conf = None
+    with open(conf_path) as conf_file:
+        conf = json5.load(conf_file)
+        branches = conf["branches"]
+
+    cmd = ["asv", "run"]
+
+    if git_ref:
+        cmd.append(git_ref)
+    else:
+        cmd.append("-E")
+        cmd.append("existing:same")
+
+    # Pass arguments to ASV
+    if verbose:
+        cmd.append("-v")
+
+    if show_stderr:
+        cmd.append("-e")
+
+    if quick:
+        cmd.append("-q")
+
+    if machine:
+        cmd.append(f"-m={machine}")
+
+    # By default, dev environment will use the checked out commit hash
+    # and prod the commit corresponding to their version tag.
+    if set_commit_hash is None and git_ref is None:
+        version = eradiate.__version__
+        if "dev" in version:
+            set_commit_hash, _ = utils.get_commit_info()
+        else:
+            cmd = f"git rev-list -n 1 v{version}"
+            if verbose:
+                click.echo(f"Running {cmd}")
+            set_commit_hash = utils.get_command_output(cmd)
+
+    if set_commit_hash:
+        cmd.append(f"--set-commit-hash={set_commit_hash}")
+
+        commit_branches_raw = utils.get_command_output(
+            f"git branch --contains {set_commit_hash} "
+        )
+
+        commit_branches_raw = commit_branches_raw.replace("*", "")
+        commit_branches_raw = commit_branches_raw.replace(" ", "")
+        commit_branches = commit_branches_raw.split("\n")
+
+        branch_in_conf = False
+        for branch in branches:
+            if branch in commit_branches:
+                branch_in_conf = True
+
+        if not branch_in_conf:
+            if click.confirm(
+                f"The branch '{commit_branches[0]}' you are about to benchmark isn't tracked by asv.conf.json. Are you sure you want to continue?",
+                abort=True,
+            ):
+                pass
+
+    # construct and run the full command
+    cmd = " ".join(cmd)
+    if verbose:
+        click.echo(f"Running : {cmd}")
+    subprocess.run(cmd, shell=True)
+
+    if archive_dir and not quick:
+        if verbose:
+            click.echo("Archiving results:")
+
+        if machine is None:
+            # get default machine name if none were given
+            uname = platform.uname()
+            machine = uname.node
+
+        if verbose:
+            click.echo(f"\t Loading current database at {benchmark_dir}")
+
+        # get all results in database
+        current_db = ASVDb(benchmark_dir)
+        results = current_db.getResults()
+
+        if verbose:
+            click.echo(f"\t Loading target database at {archive_dir}")
+
+        (repo, branch) = utils.get_repo_info()
+        target_db = ASVDb(archive_dir, repo=repo, branches=[branch])
+
+        commit_list = []
+
+        if set_commit_hash:
+            commit_list.append(set_commit_hash[:8])
+        elif git_ref:
+            commit_list_raw = utils.get_command_output(f"git rev-list {git_ref}")
+            commit_list_raw = commit_list_raw.split("\n")
+            commit_list = [commit[:8] for commit in commit_list_raw]
+
+        # filter by machine name and commit hash
+        for result in results:
+            info = result[0]
+            if info.machineName == machine and info.commitHash[:8] in commit_list:
+                if verbose:
+                    click.echo(
+                        f"\t Archiving {info.commitHash[:8]}-{info.envName}.json"
+                    )
+                target_db.addResults(info, result[1])
+
+
+if __name__ == "__main__":
+    benchmark()

--- a/src/eradiate/test_tools/benchmark/cli.py
+++ b/src/eradiate/test_tools/benchmark/cli.py
@@ -60,13 +60,12 @@ def benchmark(
     set_commit_hash, archive_dir, git_ref, verbose, show_stderr, quick, machine
 ):
     """
-    Benchmark test suite based on ASV. By default, runs the test suite on the current
-    environment. Specify a git-ref range to run the benchmark on cloned projects (ASV's default).
+    Benchmark test suite based on ASV. By default, runs the test suite on the
+    current environment. Specify a git-ref range to run the benchmark on
+    cloned projects (ASV's default).
 
-    Warning!
-    --------
-    Prod environment cannot be tested yet because no packaged versions contain
-    those changes yet.
+    Warning! Production environment cannot be tested yet because no
+    packaged versions contain those changes yet.
     """
 
     # get current benchmark directory

--- a/src/eradiate/test_tools/benchmark/utils.py
+++ b/src/eradiate/test_tools/benchmark/utils.py
@@ -1,0 +1,60 @@
+import subprocess
+
+
+def get_command_output(cmd):
+    """
+    Run a command in the shell and return the output.
+    Will raise and display any errors too.
+
+    Parameters
+    ----------
+    cmd : str
+        Command to run in shell, formatted as used in shell directly.
+
+    Returns
+    -------
+    str
+        Stdout of the process run in shell.
+    """
+    result = subprocess.run(
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True
+    )
+    stdout = result.stdout.decode().strip()
+    if result.returncode == 0:
+        return stdout
+
+    stderr = result.stderr.decode().strip()
+    raise RuntimeError(
+        "Problem running '%s' (STDOUT: '%s' STDERR: '%s')" % (cmd, stdout, stderr)
+    )
+
+
+def get_repo_info():
+    """
+    Returns
+    -------
+    str
+        The remote repo url.
+    str
+        The branch currently checked out.
+    """
+    out = get_command_output("git remote -v")
+    repo = out.split("\n")[-1].split()[1]
+    branch = get_command_output("git rev-parse --abbrev-ref HEAD")
+    return (repo, branch)
+
+
+def get_commit_info():
+    """
+    Get currently checked out git commit hash and time of commit.
+
+    Returns
+    -------
+    str
+        Commit hash currently checked out.
+    str
+        Time of commit.
+    """
+    commitHash = get_command_output("git rev-parse HEAD")
+    commitTime = get_command_output("git log -n1 --pretty=%%ct %s" % commitHash)
+    return (commitHash, str(int(commitTime) * 1000))

--- a/src/eradiate/test_tools/test_cases/atmospheres.py
+++ b/src/eradiate/test_tools/test_cases/atmospheres.py
@@ -1,0 +1,143 @@
+import numpy as np
+
+from ...experiments import AtmosphereExperiment
+from ...units import unit_registry as ureg
+
+
+# TODO : This probably needs to go somewhere else or get called by fixtures
+def absorption_database_error_handler_config():
+    """
+    Error handler configuration for absorption coefficient interpolation.
+
+    Notes
+    -----
+    This configuration is chosen to ignore all interpolation issues (except
+    bounds error along the mole fraction dimension) because warnings are
+    captured by pytest which will raise.
+    Ignoring the bounds on pressure and temperature is safe because
+    out-of-bounds values usually correspond to locations in the atmosphere
+    that are so high that the contribution to the absorption coefficient
+    are negligible at these heights.
+    The bounds error for the 'x' (mole fraction) coordinate is considered
+    fatal.
+    """
+    return {
+        "p": {"missing": "raise", "scalar": "raise", "bounds": "ignore"},
+        "t": {"missing": "raise", "scalar": "raise", "bounds": "ignore"},
+        "x": {"missing": "ignore", "scalar": "ignore", "bounds": "raise"},
+    }
+
+
+def create_rpv_afgl1986_continental_brfpp(absorption_database_error_handler_config):
+    r"""
+    RPV AFGL1986 Aerosol
+    ====================
+
+    Rationale
+    ---------
+
+    This test case uses a basic atmospheric scene:
+
+    * RPV surface emulating a canopy
+    * Molecular atmosphere following the AFGL 1986 model
+    * Aerosol layer at 1km elevation
+
+    Parameters
+
+    * Atmosphere: Molecular atmosphere using the agfl1986 profile
+    * Aerosol layer: 16 layers from 1km to 2km height, :math:`\tau_{500} = 0.5`
+      Radiative properties from the Govaerts 2021 Continental dataset
+    * Surface: Square surface with RPV BSDF with :math:`k = 0.95`, :math:`g = -0.1`
+      and :math:`\rho_0 = 0.027685`
+    * Illumination: Directional illumination with a zenith angle :math:`\theta = 20°`
+    * Sensor: Distant reflectance measure, covering a plane, (76 angular points)
+    """
+
+    return AtmosphereExperiment(
+        surface={"type": "rpv", "k": 0.95, "g": -0.1, "rho_0": 0.027685},
+        illumination={
+            "type": "directional",
+            "zenith": 20 * ureg.deg,
+            "irradiance": 20.0,
+        },
+        measures={
+            "type": "mdistant",
+            "construct": "hplane",
+            "azimuth": 0.0,
+            "zeniths": np.arange(-75.0, 75.01, 2.0),
+            "srf": {"type": "multi_delta", "wavelengths": 550 * ureg.nm},
+        },
+        atmosphere={
+            "type": "heterogeneous",
+            "molecular_atmosphere": {
+                "type": "molecular",
+                "thermoprops": {
+                    "identifier": "afgl_1986-us_standard",
+                    "z": np.arange(0, 120.1, 0.1) * ureg.km,
+                    "additional_molecules": False,
+                },
+                "absorption_data": "monotropa",
+                "error_handler_config": absorption_database_error_handler_config,
+            },
+            "particle_layers": {
+                "type": "particle_layer",
+                "bottom": 1 * ureg.km,
+                "top": 2 * ureg.km,
+                "tau_ref": 0.5,
+                "dataset": "govaerts_2021-continental",
+            },
+        },
+    )
+
+
+def create_rpv_afgl1986_brfpp(absorption_database_error_handler_config):
+    r"""
+    RPV AFGL1986
+    ============
+
+    Rationale
+    ---------
+
+    This test case uses a basic atmospheric scene:
+
+    * RPV surface emulating a canopy
+    * Molecular atmosphere following the AFGL 1986 model
+
+    Parameters
+
+    * Atmosphere: Molecular atmosphere using the agfl1986 profile
+    * Surface: Square surface with RPV BSDF with :math:`k = 0.95`, :math:`g = -0.1`
+      and :math:`\rho_0 = 0.027685`
+    * Illumination: Directional illumination with a zenith angle :math:`\theta = 20°`
+    * Sensor: Distant reflectance measure, covering a plane, (76 angular points)
+    """
+    return AtmosphereExperiment(
+        surface={"type": "rpv", "k": 0.95, "g": -0.1, "rho_0": 0.027685},
+        illumination={
+            "type": "directional",
+            "zenith": 20 * ureg.deg,
+            "irradiance": 20.0,
+        },
+        measures=[
+            {
+                "type": "mdistant",
+                "construct": "hplane",
+                "azimuth": 0.0,
+                "zeniths": np.arange(-75.0, 75.01, 2.0),
+                "srf": {"type": "multi_delta", "wavelengths": 550 * ureg.nm},
+            }
+        ],
+        atmosphere={
+            "type": "heterogeneous",
+            "molecular_atmosphere": {
+                "type": "molecular",
+                "thermoprops": {
+                    "identifier": "afgl_1986-us_standard",
+                    "z": np.linspace(0, 120, 61) * ureg.km,
+                    "additional_molecules": False,
+                },
+                "absorption_data": "monotropa",
+                "error_handler_config": absorption_database_error_handler_config,
+            },
+        },
+    )

--- a/src/eradiate/test_tools/test_cases/rami4atm.py
+++ b/src/eradiate/test_tools/test_cases/rami4atm.py
@@ -1,0 +1,89 @@
+import numpy as np
+
+from eradiate import unit_registry as ureg
+from eradiate.experiments import AtmosphereExperiment
+
+
+def create_rami4atm_hom00_bla_sd2s_m03_z30a000_brfpp():
+    r"""
+    RAMI4ATM HOM00_BLA_SD2S_M03
+    ===========================
+
+    Rationale
+    ---------
+    This test case uses a basic atmospheric scene:
+
+    * black surface
+    * Molecular atmosphere following the AFGL 1986 model
+    * Aerosol layer at 1km elevation
+
+    Parameters
+
+    * Atmosphere: molecular atmosphere using the AFGL 1986 profile
+      (U.S. standard)
+    * Aerosol layer: uniform, covers [0, 2] km extent, :math:`\tau_{500} = 0.2`;
+      radiative properties from the ``govaerts_2021-desert`` dataset
+    * Surface: black
+    * Illumination: directional illumination with a zenith angle
+      :math:`\theta = 30°`
+    * Measure: distant measure, covering the principal plane for
+      :math:`\theta \in [-75, 75]°`
+    """
+
+    config = {
+        "surface": {
+            "reflectance": {"value": 0.0, "type": "uniform"},
+            "type": "lambertian",
+        },
+        "atmosphere": {
+            "molecular_atmosphere": {
+                "has_absorption": False,
+                "has_scattering": True,
+                "type": "molecular",
+                "thermoprops": {
+                    "identifier": "afgl_1986-us_standard",
+                    "z": np.arange(0, 120.05, 0.05) * ureg.km,
+                },
+                "absorption_data": "monotropa",
+            },
+            "particle_layers": [
+                {
+                    "bottom": 0,
+                    "bottom_units": "meter",
+                    "top": 2000,
+                    "top_units": "meter",
+                    "distribution": {"type": "uniform"},
+                    "tau_ref": 0.2,
+                    "dataset": "govaerts_2021-desert",
+                }
+            ],
+            "type": "heterogeneous",
+        },
+        "illumination": {
+            "zenith": 30.0,
+            "zenith_units": "degree",
+            "azimuth": 0.0,
+            "azimuth_units": "degree",
+            "type": "directional",
+        },
+        "measures": [
+            {
+                "type": "mdistant",
+                "construct": "hplane",
+                "zeniths": np.arange(-75, 76, 2),
+                "zeniths_units": "degree",
+                "azimuth": 0.0,
+                "azimuth_units": "degree",
+                "srf": "sentinel_2a-msi-3",
+                "spp": 1000,
+            }
+        ],
+        "quad_spec": {
+            "type": "fixed",
+            "quad_type": "gauss_legendre",
+            "n": 16,
+        },
+    }
+
+    return AtmosphereExperiment(**config)
+    

--- a/src/eradiate/test_tools/test_cases/romc.py
+++ b/src/eradiate/test_tools/test_cases/romc.py
@@ -1,0 +1,352 @@
+import numpy as np
+
+from eradiate.data import data_store
+from eradiate.experiments import CanopyExperiment
+from eradiate.units import unit_registry as ureg
+
+
+def fetch_het01_brfpp():
+    r"""
+    Fetches data necessary for test case het01_brfpp. 
+    Note that this function can be used to prefetch data 
+    before running a test case.
+
+    Returns
+    -------
+    dict
+        dictionary containing the various data stores.
+    """
+
+    data = {}
+    data["leaf_spec_path"] = data_store.fetch(
+        "tests/regression_test_specifications/het01/het01_UNI_sphere.def"
+    )
+    data["leaf_pos_path"] = data_store.fetch(
+        "tests/regression_test_specifications/het01/het01_UNI_instances.def"
+    )
+
+    return data
+
+def create_het01_brfpp(prefetched_data = None):
+    r"""
+    Floating spheres (HET01)
+    ========================
+
+    Rationale
+    ---------
+
+    This test case implements a basic canopy scene:
+
+    * Surface with lambertian reflectance
+    * No atmosphere
+    * Three dimensional canopy
+
+    Parameters
+
+    * Surface: Square surface with labmertian BSDF with :math:`r = 0.159`
+    * Canopy: Floating spheres made up of disks with bilambertian bsdf model
+      Leaf reflectance is 0.4957, transmittance is 0.4409.
+      Disk and sphere positioning follow the HET01 scenario of the RAMI-3 benchmark
+    * Illumination: Directional illumination with a zenith angle :math:`\theta = 20°`
+    * Sensor: Distant reflectance measure, covering a plane, (76 angular points)
+
+    """
+    if prefetched_data is None :
+        prefetched_data = fetch_het01_brfpp()
+
+    leaf_spec_path = prefetched_data["leaf_spec_path"]
+    leaf_pos_path = prefetched_data["leaf_pos_path"]
+
+    return CanopyExperiment(
+        canopy={
+            "type": "discrete_canopy",
+            "instanced_canopy_elements": [
+                {
+                    "construct": "from_file",
+                    "filename": leaf_pos_path,
+                    "canopy_element": {
+                        "type": "leaf_cloud",
+                        "construct": "from_file",
+                        "filename": leaf_spec_path,
+                        "leaf_reflectance": 0.4957,
+                        "leaf_transmittance": 0.4409,
+                        "id": "spherical_leaf_cloud",
+                    },
+                },
+            ],
+            "size": [100, 100, 30] * ureg.m,
+        },
+        surface={"type": "lambertian", "reflectance": 0.159},
+        padding=20,
+        measures=[
+            {
+                "type": "mdistant",
+                "construct": "hplane",
+                "spp": 10000,
+                "azimuth": 180 * ureg.deg,
+                "zeniths": np.arange(-75, 75.01, 2) * ureg.deg,
+                "target": {
+                    "type": "rectangle",
+                    "xmin": -50 * ureg.m,
+                    "xmax": 50 * ureg.m,
+                    "ymin": -50 * ureg.m,
+                    "ymax": 50 * ureg.m,
+                    "z": 30 * ureg.m,
+                },
+            }
+        ],
+        illumination={
+            "type": "directional",
+            "zenith": 20 * ureg.deg,
+            "azimuth": 0.0 * ureg.deg,
+            "irradiance": 20.0,
+        },
+        integrator={"type": "path", "max_depth": -1},
+    )
+
+def fetch_het04a1_brfpp():
+    r"""
+    Fetches data necessary for test case het04_brfpp. 
+    Note that this function can be used to prefetch data 
+    before running a test case.
+
+    Returns
+    -------
+    dict
+        dictionary containing the various data stores.
+    """
+
+    data = {}
+
+    data["leaf_spec_path_sph"] = data_store.fetch(
+        "tests/regression_test_specifications/het04/het04_sph.def"
+    )
+    data["leaf_pos_path_sph"] = data_store.fetch(
+        "tests/regression_test_specifications/het04/het04_sph_positions.def"
+    )
+    data["leaf_spec_path_cyl"] = data_store.fetch(
+        "tests/regression_test_specifications/het04/het04_cyl.def"
+    )
+    data["leaf_pos_path_cyl"] = data_store.fetch(
+        "tests/regression_test_specifications/het04/het04_cyl_positions.def"
+    )
+    
+    return data
+
+def create_het04a1_brfpp(prefetched_data = None):
+    r"""
+    Real zoom in (HET04a1)
+    ======================
+
+    This is a regression test, which compares the simulation results of the
+    current branch to an older reference version.
+
+    Rationale
+    ---------
+
+    This test case implements a basic canopy scene:
+
+    * Surface with lambertian reflectance
+    * No atmosphere
+    * Three dimensional canopy
+
+    Parameters
+
+    * Surface: Square surface with labmertian BSDF with :math:`r = 0.15`
+    * Canopy:
+
+      * Floating spheres made up of disks with bilambertian bsdf model.
+        Leaf reflectance is 0.49, transmittance is 0.41.
+      * Floating cylinders made up of disks with bilambertian bsdf model.
+        Leaf reflectance is 0.45, transmittance is 0.43.
+
+      Disk, sphere and cylinder positioning follow the HET04 scenario of the
+      RAMI-3 benchmark.
+    * Illumination: Directional illumination with a zenith angle :math:`\theta = 20°`
+    * Sensor: Distant reflectance measure, covering a plane, (76 angular points). 
+      This test implements the variant a1 of the HET04
+      scenario, in which the entire scene is targeted by the sensor.
+
+    """
+
+    if prefetched_data is None :
+        prefetched_data = fetch_het04a1_brfpp()
+
+    leaf_spec_path_sph = prefetched_data["leaf_spec_path_sph"]
+    leaf_pos_path_sph = prefetched_data["leaf_pos_path_sph"]
+    leaf_spec_path_cyl = prefetched_data["leaf_spec_path_cyl"]
+    leaf_pos_path_cyl = prefetched_data["leaf_pos_path_cyl"]
+
+    return CanopyExperiment(
+        canopy={
+            "type": "discrete_canopy",
+            "instanced_canopy_elements": [
+                {
+                    "construct": "from_file",
+                    "filename": leaf_pos_path_sph,
+                    "canopy_element": {
+                        "type": "leaf_cloud",
+                        "construct": "from_file",
+                        "filename": leaf_spec_path_sph,
+                        "leaf_reflectance": 0.49,
+                        "leaf_transmittance": 0.41,
+                        "id": "spherical_leaf_cloud",
+                    },
+                },
+                {
+                    "construct": "from_file",
+                    "filename": leaf_pos_path_cyl,
+                    "canopy_element": {
+                        "type": "leaf_cloud",
+                        "construct": "from_file",
+                        "filename": leaf_spec_path_cyl,
+                        "leaf_reflectance": 0.45,
+                        "leaf_transmittance": 0.3,
+                        "id": "cylindrical_leaf_cloud",
+                    },
+                },
+            ],
+            "size": [270, 270, 15] * ureg.m,
+        },
+        surface={"type": "lambertian", "reflectance": 0.15},
+        padding=5,
+        measures=[
+            {
+                "type": "mdistant",
+                "construct": "hplane",
+                "spp": 20000,
+                "azimuth": 180 * ureg.deg,
+                "zeniths": np.arange(-75, 75.01, 2) * ureg.deg,
+                "target": {
+                    "type": "rectangle",
+                    "xmin": -135 * ureg.m,
+                    "xmax": 135 * ureg.m,
+                    "ymin": -135 * ureg.m,
+                    "ymax": 135 * ureg.m,
+                    "z": 15 * ureg.m,
+                },
+            }
+        ],
+        illumination={
+            "type": "directional",
+            "zenith": 20 * ureg.deg,
+            "azimuth": 0.0 * ureg.deg,
+            "irradiance": 20.0,
+        },
+        integrator={"type": "path", "max_depth": -1},
+    )
+
+def fetch_het06_brfpp():
+    r"""
+    Fetches data necessary for test case het04_brfpp. 
+    Note that this function can be used to prefetch data 
+    before running a test case.
+
+    Returns
+    -------
+    dict
+        dictionary containing the various data stores.
+    """
+
+    data = {}
+
+    data["tree_pos_path"] = data_store.fetch(
+        "tests/regression_test_specifications/het06/het06_scene.def"
+    )
+
+    return data
+
+def create_het06_brfpp(prefetched_data = None):
+    r"""
+    Coniferous forest (HET06)
+    =========================
+
+    This is a regression test, which compares the simulation results of the
+    current branch to an older reference version.
+
+    Rationale
+    ---------
+
+    This test case implements a basic canopy scene:
+
+    * Surface with lambertian reflectance
+    * No atmosphere
+    * Three dimensional canopy
+
+    Parameters
+
+    * Surface: Square surface with labmertian BSDF with :math:`r = 0.86`
+    * Canopy: Coniferous trees made up of a conical leaf cloud and a cylindrical
+      trunk.
+
+      * Leaf reflectance: 0.08
+      * Leaf transmittance: 0.03
+      * Trunk reflectance: 0.14
+
+      Disk and tree positioning follow the HET06 scenario of the RAMI-3 benchmark
+    * Illumination: Directional illumination with a zenith angle :math:`\theta = 20°`
+    * Sensor: Distant reflectance measure, covering a plane, (76 angular points).
+
+    """
+
+    if prefetched_data is None :
+        prefetched_data = fetch_het06_brfpp()
+
+    tree_pos_path = prefetched_data["tree_pos_path"]
+
+    return CanopyExperiment(
+        canopy={
+            "type": "discrete_canopy",
+            "instanced_canopy_elements": [
+                {
+                    "construct": "from_file",
+                    "filename": tree_pos_path,
+                    "canopy_element": {
+                        "type": "abstract_tree",
+                        "trunk_height": 1.5 * ureg.m,
+                        "trunk_radius": 0.15 * ureg.m,
+                        "trunk_reflectance": 0.14,
+                        "leaf_cloud_extra_offset": [0.0, 0.0, 0.0] * ureg.m,
+                        "id": "conifer_tree",
+                        "leaf_cloud": {
+                            "construct": "cone",
+                            "l_vertical": 12.0 * ureg.m,
+                            "leaf_radius": 0.05,
+                            "radius": 1.8 * ureg.m,
+                            "n_leaves": 6480,
+                            "leaf_reflectance": 0.08,
+                            "leaf_transmittance": 0.03,
+                            "id": "conical_leaf_cloud",
+                        },
+                    },
+                }
+            ],
+            "size": [500, 500, 13.5] * ureg.m,
+        },
+        surface={"type": "lambertian", "reflectance": 0.86},
+        padding=0,
+        measures=[
+            {
+                "type": "mdistant",
+                "construct": "hplane",
+                "spp": 10000,
+                "azimuth": 180 * ureg.deg,
+                "zeniths": np.arange(-75, 75.01, 2) * ureg.deg,
+                "target": {
+                    "type": "rectangle",
+                    "xmin": -250 * ureg.m,
+                    "xmax": 250 * ureg.m,
+                    "ymin": -250 * ureg.m,
+                    "ymax": 250 * ureg.m,
+                    "z": 6.75 * ureg.m,
+                },
+            }
+        ],
+        illumination={
+            "type": "directional",
+            "zenith": 40 * ureg.deg,
+            "azimuth": 0.0 * ureg.deg,
+            "irradiance": 20.0,
+        },
+        integrator={"type": "path", "max_depth": -1},
+    )

--- a/src/eradiate/test_tools/util.py
+++ b/src/eradiate/test_tools/util.py
@@ -14,6 +14,9 @@ from ..data import data_store
 from ..exceptions import DataError
 from ..typing import PathLike
 
+from typing import Callable, TypeVar, Any
+from typing_extensions import ParamSpec, TypeAlias
+
 
 def skipif_data_not_found(path: PathLike, action: t.Callable | None = None) -> None:
     """
@@ -70,3 +73,55 @@ def missing_artefact(filename: PathLike) -> None:
 
     else:
         raise ValueError(f"unsupported file extension {filename.suffix}")
+
+T = TypeVar('T')
+P = ParamSpec('P')
+WrappedFuncDeco: TypeAlias = Callable[[Callable[P, T]], Callable[P, T]]
+
+def copy_doc(copy_func: Callable[..., Any]) -> WrappedFuncDeco[P, T]:
+    """Copies the doc string of the given function to another. 
+    This function is intended to be used as a decorator.
+
+    .. code-block:: python3
+
+        def foo():
+            '''This is a foo doc string'''
+            ...
+
+        @copy_doc(foo)
+        def bar():
+            ...
+    """
+
+    def wrapped(func: Callable[P, T]) -> Callable[P, T]:
+        func.__doc__ = copy_func.__doc__
+        return func
+
+    return wrapped
+
+def append_doc(copy_func: Callable[..., Any], prepend=False) -> WrappedFuncDeco[P, T]:
+    """Append the doc string of the given function to another. 
+    If prepend is true, will place the copied doc string in front
+    of the decorated function's doc string.
+    This function is intended to be used as a decorator.
+
+    .. code-block:: python3
+
+        def foo():
+            '''This is a foo doc string'''
+            ...
+
+        @append_doc(foo)
+        def bar():
+            '''This is a bar doc string'''
+            ...
+    """
+
+    def wrapped(func: Callable[P, T]) -> Callable[P, T]:
+        if prepend:
+            func.__doc__ = copy_func.__doc__ + "\n" + func.__doc__
+        else:
+            func.__doc__ = func.__doc__ + "\n" + copy_func.__doc__ 
+        return func
+
+    return wrapped

--- a/tests/03_regression/atmospheres/test_rpv_afgl1986.py
+++ b/tests/03_regression/atmospheres/test_rpv_afgl1986.py
@@ -1,12 +1,12 @@
-import numpy as np
 import pytest
 
 import eradiate
-from eradiate.experiments import AtmosphereExperiment
 from eradiate.test_tools.regression import Chi2Test
-from eradiate.units import unit_registry as ureg
+from eradiate.test_tools.test_cases.atmospheres import create_rpv_afgl1986_brfpp
+from eradiate.test_tools.util import append_doc
 
 
+@append_doc(create_rpv_afgl1986_brfpp)
 @pytest.mark.regression
 def test_rpv_afgl1986_brfpp(
     mode_ckd_double,
@@ -21,59 +21,13 @@ def test_rpv_afgl1986_brfpp(
     This is a regression test, which compares the simulation results of the
     current branch to an older reference version.
 
-    Rationale
-    ---------
-
-    This test case uses a basic atmospheric scene:
-
-    * RPV surface emulating a canopy
-    * Molecular atmosphere following the AFGL 1986 model
-
-    Parameters
-
-    * Atmosphere: Molecular atmosphere using the agfl1986 profile
-    * Surface: Square surface with RPV BSDF with :math:`k = 0.95`, :math:`g = -0.1`
-      and :math:`\rho_0 = 0.027685`
-    * Illumination: Directional illumination with a zenith angle :math:`\theta = 20°`
-    * Sensor: Distant reflectance measure, covering a plane, (76 angular points,
-      10000 samples per pixel)
-
-    Expected behaviour
+     Expected behaviour
     ------------------
 
     This test uses the Chi-squared criterion with a threshold of 0.05.
 
     """
-    exp = AtmosphereExperiment(
-        surface={"type": "rpv", "k": 0.95, "g": -0.1, "rho_0": 0.027685},
-        illumination={
-            "type": "directional",
-            "zenith": 20 * ureg.deg,
-            "irradiance": 20.0,
-        },
-        measures=[
-            {
-                "type": "mdistant",
-                "construct": "hplane",
-                "azimuth": 0.0,
-                "zeniths": np.arange(-75.0, 75.01, 2.0),
-                "srf": {"type": "multi_delta", "wavelengths": 550 * ureg.nm},
-            }
-        ],
-        atmosphere={
-            "type": "heterogeneous",
-            "molecular_atmosphere": {
-                "type": "molecular",
-                "thermoprops": {
-                    "identifier": "afgl_1986-us_standard",
-                    "z": np.linspace(0, 120, 61) * ureg.km,
-                    "additional_molecules": False,
-                },
-                "absorption_data": "monotropa",
-                "error_handler_config": absorption_database_error_handler_config,
-            },
-        },
-    )
+    exp = create_rpv_afgl1986_brfpp(absorption_database_error_handler_config)
     result = eradiate.run(exp, spp=10000)
 
     test = Chi2Test(

--- a/tests/03_regression/atmospheres/test_rpv_afgl1986_continental.py
+++ b/tests/03_regression/atmospheres/test_rpv_afgl1986_continental.py
@@ -1,12 +1,14 @@
-import numpy as np
 import pytest
 
 import eradiate
-from eradiate.experiments import AtmosphereExperiment
 from eradiate.test_tools.regression import Chi2Test
-from eradiate.units import unit_registry as ureg
+from eradiate.test_tools.test_cases.atmospheres import (
+    create_rpv_afgl1986_continental_brfpp,
+)
+from eradiate.test_tools.util import append_doc
 
 
+@append_doc(create_rpv_afgl1986_continental_brfpp)
 @pytest.mark.regression
 def test_rpv_afgl1986_continental_brfpp(
     mode_ckd_double,
@@ -21,26 +23,6 @@ def test_rpv_afgl1986_continental_brfpp(
     This is a regression test, which compares the simulation results of the
     current branch to an older reference version.
 
-    Rationale
-    ---------
-
-    This test case uses a basic atmospheric scene:
-
-    * RPV surface emulating a canopy
-    * Molecular atmosphere following the AFGL 1986 model
-    * Aerosol layer at 1km elevation
-
-    Parameters
-
-    * Atmosphere: Molecular atmosphere using the agfl1986 profile
-    * Aerosol layer: 16 layers from 1km to 2km height, :math:`\tau_{500} = 0.5`
-      Radiative properties from the Govaerts 2021 Continental dataset
-    * Surface: Square surface with RPV BSDF with :math:`k = 0.95`, :math:`g = -0.1`
-      and :math:`\rho_0 = 0.027685`
-    * Illumination: Directional illumination with a zenith angle :math:`\theta = 20°`
-    * Sensor: Distant reflectance measure, covering a plane, (76 angular points,
-      10000 samples per pixel)
-
     Expected behaviour
     ------------------
 
@@ -48,40 +30,8 @@ def test_rpv_afgl1986_continental_brfpp(
 
     """
 
-    exp = AtmosphereExperiment(
-        surface={"type": "rpv", "k": 0.95, "g": -0.1, "rho_0": 0.027685},
-        illumination={
-            "type": "directional",
-            "zenith": 20 * ureg.deg,
-            "irradiance": 20.0,
-        },
-        measures={
-            "type": "mdistant",
-            "construct": "hplane",
-            "azimuth": 0.0,
-            "zeniths": np.arange(-75.0, 75.01, 2.0),
-            "srf": {"type": "multi_delta", "wavelengths": 550 * ureg.nm},
-        },
-        atmosphere={
-            "type": "heterogeneous",
-            "molecular_atmosphere": {
-                "type": "molecular",
-                "thermoprops": {
-                    "identifier": "afgl_1986-us_standard",
-                    "z": np.arange(0, 120.1, 0.1) * ureg.km,
-                    "additional_molecules": False,
-                },
-                "absorption_data": "monotropa",
-                "error_handler_config": absorption_database_error_handler_config,
-            },
-            "particle_layers": {
-                "type": "particle_layer",
-                "bottom": 1 * ureg.km,
-                "top": 2 * ureg.km,
-                "tau_ref": 0.5,
-                "dataset": "govaerts_2021-continental",
-            },
-        },
+    exp = create_rpv_afgl1986_continental_brfpp(
+        absorption_database_error_handler_config
     )
     result = eradiate.run(exp, spp=10000)
 

--- a/tests/03_regression/rami4atm/test_rami4atm_hom00_bla_sd2s_m03_z30a000_brfpp.py
+++ b/tests/03_regression/rami4atm/test_rami4atm_hom00_bla_sd2s_m03_z30a000_brfpp.py
@@ -1,12 +1,14 @@
-import numpy as np
 import pytest
 
 import eradiate
-from eradiate import unit_registry as ureg
-from eradiate.experiments import AtmosphereExperiment
 from eradiate.test_tools.regression import Chi2Test
+from eradiate.test_tools.test_cases.rami4atm import (
+    create_rami4atm_hom00_bla_sd2s_m03_z30a000_brfpp,
+)
+from eradiate.test_tools.util import append_doc
 
 
+@append_doc(create_rami4atm_hom00_bla_sd2s_m03_z30a000_brfpp)
 @pytest.mark.regression
 def test_rami4atm_hom00_bla_sd2s_m03_z30a000_brfpp(
     mode_ckd_double, artefact_dir, session_timestamp
@@ -19,87 +21,13 @@ def test_rami4atm_hom00_bla_sd2s_m03_z30a000_brfpp(
     of the RAMI4ATM benchmark. The reference solution is trusted and compared
     against the libRadtran and RTMOM radiative transfer models.
 
-    Rationale
-    ---------
-    This test case uses a basic atmospheric scene:
-
-    * black surface
-    * Molecular atmosphere following the AFGL 1986 model
-    * Aerosol layer at 1km elevation
-
-    Parameters
-
-    * Atmosphere: molecular atmosphere using the AFGL 1986 profile
-      (U.S. standard)
-    * Aerosol layer: uniform, covers [0, 2] km extent, :math:`\tau_{500} = 0.2`;
-      radiative properties from the ``govaerts_2021-desert`` dataset
-    * Surface: black
-    * Illumination: directional illumination with a zenith angle
-      :math:`\theta = 30°`
-    * Measure: distant measure, covering the principal plane for
-      :math:`\theta \in [-75, 75]°`
-
     Expected behaviour
     ------------------
     This test uses the Chi-squared criterion with a threshold of 0.05.
+
     """
 
-    config = {
-        "surface": {
-            "reflectance": {"value": 0.0, "type": "uniform"},
-            "type": "lambertian",
-        },
-        "atmosphere": {
-            "molecular_atmosphere": {
-                "has_absorption": False,
-                "has_scattering": True,
-                "type": "molecular",
-                "thermoprops": {
-                    "identifier": "afgl_1986-us_standard",
-                    "z": np.arange(0, 120.05, 0.05) * ureg.km,
-                },
-                "absorption_data": "monotropa",
-            },
-            "particle_layers": [
-                {
-                    "bottom": 0,
-                    "bottom_units": "meter",
-                    "top": 2000,
-                    "top_units": "meter",
-                    "distribution": {"type": "uniform"},
-                    "tau_ref": 0.2,
-                    "dataset": "govaerts_2021-desert",
-                }
-            ],
-            "type": "heterogeneous",
-        },
-        "illumination": {
-            "zenith": 30.0,
-            "zenith_units": "degree",
-            "azimuth": 0.0,
-            "azimuth_units": "degree",
-            "type": "directional",
-        },
-        "measures": [
-            {
-                "type": "mdistant",
-                "construct": "hplane",
-                "zeniths": np.arange(-75, 76, 2),
-                "zeniths_units": "degree",
-                "azimuth": 0.0,
-                "azimuth_units": "degree",
-                "srf": "sentinel_2a-msi-3",
-                "spp": 1000,
-            }
-        ],
-        "quad_spec": {
-            "type": "fixed",
-            "quad_type": "gauss_legendre",
-            "n": 16,
-        },
-    }
-
-    exp = AtmosphereExperiment(**config)
+    exp = create_rami4atm_hom00_bla_sd2s_m03_z30a000_brfpp()
     result = eradiate.run(exp)
 
     test = Chi2Test(

--- a/tests/03_regression/romc/test_het04.py
+++ b/tests/03_regression/romc/test_het04.py
@@ -1,13 +1,12 @@
-import numpy as np
 import pytest
 
 import eradiate
-from eradiate.data import data_store
-from eradiate.experiments import CanopyExperiment
 from eradiate.test_tools.regression import Chi2Test
-from eradiate.units import unit_registry as ureg
+from eradiate.test_tools.test_cases.romc import create_het04a1_brfpp
+from eradiate.test_tools.util import append_doc
 
 
+@append_doc(create_het04a1_brfpp)
 @pytest.mark.regression
 def test_het04a1_brfpp(mode_mono_double, artefact_dir, session_timestamp):
     r"""
@@ -50,78 +49,7 @@ def test_het04a1_brfpp(mode_mono_double, artefact_dir, session_timestamp):
 
     """
 
-    leaf_spec_path_sph = data_store.fetch(
-        "tests/regression_test_specifications/het04/het04_sph.def"
-    )
-    leaf_pos_path_sph = data_store.fetch(
-        "tests/regression_test_specifications/het04/het04_sph_positions.def"
-    )
-    leaf_spec_path_cyl = data_store.fetch(
-        "tests/regression_test_specifications/het04/het04_cyl.def"
-    )
-    leaf_pos_path_cyl = data_store.fetch(
-        "tests/regression_test_specifications/het04/het04_cyl_positions.def"
-    )
-
-    exp = CanopyExperiment(
-        canopy={
-            "type": "discrete_canopy",
-            "instanced_canopy_elements": [
-                {
-                    "construct": "from_file",
-                    "filename": leaf_pos_path_sph,
-                    "canopy_element": {
-                        "type": "leaf_cloud",
-                        "construct": "from_file",
-                        "filename": leaf_spec_path_sph,
-                        "leaf_reflectance": 0.49,
-                        "leaf_transmittance": 0.41,
-                        "id": "spherical_leaf_cloud",
-                    },
-                },
-                {
-                    "construct": "from_file",
-                    "filename": leaf_pos_path_cyl,
-                    "canopy_element": {
-                        "type": "leaf_cloud",
-                        "construct": "from_file",
-                        "filename": leaf_spec_path_cyl,
-                        "leaf_reflectance": 0.45,
-                        "leaf_transmittance": 0.3,
-                        "id": "cylindrical_leaf_cloud",
-                    },
-                },
-            ],
-            "size": [270, 270, 15] * ureg.m,
-        },
-        surface={"type": "lambertian", "reflectance": 0.15},
-        padding=5,
-        measures=[
-            {
-                "type": "mdistant",
-                "construct": "hplane",
-                "spp": 20000,
-                "azimuth": 180 * ureg.deg,
-                "zeniths": np.arange(-75, 75.01, 2) * ureg.deg,
-                "target": {
-                    "type": "rectangle",
-                    "xmin": -135 * ureg.m,
-                    "xmax": 135 * ureg.m,
-                    "ymin": -135 * ureg.m,
-                    "ymax": 135 * ureg.m,
-                    "z": 15 * ureg.m,
-                },
-            }
-        ],
-        illumination={
-            "type": "directional",
-            "zenith": 20 * ureg.deg,
-            "azimuth": 0.0 * ureg.deg,
-            "irradiance": 20.0,
-        },
-        integrator={"type": "path", "max_depth": -1},
-    )
-
+    exp = create_het04a1_brfpp()
     result = eradiate.run(exp)
 
     test = Chi2Test(

--- a/tests/03_regression/romc/test_het06.py
+++ b/tests/03_regression/romc/test_het06.py
@@ -1,13 +1,12 @@
-import numpy as np
 import pytest
 
 import eradiate
-from eradiate.data import data_store
-from eradiate.experiments import CanopyExperiment
 from eradiate.test_tools.regression import Chi2Test
-from eradiate.units import unit_registry as ureg
+from eradiate.test_tools.test_cases.romc import create_het06_brfpp
+from eradiate.test_tools.util import append_doc
 
 
+@append_doc(create_het06_brfpp)
 @pytest.mark.regression
 def test_het06_brfpp(mode_mono_double, artefact_dir, session_timestamp):
     r"""
@@ -17,30 +16,6 @@ def test_het06_brfpp(mode_mono_double, artefact_dir, session_timestamp):
     This is a regression test, which compares the simulation results of the
     current branch to an older reference version.
 
-    Rationale
-    ---------
-
-    This test case implements a basic canopy scene:
-
-    * Surface with lambertian reflectance
-    * No atmosphere
-    * Three dimensional canopy
-
-    Parameters
-
-    * Surface: Square surface with labmertian BSDF with :math:`r = 0.86`
-    * Canopy: Coniferous trees made up of a conical leaf cloud and a cylindrical
-      trunk.
-
-      * Leaf reflectance: 0.08
-      * Leaf transmittance: 0.03
-      * Trunk reflectance: 0.14
-
-      Disk and tree positioning follow the HET06 scenario of the RAMI-3 benchmark
-    * Illumination: Directional illumination with a zenith angle :math:`\theta = 20°`
-    * Sensor: Distant reflectance measure, covering a plane, (76 angular points,
-      10000 samples per pixel)
-
     Expected behaviour
     ------------------
 
@@ -48,67 +23,7 @@ def test_het06_brfpp(mode_mono_double, artefact_dir, session_timestamp):
 
     """
 
-    tree_pos_path = data_store.fetch(
-        "tests/regression_test_specifications/het06/het06_scene.def"
-    )
-
-    exp = CanopyExperiment(
-        canopy={
-            "type": "discrete_canopy",
-            "instanced_canopy_elements": [
-                {
-                    "construct": "from_file",
-                    "filename": tree_pos_path,
-                    "canopy_element": {
-                        "type": "abstract_tree",
-                        "trunk_height": 1.5 * ureg.m,
-                        "trunk_radius": 0.15 * ureg.m,
-                        "trunk_reflectance": 0.14,
-                        "leaf_cloud_extra_offset": [0.0, 0.0, 0.0] * ureg.m,
-                        "id": "conifer_tree",
-                        "leaf_cloud": {
-                            "construct": "cone",
-                            "l_vertical": 12.0 * ureg.m,
-                            "leaf_radius": 0.05,
-                            "radius": 1.8 * ureg.m,
-                            "n_leaves": 6480,
-                            "leaf_reflectance": 0.08,
-                            "leaf_transmittance": 0.03,
-                            "id": "conical_leaf_cloud",
-                        },
-                    },
-                }
-            ],
-            "size": [500, 500, 13.5] * ureg.m,
-        },
-        surface={"type": "lambertian", "reflectance": 0.86},
-        padding=0,
-        measures=[
-            {
-                "type": "mdistant",
-                "construct": "hplane",
-                "spp": 10000,
-                "azimuth": 180 * ureg.deg,
-                "zeniths": np.arange(-75, 75.01, 2) * ureg.deg,
-                "target": {
-                    "type": "rectangle",
-                    "xmin": -250 * ureg.m,
-                    "xmax": 250 * ureg.m,
-                    "ymin": -250 * ureg.m,
-                    "ymax": 250 * ureg.m,
-                    "z": 6.75 * ureg.m,
-                },
-            }
-        ],
-        illumination={
-            "type": "directional",
-            "zenith": 40 * ureg.deg,
-            "azimuth": 0.0 * ureg.deg,
-            "irradiance": 20.0,
-        },
-        integrator={"type": "path", "max_depth": -1},
-    )
-
+    exp = create_het06_brfpp()
     result = eradiate.run(exp)
 
     test = Chi2Test(


### PR DESCRIPTION
# Description

Adding a new benchmark test suite and infrastructure to the project that will enable continuous tracking of eradiate's performance. This will help find regressions and have a better understanding of the impact of our changes to the performance of the project. 

The benchmark infrastructure is based on the ASV package which runs statistical benchmark tests. The package allows users to test the project over a range of commits and environments, and includes a browser GUI and regression tests. The package has been integrated in the `benchmarks` directory. 

The tests written are directly taken from the existing regression tests. The tests were refactored so that both the regression tests and the benchmark test both call the same library of test cases. 

Additionally, a new click CLI was added as a thin wrapper to the ASV wrapper. While ASV defaults to using a git-ref and cloning the project to benchmark it, our CLI defaults to using the current environment for tests. This favours a manual testing approach as we release new features on branches such as main or next. 
The CLI also include an update and custom version of ASVDb that lets us archive results to an external database. This will be useful to archive results to a central ASV database.

Note that the dependencies have changed and were updated accordingly. 

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `next` branch
- [ ] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
