### PR TITLE
Added the InterpolatedTexture

### DIFF
--- a/docs/src/release_notes/v0.28.x.md
+++ b/docs/src/release_notes/v0.28.x.md
@@ -7,6 +7,7 @@
 
 * Added piecewise medium and integrator ({ghpr}`421`).
 * 🖥️ Added benchmarking infrastructure and cases ({ghpr}`423`).
+* Added interpolated texture ({ghpr}`427`).
 
 % ### Changed
 % ### Fixed

--- a/src/eradiate/scenes/__init__.pyi
+++ b/src/eradiate/scenes/__init__.pyi
@@ -10,3 +10,4 @@ from . import phase as phase
 from . import shapes as shapes
 from . import spectra as spectra
 from . import surface as surface
+from . import textures as textures

--- a/src/eradiate/scenes/textures/__init__.py
+++ b/src/eradiate/scenes/textures/__init__.py
@@ -1,0 +1,5 @@
+import lazy_loader
+
+__getattr__, __dir__, __all__ = lazy_loader.attach_stub(__name__, __file__)
+
+del lazy_loader

--- a/src/eradiate/scenes/textures/__init__.pyi
+++ b/src/eradiate/scenes/textures/__init__.pyi
@@ -1,0 +1,1 @@
+from .interpolated import InterpolatedTexture as InterpolatedTexture

--- a/src/eradiate/scenes/textures/interpolated.py
+++ b/src/eradiate/scenes/textures/interpolated.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from functools import singledispatchmethod
+
+import attrs
+import numpy as np
+import pint
+import pinttr
+
+from ..core import NodeSceneElement
+from ...attrs import documented, parse_docs
+from ...kernel import InitParameter, UpdateParameter
+from ...spectral.index import (
+    CKDSpectralIndex,
+    MonoSpectralIndex,
+    SpectralIndex,
+)
+from ...units import unit_context_config as ucc
+
+
+# the "data" parameter must be first in the args list of the function provided to
+# `np.apply_along_axis` but third in the args of `np.interp`
+def my_interp1d(data, w, wavelengths):
+    return np.interp(w, wavelengths, data, left=0.0, right=0.0)
+
+
+@parse_docs
+@attrs.define(eq=False, slots=False)
+class InterpolatedTexture(NodeSceneElement):
+    """
+    Spectrally interpolated texture.
+
+    Notes
+    -----
+    Interpolation uses :func:`numpy.interp`. Evaluation is as follows:
+
+    * in ``mono_*`` modes, the spectrum is evaluated at the spectral context
+      wavelength;
+    * in ``ckd_*`` modes, the spectrum is evaluated as the average value over
+      the spectral context bin.
+    """
+
+    wavelengths: pint.Quantity = documented(
+        pinttr.field(
+            units=ucc.deferred("wavelength"),
+            converter=[
+                np.atleast_1d,
+                pinttr.converters.to_units(ucc.deferred("wavelength")),
+            ],
+            kw_only=True,
+        ),
+        doc="Wavelengths defining the interpolation grid. Values must be "
+        "monotonically increasing.",
+        type="quantity",
+    )
+
+    @wavelengths.validator
+    def _wavelengths_validator(self, attribute, value):
+        # wavelength must be monotonically increasing
+        if not np.all(np.diff(value) > 0):
+            raise ValueError("wavelengths must be monotonically increasing")
+
+    data: np.typing.ArrayLike = documented(
+        attrs.field(
+            converter=np.atleast_3d,
+            kw_only=True,
+        ),
+        doc="Texture data. Must be 3d and the third dimension must match "
+        "the length of ``wavelengths``",
+        type="array-like",
+        init_type="array-like",
+    )
+
+    @data.validator
+    def _data_validator(self, attribute, value):
+        if not np.shape(value)[2] == np.shape(self.wavelengths)[0]:
+            raise ValueError(
+                f"while validating '{attribute.name}': Spectral dimension must match"
+                f"length of wavelength array."
+            )
+        if not (value.shape[0] >= 2 and value.shape[1] <= 2):
+            raise ValueError(
+                f"while validating '{attribute.name}': Texture must at least have"
+                f"2 by 2 pixels."
+            )
+
+    @singledispatchmethod
+    def eval(self, si: SpectralIndex) -> pint.Quantity:
+        """
+        Evaluate spectrum at a given spectral index.
+
+        Parameters
+        ----------
+        si : :class:`.SpectralIndex`
+            Spectral index.
+
+        Returns
+        -------
+        value : quantity
+            Evaluated spectrum.
+
+        Notes
+        -----
+        This method dispatches evaluation to specialized methods depending
+        on the spectral index type.
+        """
+        raise NotImplementedError
+
+    @eval.register(MonoSpectralIndex)
+    def _(self, si) -> pint.Quantity:
+        return self.eval_mono(w=si.w)
+
+    @eval.register(CKDSpectralIndex)
+    def _(self, si) -> pint.Quantity:
+        return self.eval_ckd(w=si.w, g=si.g)
+
+    def eval_mono(self, w: pint.Quantity) -> pint.Quantity:
+        return np.atleast_3d(
+            np.apply_along_axis(my_interp1d, 2, self.data, w, self.wavelengths)
+        )
+
+    def eval_ckd(self, w: pint.Quantity, g: float) -> pint.Quantity:
+        return self.eval_mono(w=w)
+
+    @property
+    def template(self) -> dict:
+        # Inherit docstring
+
+        return {
+            "type": "bitmap",
+            "filter_type": "nearest",
+            "wrap_mode": "clamp",
+            "raw": True,
+            "data": InitParameter(evaluator=lambda ctx: self.eval(ctx.si)),
+        }
+
+    @property
+    def params(self) -> dict:
+        # Inherit docstring
+
+        return {
+            "data": UpdateParameter(
+                evaluator=lambda ctx: self.eval(ctx.si),
+                flags=UpdateParameter.Flags.SPECTRAL,
+            )
+        }

--- a/tests/01_unit/scenes/textures/test_interpolated.py
+++ b/tests/01_unit/scenes/textures/test_interpolated.py
@@ -1,0 +1,86 @@
+import mitsuba as mi
+import numpy as np
+import pytest
+
+import eradiate
+from eradiate import unit_registry as ureg
+from eradiate.scenes.textures import InterpolatedTexture
+from eradiate.spectral.index import SpectralIndex
+from eradiate.test_tools.types import check_scene_element
+
+
+@pytest.mark.parametrize(
+    "wavelengths, data, expected",
+    [
+        (None, None, TypeError),
+        ([500.0, 600.0], None, TypeError),
+        (None, [[[0.0, 1.0]]], TypeError),
+        ([500.0, 600.0], [[0.0, 1.0], [0.0, 1.0], [0.0, 1.0], [0.0, 1.0]], ValueError),
+        ([500.0, 600.0], [[[0.0], [1.0]], [[0.0], [1.0]]], ValueError),
+        ([500.0, 400.0], [[[0.0, 1.0]]], ValueError),
+        (
+            [400.0, 500.0],
+            [[[0.0, 1.0], [0.0, 1.0]], [[0.0, 1.0], [0.0, 1.0]]],
+            InterpolatedTexture(
+                wavelengths=[400.0, 500.0],
+                data=[[[0.0, 1.0], [0.0, 1.0]], [[0.0, 1.0], [0.0, 1.0]]],
+            ),
+        ),
+    ],
+    ids=[
+        "no_args",
+        "missing_args_1",
+        "missing_args_2",
+        "values_shape_1",
+        "values_shape_2",
+        "wavelength_monotonicity",
+        "valid",
+    ],
+)
+def test_interpolated_texture_construct(modes_all, wavelengths, data, expected):
+    if isinstance(expected, InterpolatedTexture):
+        t = InterpolatedTexture(wavelengths=wavelengths, data=data)
+        assert np.all(t.data == expected.data)
+        assert np.all(t.wavelengths == expected.wavelengths)
+
+    elif issubclass(expected, Exception):
+        with pytest.raises(expected):
+            if not wavelengths:
+                InterpolatedTexture(data=data)
+            elif not data:
+                InterpolatedTexture(wavelengths=wavelengths)
+            else:
+                InterpolatedTexture(wavelengths=wavelengths, data=data)
+
+    else:
+        raise RuntimeError
+
+
+def test_interpolated_texture_eval(modes_all):
+    if eradiate.mode().is_mono:
+        si = SpectralIndex.new(w=550.0 * ureg.nm)
+        expected = 0.5
+
+    elif eradiate.mode().is_ckd:
+        si = SpectralIndex.new(w=550.0 * ureg.nm, g=0)
+        expected = 0.5
+
+    else:
+        raise NotImplementedError
+
+    t = InterpolatedTexture(
+        wavelengths=[500, 600],
+        data=[[[0.0, 1.0], [0.0, 1.0]], [[0.0, 1.0], [0.0, 1.0]]],
+    )
+
+    assert np.allclose(t.eval(si), expected)
+
+
+def test_interpolated_texture_kernel_dict(modes_all):
+    t = InterpolatedTexture(
+        wavelengths=[500, 600],
+        data=[[[0.0, 1.0], [0.0, 1.0]], [[0.0, 1.0], [0.0, 1.0]]],
+    )
+    mi_wrapper = check_scene_element(t, mi.Texture)
+
+    assert np.allclose(mi_wrapper.parameters["data"], 0.5)


### PR DESCRIPTION
# Description

This PR introduces the InterpolatedTexture class in Eradiate. This is a limited wrapper around the mitsuba `bitmap` texture class. It is limited in the sense that it fixes the `warp_mode` to `clamp` and it fixes the `filter` to `nearest`. At this point it also only supports instantiation from an array of numbers. File based instantiation is not supported.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `next` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
