### PR TITLE
`KernelDictTemplate`: Flatten automatically nested dicts

### DIFF
--- a/docs/src/release_notes/v0.29.x.md
+++ b/docs/src/release_notes/v0.29.x.md
@@ -146,8 +146,11 @@ codebase yet. This upgrade is planned for the next major release.
   an alternative.
 
 % ### Removed
-%
-% ### Added
+
+### Added
+
+* Automatically flatten nested dictionaries used for initialization or
+  assignments to {class}`.KernelDictTemplate` ({ghpr}`459`).
 
 ### Changed
 

--- a/tests/01_unit/kernel/test_kernel_dict.py
+++ b/tests/01_unit/kernel/test_kernel_dict.py
@@ -10,6 +10,19 @@ from eradiate.kernel import (
 )
 
 
+def test_kernel_dict_template_init():
+    template = KernelDictTemplate({"foo": {"bar": 0}, "bar": {"baz": {"qux": 0}}})
+    assert template.data == {"foo.bar": 0, "bar.baz.qux": 0}
+
+
+def test_kernel_dict_template_setitem():
+    template = KernelDictTemplate()
+    template["foo"] = {"bar": 0}
+    template["bar"] = {"baz": {"qux": 0}}
+    template["baz"] = 0
+    assert template.data == {"foo.bar": 0, "bar.baz.qux": 0, "baz": 0}
+
+
 def test_kernel_dict_template_render():
     template = KernelDictTemplate(
         {


### PR DESCRIPTION
# Description

This PR updates the `KernelDictTemplate` to automatically flatten nested dictionaries used for initialization or assignment.

**Example:**

Prior to this update, the following:

```python
d = KernelDictTemplate(
    {
        "type": "diffuse", 
        "reflectance": {
            "type": "uniform", 
            "value": InitParameter(lambda ctx: 1 if ctx.si.w == 550 else 0)
        }
    }
)
d.render(ctx)  # assuming ctx initialized somewhere else
```
would result in the rendered dictionary still containing unrendered parameters, *e.g*
```python
{
    "type": "diffuse", 
    "reflectance": {
        "type": "uniform", 
        "value": InitParameter(lambda ctx: 1 if ctx.si.w == 550 else 0)
    }
}
```
While this is expected behaviour, it also means that nested dictionaries must be manually flattened by the user. This is unintuitive.

After this update, nested dicts used for initialization or assignments are flattened automatically, meaning that in the example above, the dictionary is converted to
```python
{
    "type": "diffuse",
    "reflectance.type": "uniform",
    "reflectance.value": InitParameter(lambda ctx: 1 if ctx.si.w == 550 else 0)
}
```
and renders as
```python
{
    "type": "diffuse", 
    "reflectance": {
        "type": "uniform", 
        "value": 1.0
    }
}
```

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
