### PR TITLE
[FIX] Fix lookup of `thermoprops` in cases of missing molecular species.

### DIFF
--- a/src/eradiate/radprops/_absorption.py
+++ b/src/eradiate/radprops/_absorption.py
@@ -804,8 +804,12 @@ class AbsorptionDatabase:
         x_ds_scalar = [coord for coord in x_ds if ds[coord].size == 1]
         x_ds_array = set(x_ds) - set(x_ds_scalar)
 
+        x_thermoprops = [dv for dv in thermoprops.data_vars if dv.startswith("x_")]
+        x_missing = set(x_ds_array) - set(x_thermoprops)
+        x_ds_array = x_ds_array - x_missing
+
         # -- Select on scalar coordinates
-        result = result.isel(**{x: 0 for x in x_ds_scalar})
+        result = result.isel(**{x: 0 for x in x_ds_scalar + list(x_missing)})
 
         # -- Interpolate on array coordinates
         bounds_error = error_handling_config.x.bounds is ErrorHandlingAction.RAISE


### PR DESCRIPTION
# Description

We found an issue where the absorption database in the radprofile may have more molecule than the ones present in `thermoprops`. This raises an error as we are attempting to access a missing coordinate. This PR introduces a fix to make the lookup more robust: we first find all species that are present in the absorption database but missing from `thermoprops`, and slice the absorption database at the first value along those coordinates. 

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [ ] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
