### PR TITLE
Minor refactoring of attrs-based features

### DIFF
--- a/docs/rst/reference_api/attrs.rst
+++ b/docs/rst/reference_api/attrs.rst
@@ -17,6 +17,10 @@ Attributes
 Attribute docs extension
 ------------------------
 
+.. autofunction:: define
+
+.. autofunction:: frozen
+
 .. autofunction:: parse_docs
 
 .. autofunction:: documented

--- a/docs/src/release_notes/v0.29.x.md
+++ b/docs/src/release_notes/v0.29.x.md
@@ -19,6 +19,7 @@
 ### Changed
 
 * ⚠️ Refactored DEM handling infrastructure ({ghpr}`428`).
+* ⚠️ Refactored *attrs*-based features ({ghpr}`437`).
 
 % ### Fixed
 %

--- a/src/eradiate/_mode.py
+++ b/src/eradiate/_mode.py
@@ -7,7 +7,7 @@ import typing as t
 import attrs
 import mitsuba
 
-from .attrs import documented, parse_docs
+from .attrs import documented, frozen
 from .exceptions import UnsupportedModeError
 
 # ------------------------------------------------------------------------------
@@ -150,8 +150,7 @@ def _mode_registry() -> dict[str, Mode]:
     }
 
 
-@parse_docs
-@attrs.frozen
+@frozen
 class Mode:
     """
     Data structure describing Eradiate's operational mode and associated

--- a/src/eradiate/attrs.py
+++ b/src/eradiate/attrs.py
@@ -249,6 +249,7 @@ def parse_docs(cls: type) -> type:
 
     docs = {}
     for field in cls.__attrs_attrs__:
+        # Collect documentation entries
         if MetadataKey.DOC in field.metadata:
             # Collect field docstring
             docs[field.name] = _FieldDoc(doc=field.metadata[MetadataKey.DOC])
@@ -377,3 +378,29 @@ def get_doc(cls: type, attrib: str, field: str) -> str:
         )
 
     raise ValueError(f"unsupported attribute doc field {field}")
+
+
+def define(maybe_cls=None, **kwargs):
+    """
+    A wrapper around :func:`attrs.define` that automatically applies docstring
+    processing with :func:`.parse_docs`. All arguments are forwarded to
+    :func:`attrs.define`.
+    """
+
+    def wrap(cls):
+        return parse_docs(attrs.define(maybe_cls=cls, **kwargs))
+
+    return wrap if maybe_cls is None else wrap(maybe_cls)
+
+
+def frozen(maybe_cls=None, **kwargs):
+    """
+    A wrapper around :func:`attrs.frozen` that automatically applies docstring
+    processing with :func:`.parse_docs`. All arguments are forwarded to
+    :func:`attrs.frozen`.
+    """
+
+    def wrap(cls):
+        return parse_docs(attrs.frozen(maybe_cls=cls, **kwargs))
+
+    return wrap if maybe_cls is None else wrap(maybe_cls)

--- a/src/eradiate/contexts.py
+++ b/src/eradiate/contexts.py
@@ -4,7 +4,7 @@ import typing as t
 
 import attrs
 
-from .attrs import documented, parse_docs
+from .attrs import define, documented
 from .spectral import SpectralIndex
 
 # ------------------------------------------------------------------------------
@@ -38,8 +38,7 @@ class Context:
 # ------------------------------------------------------------------------------
 
 
-@parse_docs
-@attrs.define
+@define
 class KernelContext(Context):
     """
     Kernel evaluation context data structure. This class is used *e.g.* to store

--- a/src/eradiate/data/_blind_directory.py
+++ b/src/eradiate/data/_blind_directory.py
@@ -6,13 +6,12 @@ from pathlib import Path
 import attrs
 
 from ._core import DataStore
-from ..attrs import documented, parse_docs
+from ..attrs import define, documented
 from ..exceptions import DataError
 from ..typing import PathLike
 
 
-@parse_docs
-@attrs.define
+@define
 class BlindDirectoryDataStore(DataStore):
     """
     Serve files stored in a directory.

--- a/src/eradiate/data/_blind_online.py
+++ b/src/eradiate/data/_blind_online.py
@@ -12,7 +12,7 @@ import pooch
 from requests import RequestException
 
 from ._core import DataStore, expand_rules
-from ..attrs import documented, parse_docs
+from ..attrs import define, documented
 from ..exceptions import DataError
 from ..typing import PathLike
 from ..util.misc import LoggingContext
@@ -20,8 +20,7 @@ from ..util.misc import LoggingContext
 logger = logging.getLogger(__name__)
 
 
-@parse_docs
-@attrs.define
+@define
 class BlindOnlineDataStore(DataStore):
     """
     Serve data downloaded from a remote source without integrity check.

--- a/src/eradiate/data/_multi.py
+++ b/src/eradiate/data/_multi.py
@@ -7,13 +7,12 @@ from pathlib import Path
 import attrs
 
 from ._core import DataStore
-from ..attrs import documented, parse_docs
+from ..attrs import define, documented
 from ..exceptions import DataError
 from ..typing import PathLike
 
 
-@parse_docs
-@attrs.define
+@define
 class MultiDataStore(DataStore):
     """
     Chain requests on multiple data stores.

--- a/src/eradiate/data/_safe_directory.py
+++ b/src/eradiate/data/_safe_directory.py
@@ -11,13 +11,12 @@ from pathlib import Path
 import attrs
 
 from ._core import DataStore, load_rules, make_registry, registry_from_file
-from ..attrs import documented, parse_docs
+from ..attrs import define, documented
 from ..exceptions import DataError
 from ..typing import PathLike
 
 
-@parse_docs
-@attrs.define
+@define
 class SafeDirectoryDataStore(DataStore):
     """
     Serve files stored in a directory. This data store will only serve files

--- a/src/eradiate/experiments/_atmosphere.py
+++ b/src/eradiate/experiments/_atmosphere.py
@@ -12,7 +12,7 @@ from ._helpers import (
     measure_inside_atmosphere,
     surface_converter,
 )
-from ..attrs import AUTO, documented, parse_docs
+from ..attrs import AUTO, define, documented
 from ..scenes.atmosphere import (
     Atmosphere,
     HeterogeneousAtmosphere,
@@ -38,8 +38,7 @@ from ..units import unit_context_config as ucc
 logger = logging.getLogger(__name__)
 
 
-@parse_docs
-@attrs.define
+@define
 class AtmosphereExperiment(EarthObservationExperiment):
     """
     Simulate radiation in a one-dimensional scene. This experiment approximates

--- a/src/eradiate/experiments/_canopy.py
+++ b/src/eradiate/experiments/_canopy.py
@@ -7,7 +7,7 @@ import attrs
 from ._core import EarthObservationExperiment
 from ._helpers import surface_converter
 from .. import validators
-from ..attrs import AUTO, documented, parse_docs
+from ..attrs import AUTO, define, documented
 from ..scenes.biosphere import Canopy, biosphere_factory
 from ..scenes.bsdfs import LambertianBSDF
 from ..scenes.core import SceneElement
@@ -17,8 +17,7 @@ from ..scenes.shapes import RectangleShape
 from ..scenes.surface import BasicSurface
 
 
-@parse_docs
-@attrs.define
+@define
 class CanopyExperiment(EarthObservationExperiment):
     """
     Simulate radiation in a scene with an explicit canopy and no atmosphere.

--- a/src/eradiate/experiments/_canopy_atmosphere.py
+++ b/src/eradiate/experiments/_canopy_atmosphere.py
@@ -14,7 +14,7 @@ from ._helpers import (
     surface_converter,
 )
 from .. import validators
-from ..attrs import AUTO, documented, parse_docs
+from ..attrs import AUTO, define, documented
 from ..scenes.atmosphere import (
     Atmosphere,
     HeterogeneousAtmosphere,
@@ -43,8 +43,7 @@ from ..units import unit_registry as ureg
 logger = logging.getLogger(__name__)
 
 
-@parse_docs
-@attrs.define
+@define
 class CanopyAtmosphereExperiment(EarthObservationExperiment):
     """
     Simulate radiation in a scene with an explicit canopy and atmosphere.

--- a/src/eradiate/experiments/_core.py
+++ b/src/eradiate/experiments/_core.py
@@ -16,7 +16,7 @@ import eradiate
 
 from .. import converters, validators
 from .. import pipelines as pl
-from ..attrs import AUTO, documented, parse_docs
+from ..attrs import AUTO, define, documented
 from ..contexts import KernelContext, MultiGenerator
 from ..kernel import MitsubaObjectWrapper, mi_render, mi_traverse
 from ..rng import SeedState
@@ -55,8 +55,7 @@ def _convert_spectral_set(value):
         return value
 
 
-@parse_docs
-@attrs.define
+@define
 class Experiment(ABC):
     """
     Abstract base class for all Eradiate experiments. An experiment consists of
@@ -284,8 +283,7 @@ def _extra_objects_converter(value: dict | None) -> dict:
     return result
 
 
-@parse_docs
-@attrs.define
+@define
 class EarthObservationExperiment(Experiment, ABC):
     """
     Abstract based class for experiments illuminated by a distant directional

--- a/src/eradiate/experiments/_dem.py
+++ b/src/eradiate/experiments/_dem.py
@@ -13,7 +13,7 @@ from ._helpers import (
     measure_inside_atmosphere,
     surface_converter,
 )
-from ..attrs import AUTO, documented, parse_docs
+from ..attrs import AUTO, define, documented
 from ..scenes.atmosphere import (
     Atmosphere,
     HeterogeneousAtmosphere,
@@ -35,8 +35,7 @@ from ..scenes.surface import BasicSurface, DEMSurface
 logger = logging.getLogger(__name__)
 
 
-@parse_docs
-@attrs.define
+@define
 class DEMExperiment(EarthObservationExperiment):
     """
     Simulate radiation in a scene with a digital elevation model (DEM) under a

--- a/src/eradiate/kernel/_kernel_dict.py
+++ b/src/eradiate/kernel/_kernel_dict.py
@@ -12,13 +12,12 @@ from collections import UserDict
 import attrs
 import mitsuba as mi
 
-from ..attrs import documented, parse_docs
+from ..attrs import define, documented
 from ..contexts import KernelContext
 from ..util.misc import nest
 
 
-@parse_docs
-@attrs.define
+@define
 class InitParameter:
     """
     This class declares an Eradiate parameter in a Mitsuba scene dictionary. It
@@ -40,8 +39,7 @@ class InitParameter:
         return self.evaluator(ctx)
 
 
-@parse_docs
-@attrs.define
+@define
 class UpdateParameter:
     """
     This class declares an Eradiate parameter in a Mitsuba scene parameter

--- a/src/eradiate/kernel/_render.py
+++ b/src/eradiate/kernel/_render.py
@@ -10,7 +10,7 @@ from tqdm.auto import tqdm
 
 from ._kernel_dict import UpdateMapTemplate
 from .. import config
-from ..attrs import documented, parse_docs
+from ..attrs import define, documented, frozen
 from ..contexts import KernelContext
 from ..rng import SeedState, root_seed_state
 
@@ -22,8 +22,7 @@ logger = logging.getLogger(__name__)
 # ------------------------------------------------------------------------------
 
 
-@parse_docs
-@attrs.frozen
+@frozen
 class TypeIdLookupStrategy:
     """
     This parameter ID lookup strategy searches for a Mitsuba type and object ID
@@ -66,8 +65,7 @@ class TypeIdLookupStrategy:
 # ------------------------------------------------------------------------------
 
 
-@parse_docs
-@attrs.define
+@define
 class MitsubaObjectWrapper:
     """
     This container aggregates a Mitsuba object, its associated parameters and a

--- a/src/eradiate/plot.py
+++ b/src/eradiate/plot.py
@@ -16,7 +16,7 @@ from matplotlib.figure import Figure
 from matplotlib.gridspec import SubplotSpec
 from xarray.plot import FacetGrid
 
-from eradiate.radprops import CKDAbsorptionDatabase, MonoAbsorptionDatabase
+from .radprops import CKDAbsorptionDatabase, MonoAbsorptionDatabase
 
 
 def set_style(rc=None):

--- a/src/eradiate/quad.py
+++ b/src/eradiate/quad.py
@@ -7,7 +7,7 @@ from enum import Enum
 import attrs
 import numpy as np
 
-from .attrs import documented, parse_docs
+from .attrs import define, documented
 from .util.misc import str_summary_numpy
 
 
@@ -18,8 +18,7 @@ class QuadType(Enum):
     GAUSS_LOBATTO = "gauss_lobatto"
 
 
-@parse_docs
-@attrs.define(eq=False, frozen=True)
+@define(eq=False, frozen=True)
 class Quad:
     """
     A data class storing information about a quadrature rule. Nodes and weights

--- a/src/eradiate/radprops/_absorption.py
+++ b/src/eradiate/radprops/_absorption.py
@@ -25,7 +25,7 @@ import eradiate
 
 from .. import config
 from .._mode import SpectralMode
-from ..attrs import documented, parse_docs
+from ..attrs import define, documented
 from ..data import data_store
 from ..exceptions import InterpolationError, UnsupportedModeError
 from ..typing import PathLike
@@ -33,6 +33,7 @@ from ..units import to_quantity
 from ..units import unit_registry as ureg
 
 logger = logging.getLogger(__name__)
+
 
 # ------------------------------------------------------------------------------
 #                           Error handling components
@@ -92,13 +93,13 @@ ERROR_HANDLING_CONFIG_DEFAULT = ErrorHandlingConfiguration.convert(
     config.settings.ABSORPTION_DATABASE.ERROR_HANDLING
 )
 
+
 # ------------------------------------------------------------------------------
 #                           Database type definitions
 # ------------------------------------------------------------------------------
 
 
-@parse_docs
-@attrs.define(repr=False, eq=False)
+@define(repr=False, eq=False)
 class AbsorptionDatabase:
     """
     Common parent type for absorption coefficient databases.

--- a/src/eradiate/radprops/_atmosphere.py
+++ b/src/eradiate/radprops/_atmosphere.py
@@ -14,15 +14,14 @@ from joseki.profiles.core import interp
 from ._absorption import AbsorptionDatabase
 from ._core import RadProfile, ZGrid, make_dataset
 from .rayleigh import compute_sigma_s_air
-from ..attrs import documented, parse_docs
+from ..attrs import define, documented
 from ..converters import convert_thermoprops
 from ..units import to_quantity
 from ..units import unit_registry as ureg
 from ..util.misc import cache_by_id, summary_repr
 
 
-@parse_docs
-@attrs.define(eq=False)
+@define(eq=False)
 class AtmosphereRadProfile(RadProfile):
     """
     Atmospheric radiative profile.

--- a/src/eradiate/radprops/_core.py
+++ b/src/eradiate/radprops/_core.py
@@ -14,7 +14,7 @@ from pinttr.util import ensure_units
 import eradiate
 
 from .._factory import Factory
-from ..attrs import documented, parse_docs
+from ..attrs import documented, frozen
 from ..spectral.index import CKDSpectralIndex, MonoSpectralIndex, SpectralIndex
 from ..units import unit_context_config as ucc
 from ..units import unit_registry as ureg
@@ -171,8 +171,7 @@ def make_dataset(
     )
 
 
-@parse_docs
-@attrs.frozen(eq=False, init=False)
+@frozen(eq=False, init=False)
 class ZGrid:
     """
     A container for a regular altitude grid.

--- a/src/eradiate/scenes/atmosphere/_core.py
+++ b/src/eradiate/scenes/atmosphere/_core.py
@@ -19,7 +19,7 @@ from ..geometry import PlaneParallelGeometry, SceneGeometry, SphericalShellGeome
 from ..phase import PhaseFunction
 from ..shapes import Shape
 from ..._factory import Factory
-from ...attrs import documented, get_doc, parse_docs
+from ...attrs import define, documented, get_doc
 from ...cfconventions import ATTRIBUTES
 from ...contexts import KernelContext
 from ...exceptions import UnsupportedModeError
@@ -67,8 +67,7 @@ atmosphere_factory.register_lazy_batch(
 )
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class Atmosphere(CompositeSceneElement, ABC):
     """
     Abstract base class defining common facilities for all atmospheres.
@@ -352,8 +351,7 @@ class Atmosphere(CompositeSceneElement, ABC):
         )
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class AbstractHeterogeneousAtmosphere(Atmosphere, ABC):
     """
     Abstract base class for heterogeneous atmospheres.

--- a/src/eradiate/scenes/atmosphere/_heterogeneous.py
+++ b/src/eradiate/scenes/atmosphere/_heterogeneous.py
@@ -17,7 +17,7 @@ from ._molecular import MolecularAtmosphere
 from ._particle_layer import ParticleLayer
 from ..core import traverse
 from ..phase import BlendPhaseFunction, PhaseFunction
-from ...attrs import documented, parse_docs
+from ...attrs import define, documented
 from ...contexts import KernelContext
 from ...kernel import TypeIdLookupStrategy
 from ...radprops import ZGrid
@@ -57,8 +57,7 @@ def _particle_layer_converter(value):
         return result
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class HeterogeneousAtmosphere(AbstractHeterogeneousAtmosphere):
     """
     Heterogeneous atmosphere scene element [``heterogeneous``].

--- a/src/eradiate/scenes/atmosphere/_homogeneous.py
+++ b/src/eradiate/scenes/atmosphere/_homogeneous.py
@@ -8,7 +8,7 @@ from ._core import Atmosphere
 from ..core import traverse
 from ..phase import PhaseFunction, RayleighPhaseFunction, phase_function_factory
 from ..spectra import AirScatteringCoefficientSpectrum, Spectrum, spectrum_factory
-from ...attrs import documented, parse_docs
+from ...attrs import define, documented
 from ...contexts import KernelContext
 from ...kernel import InitParameter, TypeIdLookupStrategy, UpdateParameter
 from ...spectral.ckd import BinSet
@@ -18,8 +18,7 @@ from ...units import unit_context_kernel as uck
 from ...validators import has_quantity
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class HomogeneousAtmosphere(Atmosphere):
     """
     Homogeneous atmosphere scene element [``homogeneous``].

--- a/src/eradiate/scenes/atmosphere/_molecular.py
+++ b/src/eradiate/scenes/atmosphere/_molecular.py
@@ -15,7 +15,7 @@ import eradiate
 from ._core import AbstractHeterogeneousAtmosphere
 from ..core import traverse
 from ..phase import PhaseFunction, RayleighPhaseFunction, phase_function_factory
-from ...attrs import documented, parse_docs
+from ...attrs import define, documented
 from ...contexts import KernelContext
 from ...converters import convert_thermoprops
 from ...exceptions import UnsupportedModeError
@@ -43,8 +43,7 @@ def _default_absorption_data():
         raise UnsupportedModeError(unsupported=["mono", "ckd"])
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class MolecularAtmosphere(AbstractHeterogeneousAtmosphere):
     """
     Molecular atmosphere scene element [``molecular``].

--- a/src/eradiate/scenes/atmosphere/_particle_dist.py
+++ b/src/eradiate/scenes/atmosphere/_particle_dist.py
@@ -19,7 +19,7 @@ import numpy as np
 import scipy.interpolate
 
 from ..._factory import Factory
-from ...attrs import documented, parse_docs
+from ...attrs import define, documented
 
 particle_distribution_factory = Factory()
 particle_distribution_factory.register_lazy_batch(
@@ -34,8 +34,7 @@ particle_distribution_factory.register_lazy_batch(
 )
 
 
-@parse_docs
-@attrs.define
+@define
 class ParticleDistribution(ABC):
     """
     Abstract base class for particle distributions used to define particle
@@ -51,8 +50,7 @@ class ParticleDistribution(ABC):
         pass
 
 
-@parse_docs
-@attrs.define
+@define
 class UniformParticleDistribution(ParticleDistribution):
     r"""
     Uniform particle distribution. Returns values given by the uniform PDF
@@ -100,8 +98,7 @@ class UniformParticleDistribution(ParticleDistribution):
         )
 
 
-@parse_docs
-@attrs.define(init=False)
+@define(init=False)
 class ExponentialParticleDistribution(ParticleDistribution):
     r"""
     Exponential particle distribution. Returns values given by the normalized
@@ -157,8 +154,7 @@ class ExponentialParticleDistribution(ParticleDistribution):
         )
 
 
-@parse_docs
-@attrs.define
+@define
 class GaussianParticleDistribution(ParticleDistribution):
     r"""
     Gaussian particle distribution. Returns values given by the Gaussian
@@ -202,8 +198,7 @@ class GaussianParticleDistribution(ParticleDistribution):
         )
 
 
-@parse_docs
-@attrs.define
+@define
 class ArrayParticleDistribution(ParticleDistribution):
     """
     Particle distribution specified by an array of values.
@@ -331,8 +326,7 @@ class ArrayParticleDistribution(ParticleDistribution):
         return f(x)
 
 
-@parse_docs
-@attrs.define
+@define
 class InterpolatorParticleDistribution(ParticleDistribution):
     """
     A flexible particle distribution which redirects its calls to an

--- a/src/eradiate/scenes/atmosphere/_particle_layer.py
+++ b/src/eradiate/scenes/atmosphere/_particle_layer.py
@@ -17,7 +17,7 @@ from ._particle_dist import ParticleDistribution, particle_distribution_factory
 from ..core import traverse
 from ..phase import TabulatedPhaseFunction
 from ... import converters, data
-from ...attrs import documented, parse_docs
+from ...attrs import define, documented
 from ...contexts import KernelContext
 from ...kernel import UpdateParameter
 from ...radprops import ZGrid
@@ -47,8 +47,7 @@ def _particle_layer_distribution_converter(value):
     return particle_distribution_factory.convert(value)
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class ParticleLayer(AbstractHeterogeneousAtmosphere):
     """
     Particle layer scene element [``particle_layer``].

--- a/src/eradiate/scenes/biosphere/_core.py
+++ b/src/eradiate/scenes/biosphere/_core.py
@@ -12,7 +12,7 @@ import pinttr
 from ..core import CompositeSceneElement
 from ... import validators
 from ..._factory import Factory
-from ...attrs import documented, get_doc, parse_docs
+from ...attrs import define, documented, get_doc
 from ...kernel import UpdateParameter
 from ...typing import PathLike
 from ...units import unit_context_config as ucc
@@ -53,8 +53,7 @@ biosphere_factory.register_lazy_batch(
 )
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class Canopy(CompositeSceneElement, ABC):
     """
     Abstract base class for all canopies.
@@ -90,8 +89,7 @@ class Canopy(CompositeSceneElement, ABC):
     )
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class CanopyElement(CompositeSceneElement, ABC):
     """
     Abstract base class representing a component of a :class:`.Canopy` object.
@@ -128,8 +126,7 @@ class CanopyElement(CompositeSceneElement, ABC):
         return flatten({**self._params_bsdfs, **self._params_shapes})
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class InstancedCanopyElement(CompositeSceneElement):
     """
     Instanced canopy element [``instanced``].

--- a/src/eradiate/scenes/biosphere/_discrete.py
+++ b/src/eradiate/scenes/biosphere/_discrete.py
@@ -12,7 +12,7 @@ import pinttr
 
 from ._core import Canopy, InstancedCanopyElement, biosphere_factory
 from ._leaf_cloud import CuboidLeafCloudParams, LeafCloud
-from ...attrs import documented, parse_docs
+from ...attrs import define, documented
 from ...units import unit_context_config as ucc
 
 
@@ -25,8 +25,7 @@ def _instanced_canopy_elements_converter(value):
     return biosphere_factory.convert(value)
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class DiscreteCanopy(Canopy):
     """
     Discrete canopy scene element [``discrete_canopy``].

--- a/src/eradiate/scenes/biosphere/_leaf_cloud.py
+++ b/src/eradiate/scenes/biosphere/_leaf_cloud.py
@@ -15,7 +15,7 @@ from ._core import CanopyElement
 from ..core import SceneElement, traverse
 from ..spectra import Spectrum, spectrum_factory
 from ... import validators
-from ...attrs import documented, get_doc, parse_docs
+from ...attrs import define, documented, get_doc
 from ...kernel import TypeIdLookupStrategy, UpdateParameter
 from ...units import unit_context_config as ucc
 from ...units import unit_context_kernel as uck
@@ -208,8 +208,7 @@ def _leaf_cloud_radii(n_leaves, leaf_radius):
     return np.full((n_leaves,), leaf_radius)
 
 
-@parse_docs
-@attrs.define
+@define
 class LeafCloudParams:
     """
     Base class to implement advanced parameter checking for :class:`.LeafCloud`
@@ -299,8 +298,7 @@ class LeafCloudParams:
         return self._leaf_radius
 
 
-@parse_docs
-@attrs.define
+@define
 class CuboidLeafCloudParams(LeafCloudParams):
     """
     Advanced parameter checking class for the cuboid :class:`.LeafCloud`
@@ -441,8 +439,7 @@ class CuboidLeafCloudParams(LeafCloudParams):
         return f"CuboidLeafCloudParams({', '.join(result)})"
 
 
-@parse_docs
-@attrs.define
+@define
 class SphereLeafCloudParams(LeafCloudParams):
     """
     Advanced parameter checking class for the sphere :class:`.LeafCloud`
@@ -465,8 +462,7 @@ class SphereLeafCloudParams(LeafCloudParams):
         return self._radius
 
 
-@parse_docs
-@attrs.define
+@define
 class EllipsoidLeafCloudParams(LeafCloudParams):
     """
     Advanced parameter checking class for the ellipsoid :class:`.LeafCloud`
@@ -530,8 +526,7 @@ class EllipsoidLeafCloudParams(LeafCloudParams):
         return self._c
 
 
-@parse_docs
-@attrs.define
+@define
 class CylinderLeafCloudParams(LeafCloudParams):
     """
     Advanced parameter checking class for the cylinder :class:`.LeafCloud`
@@ -565,8 +560,7 @@ class CylinderLeafCloudParams(LeafCloudParams):
         return self._l_vertical
 
 
-@parse_docs
-@attrs.define
+@define
 class ConeLeafCloudParams(LeafCloudParams):
     """
     Advanced parameter checking class for the cone :class:`.LeafCloud`
@@ -600,8 +594,7 @@ class ConeLeafCloudParams(LeafCloudParams):
         return self._l_vertical
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class LeafCloud(CanopyElement):
     """
     A container class for leaf clouds in abstract discrete canopies.

--- a/src/eradiate/scenes/biosphere/_tree.py
+++ b/src/eradiate/scenes/biosphere/_tree.py
@@ -15,15 +15,14 @@ from ._leaf_cloud import LeafCloud
 from ..core import SceneElement, traverse
 from ..spectra import Spectrum, spectrum_factory
 from ... import validators
-from ...attrs import documented, get_doc, parse_docs
+from ...attrs import define, documented, get_doc
 from ...kernel import TypeIdLookupStrategy, UpdateParameter
 from ...units import unit_context_config as ucc
 from ...units import unit_context_kernel as uck
 from ...units import unit_registry as ureg
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class Tree(CanopyElement, ABC):
     """
     Abstract base class for tree-like canopy elements.
@@ -41,8 +40,7 @@ def _leaf_cloud_converter(value):
     return biosphere_factory.convert(value)
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class AbstractTree(Tree):
     """
     A container class for abstract trees in discrete canopies.
@@ -214,8 +212,7 @@ class AbstractTree(Tree):
         return {}
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class MeshTree(Tree):
     """
     A container class for mesh based tree-like objects in canopies.
@@ -286,8 +283,7 @@ class MeshTree(Tree):
         return {}
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class MeshTreeElement:
     """
     Container class for mesh based constituents of tree-like objects in a canopy.

--- a/src/eradiate/scenes/bsdfs/_checkerboard.py
+++ b/src/eradiate/scenes/bsdfs/_checkerboard.py
@@ -7,12 +7,11 @@ from ._core import BSDF
 from ..core import traverse
 from ..spectra import Spectrum, spectrum_factory
 from ... import validators
-from ...attrs import documented, parse_docs
+from ...attrs import define, documented
 from ...kernel import TypeIdLookupStrategy, UpdateParameter
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class CheckerboardBSDF(BSDF):
     """
     Checkerboard BSDF [``checkerboard``].

--- a/src/eradiate/scenes/bsdfs/_core.py
+++ b/src/eradiate/scenes/bsdfs/_core.py
@@ -2,11 +2,9 @@ from __future__ import annotations
 
 from abc import ABC
 
-import attrs
-
 from ..core import NodeSceneElement
 from ..._factory import Factory
-from ...attrs import parse_docs
+from ...attrs import define
 
 bsdf_factory = Factory()
 bsdf_factory.register_lazy_batch(
@@ -23,8 +21,7 @@ bsdf_factory.register_lazy_batch(
 )
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class BSDF(NodeSceneElement, ABC):
     """
     Abstract base class  for all BSDF scene elements.

--- a/src/eradiate/scenes/bsdfs/_hapke.py
+++ b/src/eradiate/scenes/bsdfs/_hapke.py
@@ -7,12 +7,11 @@ from ._core import BSDF
 from ..core import traverse
 from ..spectra import Spectrum, spectrum_factory
 from ... import validators
-from ...attrs import documented, parse_docs
+from ...attrs import define, documented
 from ...kernel import TypeIdLookupStrategy, UpdateParameter
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class HapkeBSDF(BSDF):
     """
     Hapke BSDF [``hapke``].

--- a/src/eradiate/scenes/bsdfs/_lambertian.py
+++ b/src/eradiate/scenes/bsdfs/_lambertian.py
@@ -7,12 +7,11 @@ from ._core import BSDF
 from ..core import traverse
 from ..spectra import Spectrum, spectrum_factory
 from ... import validators
-from ...attrs import documented, parse_docs
+from ...attrs import define, documented
 from ...kernel import TypeIdLookupStrategy, UpdateParameter
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class LambertianBSDF(BSDF):
     """
     Lambertian BSDF [``lambertian``].

--- a/src/eradiate/scenes/bsdfs/_mqdiffuse.py
+++ b/src/eradiate/scenes/bsdfs/_mqdiffuse.py
@@ -7,15 +7,14 @@ import xarray as xr
 
 from ._core import BSDF
 from ... import converters
-from ...attrs import documented, parse_docs
+from ...attrs import define, documented
 from ...kernel import InitParameter, UpdateParameter
 from ...units import to_quantity
 from ...units import unit_registry as ureg
 from ...util.misc import summary_repr
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class MQDiffuseBSDF(BSDF):
     """
     Measured quasi-diffuse BSDF [``mqdiffuse``].

--- a/src/eradiate/scenes/bsdfs/_opacity_mask.py
+++ b/src/eradiate/scenes/bsdfs/_opacity_mask.py
@@ -8,7 +8,7 @@ from ._core import BSDF, bsdf_factory
 from ._lambertian import LambertianBSDF
 from ..core import traverse
 from ... import converters
-from ...attrs import documented, parse_docs
+from ...attrs import define, documented
 from ...kernel import TypeIdLookupStrategy, UpdateParameter
 
 
@@ -26,8 +26,7 @@ def _to_bitmap(value):
         return value
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class OpacityMaskBSDF(BSDF):
     """
     Opacity Mask BSDF [``opacity_mask``]

--- a/src/eradiate/scenes/bsdfs/_rpv.py
+++ b/src/eradiate/scenes/bsdfs/_rpv.py
@@ -7,12 +7,11 @@ from ._core import BSDF
 from ..core import traverse
 from ..spectra import Spectrum, spectrum_factory
 from ... import validators
-from ...attrs import documented, parse_docs
+from ...attrs import define, documented
 from ...kernel import TypeIdLookupStrategy, UpdateParameter
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class RPVBSDF(BSDF):
     """
     RPV BSDF [``rpv``].

--- a/src/eradiate/scenes/bsdfs/_rtls.py
+++ b/src/eradiate/scenes/bsdfs/_rtls.py
@@ -9,13 +9,12 @@ from ._core import BSDF
 from ..core import traverse
 from ..spectra import Spectrum, spectrum_factory
 from ... import validators
-from ...attrs import documented, parse_docs
+from ...attrs import define, documented
 from ...kernel import TypeIdLookupStrategy, UpdateParameter
 from ...units import unit_context_config as ucc
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class RTLSBSDF(BSDF):
     """
     RTLS BSDF [``rtls``].

--- a/src/eradiate/scenes/core.py
+++ b/src/eradiate/scenes/core.py
@@ -13,7 +13,7 @@ import pinttr
 from pinttr.util import ensure_units
 
 from .._factory import Factory
-from ..attrs import documented, parse_docs
+from ..attrs import define, documented, frozen
 from ..exceptions import TraversalError
 from ..kernel import KernelDictTemplate, UpdateMapTemplate, UpdateParameter
 from ..units import unit_context_config as ucc
@@ -24,8 +24,7 @@ from ..units import unit_registry as ureg
 # ------------------------------------------------------------------------------
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class SceneElement(ABC):
     """
     Abstract base class for all scene elements.
@@ -93,8 +92,7 @@ class SceneElement(ABC):
         pass
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class NodeSceneElement(SceneElement, ABC):
     """
     Abstract base class for scene elements which expand as a single Mitsuba
@@ -147,8 +145,7 @@ class NodeSceneElement(SceneElement, ABC):
                 callback.put_object(name, obj)
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class InstanceSceneElement(SceneElement, ABC):
     """
     Abstract base class for scene elements which represent a node in the Mitsuba
@@ -176,8 +173,7 @@ class InstanceSceneElement(SceneElement, ABC):
             callback.put_params(self.params)
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class CompositeSceneElement(SceneElement, ABC):
     """
     Abstract based class for scene elements which expand to multiple Mitsuba
@@ -237,8 +233,7 @@ class CompositeSceneElement(SceneElement, ABC):
                     callback.put_params({f"{name}.{k}": v for k, v in params.items()})
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class Ref(NodeSceneElement):
     """
     A scene element which represents a reference to a Mitsuba scene tree node.
@@ -259,8 +254,7 @@ class Ref(NodeSceneElement):
         return {"type": "ref", "id": self.id}
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class Scene(NodeSceneElement):
     """
     A generic scene element container which expands as a :class:`mitsuba.Scene`
@@ -291,8 +285,7 @@ class Scene(NodeSceneElement):
 # ------------------------------------------------------------------------------
 
 
-@parse_docs
-@attrs.define
+@define
 class SceneTraversal:
     """
     Data structure used to collect kernel dictionary data during scene element
@@ -407,8 +400,7 @@ def traverse(node: NodeSceneElement) -> tuple[KernelDictTemplate, UpdateMapTempl
 # -- Misc (to be moved elsewhere) ----------------------------------------------
 
 
-@parse_docs
-@attrs.frozen
+@frozen
 class BoundingBox:
     """
     A basic data class representing an axis-aligned bounding box with

--- a/src/eradiate/scenes/geometry.py
+++ b/src/eradiate/scenes/geometry.py
@@ -10,7 +10,7 @@ import pint
 import pinttr
 
 from .shapes import CuboidShape, RectangleShape, Shape, SphereShape
-from ..attrs import documented, parse_docs
+from ..attrs import define, documented
 from ..constants import EARTH_RADIUS
 from ..kernel import map_cube, map_unit_cube
 from ..radprops import ZGrid
@@ -19,8 +19,7 @@ from ..units import unit_context_kernel as uck
 from ..units import unit_registry as ureg
 
 
-@parse_docs
-@attrs.define
+@define
 class SceneGeometry(ABC):
     """
     Abstract base class defining a scene geometry.
@@ -168,8 +167,7 @@ class SceneGeometry(ABC):
         pass
 
 
-@parse_docs
-@attrs.define
+@define
 class PlaneParallelGeometry(SceneGeometry):
     """
     Plane parallel geometry.
@@ -215,8 +213,7 @@ class PlaneParallelGeometry(SceneGeometry):
         return RectangleShape.surface(altitude=self.ground_altitude, width=self.width)
 
 
-@parse_docs
-@attrs.define
+@define
 class SphericalShellGeometry(SceneGeometry):
     """
     Spherical shell geometry.

--- a/src/eradiate/scenes/illumination/_astro_object.py
+++ b/src/eradiate/scenes/illumination/_astro_object.py
@@ -1,20 +1,18 @@
 from __future__ import annotations
 
-import attrs
 import numpy as np
 import pint
 import pinttr
 
 from ._core import AbstractDirectionalIllumination
-from ...attrs import documented, parse_docs
+from ...attrs import define, documented
 from ...frame import angles_to_direction
 from ...units import unit_context_config as ucc
 from ...units import unit_registry as ureg
 from ...validators import is_positive
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class AstroObjectIllumination(AbstractDirectionalIllumination):
     """
     Astronomical Object Illumination scene element [``astro_object``].

--- a/src/eradiate/scenes/illumination/_constant.py
+++ b/src/eradiate/scenes/illumination/_constant.py
@@ -5,12 +5,11 @@ import attrs
 from ._core import Illumination
 from ..core import NodeSceneElement
 from ..spectra import Spectrum, spectrum_factory
-from ...attrs import documented, parse_docs
+from ...attrs import define, documented
 from ...validators import has_quantity
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class ConstantIllumination(Illumination):
     """
     Constant illumination scene element [``constant``].

--- a/src/eradiate/scenes/illumination/_core.py
+++ b/src/eradiate/scenes/illumination/_core.py
@@ -13,7 +13,7 @@ import pinttrs
 from ..core import NodeSceneElement
 from ..spectra import SolarIrradianceSpectrum, Spectrum, spectrum_factory
 from ..._factory import Factory
-from ...attrs import documented, get_doc, parse_docs
+from ...attrs import define, documented, get_doc
 from ...config import settings
 from ...frame import AzimuthConvention, angles_to_direction
 from ...units import unit_context_config as ucc
@@ -32,8 +32,7 @@ illumination_factory.register_lazy_batch(
 )
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class Illumination(NodeSceneElement, ABC):
     """
     Abstract base class for all illumination scene elements.
@@ -66,9 +65,8 @@ def _azimuth_converter(value):
         return value
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
-class AbstractDirectionalIllumination(Illumination):
+@define(eq=False, slots=False)
+class AbstractDirectionalIllumination(Illumination, ABC):
     """
     Abstract interface to directional-like illuminants.
     """

--- a/src/eradiate/scenes/illumination/_directional.py
+++ b/src/eradiate/scenes/illumination/_directional.py
@@ -1,14 +1,11 @@
 from __future__ import annotations
 
-import attrs
-
 from ._core import AbstractDirectionalIllumination
 from ..core import NodeSceneElement
-from ...attrs import parse_docs
+from ...attrs import define
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class DirectionalIllumination(AbstractDirectionalIllumination):
     """
     Directional illumination scene element [``directional``].

--- a/src/eradiate/scenes/illumination/_spot.py
+++ b/src/eradiate/scenes/illumination/_spot.py
@@ -13,15 +13,14 @@ from ._core import Illumination
 from ..core import NodeSceneElement
 from ..spectra import Spectrum, spectrum_factory
 from ... import validators
-from ...attrs import documented, parse_docs
+from ...attrs import define, documented
 from ...units import unit_context_config as ucc
 from ...units import unit_context_kernel as uck
 from ...units import unit_registry as ureg
 from ...validators import has_quantity
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class SpotIllumination(Illumination):
     """
     Spot illumination scene element [``spot``].

--- a/src/eradiate/scenes/integrators/_core.py
+++ b/src/eradiate/scenes/integrators/_core.py
@@ -6,7 +6,7 @@ import attrs
 
 from ..core import NodeSceneElement
 from ..._factory import Factory
-from ...attrs import documented, get_doc, parse_docs
+from ...attrs import define, documented, get_doc
 
 integrator_factory = Factory()
 integrator_factory.register_lazy_batch(
@@ -20,8 +20,7 @@ integrator_factory.register_lazy_batch(
 )
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class Integrator(NodeSceneElement, ABC):
     """
     Abstract base class for all integrator elements.

--- a/src/eradiate/scenes/integrators/_path_tracers.py
+++ b/src/eradiate/scenes/integrators/_path_tracers.py
@@ -5,11 +5,10 @@ import attrs
 import eradiate
 
 from ._core import Integrator
-from ...attrs import documented, parse_docs
+from ...attrs import define, documented
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class MonteCarloIntegrator(Integrator):
     """
     Base class for integrator elements wrapping kernel classes
@@ -79,8 +78,7 @@ class MonteCarloIntegrator(Integrator):
         return result
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class PathIntegrator(MonteCarloIntegrator):
     """
     A thin interface to the path tracer kernel plugin.
@@ -95,8 +93,7 @@ class PathIntegrator(MonteCarloIntegrator):
         return "path"
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class VolPathIntegrator(MonteCarloIntegrator):
     """
     A thin interface to the volumetric path tracer kernel plugin.
@@ -110,8 +107,7 @@ class VolPathIntegrator(MonteCarloIntegrator):
         return "volpath"
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class VolPathMISIntegrator(MonteCarloIntegrator):
     """
     A thin interface to the volumetric path tracer (with spectral multiple
@@ -136,8 +132,7 @@ class VolPathMISIntegrator(MonteCarloIntegrator):
         return result
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class PiecewiseVolPathIntegrator(MonteCarloIntegrator):
     """
     A thin interface to the piecewise volumetric path tracer kernel plugin.

--- a/src/eradiate/scenes/measure/_core.py
+++ b/src/eradiate/scenes/measure/_core.py
@@ -19,7 +19,7 @@ from ..spectra import (
 )
 from ... import validators
 from ..._factory import Factory
-from ...attrs import documented, get_doc, parse_docs
+from ...attrs import define, documented, get_doc
 from ...kernel import InitParameter
 from ...srf_tools import convert as convert_srf
 from ...units import PhysicalQuantity
@@ -129,8 +129,7 @@ def _str_summary_raw(x):
         return f"dict<{len(keys)} items>({{{keys[0]}: {{...}} , ... }})"
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class Measure(NodeSceneElement, ABC):
     """
     Abstract base class for all measure scene elements.

--- a/src/eradiate/scenes/measure/_distant.py
+++ b/src/eradiate/scenes/measure/_distant.py
@@ -13,7 +13,7 @@ from pinttr.util import ensure_units
 
 from ._core import Measure
 from ... import converters, frame, validators
-from ...attrs import documented, parse_docs
+from ...attrs import define, documented
 from ...config import settings
 from ...units import symbol
 from ...units import unit_context_config as ucc
@@ -99,8 +99,7 @@ def _target_point_rectangle_xyz_converter(x):
     )
 
 
-@parse_docs
-@attrs.define
+@define
 class TargetPoint(Target):
     """
     Point target or origin specification.
@@ -127,8 +126,7 @@ class TargetPoint(Target):
         return self.xyz.m_as(uck.get("length"))
 
 
-@parse_docs
-@attrs.define
+@define
 class TargetRectangle(Target):
     """
     Rectangle target origin specification.
@@ -250,8 +248,7 @@ class TargetRectangle(Target):
 # ------------------------------------------------------------------------------
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class AbstractDistantMeasure(Measure, ABC):
     """
     Abstract interface of all distant measure classes.
@@ -311,8 +308,7 @@ class AbstractDistantMeasure(Measure, ABC):
         return self.ray_offset is None
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class DistantMeasure(AbstractDistantMeasure):
     """
     Single-pixel distant measure scene element [``distant``]
@@ -446,8 +442,7 @@ class DistantMeasure(AbstractDistantMeasure):
         }
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class MultiPixelDistantMeasure(AbstractDistantMeasure):
     """
     Multi-pixel distant measure scene element [``mpdistant``, ``multipixel_distant``]

--- a/src/eradiate/scenes/measure/_distant_flux.py
+++ b/src/eradiate/scenes/measure/_distant_flux.py
@@ -7,7 +7,7 @@ import pint
 
 from ._distant import AbstractDistantMeasure
 from ... import frame, validators
-from ...attrs import documented, parse_docs
+from ...attrs import define, documented
 from ...config import settings
 from ...units import symbol
 from ...units import unit_context_config as ucc
@@ -15,8 +15,7 @@ from ...units import unit_context_kernel as uck
 from ...warp import square_to_uniform_hemisphere
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class DistantFluxMeasure(AbstractDistantMeasure):
     """
     Distant radiosity measure scene element [``distantflux``, ``distant_flux``].

--- a/src/eradiate/scenes/measure/_hemispherical_distant.py
+++ b/src/eradiate/scenes/measure/_hemispherical_distant.py
@@ -9,7 +9,7 @@ import pinttr
 
 from ._distant import AbstractDistantMeasure
 from ... import frame, validators
-from ...attrs import documented, parse_docs
+from ...attrs import define, documented
 from ...config import settings
 from ...units import symbol
 from ...units import unit_context_config as ucc
@@ -18,8 +18,7 @@ from ...units import unit_registry as ureg
 from ...warp import square_to_uniform_hemisphere
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class HemisphericalDistantMeasure(AbstractDistantMeasure):
     """
     Hemispherical distant radiance measure scene element

--- a/src/eradiate/scenes/measure/_multi_distant.py
+++ b/src/eradiate/scenes/measure/_multi_distant.py
@@ -10,7 +10,7 @@ import pinttr
 
 from ._distant import AbstractDistantMeasure
 from ... import converters, frame
-from ...attrs import documented, parse_docs
+from ...attrs import define, documented
 from ...config import settings
 from ...units import symbol
 from ...units import unit_context_config as ucc
@@ -23,8 +23,7 @@ from ...util.misc import flatten
 # ------------------------------------------------------------------------------
 
 
-@parse_docs
-@attrs.define
+@define
 class Layout(ABC):
     """
     Abstract base class for all viewing direction layouts.
@@ -149,8 +148,7 @@ def _angles_converter(value):
     return (np.stack((zeniths, azimuths % 360), axis=1) * ureg.deg).to(angle_units)
 
 
-@parse_docs
-@attrs.define
+@define
 class AngleLayout(Layout):
     """
     A viewing direction layout directly defined by explicit (zenith, azimuth)
@@ -187,8 +185,7 @@ class AngleLayout(Layout):
         return self._angles
 
 
-@parse_docs
-@attrs.define
+@define
 class AzimuthRingLayout(Layout):
     """
     A viewing direction layout defined by a single zenith and a vector of
@@ -246,8 +243,7 @@ class AzimuthRingLayout(Layout):
         return np.hstack((zeniths, azimuths)) * angle_units
 
 
-@parse_docs
-@attrs.define
+@define
 class DirectionLayout(Layout):
     """
     A viewing direction layout directly defined by explicit (zenith, azimuth)
@@ -283,8 +279,7 @@ class DirectionLayout(Layout):
         return self._directions
 
 
-@parse_docs
-@attrs.define
+@define
 class HemispherePlaneLayout(Layout):
     """
     A viewing direction layout defined by a single azimuth and a vector of
@@ -331,8 +326,7 @@ class HemispherePlaneLayout(Layout):
         return np.hstack((zeniths, azimuths)) * angle_units
 
 
-@parse_docs
-@attrs.define
+@define
 class GridLayout(Layout):
     """
     A viewing direction layout defined as the Cartesian product of an azimuth
@@ -404,8 +398,7 @@ def _extract_kwargs(kwargs: dict, keys: list[str]) -> dict:
     return {key: kwargs.pop(key) for key in keys if key in kwargs}
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class MultiDistantMeasure(AbstractDistantMeasure):
     """
     Multi-distant radiance measure scene element [``mdistant``, ``multi_distant``].

--- a/src/eradiate/scenes/measure/_multi_radiancemeter.py
+++ b/src/eradiate/scenes/measure/_multi_radiancemeter.py
@@ -6,15 +6,14 @@ import pint
 import pinttr
 
 from ._core import Measure
-from ...attrs import documented, parse_docs
+from ...attrs import define, documented
 from ...units import symbol
 from ...units import unit_context_config as ucc
 from ...units import unit_context_kernel as uck
 from ...units import unit_registry as ureg
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class MultiRadiancemeterMeasure(Measure):
     """
     Radiance meter array measure scene element [``mradiancemeter``,

--- a/src/eradiate/scenes/measure/_perspective.py
+++ b/src/eradiate/scenes/measure/_perspective.py
@@ -8,15 +8,14 @@ import pinttr
 
 from ._core import Measure
 from ... import validators
-from ...attrs import documented, parse_docs
+from ...attrs import define, documented
 from ...units import symbol
 from ...units import unit_context_config as ucc
 from ...units import unit_context_kernel as uck
 from ...units import unit_registry as ureg
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class PerspectiveCameraMeasure(Measure):
     """
     Perspective camera scene element [``perspective``].

--- a/src/eradiate/scenes/measure/_radiancemeter.py
+++ b/src/eradiate/scenes/measure/_radiancemeter.py
@@ -1,21 +1,19 @@
 from __future__ import annotations
 
-import attrs
 import numpy as np
 import pint
 import pinttr
 
 from ._core import Measure
 from ... import validators
-from ...attrs import documented, parse_docs
+from ...attrs import define, documented
 from ...units import symbol
 from ...units import unit_context_config as ucc
 from ...units import unit_context_kernel as uck
 from ...units import unit_registry as ureg
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class RadiancemeterMeasure(Measure):
     """
     Radiance meter measure scene element [``radiancemeter``].

--- a/src/eradiate/scenes/phase/_core.py
+++ b/src/eradiate/scenes/phase/_core.py
@@ -6,7 +6,7 @@ import attrs
 
 from ..core import NodeSceneElement, SceneElement
 from ..._factory import Factory
-from ...attrs import documented, get_doc, parse_docs
+from ...attrs import define, documented, get_doc
 
 phase_function_factory = Factory()
 phase_function_factory.register_lazy_batch(
@@ -41,8 +41,7 @@ phase_function_factory.register_lazy_batch(
 )
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class PhaseFunction(NodeSceneElement, ABC):
     """
     An abstract base class defining common facilities for all phase functions.

--- a/src/eradiate/scenes/phase/_hg.py
+++ b/src/eradiate/scenes/phase/_hg.py
@@ -5,12 +5,11 @@ import attrs
 from ._core import PhaseFunction
 from ..spectra import Spectrum, spectrum_factory
 from ... import validators
-from ...attrs import documented, parse_docs
+from ...attrs import define, documented
 from ...kernel import InitParameter, UpdateParameter
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class HenyeyGreensteinPhaseFunction(PhaseFunction):
     """
     Henyey-Greenstein phase function [``hg``].

--- a/src/eradiate/scenes/phase/_isotropic.py
+++ b/src/eradiate/scenes/phase/_isotropic.py
@@ -1,11 +1,8 @@
-import attrs
-
 from ._core import PhaseFunction
-from ...attrs import parse_docs
+from ...attrs import define
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class IsotropicPhaseFunction(PhaseFunction):
     """
     Isotropic phase function [``isotropic``].

--- a/src/eradiate/scenes/phase/_rayleigh.py
+++ b/src/eradiate/scenes/phase/_rayleigh.py
@@ -5,11 +5,10 @@ import attrs
 import eradiate
 
 from ._core import PhaseFunction
-from ...attrs import documented, parse_docs
+from ...attrs import define, documented
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class RayleighPhaseFunction(PhaseFunction):
     """
     Rayleigh phase function [``rayleigh``].

--- a/src/eradiate/scenes/phase/_tabulated.py
+++ b/src/eradiate/scenes/phase/_tabulated.py
@@ -10,7 +10,7 @@ import xarray as xr
 import eradiate
 
 from ._core import PhaseFunction
-from ...attrs import documented, parse_docs
+from ...attrs import define, documented
 from ...kernel import InitParameter, UpdateParameter
 from ...spectral.index import (
     CKDSpectralIndex,
@@ -47,8 +47,7 @@ def _validate_data(instance, attribute, value):
         )
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class TabulatedPhaseFunction(PhaseFunction):
     r"""
     Tabulated phase function [``tab_phase``].

--- a/src/eradiate/scenes/shapes/_buffermesh.py
+++ b/src/eradiate/scenes/shapes/_buffermesh.py
@@ -10,15 +10,14 @@ import pinttr
 
 from ._core import ShapeInstance
 from ..core import BoundingBox, traverse
-from ...attrs import documented, parse_docs
+from ...attrs import define, documented
 from ...contexts import KernelContext
 from ...kernel import UpdateParameter
 from ...units import unit_context_config as ucc
 from ...units import unit_context_kernel as uck
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class BufferMeshShape(ShapeInstance):
     """
     Buffer mesh shape [``buffer_mesh``].

--- a/src/eradiate/scenes/shapes/_core.py
+++ b/src/eradiate/scenes/shapes/_core.py
@@ -9,7 +9,7 @@ from ..bsdfs import BSDF, bsdf_factory
 from ..core import BoundingBox, InstanceSceneElement, NodeSceneElement, Ref
 from ... import converters
 from ..._factory import Factory
-from ...attrs import documented, get_doc, parse_docs
+from ...attrs import define, documented, get_doc
 
 shape_factory = Factory()
 shape_factory.register_lazy_batch(
@@ -24,8 +24,7 @@ shape_factory.register_lazy_batch(
 )
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class Shape:
     """
     Abstract interface for all shape scene elements.

--- a/src/eradiate/scenes/shapes/_cuboid.py
+++ b/src/eradiate/scenes/shapes/_cuboid.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import typing as t
 
-import attrs
 import mitsuba as mi
 import numpy as np
 import pint
@@ -12,7 +11,7 @@ from pinttr.util import ensure_units
 from ._core import ShapeNode
 from ..bsdfs import BSDF
 from ..core import BoundingBox
-from ...attrs import documented, parse_docs
+from ...attrs import define, documented
 from ...contexts import KernelContext
 from ...kernel.transform import transform_affine
 from ...units import unit_context_config as ucc
@@ -35,8 +34,7 @@ def _edges_converter(x):
     return x * length_units
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class CuboidShape(ShapeNode):
     """
     Cuboid shape [``cuboid``].

--- a/src/eradiate/scenes/shapes/_filemesh.py
+++ b/src/eradiate/scenes/shapes/_filemesh.py
@@ -6,11 +6,10 @@ import attrs
 
 from ._core import ShapeNode
 from ..core import BoundingBox
-from ...attrs import documented, parse_docs
+from ...attrs import define, documented
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class FileMeshShape(ShapeNode):
     """
     File based mesh shape [``file_mesh``].

--- a/src/eradiate/scenes/shapes/_rectangle.py
+++ b/src/eradiate/scenes/shapes/_rectangle.py
@@ -10,7 +10,7 @@ from ._core import ShapeNode
 from ..bsdfs import BSDF
 from ..core import BoundingBox
 from ... import validators
-from ...attrs import documented, parse_docs
+from ...attrs import define, documented
 from ...units import unit_context_config as ucc
 from ...units import unit_context_kernel as uck
 from ...units import unit_registry as ureg
@@ -36,8 +36,7 @@ def _edges_converter(value):
     return value * length_units
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class RectangleShape(ShapeNode):
     """
     Rectangle shape [``rectangle``].

--- a/src/eradiate/scenes/shapes/_sphere.py
+++ b/src/eradiate/scenes/shapes/_sphere.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import attrs
 import mitsuba as mi
 import numpy as np
 import pint
@@ -10,7 +9,7 @@ from pinttr.util import ensure_units
 from ._core import ShapeNode
 from ..bsdfs import BSDF
 from ..core import BoundingBox
-from ...attrs import documented, parse_docs
+from ...attrs import define, documented
 from ...constants import EARTH_RADIUS
 from ...units import unit_context_config as ucc
 from ...units import unit_context_kernel as uck
@@ -21,8 +20,7 @@ def _normalize(v: np.typing.ArrayLike) -> np.ndarray:
     return np.array(v) / np.linalg.norm(v)
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class SphereShape(ShapeNode):
     """
     Sphere shape [``sphere``].

--- a/src/eradiate/scenes/spectra/_air_scattering_coefficient.py
+++ b/src/eradiate/scenes/spectra/_air_scattering_coefficient.py
@@ -4,15 +4,14 @@ import attrs
 import pint
 
 from ._core import Spectrum
-from ...attrs import parse_docs
+from ...attrs import define
 from ...kernel import InitParameter, UpdateParameter
 from ...radprops.rayleigh import compute_sigma_s_air
 from ...units import PhysicalQuantity
 from ...units import unit_context_kernel as uck
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class AirScatteringCoefficientSpectrum(Spectrum):
     """
     Air scattering coefficient spectrum [``air_scattering_coefficient``].

--- a/src/eradiate/scenes/spectra/_core.py
+++ b/src/eradiate/scenes/spectra/_core.py
@@ -9,7 +9,7 @@ import pint
 
 from ..core import NodeSceneElement
 from ..._factory import Factory
-from ...attrs import documented, parse_docs
+from ...attrs import define, documented
 from ...spectral.ckd import BinSet
 from ...spectral.index import (
     CKDSpectralIndex,
@@ -116,8 +116,7 @@ spectrum_factory.register_lazy_batch(
 )
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class Spectrum(NodeSceneElement, ABC):
     """
     Spectrum interface.

--- a/src/eradiate/scenes/spectra/_interpolated.py
+++ b/src/eradiate/scenes/spectra/_interpolated.py
@@ -8,7 +8,7 @@ import xarray as xr
 
 from ._core import Spectrum
 from ... import converters, validators
-from ...attrs import documented, parse_docs
+from ...attrs import define, documented
 from ...kernel import InitParameter, UpdateParameter
 from ...spectral.ckd import BinSet
 from ...spectral.mono import WavelengthSet
@@ -18,8 +18,7 @@ from ...units import unit_context_kernel as uck
 from ...units import unit_registry as ureg
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False, init=False)
+@define(eq=False, slots=False, init=False)
 class InterpolatedSpectrum(Spectrum):
     """
     Linearly interpolated spectrum [``interpolated``].

--- a/src/eradiate/scenes/spectra/_multi_delta.py
+++ b/src/eradiate/scenes/spectra/_multi_delta.py
@@ -1,21 +1,19 @@
 from __future__ import annotations
 
-import attrs
 import numpy as np
 import pint
 import pinttr
 
 from ._core import Spectrum
 from ... import validators
-from ...attrs import documented, parse_docs
+from ...attrs import define, documented
 from ...spectral.ckd import BinSet
 from ...spectral.mono import WavelengthSet
 from ...units import unit_context_kernel as uck
 from ...util.misc import summary_repr_vector
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class MultiDeltaSpectrum(Spectrum):
     """
     A spectrum made of multiple translated Dirac delta [``multi_delta``].

--- a/src/eradiate/scenes/spectra/_solar_irradiance.py
+++ b/src/eradiate/scenes/spectra/_solar_irradiance.py
@@ -12,7 +12,7 @@ import xarray as xr
 
 from ._core import Spectrum
 from ... import converters, data, validators
-from ...attrs import documented, parse_docs
+from ...attrs import define, documented
 from ...kernel import InitParameter, UpdateParameter
 from ...units import PhysicalQuantity, to_quantity
 from ...units import unit_context_kernel as uck
@@ -45,8 +45,7 @@ def _datetime_converter(x: t.Any):
         return dateutil.parser.parse(x)
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class SolarIrradianceSpectrum(Spectrum):
     """
     Solar irradiance spectrum [``solar_irradiance``].

--- a/src/eradiate/scenes/spectra/_uniform.py
+++ b/src/eradiate/scenes/spectra/_uniform.py
@@ -6,7 +6,7 @@ import pint
 import pinttr
 
 from ._core import Spectrum
-from ...attrs import documented, parse_docs
+from ...attrs import define, documented
 from ...kernel import InitParameter, UpdateParameter
 from ...units import PhysicalQuantity
 from ...units import unit_context_config as ucc
@@ -14,8 +14,7 @@ from ...units import unit_context_kernel as uck
 from ...units import unit_registry as ureg
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False, init=False)
+@define(eq=False, slots=False, init=False)
 class UniformSpectrum(Spectrum):
     """
     Uniform spectrum [``uniform``] (*i.e.* constant vs wavelength).

--- a/src/eradiate/scenes/surface/_basic.py
+++ b/src/eradiate/scenes/surface/_basic.py
@@ -9,13 +9,12 @@ from ._core import Surface
 from ..bsdfs import BSDF, LambertianBSDF, bsdf_factory
 from ..core import Ref, SceneTraversal, traverse
 from ..shapes import RectangleShape, SphereShape, shape_factory
-from ...attrs import documented, parse_docs
+from ...attrs import define, documented
 from ...exceptions import OverriddenValueWarning, TraversalError
 from ...kernel import TypeIdLookupStrategy, UpdateParameter
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class BasicSurface(Surface):
     """
     Basic surface [``basic``].

--- a/src/eradiate/scenes/surface/_central_patch.py
+++ b/src/eradiate/scenes/surface/_central_patch.py
@@ -14,7 +14,7 @@ from ._core import Surface
 from ..bsdfs import BSDF, BlackBSDF, LambertianBSDF, bsdf_factory
 from ..core import Ref, SceneTraversal, traverse
 from ..shapes import RectangleShape, shape_factory
-from ...attrs import documented, parse_docs
+from ...attrs import define, documented
 from ...exceptions import OverriddenValueWarning, TraversalError
 from ...units import unit_context_config as ucc
 
@@ -34,8 +34,7 @@ def _edges_converter(value):
     return value * length_units
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class CentralPatchSurface(Surface):
     """
     Central patch surface [``central_patch``].

--- a/src/eradiate/scenes/surface/_core.py
+++ b/src/eradiate/scenes/surface/_core.py
@@ -6,7 +6,7 @@ import attrs
 
 from ..core import CompositeSceneElement, NodeSceneElement
 from ..._factory import Factory
-from ...attrs import documented, get_doc, parse_docs
+from ...attrs import define, documented, get_doc
 
 surface_factory = Factory()
 surface_factory.register_lazy_batch(
@@ -19,8 +19,7 @@ surface_factory.register_lazy_batch(
 )
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class Surface(CompositeSceneElement, ABC):
     """
     An abstract base class defining common facilities for all surfaces.

--- a/src/eradiate/scenes/surface/_dem.py
+++ b/src/eradiate/scenes/surface/_dem.py
@@ -22,7 +22,7 @@ from ..shapes import (
     SphereShape,
     shape_factory,
 )
-from ...attrs import documented, get_doc, parse_docs
+from ...attrs import define, documented, get_doc
 from ...constants import EARTH_RADIUS
 from ...units import symbol, to_quantity
 from ...units import unit_context_config as ucc
@@ -469,8 +469,7 @@ def mesh_from_dem(
     return mesh, xlon_lim, ylat_lim
 
 
-@parse_docs
-@attrs.define(eq=False, slots=False)
+@define(eq=False, slots=False)
 class DEMSurface(Surface):
     """
     DEM Surface [``dem``]

--- a/src/eradiate/spectral/ckd.py
+++ b/src/eradiate/spectral/ckd.py
@@ -12,7 +12,7 @@ import xarray as xr
 
 from .index import CKDSpectralIndex
 from .spectral_set import SpectralSet
-from ..attrs import documented, parse_docs
+from ..attrs import define, documented
 from ..constants import SPECTRAL_RANGE_MAX, SPECTRAL_RANGE_MIN
 from ..quad import Quad, QuadType
 from ..radprops import CKDAbsorptionDatabase
@@ -29,8 +29,7 @@ logger = logging.getLogger(__name__)
 # ------------------------------------------------------------------------------
 
 
-@parse_docs
-@attrs.define(eq=False, frozen=True, slots=True)
+@define(eq=False, frozen=True, slots=True)
 class Bin:
     """
     A data class representing a spectral bin in CKD modes.
@@ -114,8 +113,7 @@ class Bin:
 _DEFAULT_NG: int = 16
 
 
-@parse_docs
-@attrs.define
+@define
 class QuadSpec:
     """
     Abstract base class for all quadrature specification patterns.
@@ -200,8 +198,7 @@ class QuadSpec:
         raise NotImplementedError
 
 
-@parse_docs
-@attrs.define
+@define
 class QuadSpecFixed(QuadSpec):
     """
     Fixed number of quadrature points [``fixed``]
@@ -235,8 +232,7 @@ class QuadSpecFixed(QuadSpec):
         return Quad.new(type=self.quad_type, n=self.n)
 
 
-@parse_docs
-@attrs.define
+@define
 class QuadSpecMinError(QuadSpec):
     """
     Error-minimizing number of quadrature points [``minimize_error``]
@@ -266,8 +262,7 @@ class QuadSpecMinError(QuadSpec):
         return Quad.new(type=quad_type, n=n)
 
 
-@parse_docs
-@attrs.define
+@define
 class QuadSpecErrorThreshold(QuadSpec):
     """
     Error-threshold number of quadrature points [``error_threshold``]
@@ -378,8 +373,7 @@ def ng_threshold(
 # ------------------------------------------------------------------------------
 
 
-@parse_docs
-@attrs.define(eq=False, frozen=True, slots=True)
+@define(eq=False, frozen=True, slots=True)
 class BinSet(SpectralSet):
     """
     A data class representing a bin set used in CKD mode.

--- a/src/eradiate/spectral/index.py
+++ b/src/eradiate/spectral/index.py
@@ -38,7 +38,7 @@ import eradiate
 
 from .. import validators
 from .._mode import SpectralMode
-from ..attrs import documented, parse_docs
+from ..attrs import define, documented
 from ..exceptions import ModeError
 from ..units import unit_context_config as ucc
 from ..units import unit_registry as ureg
@@ -129,8 +129,7 @@ class SpectralIndex(ABC):
             raise ValueError(f"Cannot convert {value} to a spectral index.")
 
 
-@parse_docs
-@attrs.define(eq=False, frozen=True, slots=True)
+@define(eq=False, frozen=True, slots=True)
 class MonoSpectralIndex(SpectralIndex):
     """
     Monochromatic spectral index.
@@ -169,8 +168,7 @@ class MonoSpectralIndex(SpectralIndex):
         return float(self.w.m_as(ureg.nm))
 
 
-@parse_docs
-@attrs.define(eq=False, frozen=True, slots=True)
+@define(eq=False, frozen=True, slots=True)
 class CKDSpectralIndex(SpectralIndex):
     """
     CKD spectral index.

--- a/src/eradiate/spectral/mono.py
+++ b/src/eradiate/spectral/mono.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import logging
 import typing as t
 
-import attrs
 import numpy as np
 import pint
 import pinttr
@@ -11,7 +10,7 @@ import xarray as xr
 
 from .index import MonoSpectralIndex
 from .spectral_set import SpectralSet
-from ..attrs import documented, parse_docs
+from ..attrs import define, documented
 from ..constants import SPECTRAL_RANGE_MAX, SPECTRAL_RANGE_MIN
 from ..radprops import MonoAbsorptionDatabase
 from ..units import to_quantity
@@ -21,8 +20,7 @@ from ..units import unit_registry as ureg
 logger = logging.getLogger(__name__)
 
 
-@parse_docs
-@attrs.define(eq=False, frozen=True, slots=True)
+@define(eq=False, frozen=True, slots=True)
 class WavelengthSet(SpectralSet):
     """
     A data class representing a wavelength set used in monochromatic modes.

--- a/src/eradiate/test_tools/regression.py
+++ b/src/eradiate/test_tools/regression.py
@@ -12,7 +12,7 @@ import numpy as np
 import xarray as xr
 
 from .. import data
-from ..attrs import documented, parse_docs
+from ..attrs import define, documented
 from ..exceptions import DataError
 from ..typing import PathLike
 from ..util.misc import summary_repr
@@ -127,8 +127,7 @@ def reference_converter(
         return None
 
 
-@parse_docs
-@attrs.define
+@define
 class RegressionTest(ABC):
     """
     Common interface for tests based on the comparison of a result array against
@@ -309,8 +308,7 @@ class RegressionTest(ABC):
             )
 
 
-@parse_docs
-@attrs.define
+@define
 class RMSETest(RegressionTest):
     """
     This class implements a simple test based on the root mean squared
@@ -338,8 +336,7 @@ class RMSETest(RegressionTest):
         return rmse <= self.threshold, rmse
 
 
-@parse_docs
-@attrs.define
+@define
 class Chi2Test(RegressionTest):
     """
     This class implements a statistical test for the regression testing


### PR DESCRIPTION
# Description

This PR contains a long overdue refactoring of the our *attrs*-based features. In essence, it's not much more than providing a nicer interface to our *attrs* boilerplate: from

```python
import attrs
from eradiate.attrs import parse_docs

@parse_doc
@attrs.define
class MyClass:
    ...
```

we move to

```python
from eradiate.attrs import define

@define
class MyClass:
    ...
```

I also refactored the `eradiate.attrs.get_doc()` function (cleaner logic and better type hints).

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `next` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
