### PR TITLE
[Fix] Set all volume's filter types to `nearest`

### DIFF
--- a/docs/src/release_notes/v0.30.x.md
+++ b/docs/src/release_notes/v0.30.x.md
@@ -10,8 +10,8 @@
 
 ### Removed
 
-* The {class}`MolecularAtmosphere` constructor no longer accepts a `phase_function`
-  parameter ({ghpr}`460`).
+* The {class}`MolecularAtmosphere` constructor no longer accepts a
+  `phase_function` parameter ({ghpr}`460`).
 
 ### Added
 
@@ -27,5 +27,6 @@
 
 * Fixed Gaussian SRF padding strategy ({ghpr}`458`).
 * Package metadata now explicitly mentions that supported Python is up to 3.12.
+* Fixed incorrect interpolation method in volume data textures ({ghpr}`465`).
 
 % ### Internal changes

--- a/src/eradiate/scenes/atmosphere/_core.py
+++ b/src/eradiate/scenes/atmosphere/_core.py
@@ -660,6 +660,7 @@ class AbstractHeterogeneousAtmosphere(Atmosphere, ABC):
                         ),
                     ),
                     "to_world": to_world,
+                    "filter_type": "nearest",
                 },
                 "sigma_t": {
                     "type": "gridvolume",
@@ -674,6 +675,7 @@ class AbstractHeterogeneousAtmosphere(Atmosphere, ABC):
                         ),
                     ),
                     "to_world": to_world,
+                    "filter_type": "nearest",
                 },
             }
 
@@ -695,6 +697,7 @@ class AbstractHeterogeneousAtmosphere(Atmosphere, ABC):
                                 ).astype(np.float32)
                             ),
                         ),
+                        "filter_type": "nearest",
                     },
                     "to_world": to_world,
                     "rmin": volume_rmin,
@@ -713,6 +716,7 @@ class AbstractHeterogeneousAtmosphere(Atmosphere, ABC):
                                 ).astype(np.float32)
                             ),
                         ),
+                        "filter_type": "nearest",
                     },
                     "to_world": to_world,
                     "rmin": volume_rmin,

--- a/src/eradiate/scenes/phase/_blend.py
+++ b/src/eradiate/scenes/phase/_blend.py
@@ -216,6 +216,7 @@ class BlendPhaseFunction(PhaseFunction):
 
                 result[f"{prefix}weight.type"] = "gridvolume"
                 result[f"{prefix}weight.grid"] = InitParameter(eval_conditional_weights)
+                result[f"{prefix}weight.filter_type"] = "nearest"
 
                 if self.geometry is not None:
                     result[f"{prefix}weight.to_world"] = (
@@ -237,6 +238,7 @@ class BlendPhaseFunction(PhaseFunction):
                 result[f"{prefix}weight.volume.grid"] = InitParameter(
                     eval_conditional_weights
                 )
+                result[f"{prefix}weight.volume.filter_type"] = "nearest"
                 result[f"{prefix}weight.to_world"] = (
                     self.geometry.atmosphere_volume_to_world
                 )

--- a/src/eradiate/scenes/phase/_rayleigh.py
+++ b/src/eradiate/scenes/phase/_rayleigh.py
@@ -109,6 +109,7 @@ class RayleighPhaseFunction(PhaseFunction):
                     ),
                 )
                 result["depolarization.to_world"] = to_world
+                result["depolarization.filter_type"] = "nearest"
 
             elif isinstance(self.geometry, SphericalShellGeometry):
                 volume_rmin = self.geometry.atmosphere_volume_rmin
@@ -124,6 +125,7 @@ class RayleighPhaseFunction(PhaseFunction):
                         ).astype(np.float32),
                     ),
                 )
+                result["depolarization.volume.filter_type"] = "nearest"
                 result["depolarization.to_world"] = to_world
                 result["depolarization.rmin"] = volume_rmin
 

--- a/tests/01_unit/scenes/phase/test_blend.py
+++ b/tests/01_unit/scenes/phase/test_blend.py
@@ -243,12 +243,14 @@ def test_blend_phase_kernel_dict_2_components(mode_mono, kwargs):
         "phase_1.type": "rayleigh",
         "weight.type": "gridvolume",
         "weight.grid": np.reshape(phase.eval_conditional_weights(ctx.si), (-1, 1, 1)),
+        "weight.filter_type": "nearest",
     }
     if "geometry" in kwargs:
         geometry = SceneGeometry.convert(kwargs["geometry"])
         expected["weight.to_world"] = np.array(
             geometry.atmosphere_volume_to_world.matrix
         )
+
     assert_cmp_dict(kernel_dict, expected)
 
     # Check that the parameter map is correct
@@ -317,11 +319,13 @@ def test_blend_phase_kernel_dict_3_components(mode_mono, kwargs, expected_mi_wei
         "type": "blendphase",
         "weight.type": "gridvolume",
         "weight.grid": np.reshape(expected_mi_weights[0], (-1, 1, 1)),
+        "weight.filter_type": "nearest",
         "phase_0.type": "hg",
         "phase_0.g": -0.1,
         "phase_1.type": "blendphase",
         "phase_1.weight.type": "gridvolume",
         "phase_1.weight.grid": np.reshape(expected_mi_weights[1], (-1, 1, 1)),
+        "phase_1.weight.filter_type": "nearest",
         "phase_1.phase_0.type": "rayleigh",
         "phase_1.phase_1.type": "hg",
         "phase_1.phase_1.g": 0.1,


### PR DESCRIPTION
# Description

Hello, I found that the `gridvolumes` used in Eradiate don't set their filter types, which means they default to a trilinear interpolation filter. This in turn yields inexact values during the integration. This is usually not a problem as Eradiate uses many layers to represent the atmosphere. Furthermore, the null collision integrator is robust to this filter. This is not the case for the piecewise integrator, where inexact values of the extinction coefficient can lead to positive throughput, and thus very large errors.
This fix makes sure that all instance of `gridvolumes` see their `filter_type` set to `nearest`. This also includes a change to the blend phase unit test that need to check for dictionary parity.

# Checklist

- [X] The code follows the relevant coding guidelines
- [X] The code generates no new warnings
- [X] The code is appropriately documented
- [X] The code is tested to prove its function
- [X] The feature branch is rebased on the current state of the `next` branch
- [x] I updated the change log if relevant
- [X] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
