### PR TITLE
Transitional expert interface

### DIFF
--- a/docs/src/release_notes/v0.29.x.md
+++ b/docs/src/release_notes/v0.29.x.md
@@ -2,6 +2,10 @@
 
 ## v0.29.1 (upcoming release)
 
+### Added
+
+* Added the *transitional expert interface* ({ghpr}`452`).
+
 ### Fixed
 
 * Fixed incorrect logging configuration in the command-line interface.

--- a/src/eradiate/kernel/__init__.pyi
+++ b/src/eradiate/kernel/__init__.pyi
@@ -8,6 +8,8 @@ from ._kernel_dict import InitParameter as InitParameter
 from ._kernel_dict import KernelDictTemplate as KernelDictTemplate
 from ._kernel_dict import UpdateMapTemplate as UpdateMapTemplate
 from ._kernel_dict import UpdateParameter as UpdateParameter
+from ._kernel_dict import dict_parameter as dict_parameter
+from ._kernel_dict import scene_parameter as scene_parameter
 from ._render import MitsubaObjectWrapper as MitsubaObjectWrapper
 from ._render import TypeIdLookupStrategy as TypeIdLookupStrategy
 from ._render import mi_render as mi_render

--- a/src/eradiate/kernel/_kernel_dict.py
+++ b/src/eradiate/kernel/_kernel_dict.py
@@ -100,6 +100,43 @@ class UpdateParameter:
         return self.evaluator(ctx)
 
 
+def dict_parameter(maybe_fn=None):
+    """
+    This function wraps another one into a :class:`.UpdateParameter` instance.
+    It is primarily meant to be used as a decorator.
+
+    Parameters
+    ----------
+    maybe_fn : callable, optional
+    """
+    return InitParameter if maybe_fn is None else InitParameter(maybe_fn)
+
+
+def scene_parameter(
+    maybe_fn=None, flags: UpdateParameter.Flags = UpdateParameter.Flags.ALL
+):
+    """
+    This decorator wraps the function to which it is applied into an
+    :class:`.UpdateParameter` instance.
+
+    Parameters
+    ----------
+    maybe_fn : callable, optional
+
+    flags : .UpdateParameter.Flags, optional
+        Scene parameter flags used for filtering during a scene parameter loop.
+
+    Returns
+    -------
+    callable
+    """
+
+    def wrap(f):
+        return UpdateParameter(f, flags=flags)
+
+    return wrap if maybe_fn is None else wrap(maybe_fn)
+
+
 @attrs.define(slots=False)
 class KernelDictTemplate(UserDict):
     """


### PR DESCRIPTION
# Description

This PR introduces the *transitional expert* interface. It allows Mitsuba scene objects to be injected directly into the scene dictionary produced by an `Experiment` instance. Changes are as follows:

* The `mi_traverse()` function now pins scene tree node names to the current node ID if it exists. This behaviour can be controlled through a new `name_id_override` parameter which accepts regular expressions to define filters on pinned nodes. This improves the predictability of scene parameter names.

* The `InitParameter` and `UpdateParameter` classes can now wrap functions using respectively the `dict_parameter` and `scene_parameter` decorators. This improves the readability of scene parameter definitions. The naming convention is consistent with the upcoming full-blown expert interface (which will rename the aforementioned classes).

* All final `EarthObservationExperiment` subclasses now have two new fields. The `kdict` field allows the insertion of a Mitsuba scene dictionary fragment in the scene dictionary produced by the `Experiment`, and the `kpmap` field allows the insertion of additional scene parameter updates in the scene parameter mapping produced by the `Experiment`.

* All final `EarthObservationExperiment` subclasses have new methods `kdict_base()` and `kpmap_base()` that produce the baseline scene dictionary and scene parameter update map. The current implementation is inefficient and is not used to perform scene dictionary assembly.

* All final `EarthObservationExperiment` subclasses have new methods `kdict_full()` and `kpmap_full()` that produce the final scene dictionary and scene parameter update map, *i.e.* the baseline merged with user custom additions.

See [this gist](https://gist.github.com/leroyvn/c3f8ddf6287ec3cfa275a56d6c656706) for an example.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
