### PR TITLE
Fix `mi_traverse()` name ID override with alias tracking

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,7 +13,7 @@ if RTD:
     html_context["READTHEDOCS"] = True
 
     # Mock Mitsuba modules (required to render on RTD)
-    MOCK_MODULES = ["mitsuba", "mitsuba.scalar_rgb", "drjit"]
+    MOCK_MODULES = ["mitsuba", "mitsuba.python.util", "mitsuba.scalar_rgb", "drjit"]
     for mod_name in MOCK_MODULES:
         sys.modules[mod_name] = mock.Mock()
 

--- a/docs/rst/reference_api/radprops.rst
+++ b/docs/rst/reference_api/radprops.rst
@@ -15,8 +15,6 @@
 
 .. rubric:: Classes
 
-**Factory**: :data:`rad_profile_factory`
-
 .. autosummary::
    :recursive:
    :toctree: generated/autosummary/

--- a/docs/src/release_notes/v0.29.x.md
+++ b/docs/src/release_notes/v0.29.x.md
@@ -160,5 +160,7 @@ codebase yet. This upgrade is planned for the next major release.
 ### Fixed
 
 * Fixed Gaussian SRF padding strategy ({ghpr}`458`).
+* Fixed {func}`mi_traverse` name ID override for non-top-level nodes
+  ({ghpr}`461`).
 
 % ### Internal changes

--- a/src/eradiate/radprops/__init__.pyi
+++ b/src/eradiate/radprops/__init__.pyi
@@ -6,4 +6,3 @@ from ._absorption import MonoAbsorptionDatabase as MonoAbsorptionDatabase
 from ._atmosphere import AtmosphereRadProfile as AtmosphereRadProfile
 from ._core import RadProfile as RadProfile
 from ._core import ZGrid as ZGrid
-from ._core import rad_profile_factory as rad_profile_factory

--- a/src/eradiate/scenes/atmosphere/_util.py
+++ b/src/eradiate/scenes/atmosphere/_util.py
@@ -7,8 +7,8 @@ import pandas as pd
 import xarray as xr
 from tqdm.auto import tqdm
 
-from . import HeterogeneousAtmosphere
 from ._core import AbstractHeterogeneousAtmosphere
+from ._heterogeneous import HeterogeneousAtmosphere
 from ...cfconventions import ATTRIBUTES
 from ...spectral import (
     CKDQuadConfig,

--- a/src/eradiate/spectral/grid.py
+++ b/src/eradiate/spectral/grid.py
@@ -11,8 +11,8 @@ import pint
 import pinttrs
 from pinttrs.util import ensure_units
 
-from . import CKDSpectralIndex, MonoSpectralIndex, SpectralIndex
 from .ckd_quad import CKDQuadConfig, CKDQuadPolicy
+from .index import CKDSpectralIndex, MonoSpectralIndex, SpectralIndex
 from .response import BandSRF, DeltaSRF, SpectralResponseFunction, UniformSRF
 from .. import converters
 from .._mode import ModeFlag, SubtypeDispatcher


### PR DESCRIPTION
# Description

This PR fixes the name ID override feature added the `mi_traverse()` function. Prior to this update, ID-aliased node updates could fail when the aliased object would not be declared at the top level of the scene because the scene update algorithm would not be able to reach the parent object to an ID-aliased node. This is solved by adding an alias tracking mapping to the `SceneParameter` object and following aliases upon scene parameter update.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
