### PR TITLE
Add option to select specific measures to process

### DIFF
--- a/docs/src/release_notes/v0.30.x.md
+++ b/docs/src/release_notes/v0.30.x.md
@@ -22,6 +22,9 @@
   interface to user-defined raw radiative atmospheric profile data and is mostly
   used for debugging purposes. Note that it currently only supports
   monochromatic evaluation and will use it as a fallback in CKD modes.
+* The {func}`.run` function, {meth}`.Experiment.process` and
+  {meth}`.Experiment.postprocess` now accept a `measures` argument that allows
+  to specify which measures will be processed {ghpr}`471`.
 
 ### Changed
 

--- a/tests/01_unit/experiments/test_core.py
+++ b/tests/01_unit/experiments/test_core.py
@@ -1,3 +1,4 @@
+import pytest
 import xarray as xr
 
 import eradiate.kernel.logging
@@ -7,15 +8,15 @@ from eradiate.units import unit_registry as ureg
 eradiate.kernel.install_logging()
 
 
-def test_run_function(modes_all_double):
-    measure = {
-        "type": "mdistant",
-        "srf": {
-            "type": "multi_delta",
-            "wavelengths": [540, 550] * ureg.nm,
-        },
-    }
+@pytest.mark.parametrize("measures", [None, 1, [0, 1]])
+def test_run_function(modes_all_double, measures):
+    srf = {"type": "delta", "wavelengths": [540, 550] * ureg.nm}
 
-    exp = AtmosphereExperiment(atmosphere=None, measures=measure)
+    exp = AtmosphereExperiment(
+        atmosphere=None,
+        measures=[
+            {"type": "mdistant", "id": f"mdistant_{i}", "srf": srf} for i in range(3)
+        ],
+    )
     result = eradiate.run(exp)
-    assert isinstance(result, xr.Dataset)
+    assert isinstance(result, xr.Dataset if measures == 1 else dict)


### PR DESCRIPTION
# Description

This PR updates the `run()` function and the `Experiment.process()` and `Experiment.postprocess()` methods to allow selecting the measures that will be computed. The default behaviour remains unchanged.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
