### PR TITLE
[Feature] New Ocean Legacy BSDF

### DIFF
--- a/docs/references.bib
+++ b/docs/references.bib
@@ -176,6 +176,19 @@
   year         = 2022,
   note         = {https://mitsuba-renderer.org}
 }
+@article{Kotchenova2006The6SVRTM,
+title = {Validation of a vector version of the 6S radiative transfer code for atmospheric correction of satellite data. Part I: Path radiance},
+author = {Svetlana Y. Kotchenova and Eric F. Vermote and Raffaella Matarrese and Frank J. Klemm, Jr.},
+year = {2006},
+month = {Sep},
+journal = {Appl. Opt.},
+number = {26},
+pages = {6762--6774},
+publisher = {Optica Publishing Group},
+volume = {45},
+url = {https://opg.optica.org/ao/abstract.cfm?URI=ao-45-26-6762},
+doi = {10.1364/AO.45.006762},
+}
 @book{Liou2002IntroductionAtmosphericRadiation,
   title        = {An Introduction to Atmospheric Radiation},
   author       = {Liou, Kuo-Nan},
@@ -209,6 +222,17 @@
   url          = {https://mcst.gsfc.nasa.gov/sites/default/files/file_attachments/MODIS_PFM_IB_OOB_RSR_merged.xls},
   institution  = {National Aeronautics and Space Administration},
   howpublished = {https://mcst.gsfc.nasa.gov/calibration/parameters}
+}
+@article{Morel1988ModelingUpperOcean,
+title={Optical modeling of the Upper Ocean in relation to its biogenous matter content (case I waters)},
+author={Morel, André},
+year={1988},
+month={Sep},
+journal={Journal of Geophysical Research: Oceans},
+volume={93},
+number={C9},
+DOI={10.1029/jc093ic09p10749},
+pages={10749–10768}
 }
 @techreport{NASA1976USStandardAtmosphere,
   title        = {{U.S. Standard Atmosphere}, 1976},
@@ -376,4 +400,3 @@
   url          = {https://www.osapublishing.org/ao/abstract.cfm?uri=ao-19-20-3427},
   shortjournal = {Appl. Opt., AO}
 }
-

--- a/docs/rst/reference_api/scenes.rst
+++ b/docs/rst/reference_api/scenes.rst
@@ -331,6 +331,7 @@ Quick access
    HapkeBSDF
    LambertianBSDF
    MQDiffuseBSDF
+   OceanLegacyBSDF
    OpacityMaskBSDF
    RPVBSDF
    RTLSBSDF

--- a/src/eradiate/scenes/bsdfs/__init__.pyi
+++ b/src/eradiate/scenes/bsdfs/__init__.pyi
@@ -2,9 +2,10 @@ from ._black import BlackBSDF as BlackBSDF
 from ._checkerboard import CheckerboardBSDF as CheckerboardBSDF
 from ._core import BSDF as BSDF
 from ._core import bsdf_factory as bsdf_factory
+from ._hapke import HapkeBSDF as HapkeBSDF
 from ._lambertian import LambertianBSDF as LambertianBSDF
 from ._mqdiffuse import MQDiffuseBSDF as MQDiffuseBSDF
+from ._ocean_legacy import OceanLegacyBSDF as OceanLegacyBSDF
 from ._opacity_mask import OpacityMaskBSDF as OpacityMaskBSDF
 from ._rpv import RPVBSDF as RPVBSDF
 from ._rtls import RTLSBSDF as RTLSBSDF
-from ._hapke import HapkeBSDF as HapkeBSDF

--- a/src/eradiate/scenes/bsdfs/_core.py
+++ b/src/eradiate/scenes/bsdfs/_core.py
@@ -13,6 +13,7 @@ bsdf_factory.register_lazy_batch(
         ("_checkerboard.CheckerboardBSDF", "checkerboard", {}),
         ("_lambertian.LambertianBSDF", "lambertian", {}),
         ("_mqdiffuse.MQDiffuseBSDF", "mqdiffuse", {}),
+        ("_ocean_legacy.OceanLegacyBSDF", "ocean_legacy", {}),
         ("_opacity_mask.OpacityMaskBSDF", "opacity_mask", {}),
         ("_rpv.RPVBSDF", "rpv", {}),
         ("_rtls.RTLSBSDF", "rtls", {}),

--- a/src/eradiate/scenes/bsdfs/_ocean_legacy.py
+++ b/src/eradiate/scenes/bsdfs/_ocean_legacy.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import pint
+import pinttrs
+
+from ._core import BSDF
+from ...attrs import define, documented
+from ...kernel import InitParameter, UpdateParameter
+from ...units import unit_context_config as ucc
+from ...units import unit_registry as ureg
+from ...validators import is_positive
+
+
+@define(eq=False, slots=False)
+class OceanLegacyBSDF(BSDF):
+    """
+    Ocean Legacy BSDF [``ocean_legacy``].
+
+    This BSDF implements the 6SV ocean surface model as described in
+    :cite:t:`Kotchenova2006The6SVRTM`. This model treats the ocean as an opaque
+    surface, and models the sunglint, whitecap and underlight components
+    of the ocean reflectance. It depends on wind properties and
+    pigmentation and chlorinity which makes it suitable to represent
+    case I waters as defined by :cite:t:`Morel1988ModelingUpperOcean`.
+
+    See Also
+    --------
+    :ref:`plugin-bsdf-ocean_legacy`
+
+    Notes
+    -----
+     The ``wind_direction`` parameter indicates the azimuth angle of the wind and
+    is interpreted using the :ref:`North left convention <sec-user_guide-conventions-azimuth>`.
+    """
+
+    wind_speed: pint.Quantity = documented(
+        pinttrs.field(
+            units=ureg("m/s").units,
+            factory=lambda: 0.01 * ureg("m/s"),
+            validator=[is_positive, pinttrs.validators.has_compatible_units],
+        ),
+        doc="Wind speed [m/s] at 10 meters above the surface.",
+        type="quantity",
+        init_type="quantity or float",
+        default="0.01 m/s",
+    )
+
+    wind_direction: pint.Quantity = documented(
+        pinttrs.field(
+            factory=lambda: 0.0 * ureg.deg,
+            validator=[is_positive, pinttrs.validators.has_compatible_units],
+            units=ucc.deferred("angle"),
+        ),
+        doc="Wind azimuthal angle in *North Left-Hand convention*.\n\nUnit-enabled field (default units: ucc['angle']).",
+        type="quantity",
+        init_type="quantity or float",
+        default="0.0 deg",
+    )
+
+    chlorinity: pint.Quantity = documented(
+        pinttrs.field(
+            units=ureg.Unit("g/kg"),
+            factory=lambda: 19.0 * ureg("g/kg"),
+            validator=[is_positive, pinttrs.validators.has_compatible_units],
+        ),
+        doc="Chlorinity of water.",
+        type="quantity",
+        init_type="quantity or float",
+        default="19.0 g/kg",
+    )
+
+    pigmentation: pint.Quantity = documented(
+        pinttrs.field(
+            units=ureg.Unit("mg/m^3"),
+            factory=lambda: 0.3 * ureg("mg/m^3"),
+            validator=[is_positive, pinttrs.validators.has_compatible_units],
+        ),
+        doc="Pigmentation of water.",
+        type="quantity",
+        init_type="quantity or float",
+        default="0.3 mg/m^3",
+    )
+
+    def default_shininess(self, u: pint.Quantity):
+        """
+        Parametrizes the Blinn-Phong distribution function with respect to the
+        wind speed.
+        """
+        return (37.2455 - u.m_as("m/s")) ** 1.15
+
+    @property
+    def template(self) -> dict:
+        # Inherit docstring
+        result = {
+            "type": "ocean_legacy",
+            "wavelength": InitParameter(lambda ctx: ctx.si.w.m_as("nm")),
+            "shininess": self.default_shininess(self.wind_speed),
+            "wind_speed": self.wind_speed.m_as("m/s"),
+            "wind_direction": self.wind_direction.m_as("deg"),
+            "chlorinity": self.chlorinity.m_as("g/kg"),
+            "pigmentation": self.pigmentation.m_as("mg/m^3"),
+        }
+
+        if self.id is not None:
+            result["id"] = self.id
+
+        return result
+
+    @property
+    def params(self) -> dict[str, UpdateParameter]:
+        result = {"wavelength": UpdateParameter(lambda ctx: ctx.si.w.m_as("nm"))}
+
+        return result

--- a/tests/01_unit/scenes/bsdfs/test_ocean_legacy.py
+++ b/tests/01_unit/scenes/bsdfs/test_ocean_legacy.py
@@ -1,0 +1,35 @@
+import mitsuba as mi
+import pytest
+
+from eradiate.scenes.bsdfs import OceanLegacyBSDF
+from eradiate.test_tools.types import check_scene_element
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {},
+        {
+            "wind_speed": 1.0,
+            "wind_direction": 15.0,
+            "chlorinity": 19.0,
+            "pigmentation": 0.3,
+        },
+        {"chlorinity": 19.0, "pigmentation": 0.3},
+    ],
+    ids=["noargs", "uniform", "mixed"],
+)
+def test_ocean_legacy_construct(modes_all, kwargs):
+    # Default constructor
+    assert OceanLegacyBSDF(**kwargs)
+
+
+def test_ocean_legacy(modes_all_double):
+    bsdf = OceanLegacyBSDF(
+        wind_speed=15.0,
+        wind_direction=42.0,
+        chlorinity=19.0,
+        pigmentation=0.3,
+    )
+
+    check_scene_element(bsdf, mi.BSDF)


### PR DESCRIPTION
# Description

Hello, this PR introduces to Eradiate a new Ocean BSDF based on the 6SV model. For more details about the model itself, please refer to eradiate/mitsuba3#12. This PR includes the interface for the BSDF as well unit tests and some documentation. Note that all the fields have static units, which might be subject in the future if we start making more use of those quantities. It is also worth noting that the BRDF has been validated against 6SV, but no results have been reproduced yet. This could be done as a future step. 

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `next` branch
- [ ] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
