### PR TITLE
Fixed srf filtering

### DIFF
--- a/docs/src/release_notes/v0.28.x.md
+++ b/docs/src/release_notes/v0.28.x.md
@@ -10,7 +10,9 @@
 * Added moment integrator and radiance variance output ({ghpr}`426`).
 
 % ### Changed
-% ### Fixed
+### Fixed
+
+* Fixed out-of-bounds indexing in the SRF filtering tool ({ghpr}`429`).
 
 ### Internal changes
 

--- a/src/eradiate/srf_tools.py
+++ b/src/eradiate/srf_tools.py
@@ -567,8 +567,8 @@ def _integral_filter_bounds_symmetry(
     # Compute symmetric indexes for which the enclosed CDF reaches the target fraction
     i_max = (len(xext) - 1) // 2
     for i in range(i_max):
-        i_left = i_xmean - i
-        i_right = i_xmean + i
+        i_left = max([i_xmean - i, 0])
+        i_right = min([i_xmean + i, len(xext) - 1])
         cs = cdf[i_right] - cdf[i_left]
         if cs >= 1.0 - fraction:
             break


### PR DESCRIPTION
# Description

This PR fixes a bug in the symmetrical integral filter for the spectral response functions. In the case of highly asymmetrical datasets, the symmetrical expansion of the filtered area around the central wavelength could extend beyond the bounds of the dataset, leading to invalid indexing.

This PR extends the code and limits the indices to the bounds of the dataset. In the aforementioned case, this will lead to a situation where the filtered region would continue growing asymmetrically, when one of the indices reaches the end of the data.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `next` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
