### PR TITLE
[Feature] New `ArrayRadProfile` object

### DIFF
--- a/docs/rst/reference_api/radprops.rst
+++ b/docs/rst/reference_api/radprops.rst
@@ -21,6 +21,7 @@
 
    ZGrid
    RadProfile
+   ArrayRadProfile
    AtmosphereRadProfile
    AbsorptionDatabase
    MonoAbsorptionDatabase

--- a/src/eradiate/experiments/_helpers.py
+++ b/src/eradiate/experiments/_helpers.py
@@ -107,22 +107,24 @@ def check_geometry_atmosphere(
         If the geometry vertical extent exceeds the atmosphere vertical
         extent.
     """
-    z = to_quantity(atmosphere.thermoprops.z)
-    thermoprops_zbounds = z[[0, -1]]
-    geometry_zbounds = geometry.zgrid.levels[[0, -1]]
-    suggested_solution = (
-        "Try to set the experiment geometry so that it does not go beyond "
-        "the vertical extent of the molecular atmosphere."
-    )
-    if (geometry_zbounds[0] < thermoprops_zbounds[0]) or (
-        geometry_zbounds[1] > thermoprops_zbounds[1]
-    ):
-        raise ValueError(
-            "Attribtues 'geometry' and 'atmosphere' are incompatible: "
-            f"'geometry.zgrid' bounds ({geometry_zbounds}) go beyond the "
-            f"bounds of 'atmosphere.thermoprops' ({thermoprops_zbounds}). "
-            f"{suggested_solution}"
+
+    if atmosphere.thermoprops:
+        z = to_quantity(atmosphere.thermoprops.z)
+        thermoprops_zbounds = z[[0, -1]]
+        geometry_zbounds = geometry.zgrid.levels[[0, -1]]
+        suggested_solution = (
+            "Try to set the experiment geometry so that it does not go beyond "
+            "the vertical extent of the molecular atmosphere."
         )
+        if (geometry_zbounds[0] < thermoprops_zbounds[0]) or (
+            geometry_zbounds[1] > thermoprops_zbounds[1]
+        ):
+            raise ValueError(
+                "Attribtues 'geometry' and 'atmosphere' are incompatible: "
+                f"'geometry.zgrid' bounds ({geometry_zbounds}) go beyond the "
+                f"bounds of 'atmosphere.thermoprops' ({thermoprops_zbounds}). "
+                f"{suggested_solution}"
+            )
 
 
 def check_piecewise_compatible(

--- a/src/eradiate/experiments/_helpers.py
+++ b/src/eradiate/experiments/_helpers.py
@@ -15,7 +15,6 @@ from ..scenes.measure import (
 )
 from ..scenes.shapes import RectangleShape
 from ..scenes.surface import BasicSurface, Surface, surface_factory
-from ..units import to_quantity
 
 
 def measure_inside_atmosphere(atmosphere: Atmosphere, measure: Measure) -> bool:
@@ -108,23 +107,21 @@ def check_geometry_atmosphere(
         extent.
     """
 
-    if atmosphere.thermoprops:
-        z = to_quantity(atmosphere.thermoprops.z)
-        thermoprops_zbounds = z[[0, -1]]
-        geometry_zbounds = geometry.zgrid.levels[[0, -1]]
-        suggested_solution = (
-            "Try to set the experiment geometry so that it does not go beyond "
-            "the vertical extent of the molecular atmosphere."
+    radprops_zbounds = atmosphere.radprops_profile.zbounds
+    geometry_zbounds = geometry.zgrid.levels[[0, -1]]
+    suggested_solution = (
+        "Try to set the experiment geometry so that it does not go beyond "
+        "the vertical extent of the molecular atmosphere."
+    )
+    if (geometry_zbounds[0] < radprops_zbounds[0]) or (
+        geometry_zbounds[1] > radprops_zbounds[1]
+    ):
+        raise ValueError(
+            "Attribtues 'geometry' and 'atmosphere' are incompatible: "
+            f"'geometry.zgrid' bounds ({geometry_zbounds}) go beyond the "
+            f"bounds of 'atmosphere.thermoprops' ({radprops_zbounds}). "
+            f"{suggested_solution}"
         )
-        if (geometry_zbounds[0] < thermoprops_zbounds[0]) or (
-            geometry_zbounds[1] > thermoprops_zbounds[1]
-        ):
-            raise ValueError(
-                "Attribtues 'geometry' and 'atmosphere' are incompatible: "
-                f"'geometry.zgrid' bounds ({geometry_zbounds}) go beyond the "
-                f"bounds of 'atmosphere.thermoprops' ({thermoprops_zbounds}). "
-                f"{suggested_solution}"
-            )
 
 
 def check_piecewise_compatible(

--- a/src/eradiate/radprops/__init__.pyi
+++ b/src/eradiate/radprops/__init__.pyi
@@ -3,6 +3,7 @@ from ._absorption import AbsorptionDatabase as AbsorptionDatabase
 from ._absorption import CKDAbsorptionDatabase as CKDAbsorptionDatabase
 from ._absorption import ErrorHandlingConfiguration as ErrorHandlingConfiguration
 from ._absorption import MonoAbsorptionDatabase as MonoAbsorptionDatabase
+from ._array import ArrayRadProfile as ArrayRadProfile
 from ._atmosphere import AtmosphereRadProfile as AtmosphereRadProfile
 from ._core import RadProfile as RadProfile
 from ._core import ZGrid as ZGrid

--- a/src/eradiate/radprops/_array.py
+++ b/src/eradiate/radprops/_array.py
@@ -1,0 +1,254 @@
+"""
+Array radiative profile.
+"""
+
+from __future__ import annotations
+
+import typing as t
+
+import attrs
+import numpy as np
+import pint
+import xarray as xr
+
+from ._core import RadProfile, ZGrid, make_dataset
+from ..attrs import define, documented
+from ..units import to_quantity
+from ..units import unit_registry as ureg
+
+
+@define(eq=False)
+class ArrayRadProfile(RadProfile):
+    """
+    Array radiative profile.
+
+    This class provides an interface to generate vertical profiles of
+    atmospheric volume radiative properties (also sometimes referred to as
+    collision coefficients).
+
+    The array radiative profile is built from absorption and scattering
+    coefficient data provided as input. This can be useful for debugging and
+    benchmarking.
+    """
+
+    sigma_a: xr.DataArray | None = documented(
+        attrs.field(
+            default=None,
+        ),
+        doc="``DataArray`` of absorption coefficients "
+        "The ``DataArray`` is composed of two dimensions ``{w, z}`` representing the "
+        "wavelength and altitude respectively. Note that ``w`` must be of length "
+        "2 minimum to be correctly interpolated. ",
+        type="DataArray or None",
+        init_type="DataArray or None",
+        default="None",
+    )
+
+    sigma_s: xr.DataArray | None = documented(
+        attrs.field(
+            default=None,
+        ),
+        doc="``DataArray`` of scattering coefficients "
+        "The ``DataArray`` is composed of two dimensions ``{w, z}`` representing the "
+        "wavelength and altitude respectively. Note that ``w`` must be of length "
+        "2 minimum to be correctly interpolated. ",
+        type="DataArray or None",
+        init_type="DataArray or None",
+        default="None",
+    )
+
+    has_absorption: bool = documented(
+        attrs.field(
+            default=True,
+            converter=bool,
+            validator=attrs.validators.instance_of(bool),
+        ),
+        doc="Absorption switch. If ``True``, the absorption coefficient is "
+        "computed. Else, the absorption coefficient is not computed and "
+        "instead set to zero.",
+        type="bool",
+        default="True",
+    )
+
+    has_scattering: bool = documented(
+        attrs.field(
+            default=True,
+            converter=bool,
+            validator=attrs.validators.instance_of(bool),
+        ),
+        doc="Scattering switch. If ``True``, the scattering coefficient is "
+        "computed. Else, the scattering coefficient is not computed and "
+        "instead set to zero.",
+        type="bool",
+        default="True",
+    )
+
+    rayleigh_depolarization: np.ndarray = documented(
+        attrs.field(
+            converter=lambda x: np.array(x, dtype=np.float64),
+            kw_only=True,
+            factory=lambda: np.array(0.0),
+        ),
+        type="ndarray",
+        doc="Depolarization factor of the rayleigh phase function. "
+        "A ``ndarray`` will be interpreted as a description of the depolarization "
+        "factor at different levels of the atmosphere. Must be shaped (N,) with "
+        "N the number of layers.",
+    )
+
+    interpolation_method: str = documented(
+        attrs.field(
+            default="nearest",
+            converter=str,
+            validator=attrs.validators.instance_of(str),
+        ),
+        doc="Method of interpolation of the absorption and scattering coefficients. ",
+        type="str",
+        default="nearest",
+    )
+
+    interpolation_kwargs: dict[str, t.Any] = documented(
+        attrs.field(
+            factory=dict,
+            converter=dict,
+            validator=attrs.validators.instance_of(dict),
+        ),
+        doc="Interpolation arguments passed to xarray during interpolation. ",
+        type="dict",
+    )
+
+    def __attrs_post_init__(self):
+        self.update()
+
+    def update(self) -> None:
+        pass
+
+    @property
+    def levels(self) -> pint.Quantity:
+        NotImplementedError
+
+    @property
+    def zgrid(self) -> ZGrid:
+        NotImplementedError
+
+    def eval_albedo_mono(self, w: pint.Quantity, zgrid: ZGrid) -> pint.Quantity:
+        # Inherit docstring
+        sigma_s = self.eval_sigma_s_mono(w, zgrid)
+        sigma_t = self.eval_sigma_t_mono(w, zgrid)
+        return np.divide(
+            sigma_s, sigma_t, where=sigma_t != 0.0, out=np.zeros_like(sigma_s)
+        ).to("dimensionless")
+
+    def eval_albedo_ckd(
+        self, w: pint.Quantity, g: float, zgrid: ZGrid
+    ) -> pint.Quantity:
+        sigma_s = self.eval_sigma_s_ckd(w=w, g=g, zgrid=zgrid)
+        sigma_t = self.eval_sigma_t_ckd(w=w, g=g, zgrid=zgrid)
+        return np.divide(
+            sigma_s, sigma_t, where=sigma_t != 0.0, out=np.zeros_like(sigma_s)
+        ).to("dimensionless")
+
+    def eval_sigma_a_mono(self, w: pint.Quantity, zgrid: ZGrid) -> pint.Quantity:
+        # NOTE: this method accepts 'w'-arrays and is vectorized as far as
+        # each individual absorption dataset is concerned, namely when the
+        # wavelengths span multiple datasets we for-loop over them.
+        w = np.atleast_1d(w)
+        if self.has_absorption and self.sigma_a is not None:
+            values = self.sigma_a.interp(
+                coords={
+                    "z": zgrid.layers.m_as(self.sigma_a.z.attrs["units"]),
+                    "w": w.m_as(self.sigma_a.w.attrs["units"]),
+                },
+                method=self.interpolation_method,
+                kwargs=self.interpolation_kwargs,
+            )
+
+            values = to_quantity(values)
+            return values.squeeze()
+        else:
+            return np.zeros((w.size, zgrid.n_layers)).squeeze() / ureg.km
+
+    def eval_sigma_a_ckd(
+        self, w: pint.Quantity, g: float, zgrid: ZGrid
+    ) -> pint.Quantity:
+        return self.eval_sigma_a_mono(w=w, zgrid=zgrid)
+
+    def eval_sigma_s_mono(self, w: pint.Quantity, zgrid: ZGrid) -> pint.Quantity:
+        w = np.atleast_1d(w)
+        if self.has_scattering and self.sigma_s is not None:
+            sigma_s = self.sigma_s.interp(
+                coords={
+                    "z": zgrid.layers.m_as(self.sigma_s.z.attrs["units"]),
+                    "w": w.m_as(self.sigma_s.w.attrs["units"]),
+                },
+                method=self.interpolation_method,
+                kwargs=self.interpolation_kwargs,
+            )
+
+            sigma_s = to_quantity(sigma_s)
+            return sigma_s.squeeze()
+        else:
+            return np.zeros((1, zgrid.n_layers)) / ureg.km
+
+    def eval_sigma_s_ckd(
+        self, w: pint.Quantity, g: float, zgrid: ZGrid
+    ) -> pint.Quantity:
+        return self.eval_sigma_s_mono(w=w, zgrid=zgrid)
+
+    def eval_sigma_t_mono(self, w: pint.Quantity, zgrid: ZGrid) -> pint.Quantity:
+        sigma_a = self.eval_sigma_a_mono(w=w, zgrid=zgrid)
+        sigma_s = self.eval_sigma_s_mono(w=w, zgrid=zgrid)
+        return sigma_a + sigma_s
+
+    def eval_sigma_t_ckd(
+        self,
+        w: pint.Quantity,
+        g: float,
+        zgrid: ZGrid,
+    ) -> pint.Quantity:
+        sigma_a = self.eval_sigma_a_ckd(w=w, g=g, zgrid=zgrid)
+        sigma_s = self.eval_sigma_s_ckd(w=w, g=g, zgrid=zgrid)
+        return sigma_a + sigma_s
+
+    def eval_dataset_mono(self, w: pint.Quantity, zgrid: ZGrid) -> xr.Dataset:
+        return make_dataset(
+            wavelength=w,
+            z_level=zgrid.levels,
+            z_layer=zgrid.layers,
+            sigma_a=self.eval_sigma_a_mono(w, zgrid),
+            sigma_s=self.eval_sigma_s_mono(w, zgrid),
+        ).squeeze()
+
+    def eval_dataset_ckd(
+        self,
+        w: pint.Quantity,
+        g: float,
+        zgrid: ZGrid,
+    ) -> xr.Dataset:
+        return make_dataset(
+            wavelength=w,
+            z_level=zgrid.levels,
+            z_layer=zgrid.layers,
+            sigma_a=self.eval_sigma_a_ckd(w=w, g=g, zgrid=zgrid),
+            sigma_s=self.eval_sigma_s_ckd(w=w, g=g, zgrid=zgrid),
+        ).squeeze()
+
+    def eval_depolarization_factor_mono(
+        self, w: pint.Quantity, zgrid: ZGrid
+    ) -> pint.Quantity:
+        if self.has_scattering:
+            if isinstance(self.rayleigh_depolarization, np.ndarray):
+                return np.atleast_1d(self.rayleigh_depolarization) * ureg.dimensionless
+            else:
+                raise NotImplementedError
+
+        else:
+            return np.atleast_1d(0.0) * ureg.dimensionless
+
+    def eval_depolarization_factor_ckd(
+        self,
+        w: pint.Quantity,
+        g: float,
+        zgrid: ZGrid,
+    ) -> pint.Quantity:
+        return self.eval_depolarization_factor_mono(w=w, zgrid=zgrid)

--- a/src/eradiate/radprops/_atmosphere.py
+++ b/src/eradiate/radprops/_atmosphere.py
@@ -117,6 +117,8 @@ class AtmosphereRadProfile(RadProfile):
         "A ``ndarray`` will be interpreted as a description of the depolarization "
         "factor at different levels of the atmosphere. Must be shaped (N,) with "
         "N the number of layers.",
+        init_type="array-like or str, optional",
+        default="[0]",
     )
 
     _zgrid: ZGrid | None = attrs.field(default=None, init=False)
@@ -126,6 +128,11 @@ class AtmosphereRadProfile(RadProfile):
 
     def update(self) -> None:
         self._zgrid = ZGrid(levels=self.levels)
+
+    @property
+    def zbounds(self) -> tuple[pint.Quantity, pint.Quantity]:
+        z = to_quantity(self.thermoprops.z)
+        return tuple(z[[0, -1]])
 
     @property
     def levels(self) -> pint.Quantity:

--- a/src/eradiate/radprops/_core.py
+++ b/src/eradiate/radprops/_core.py
@@ -281,6 +281,14 @@ class RadProfile(ABC):
 
     @property
     @abstractmethod
+    def zbounds(self) -> tuple[pint.Quantity, pint.Quantity]:
+        """
+        Bounds of the z profile.
+        """
+        pass
+
+    @property
+    @abstractmethod
     def zgrid(self) -> ZGrid:
         """
         Default altitude grid used for profile evaluation.

--- a/src/eradiate/scenes/atmosphere/_molecular.py
+++ b/src/eradiate/scenes/atmosphere/_molecular.py
@@ -165,11 +165,11 @@ class MolecularAtmosphere(AbstractHeterogeneousAtmosphere):
                 attrs.validators.instance_of(RadProfile)
             ),
         ),
-        doc="Radiative properties object. "
-        "The default is None. If ``thermoprops`` is not None, "
-        "``radprops_profile`` will automatically create an .AtmosphereRadProfile. "
-        "Note that at least ``thermoprops`` or ``radprops_profile`` should be set "
-        "to a valid value. ",
+        doc="Radiative property profile. "
+        "If ``thermoprops`` is not ``None``, this field is automatically "
+        "overridden with an :class:`.AtmosphereRadProfile` during initialization. "
+        "Note that at least ``thermoprops`` or ``radprops_profile`` should not "
+        "be ``None``.",
         type=".RadProfile or None",
         init_type=".RadProfile or None",
         default="None",

--- a/tests/01_unit/radprops/test_array.py
+++ b/tests/01_unit/radprops/test_array.py
@@ -1,0 +1,98 @@
+import numpy as np
+import pytest
+import xarray as xr
+
+import eradiate
+from eradiate import unit_registry as ureg
+from eradiate.radprops import ArrayRadProfile
+
+
+@pytest.fixture
+def test_data():
+    data = np.tile(np.linspace(0, 9, 10).reshape(1, -1), (2, 1))
+    w = [545, 565]  # in nanometer
+    z = np.linspace(50, 950, 10)  # in meters
+    return xr.DataArray(
+        data=data,
+        dims=["w", "z"],
+        coords={
+            "w": ("w", w, {"description": "wavelength", "units": "nm"}),
+            "z": ("z", z, {"description": "altitude", "units": "m"}),
+        },
+        attrs={"description": "debug scattering coefficient", "units": "1/m"},
+    )
+
+
+def test_array(modes_all_double, test_data):
+    zgrid = eradiate.scenes.geometry.ZGrid(np.linspace(0, 1000, 11))
+    si = eradiate.spectral.SpectralIndex.new(w=550 * ureg.nm)
+
+    array_radprofile = ArrayRadProfile(
+        has_absorption=True,
+        has_scattering=True,
+        sigma_a=test_data,
+        sigma_s=test_data,
+        interpolation_method="nearest",
+    )
+
+    sigma_s = array_radprofile.eval_sigma_s(si, zgrid)
+    sigma_a = array_radprofile.eval_sigma_s(si, zgrid)
+
+    assert np.all(sigma_a.m_as("1/m") == test_data.isel(w=0).values)
+    assert np.all(sigma_s.m_as("1/m") == test_data.isel(w=0).values)
+
+
+def test_resample_array(modes_all_double, test_data):
+    zgrid = eradiate.scenes.geometry.ZGrid(np.linspace(0, 1000, 21))
+    si = eradiate.spectral.SpectralIndex.new(w=550 * ureg.nm)
+
+    array_radprofile = ArrayRadProfile(
+        has_absorption=True,
+        has_scattering=True,
+        sigma_a=test_data,
+        sigma_s=test_data,
+        interpolation_method="nearest",
+        interpolation_kwargs={
+            "fill_value": tuple(test_data.isel(w=0).values[[0, -1]]),
+        },
+    )
+
+    sigma_s = array_radprofile.eval_sigma_s(si, zgrid)
+    sigma_a = array_radprofile.eval_sigma_s(si, zgrid)
+
+    gt = np.repeat(test_data.isel(w=0).values, 2)
+    assert np.all(sigma_a.m_as("1/m") == gt)
+    assert np.all(sigma_s.m_as("1/m") == gt)
+
+
+def test_array_zeros(modes_all_double, test_data):
+    zgrid = eradiate.scenes.geometry.ZGrid(np.linspace(0, 1000, 11))
+    si = eradiate.spectral.SpectralIndex.new(w=550 * ureg.nm)
+
+    array_sigma_a = ArrayRadProfile(
+        has_absorption=True,
+        has_scattering=False,
+        sigma_a=test_data,
+        sigma_s=None,
+        interpolation_method="nearest",
+    )
+
+    sigma_s = array_sigma_a.eval_sigma_s(si, zgrid)
+    sigma_a = array_sigma_a.eval_sigma_a(si, zgrid)
+
+    assert np.all(sigma_a.m_as("1/m") == test_data.isel(w=0).values)
+    assert np.all(sigma_s.m_as("1/m") == np.zeros(10))
+
+    array_sigma_s = ArrayRadProfile(
+        has_absorption=False,
+        has_scattering=True,
+        sigma_a=None,
+        sigma_s=test_data,
+        interpolation_method="nearest",
+    )
+
+    sigma_s = array_sigma_s.eval_sigma_s(si, zgrid)
+    sigma_a = array_sigma_s.eval_sigma_a(si, zgrid)
+
+    assert np.all(sigma_a.m_as("1/m") == np.zeros(10))
+    assert np.all(sigma_s.m_as("1/m") == test_data.isel(w=0).values)


### PR DESCRIPTION
# Description

Hello, this PR introduces ArrayRadProp, a new RadProfile that enables the user to pass radiative properties manually. Namely, it allows to pass `sigma_s` and `sigma_a` as `DataArray`. Those values are then interpolated given a `ZGrid`. The need for such a class has come to light when working on the IPRT benchmark, in which absoprtion and scattering data are directly provided for given scenarios. This feature can thus be useful for benchmarking as well as debugging.

Of note are the functions `eval_sigma_s_mono` and and `eval_sigma_a_mono`. Please also note that I have left the `ZGrid` and `levels` properties as `NotImplementedError` as I was not able to understand how those properties were used. I would also be interested in any ways of making the check in `_helpers.py` more elegant. 

The pytest  suite was run, the new feature tested in my work for IPRT and additional tests were written. Let me know if you have any comment or feedback. Many Thanks.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `next` branch
- [ ] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
