### PR TITLE
Change the tabulated phase function interface to allow spherical and spheroidal particle shapes.

### DIFF
--- a/docs/src/release_notes/v0.29.x.md
+++ b/docs/src/release_notes/v0.29.x.md
@@ -33,7 +33,8 @@
   generated mesh ({ghpr}`435`).
 * The {class}`.BufferMesh` class can now initialize texture coordinates as well
   ({ghpr}`435`).
-* Added polarized mode, Rayleigh and tabulated phase functions ({ghpr}`438`).
+* Added polarized mode, Rayleigh and tabulated phase functions ({ghpr}`438`,
+  {ghpr}`445`).
 * A new {class}`.SpectralGrid` type hierarchy is added ({ghpr}`439`). It handles
   the spectral discretization.
 * A new {class}`.SpectralResponseFunction` type hierarchy is added
@@ -60,7 +61,7 @@
 * ⚠️ The {attr}`.Measure.srf` field is now a {class}`.SpectralResponseFunction`
   instance ({ghpr}`439`). The dictionary interface used in {class}`.Measure`
   constructors remains unchanged.
-* ⚠️ The {class}`.MultiGenerator` is moved to {mod}`eradiate.util.misc`
+* ⚠️ 🖥️ The {class}`.MultiGenerator` is moved to {mod}`eradiate.util.misc`
   ({ghpr}`439`).
 * 📖 Overhauled the
   {doc}`Spectral discretization guide </src/user_guide/spectral_discretization>`

--- a/src/eradiate/scenes/atmosphere/_particle_layer.py
+++ b/src/eradiate/scenes/atmosphere/_particle_layer.py
@@ -219,6 +219,19 @@ class ParticleLayer(AbstractHeterogeneousAtmosphere):
         default="False",
     )
 
+    particle_shape: str = documented(
+        attrs.field(
+            default="spherical",
+            kw_only=True,
+        ),
+        doc="Defines the shape of the particle. Only used in polarized mode."
+        "* spherical: 4 coefficients considered [m11, m12, m33, m34]."
+        "* spheroidal: 6 coefficients considered [m11, m12, m22, m33, m34, m44].",
+        type="str",
+        init_type="str, optional",
+        default="spherical",
+    )
+
     @has_absorption.validator
     @has_scattering.validator
     def _switch_validator(self, attribute, value):
@@ -235,6 +248,7 @@ class ParticleLayer(AbstractHeterogeneousAtmosphere):
             id=self.phase_id,
             data=self.dataset.phase,
             force_polarized_phase=self.force_polarized_phase,
+            particle_shape=self.particle_shape,
         )
 
     # --------------------------------------------------------------------------

--- a/src/eradiate/scenes/atmosphere/_particle_layer.py
+++ b/src/eradiate/scenes/atmosphere/_particle_layer.py
@@ -5,6 +5,7 @@ Particle layers.
 from __future__ import annotations
 
 from functools import singledispatchmethod
+from typing import Literal
 
 import attrs
 import numpy as np
@@ -69,10 +70,7 @@ class ParticleLayer(AbstractHeterogeneousAtmosphere):
     bottom: pint.Quantity = documented(
         pinttr.field(
             default=ureg.Quantity(0.0, ureg.km),
-            validator=[
-                is_positive,
-                pinttr.validators.has_compatible_units,
-            ],
+            validator=[is_positive, pinttr.validators.has_compatible_units],
             units=ucc.deferred("length"),
         ),
         doc="Bottom altitude of the particle layer.\n"
@@ -87,10 +85,7 @@ class ParticleLayer(AbstractHeterogeneousAtmosphere):
         pinttr.field(
             units=ucc.deferred("length"),
             default=ureg.Quantity(1.0, ureg.km),
-            validator=[
-                is_positive,
-                pinttr.validators.has_compatible_units,
-            ],
+            validator=[is_positive, pinttr.validators.has_compatible_units],
         ),
         doc="Top altitude of the particle layer.\n"
         "\n"
@@ -131,10 +126,7 @@ class ParticleLayer(AbstractHeterogeneousAtmosphere):
         pinttr.field(
             units=ucc.deferred("wavelength"),
             default=550 * ureg.nm,
-            validator=[
-                is_positive,
-                pinttr.validators.has_compatible_units,
-            ],
+            validator=[is_positive, pinttr.validators.has_compatible_units],
         ),
         doc="Reference wavelength at which the extinction optical thickness is "
         "specified.\n"
@@ -149,10 +141,7 @@ class ParticleLayer(AbstractHeterogeneousAtmosphere):
         pinttr.field(
             units=ucc.deferred("dimensionless"),
             default=ureg.Quantity(0.2, ureg.dimensionless),
-            validator=[
-                is_positive,
-                pinttr.validators.has_compatible_units,
-            ],
+            validator=[is_positive, pinttr.validators.has_compatible_units],
         ),
         doc="Extinction optical thickness at the reference wavelength.\n"
         "\n"
@@ -180,15 +169,12 @@ class ParticleLayer(AbstractHeterogeneousAtmosphere):
         "If a string is passed, it is interpreted as an identifier for a "
         "particle radiative property dataset in the Eradiate data store.",
         type="Dataset",
-        init_type="Dataset or path-like or str, optional",
-        default="govaerts_2021-continental",
+        init_type="Dataset or path-like or str",
+        default='"govaerts_2021-continental"',
     )
 
     has_absorption: bool = documented(
-        attrs.field(
-            default=True,
-            converter=bool,
-        ),
+        attrs.field(default=True, converter=bool),
         doc="Absorption bypass switch. If ``True``, the absorption coefficient "
         "is computed. Else, the absorption coefficient is not computed and "
         "instead set to zero.",
@@ -197,39 +183,12 @@ class ParticleLayer(AbstractHeterogeneousAtmosphere):
     )
 
     has_scattering: bool = documented(
-        attrs.field(
-            default=True,
-            converter=bool,
-        ),
+        attrs.field(default=True, converter=bool),
         doc="Scattering bypass switch. If ``True``, the scattering coefficient "
         "is computed. Else, the scattering coefficient is not computed and "
         "instead set to zero.",
         type="bool",
         default="True",
-    )
-
-    force_polarized_phase: bool = documented(
-        attrs.field(
-            default=False,
-            converter=bool,
-        ),
-        doc="Force the use of a polarized phase function implementation, even"
-        "when no polarization informaiton is available.",
-        type="bool",
-        default="False",
-    )
-
-    particle_shape: str = documented(
-        attrs.field(
-            default="spherical",
-            kw_only=True,
-        ),
-        doc="Defines the shape of the particle. Only used in polarized mode."
-        "* spherical: 4 coefficients considered [m11, m12, m33, m34]."
-        "* spheroidal: 6 coefficients considered [m11, m12, m22, m33, m34, m44].",
-        type="str",
-        init_type="str, optional",
-        default="spherical",
     )
 
     @has_absorption.validator
@@ -240,6 +199,24 @@ class ParticleLayer(AbstractHeterogeneousAtmosphere):
                 f"while validating {attribute.name}: at least one of "
                 "'has_absorption' and 'has_scattering' must be True"
             )
+
+    force_polarized_phase: bool = documented(
+        attrs.field(default=False, converter=bool),
+        doc="Force the use of a polarized phase function implementation, even"
+        "when no polarization information is available.",
+        type="bool",
+        default="False",
+    )
+
+    particle_shape: Literal["spherical", "spheroidal"] = documented(
+        attrs.field(default="spherical", kw_only=True),
+        doc="Defines the shape of the particle. Only used in polarized mode.\n\n"
+        '* ``"spherical"``: 4 coefficients considered [m11, m12, m33, m34].\n'
+        '* ``"spheroidal"``: 6 coefficients considered [m11, m12, m22, m33, m34, m44].',
+        type="str",
+        init_type='{"spherical", "spheroidal"}',
+        default='"spherical"',
+    )
 
     _phase: TabulatedPhaseFunction | None = attrs.field(default=None, init=False)
 

--- a/src/eradiate/scenes/phase/_tabulated.py
+++ b/src/eradiate/scenes/phase/_tabulated.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from functools import singledispatchmethod
+from typing import Literal
 
 import attrs
 import numpy as np
@@ -80,28 +81,21 @@ class TabulatedPhaseFunction(PhaseFunction):
     )
 
     force_polarized_phase: bool = documented(
-        attrs.field(
-            default=False,
-            converter=bool,
-            kw_only=True,
-        ),
+        attrs.field(default=False, converter=bool, kw_only=True),
         doc="Flag that forces the use of a polarized phase function.",
         type="bool",
-        init_type="bool, optional",
+        init_type="bool",
         default="False",
     )
 
-    particle_shape: str = documented(
-        attrs.field(
-            default="spherical",
-            kw_only=True,
-        ),
-        doc="Defines the shape of the particle. Only used in polarized mode."
-        "* spherical: 4 coefficients considered [m11, m12, m33, m34]."
-        "* spheroidal: 6 coefficients considered [m11, m12, m22, m33, m34, m44].",
+    particle_shape: Literal["spherical", "spheroidal"] = documented(
+        attrs.field(default="spherical", kw_only=True),
+        doc="Defines the shape of the particle. Only used in polarized mode.\n\n"
+        '* ``"spherical"``: 4 coefficients considered [m11, m12, m33, m34].\n'
+        '* ``"spheroidal"``: 6 coefficients considered [m11, m12, m22, m33, m34, m44].',
         type="str",
-        init_type="str, optional",
-        default="spherical",
+        init_type='{"spherical", "spheroidal"}',
+        default='"spherical"',
     )
 
     _is_irregular: bool = attrs.field(default=False, init=False, repr=False)
@@ -124,7 +118,7 @@ class TabulatedPhaseFunction(PhaseFunction):
         self._is_irregular = not np.allclose(dmu, dmu[0]) or self.is_polarized
 
     @singledispatchmethod
-    def eval(self, si: SpectralIndex, i, j) -> np.ndarray:
+    def eval(self, si: SpectralIndex, i: int, j: int) -> np.ndarray:
         """
         Evaluate phase function at a given spectral index.
 


### PR DESCRIPTION
# Description

This PR changes the interface of the tabulated phase function and `ParticleLayer` to allow the use of `spherical` and `spheroidal` particle shapes. The user can select the required particle shape by specifying the `particle_shape` property as a string. The main background difference is that eradiate will pass `m11`, `m12`, `m22`, `m33`, `m34`, and `m44` to the kernel instead of just `m11`, `m12`, `m33`, and `m44`. Note that all the diagonal terms are now passed to the kernel when no polarization data is found.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [ ] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
