### PR TITLE
data: Add monochromatic indexes to download list

### DIFF
--- a/docs/src/release_notes/v0.30.x.md
+++ b/docs/src/release_notes/v0.30.x.md
@@ -56,6 +56,9 @@ additional syntactic sugar and debugging tools.
 * ⚠️ The file download lists available from the `eradiate data fetch` command
   have been updated ({ghpr`473`}): 3 lists (`mycena`, `mycena_v1` and
   `mycena_v2`) are now available ({ghpr`473`}).
+* The missing index files for monochromatic databases have been added to the
+  stable data store and the file download lists ({ghpr}`477`), hopefully
+  preventing frequent database consistency issues.
 
 ### Fixed
 

--- a/src/eradiate/data/downloads_all.yml
+++ b/src/eradiate/data/downloads_all.yml
@@ -527,7 +527,9 @@
 - spectra/srf/terra-modis-16-raw.nc
 # Absorption coefficient datasets (monochromatic)
 - spectra/absorption/mono/gecko/gecko.nc
+- spectra/absorption/mono/gecko/index.csv
 - spectra/absorption/mono/gecko/metadata.json
+- spectra/absorption/mono/komodo/index.csv
 - spectra/absorption/mono/komodo/komodo.nc
 - spectra/absorption/mono/komodo/metadata.json
 # Absorption coefficient datasets (CKD): monotropa


### PR DESCRIPTION
# Description

This PR adds missing monochromatic absorption database index files to the download list. The safeguards that have been implemented so far are not enough to ensure the integrity of monochromatic databases, this will hopefully fix issues like #476 until we roll out the updated database format.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function (manual testing)
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
