### PR TITLE
`InterpolatedSpectrum`: Raise if initialized with NaNs

### DIFF
--- a/docs/src/release_notes/v0.30.x.md
+++ b/docs/src/release_notes/v0.30.x.md
@@ -28,5 +28,7 @@
 * Fixed Gaussian SRF padding strategy ({ghpr}`458`).
 * Package metadata now explicitly mentions that supported Python is up to 3.12.
 * Fixed incorrect interpolation method in volume data textures ({ghpr}`465`).
+* The {class}`.InterpolatedSpectrum` constructor now raises if it detects NaN
+  in the values it receives ({ghpr}`467`).
 
 % ### Internal changes

--- a/src/eradiate/scenes/spectra/_interpolated.py
+++ b/src/eradiate/scenes/spectra/_interpolated.py
@@ -56,9 +56,13 @@ class InterpolatedSpectrum(Spectrum):
 
     @wavelengths.validator
     def _wavelengths_validator(self, attribute, value):
-        # wavelength must be monotonically increasing
+        # Wavelengths must be monotonically increasing
         if not np.all(np.diff(value) > 0):
             raise ValueError("wavelengths must be monotonically increasing")
+
+        # Check values
+        if np.any(np.isnan(value)):
+            raise ValueError("Detected NaN in 'wavelengths'")
 
     values: pint.Quantity = documented(
         attrs.field(
@@ -121,6 +125,10 @@ class InterpolatedSpectrum(Spectrum):
                 f"must have the same shape, got {self.wavelengths.shape} and "
                 f"{self.values.shape}"
             )
+
+        # Check values
+        if np.any(np.isnan(value)):
+            raise ValueError("Detected NaN in 'values'")
 
     def __init__(
         self,

--- a/tests/01_unit/scenes/spectra/test_interpolated.py
+++ b/tests/01_unit/scenes/spectra/test_interpolated.py
@@ -257,3 +257,10 @@ def test_interpolated_from_dataarray(mode_mono):
     spectrum = InterpolatedSpectrum.from_dataarray(quantity="reflectance", dataarray=da)
     assert np.all(spectrum.wavelengths.m_as(da.w.attrs["units"]) == da.w.values)
     assert np.all(spectrum.values.m_as(da.attrs["units"]) == da.values)
+
+
+def test_nan(mode_mono):
+    with pytest.raises(ValueError):
+        InterpolatedSpectrum(
+            wavelengths=[500.0, 550.0, 600.0], values=[1.0, np.nan, 1.0]
+        )


### PR DESCRIPTION
# Description

This PR implements a safety check that prevents initializing an `InterpolatedSpectrum` instance with arrays that contain `NaN` values.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
