### PR TITLE
[Feature] Add radiance variance as an output of the simulation.

### DIFF
--- a/docs/src/release_notes/v0.28.x.md
+++ b/docs/src/release_notes/v0.28.x.md
@@ -7,6 +7,7 @@
 
 * Added piecewise medium and integrator ({ghpr}`421`).
 * 🖥️ Added benchmarking infrastructure and cases ({ghpr}`423`).
+* Added moment integrator and radiance variance output ({ghpr}`426`).
 
 % ### Changed
 % ### Fixed

--- a/src/eradiate/pipelines/core.py
+++ b/src/eradiate/pipelines/core.py
@@ -14,6 +14,7 @@ from rich.table import Table
 import eradiate
 
 from .._mode import Mode
+from ..scenes.integrators import Integrator
 from ..scenes.measure import Measure
 from ..scenes.spectra import InterpolatedSpectrum
 
@@ -21,7 +22,11 @@ from ..scenes.spectra import InterpolatedSpectrum
 telemetry.disable_telemetry()
 
 
-def config(measure: Measure, mode: Mode | str | None = None) -> dict:
+def config(
+    measure: Measure,
+    mode: Mode | str | None = None,
+    integrator: Integrator | None = None,
+) -> dict:
     """
     Generate a pipeline configuration for a specific scene setup.
 
@@ -32,6 +37,10 @@ def config(measure: Measure, mode: Mode | str | None = None) -> dict:
     mode : .Mode or str, optional
         Mode or mode ID for which the pipeline is configured. By default, the
         current active mode is used.
+
+    integrator : .Integrator or None, optional
+        Integrator used for the experiment; indicates whether the moment was
+        calculated during the integration.
 
     Returns
     -------
@@ -61,6 +70,9 @@ def config(measure: Measure, mode: Mode | str | None = None) -> dict:
 
     # Shall we apply spectral response function weighting (a.k.a convolution)?
     result["apply_spectral_response"] = isinstance(measure.srf, InterpolatedSpectrum)
+
+    # Should we calculate the variance in the result?
+    result["calculate_variance"] = integrator.moment if integrator is not None else False
 
     return result
 

--- a/src/eradiate/scenes/integrators/_core.py
+++ b/src/eradiate/scenes/integrators/_core.py
@@ -53,3 +53,15 @@ class Integrator(NodeSceneElement, ABC):
         init_type="float, optional",
         default="None",
     )
+
+    moment: bool = documented(
+        attrs.field(
+            default=False,
+            converter=attrs.converters.optional(bool),
+        ),
+        doc="If true, calculates the variance of the output film",
+        type="bool",
+        init_type="bool, optional",
+        default="False",
+    )
+    

--- a/src/eradiate/scenes/integrators/_path_tracers.py
+++ b/src/eradiate/scenes/integrators/_path_tracers.py
@@ -61,6 +61,9 @@ class MonteCarloIntegrator(Integrator):
         if self.hide_emitters is not None:
             result["hide_emitters"] = self.hide_emitters
 
+        if self.moment:
+            result = { "type":"moment", "nested":result }
+        
         return result
 
 


### PR DESCRIPTION
# Description

These changes add the radiance's variance as an output of an Eradiate simulation. This is done by leveraging Mitsuba's `moment` integrator, which outputs the raw second moment in a separate bitmap. The latter is transformed by Eradiate's post processing pipeline into the radiance's variance. 

To enable variance calculations, set `moment=True` in the integrator of your experiment, for example:

```python
integrator = ertsc.integrators.PiecewiseVolPathIntegrator(moment=True)
```

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
