### PR TITLE
Improve absorption database index loading error reporting

### DIFF
--- a/docs/src/release_notes/v0.28.x.md
+++ b/docs/src/release_notes/v0.28.x.md
@@ -66,3 +66,13 @@ When upgrading, pay attention to the following:
 
 * 🖥️ Switched to Mamba for Conda lock file generation ({ghpr}`425`).
 * 🖥️ Switched to uv for Pip lock file generation ({ghpr}`425`).
+
+## v0.28.1 (Upcoming release)
+
+### Changed
+
+* The CLI now displays standard stack traces instead of prettifying them with
+  Rich ({ghpr}`434). The previous behaviour is still available with the `--debug`
+  CLI option.
+* Improved error reporting when loading absorption databases with corrupt index
+  files ({ghpr}`434`).

--- a/src/eradiate/cli/__init__.py
+++ b/src/eradiate/cli/__init__.py
@@ -22,7 +22,8 @@ class LogLevel(str, Enum):
 
 
 app = typer.Typer(
-    help="Eradiate — A modern radiative transfer model for Earth observation."
+    help="Eradiate — A modern radiative transfer model for Earth observation.",
+    pretty_exceptions_enable=False,
 )
 
 
@@ -30,8 +31,17 @@ app = typer.Typer(
 def cli(
     log_level: Annotated[
         LogLevel, typer.Option(help="Set log level.")
-    ] = LogLevel.WARNING
+    ] = LogLevel.WARNING,
+    debug: Annotated[
+        bool,
+        typer.Option(
+            help="Enable debug mode. This will notably print exceptions with locals."
+        ),
+    ] = False,
 ):
+    if debug:
+        app.pretty_exceptions_enable = True
+
     logging.basicConfig(
         level=log_level.upper(),
         format="%(message)s",


### PR DESCRIPTION
# Description

This PR improves error reporting when absorption database indexes are missing or broken. It does however not further automate the fix process for safety reasons. Changes are as follows:

* Pretty exception display by the CLI is disabled by default. This makes the stack trace more readable, notably by removing locals for the displayed message which is otherwise overly verbose. Pretty exception reporting is still available by setting the `--debug` option when calling the CLI (*e.g.* `eradiate --debug data check komodo`).
* The `AbsorptionDatabase.from_directory()` function has improved error reporting. In particular, faulty index files are now referred to in exception messages, which makes it easier to locate and delete a corrupt index. I took this opportunity to factor the index loading and error detection logic.

This contributes to addressing #433.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
