### PR TITLE
Cap xarray to 2024.*

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,7 +4,7 @@ aabbtree==2.8.1
     # via eradiate (pyproject.toml)
 accessible-pygments==0.0.5
     # via pydata-sphinx-theme
-aenum==3.1.15
+aenum==3.1.16
     # via eradiate (pyproject.toml)
 alabaster==0.7.16
     # via sphinx
@@ -20,7 +20,7 @@ arrow==1.3.0
     # via isoduration
 astropy==6.0.1
     # via eradiate (pyproject.toml)
-astropy-iers-data==0.2025.3.31.0.36.18
+astropy-iers-data==0.2025.5.5.0.38.14
     # via astropy
 asttokens==3.0.0
     # via stack-data
@@ -39,7 +39,7 @@ babel==2.17.0
     #   jupyterlab-server
     #   pydata-sphinx-theme
     #   sphinx
-beautifulsoup4==4.13.3
+beautifulsoup4==4.13.4
     # via
     #   nbconvert
     #   pydata-sphinx-theme
@@ -49,7 +49,7 @@ cachetools==5.5.2
     # via eradiate (pyproject.toml)
 cerberus==1.3.7
     # via eradiate (pyproject.toml)
-certifi==2025.1.31
+certifi==2025.4.26
     # via
     #   httpcore
     #   httpx
@@ -59,7 +59,7 @@ cffi==1.17.1
     # via argon2-cffi-bindings
 cftime==1.6.4.post1
     # via netcdf4
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
     # via requests
 click==8.1.8
     # via
@@ -75,7 +75,7 @@ contourpy==1.3.0
     # via matplotlib
 cycler==0.12.1
     # via matplotlib
-debugpy==1.8.13
+debugpy==1.8.14
     # via ipykernel
 decorator==5.2.1
     # via ipython
@@ -112,9 +112,9 @@ fqdn==1.5.1
     # via jsonschema
 graphviz==0.20.3
     # via eradiate (pyproject.toml)
-h11==0.14.0
+h11==0.16.0
     # via httpcore
-httpcore==1.0.7
+httpcore==1.0.9
     # via httpx
 httpx==0.28.1
     # via jupyterlab
@@ -126,7 +126,7 @@ idna==3.10
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.6.1
+importlib-metadata==8.7.0
     # via
     #   jupyter-client
     #   jupyter-lsp
@@ -148,7 +148,7 @@ ipython==8.18.1
     #   eradiate (pyproject.toml)
     #   ipykernel
     #   ipywidgets
-ipywidgets==8.1.5
+ipywidgets==8.1.7
     # via eradiate (pyproject.toml)
 isoduration==20.11.0
     # via jsonschema
@@ -174,7 +174,7 @@ jsonschema[format-nongpl]==4.23.0
     #   jupyter-events
     #   jupyterlab-server
     #   nbformat
-jsonschema-specifications==2024.10.1
+jsonschema-specifications==2025.4.1
     # via jsonschema
 jupyter-client==8.6.3
     # via
@@ -202,13 +202,13 @@ jupyter-server==2.15.0
     #   notebook-shim
 jupyter-server-terminals==0.5.3
     # via jupyter-server
-jupyterlab==4.4.0
+jupyterlab==4.4.2
     # via eradiate (pyproject.toml)
 jupyterlab-pygments==0.3.0
     # via nbconvert
 jupyterlab-server==2.27.3
     # via jupyterlab
-jupyterlab-widgets==3.0.13
+jupyterlab-widgets==3.0.15
     # via ipywidgets
 kiwisolver==1.4.7
     # via matplotlib
@@ -241,7 +241,7 @@ mdurl==0.1.2
     # via markdown-it-py
 mistune==3.1.3
     # via nbconvert
-mypy-extensions==1.0.0
+mypy-extensions==1.1.0
     # via typing-inspect
 myst-parser==3.0.1
     # via eradiate (pyproject.toml)
@@ -286,7 +286,7 @@ numpy==1.26.4
     #   xarray
 overrides==7.7.0
     # via jupyter-server
-packaging==24.2
+packaging==25.0
     # via
     #   astropy
     #   ipykernel
@@ -314,7 +314,7 @@ parso==0.8.4
     # via jedi
 pexpect==4.9.0
     # via ipython
-pillow==11.1.0
+pillow==11.2.1
     # via matplotlib
 pint==0.24.4
     # via
@@ -334,7 +334,7 @@ pooch==1.8.2
     # via eradiate (pyproject.toml)
 prometheus-client==0.21.1
     # via jupyter-server
-prompt-toolkit==3.0.50
+prompt-toolkit==3.0.51
     # via ipython
 psutil==7.0.0
     # via ipykernel
@@ -431,7 +431,7 @@ seaborn==0.13.2
     # via eradiate (pyproject.toml)
 send2trash==1.8.3
     # via jupyter-server
-setuptools==78.1.0
+setuptools==80.3.1
     # via jupyterlab
 sf-hamilton==1.88.0
     # via eradiate (pyproject.toml)
@@ -448,7 +448,7 @@ sniffio==1.3.1
     # via anyio
 snowballstemmer==2.2.0
     # via sphinx
-soupsieve==2.6
+soupsieve==2.7
     # via beautifulsoup4
 sphinx==7.4.7
     # via
@@ -522,11 +522,11 @@ traitlets==5.14.3
     #   nbconvert
     #   nbformat
     #   nbsphinx
-typer==0.15.2
+typer==0.15.3
     # via eradiate (pyproject.toml)
 types-python-dateutil==2.9.0.20241206
     # via arrow
-typing-extensions==4.13.1
+typing-extensions==4.13.2
     # via
     #   anyio
     #   async-lru
@@ -549,7 +549,7 @@ tzdata==2025.2
     # via pandas
 uri-template==1.3.0
     # via jsonschema
-urllib3==2.3.0
+urllib3==2.4.0
     # via requests
 ussa1976==0.3.4
     # via joseki
@@ -563,7 +563,7 @@ webencodings==0.5.1
     #   tinycss2
 websocket-client==1.8.0
     # via jupyter-server
-widgetsnbextension==4.0.13
+widgetsnbextension==4.0.14
     # via ipywidgets
 xarray==2024.7.0
     # via

--- a/docs/src/release_notes/v0.30.x.md
+++ b/docs/src/release_notes/v0.30.x.md
@@ -1,6 +1,6 @@
 # v0.30.x series (current stable)
 
-## v0.30.1
+## v0.30.1 (upcoming release)
 
 ### Added
 
@@ -14,6 +14,9 @@
 
 * ⚠️ The {func}`.get_mode` getter now raises an {class}`.UnsetModeError` if no
   active mode is selected ({ghpr}`486`).
+* ⚠️ To avoid a major performance regression, the xarray dependency is capped
+  to 2025 until [this issue](https://github.com/pydata/xarray/issues/10287) is
+  solved ({ghpr}`488`).
 
 ### Fixed
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -3885,7 +3885,7 @@ packages:
 - pypi: .
   name: eradiate
   version: 0.30.0
-  sha256: 531befa001cedcd3a3a207fa5d2b64e1cb08d3a62d706e5c881d3a6c25898fa1
+  sha256: 05c7404e31a511081b5527bbcd91eb7d9ca6529c39e0ecfd3135c4e8ca0a3b63
   requires_dist:
   - aenum
   - attrs>=22.2
@@ -3909,7 +3909,7 @@ packages:
   - typer>=0.9.0
   - tqdm
   - shellingham!=1.5.1
-  - xarray>=0.19,!=0.20.*
+  - xarray>=0.19,!=0.20.*,<2025
   - eradiate-mitsuba==0.3.2 ; extra == 'kernel'
   - aabbtree ; extra == 'recommended'
   - astropy ; extra == 'recommended'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
   "typer>=0.9.0",
   "tqdm",
   "shellingham!=1.5.1", # Typer dependency; exclude this version which raises while previous don't
-  "xarray>=0.19,!=0.20.*",
+  "xarray>=0.19,!=0.20.*,<2025",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
# Description

This commit caps xarray to 2024.* to avoid a disastrous performance regression documented as part of https://github.com/pydata/xarray/issues/10287. We will lift this cap as soon as the issue is investigated and solved or we find a workaround or solution.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
