### PR TITLE
[Feature] New polarized Ocean BRDF as implemented by Mishchenko (1997).

### DIFF
--- a/docs/references.bib
+++ b/docs/references.bib
@@ -228,6 +228,15 @@ doi = {10.1364/AO.45.006762},
   issn         = {0730-0301},
   url          = {http://doi.acm.org/10.1145/3306346.3323025}
 }
+@article{Mishchenko1997AerosolRetrievalPolarization,
+  author={Mishchenko, M. I. and Travis, L. D.},
+  title={Satellite retrieval of aerosol properties over the ocean using polarization as well as intensity of reflected sunlight},
+  year={1997},
+  journal={Journal of Geophysical Research},
+  volume={102},
+  pages={16989--17013},
+  doi={10.1029/96JD02425},
+}
 @misc{MODIS2004,
   author       = {MODIS Characterization Support Team},
   year         = 2004,

--- a/docs/rst/reference_api/scenes.rst
+++ b/docs/rst/reference_api/scenes.rst
@@ -332,6 +332,7 @@ Quick access
    LambertianBSDF
    MQDiffuseBSDF
    OceanLegacyBSDF
+   OceanMishchenkoBSDF
    OpacityMaskBSDF
    RPVBSDF
    RTLSBSDF

--- a/docs/src/release_notes/v0.30.x.md
+++ b/docs/src/release_notes/v0.30.x.md
@@ -17,6 +17,7 @@
 
 * Added a 6SV-like ocean BRDF ({ghpr}`453`).
 * Added depolarization factor to the Rayleigh phase function ({ghpr}`460`).
+* Added a polarized ocean BRDF ({ghpr}`466`).
 
 ### Changed
 

--- a/src/eradiate/scenes/bsdfs/__init__.pyi
+++ b/src/eradiate/scenes/bsdfs/__init__.pyi
@@ -6,6 +6,7 @@ from ._hapke import HapkeBSDF as HapkeBSDF
 from ._lambertian import LambertianBSDF as LambertianBSDF
 from ._mqdiffuse import MQDiffuseBSDF as MQDiffuseBSDF
 from ._ocean_legacy import OceanLegacyBSDF as OceanLegacyBSDF
+from ._ocean_mishchenko import OceanMishchenkoBSDF as OceanMishchenkoBSDF
 from ._opacity_mask import OpacityMaskBSDF as OpacityMaskBSDF
 from ._rpv import RPVBSDF as RPVBSDF
 from ._rtls import RTLSBSDF as RTLSBSDF

--- a/src/eradiate/scenes/bsdfs/_ocean_mishchenko.py
+++ b/src/eradiate/scenes/bsdfs/_ocean_mishchenko.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import attrs
+import mitsuba as mi
+import pint
+import pinttrs
+
+from ._core import BSDF
+from ..core import traverse
+from ..spectra import Spectrum, spectrum_factory
+from ... import validators
+from ...attrs import define, documented
+from ...kernel import TypeIdLookupStrategy, UpdateParameter
+from ...units import unit_registry as ureg
+
+
+@define(eq=False, slots=False)
+class OceanMishchenkoBSDF(BSDF):
+    """
+    Ocean Mishchenko BSDF [``ocean_mishchenko``].
+
+    This BSDF implements the 6SV ocean surface model as described in
+    :cite:t:`Kotchenova2006The6SVRTM`. This model treats the ocean as an opaque
+    surface, and models the sunglint, whitecap and underlight components
+    of the ocean reflectance. It depends on wind properties and
+    pigmentation and chlorinity which makes it suitable to represent
+    case I waters as defined by :cite:t:`Morel1988ModelingUpperOcean`.
+
+    See Also
+    --------
+    :ref:`plugin-bsdf-ocean_legacy`
+    """
+
+    wind_speed: pint.Quantity = documented(
+        pinttrs.field(
+            units=ureg("m/s").units,
+            factory=lambda: 0.01 * ureg("m/s"),
+            validator=[validators.is_positive, pinttrs.validators.has_compatible_units],
+        ),
+        doc="Wind speed [m/s] at 10 meters above the surface.",
+        type="quantity",
+        init_type="quantity or float",
+        default="0.01 m/s",
+    )
+
+    eta: Spectrum = documented(
+        attrs.field(
+            default=1.33,
+            converter=spectrum_factory.converter("dimensionless"),
+            validator=[
+                attrs.validators.instance_of(Spectrum),
+                validators.has_quantity("dimensionless"),
+            ],
+        ),
+        doc="Real component of the water's index of refraction "
+        "processed by :data:`.spectrum_factory`.",
+        type=".Spectrum",
+        init_type=".Spectrum or dict or float",
+        default="1.33",
+    )
+
+    k: Spectrum = documented(
+        attrs.field(
+            default=0.0,
+            converter=spectrum_factory.converter("dimensionless"),
+            validator=[
+                attrs.validators.instance_of(Spectrum),
+                validators.has_quantity("dimensionless"),
+            ],
+        ),
+        doc="Imaginary component of the water's index of refraction "
+        "processed by :data:`.spectrum_factory`.",
+        type=".Spectrum",
+        init_type=".Spectrum or dict or float",
+        default="0.",
+    )
+
+    ext_ior: Spectrum = documented(
+        attrs.field(
+            default=1.0,
+            converter=spectrum_factory.converter("dimensionless"),
+            validator=[
+                attrs.validators.instance_of(Spectrum),
+                validators.has_quantity("dimensionless"),
+            ],
+        ),
+        doc="Real component of the air's index of refraction "
+        "processed by :data:`.spectrum_factory`. The imaginary component "
+        "is assumed to be zero. ",
+        type=".Spectrum",
+        init_type=".Spectrum or dict or float",
+        default="1.000277f",
+    )
+
+    def default_shininess(self, u: pint.Quantity):
+        """
+        Parametrizes the Blinn-Phong distribution function with respect to the
+        wind speed.
+        """
+        return (37.2455 - u.m_as("m/s")) ** 1.15
+
+    @property
+    def template(self) -> dict:
+        # Inherit docstring
+        objects = {
+            "eta": traverse(self.eta)[0],
+            "k": traverse(self.k)[0],
+            "ext_ior": traverse(self.ext_ior)[0],
+        }
+
+        result = {
+            "type": "ocean_mishchenko",
+            "shininess": self.default_shininess(self.wind_speed),
+            "wind_speed": self.wind_speed.m_as("m/s"),
+        }
+
+        for obj_key, obj_values in objects.items():
+            for key, value in obj_values.items():
+                result[f"{obj_key}.{key}"] = value
+
+        if self.id is not None:
+            result["id"] = self.id
+
+        return result
+
+    @property
+    def params(self) -> dict[str, UpdateParameter]:
+        # Inherit docstring
+        objects = {
+            "eta": traverse(self.eta)[1],
+            "k": traverse(self.k)[1],
+            "ext_ior": traverse(self.ext_ior)[1],
+        }
+
+        result = {}
+        for obj_key, obj_params in objects.items():
+            for key, param in obj_params.items():
+                result[f"{obj_key}.{key}"] = attrs.evolve(
+                    param,
+                    lookup_strategy=TypeIdLookupStrategy(
+                        node_type=mi.BSDF,
+                        node_id=self.id,
+                        parameter_relpath=f"{obj_key}.{key}",
+                    )
+                    if self.id is not None
+                    else None,
+                )
+
+        return result

--- a/src/eradiate/scenes/bsdfs/_ocean_mishchenko.py
+++ b/src/eradiate/scenes/bsdfs/_ocean_mishchenko.py
@@ -19,12 +19,11 @@ class OceanMishchenkoBSDF(BSDF):
     """
     Ocean Mishchenko BSDF [``ocean_mishchenko``].
 
-    This BSDF implements the 6SV ocean surface model as described in
-    :cite:t:`Kotchenova2006The6SVRTM`. This model treats the ocean as an opaque
-    surface, and models the sunglint, whitecap and underlight components
-    of the ocean reflectance. It depends on wind properties and
-    pigmentation and chlorinity which makes it suitable to represent
-    case I waters as defined by :cite:t:`Morel1988ModelingUpperOcean`.
+    This plugin implements the polarized ocean surface model as implemented
+    by :cite:t:`Mishchenko1997AerosolRetrievalPolarization`. This model treats
+    the ocean as an opaque surface and models the polarized sunglint. It depends
+    on wind speed and the index of refraction of the water and external medium
+    (assumed to be air).
 
     See Also
     --------

--- a/tests/01_unit/scenes/bsdfs/test_ocean_mishchenko.py
+++ b/tests/01_unit/scenes/bsdfs/test_ocean_mishchenko.py
@@ -1,0 +1,35 @@
+import mitsuba as mi
+import pytest
+
+from eradiate.scenes.bsdfs import OceanMishchenkoBSDF
+from eradiate.test_tools.types import check_scene_element
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {},
+        {
+            "wind_speed": 2.0,
+            "eta": 1.39,
+            "k": 0.0,
+            "ext_ior": 1.00027,
+        },
+        {"eta": 1.34, "ext_ior": 1.0},
+    ],
+    ids=["noargs", "uniform", "mixed"],
+)
+def test_ocean_legacy_construct(modes_all, kwargs):
+    # Default constructor
+    assert OceanMishchenkoBSDF(**kwargs)
+
+
+def test_ocean_legacy(modes_all_double):
+    bsdf = OceanMishchenkoBSDF(
+        wind_speed=15.0,
+        eta=1.33,
+        k=0.01,
+        ext_ior=1.02,
+    )
+
+    check_scene_element(bsdf, mi.BSDF)


### PR DESCRIPTION
# Description

This PR introduces a new polarized ocean BRDF plugin to Eradiate. This follows the implementation from Mishchenko (1997), which models the polarized reflective sunglint. This model depends on wind speed and water's index of refraction as well as the external index of refraction. This implementation is a naive approach of passing the indices of refraction and I am open to suggestion for more sophisticated approaches.

Tests were written for this BRDF and the model was validated using IPRT's A6 and B4 benchmark scenarios. 

# Checklist

- [X] The code follows the relevant coding guidelines
- [X] The code generates no new warnings
- [X] The code is appropriately documented
- [X] The code is tested to prove its function
- [X] The feature branch is rebased on the current state of the `next` branch
- [x] I updated the change log if relevant
- [X] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
