### PR TITLE
experiments: Allow to keep all Mitsuba scene parameters after init

### DIFF
--- a/docs/src/release_notes/v0.30.x.md
+++ b/docs/src/release_notes/v0.30.x.md
@@ -40,6 +40,7 @@ available as `mycena_v1`.
   to specify which measures will be processed {ghpr}`471`.
 * A new `mycena_v2` molecular absorption database (10 nm resolution) has been
   added ({ghpr`473`}).
+* Add a `drop_parameters` option to {meth}`.Experiment.init` ({ghpr}`474`).
 
 ### Changed
 

--- a/src/eradiate/experiments/_core.py
+++ b/src/eradiate/experiments/_core.py
@@ -236,9 +236,15 @@ class Experiment(ABC):
             measure.mi_results.clear()
 
     @abstractmethod
-    def init(self) -> None:
+    def init(self, drop_parameters: bool = True) -> None:
         """
         Generate kernel dictionary and initialize Mitsuba scene.
+
+        Parameters
+        ----------
+        drop_parameters : bool
+            If ``True``, drop Mitsuba scene parameters that are not used (*i.e.*
+            that do not have an updater associated).
         """
         pass
 
@@ -526,7 +532,7 @@ class EarthObservationExperiment(Experiment, ABC):
         """
         return Scene(objects={**self.scene_objects, **self.extra_objects})
 
-    def init(self):
+    def init(self, drop_parameters: bool = True):
         # Inherit docstring
 
         logger.info("Initializing kernel scene")
@@ -543,7 +549,8 @@ class EarthObservationExperiment(Experiment, ABC):
             raise RuntimeError(f"(while loading kernel scene dictionary){e}") from e
 
         # Remove unused elements from Mitsuba scene parameter table
-        self.mi_scene.drop_parameters()
+        if drop_parameters:
+            self.mi_scene.drop_parameters()
 
     def process(
         self,


### PR DESCRIPTION
# Description

This PR adds an optional `drop_parameters` parameter to the `Experiment.init()` method. When set to `False`, the parameter map extracted from the created Mitsuba scene will keep all its parameters, even those that could not be associated with an updater callable. This is useful for debugging or building a scene, *e.g.* to confirm or correct a parameter path guess.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
