### PR TITLE
BufferMesh: Add the option to specify texture coordinates

### DIFF
--- a/docs/src/release_notes/v0.29.x.md
+++ b/docs/src/release_notes/v0.29.x.md
@@ -6,7 +6,13 @@
 %
 % ### Removed
 %
-% ### Added
+
+### Added
+
+* The {func}`.mesh_from_dem` function optionally adds texture coordinates to the
+  generated mesh ({ghpr}`435`).
+* The {class}`.BufferMesh` class can now initialize texture coordinates as well
+  ({ghpr}`435`).
 
 ### Changed
 

--- a/tests/01_unit/scenes/surface/test_dem_surface.py
+++ b/tests/01_unit/scenes/surface/test_dem_surface.py
@@ -11,6 +11,7 @@ from eradiate.scenes.geometry import SphericalShellGeometry
 from eradiate.scenes.shapes import RectangleShape, SphereShape
 from eradiate.scenes.surface import DEMSurface
 from eradiate.scenes.surface._dem import (
+    _dem_texcoords,
     _transform_vertices_spherical_shell_lonlat,
     mesh_from_dem,
     triangulate_grid,
@@ -307,3 +308,17 @@ def test_dem_surface_kernel_dict(mode_mono):
     template, params = traverse(scene)
     kernel_dict = template.render(KernelContext())
     assert isinstance(mi.load_dict(kernel_dict), mi.Scene)
+
+
+def test_dem_texcoords(mode_mono):
+    vertices = np.array([[-1, -1, 1], [2, -1, 1], [-1, 2, 0], [2, 2, 1]])
+    xlim = [-1.0, 2.0]
+    ylim = [-1.0, 2.0]
+
+    texcoords = _dem_texcoords(vertices[:, 0], vertices[:, 1], xlim, ylim)
+
+    assert texcoords.shape == (4, 2)
+    assert np.allclose(
+        texcoords,
+        np.array([[0, 0], [1, 0], [0, 1], [1, 1]]),
+    )


### PR DESCRIPTION
# Description

This PR adds the option to specify texture coordinates when defining a `BufferMesh`:

* The `BufferMesh` class has an optional `texcoords` field that lets the user specify texture coordinates in the same order as vertex positions.
* The `mesh_from_dem()` function accepts a `texcoords` argument that triggers, if set to `True`, the generation of texture coordinates alongside the mesh.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
