### PR TITLE
make_gaussian: Add normalization, fix zero padding

### DIFF
--- a/docs/rst/reference_api/spectral.rst
+++ b/docs/rst/reference_api/spectral.rst
@@ -26,6 +26,14 @@ Spectral response functions
    BandSRF
    DeltaSRF
 
+Spectral response utilities
+---------------------------
+
+.. autosummary::
+   :toctree: generated/autosummary/
+
+   response.make_gaussian
+
 Spectral indexes
 ----------------
 

--- a/docs/rst/reference_api/srf_tools.rst
+++ b/docs/rst/reference_api/srf_tools.rst
@@ -5,11 +5,6 @@
 
 .. py:currentmodule:: eradiate.srf_tools
 
-Generators
-----------
-
-.. autofunction:: make_gaussian
-
 Trimming algorithms
 -------------------
 


### PR DESCRIPTION
# Description

This PR adds normalization to the `make_gaussian()` function and fixes its zero-padding option.

It also moves the function to the `spectral.response` subpackage. The previous entry point is deprecated, but kept for compatibility.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
