### PR TITLE
Experiment: Allow passing measures by ID

### DIFF
--- a/docs/rst/reference_api/experiments.rst
+++ b/docs/rst/reference_api/experiments.rst
@@ -15,6 +15,7 @@ Concrete classes
    CanopyExperiment
    CanopyAtmosphereExperiment
    DEMExperiment
+   MeasureRegistry
 
 Interfaces
 ----------

--- a/docs/src/release_notes/v0.30.x.md
+++ b/docs/src/release_notes/v0.30.x.md
@@ -39,11 +39,10 @@ available as `mycena_v1`.
   monochromatic evaluation and will use it as a fallback in CKD modes.
 * The {func}`.run` function, {meth}`.Experiment.process` and
   {meth}`.Experiment.postprocess` now accept a `measures` argument that allows
-  to specify which measures will be processed ({ghpr}`471`).
+  to specify which measures will be processed ({ghpr}`471`, {ghpr}`472`).
 * Added a new `mycena_v2` molecular absorption database (10 nm resolution)
   ({ghpr`473`}).
 * Added a `drop_parameters` option to {meth}`.Experiment.init` ({ghpr}`474`).
-
 
 ### Changed
 
@@ -69,10 +68,11 @@ available as `mycena_v1`.
   in the values it receives ({ghpr}`467`).
 * Fixed exception occurring when interpolating in a CKD absorption database that
   had species missing from the atmospheric profile ({ghpr}`470`).
-* Fixed the azimuth convention of the {class}`.MultiPixelDistantMeasure` which
-  was discarded after initialization, providing erroneous azimuth outputs
+* Fixed the azimuth convention of {class}`.MultiPixelDistantMeasure` which was
+  discarded after initialization, providing erroneous azimuth outputs
   ({ghcommit}`6f3878`).
 * Fixed the {func}`.scene_parameter` decorator, to which Mitsuba scene node
   lookup protocols were added ({ghcommit}`e786a4`).
+* Duplicate measure IDs are no longer permitted ({ghpr}`472`).
 
 % ### Internal changes

--- a/src/eradiate/experiments/__init__.pyi
+++ b/src/eradiate/experiments/__init__.pyi
@@ -3,5 +3,6 @@ from ._canopy import CanopyExperiment as CanopyExperiment
 from ._canopy_atmosphere import CanopyAtmosphereExperiment as CanopyAtmosphereExperiment
 from ._core import EarthObservationExperiment as EarthObservationExperiment
 from ._core import Experiment as Experiment
+from ._core import MeasureRegistry as MeasureRegistry
 from ._core import run as run
 from ._dem import DEMExperiment as DEMExperiment

--- a/tests/01_unit/experiments/test_core.py
+++ b/tests/01_unit/experiments/test_core.py
@@ -3,17 +3,43 @@ import xarray as xr
 
 import eradiate.kernel.logging
 from eradiate.experiments import AtmosphereExperiment
+from eradiate.experiments._core import MeasureRegistry
 from eradiate.units import unit_registry as ureg
 
 eradiate.kernel.install_logging()
 
 
+@pytest.fixture()
+def srf():
+    return {"type": "delta", "wavelengths": [540, 550] * ureg.nm}
+
+
+def test_measure_registry(mode_mono, srf):
+    m = MeasureRegistry(
+        [{"type": "mdistant", "id": f"mdistant_{i}", "srf": srf} for i in range(3)]
+    )
+
+    assert m.get_id(2) == "mdistant_2"
+    assert m.get_id("mdistant_2") == "mdistant_2"
+    assert m.get_index(2) == 2
+    assert m.get_index("mdistant_2") == 2
+
+    assert m.resolve(2) is m[2]
+    assert m.resolve("mdistant_2") is m[2]
+
+
+def test_measure_registry_fail(mode_mono, srf):
+    # Detect duplicate measure IDs
+    with pytest.raises(ValueError):
+        MeasureRegistry(
+            [{"type": "mdistant", "id": "mdistant", "srf": srf} for i in range(3)]
+        )
+
+
 @pytest.mark.parametrize(
     "measures, expected_type", [(None, dict), (1, xr.Dataset), ([0, 1], dict)]
 )
-def test_run_function(modes_all_double, measures, expected_type):
-    srf = {"type": "delta", "wavelengths": [540, 550] * ureg.nm}
-
+def test_run_function(modes_all_double, srf, measures, expected_type):
     exp = AtmosphereExperiment(
         atmosphere=None,
         measures=[


### PR DESCRIPTION
# Description

This PR allows to specify measures by ID when calling `eradiate.run()`, `Experiment.process()` or `Experiment.postprocess()`. Example:

```python
eradiate.run(exp, spp=512, measure="toa")
```

Prior behaviour is still here, except for one thing: duplicate measure IDs are no longer allowed and will raise a `ValueError`.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
