### PR TITLE
Extend covered spectral range to actual absorption database limits

### DIFF
--- a/docs/src/release_notes/v0.31.x.md
+++ b/docs/src/release_notes/v0.31.x.md
@@ -83,6 +83,8 @@ Read the following for migration instructions.
 * Added missing {class}`.HapkeBSDF` factory keyword ({ghpr}`491`).
 * Added missing irradiance spectrum scene parameters for the
   {class}`.AstroObjectIllumination` class ({ghpr}`494`).
+* Aligned canonical spectral range with actual absorption database limits
+  ({ghpr}`498`).
 
 ### Internal changes
 

--- a/src/eradiate/constants.py
+++ b/src/eradiate/constants.py
@@ -8,7 +8,7 @@ from .units import unit_registry as ureg
 EARTH_RADIUS = 6378.1 * ureg.km
 
 #: Lower bound of the default spectral range
-SPECTRAL_RANGE_MIN = 280.0 * ureg.nm
+SPECTRAL_RANGE_MIN = 250.0 * ureg.nm
 
 #: Upper bound of the default spectral range
-SPECTRAL_RANGE_MAX = 2400.0 * ureg.nm
+SPECTRAL_RANGE_MAX = 3125.0 * ureg.nm

--- a/tests/01_unit/spectral/test_grid.py
+++ b/tests/01_unit/spectral/test_grid.py
@@ -33,7 +33,7 @@ def test_mono_spectral_grid_construct(wavelengths, expected):
 
 def test_mono_spectral_grid_default():
     grid = MonoSpectralGrid.default()
-    np.testing.assert_allclose(grid.wavelengths.m, np.arange(280.0, 2401.0, 1.0))
+    np.testing.assert_allclose(grid.wavelengths.m, np.arange(250.0, 3126.0, 1.0))
 
 
 def test_mono_spectral_grid_from_absorption_database():
@@ -167,7 +167,7 @@ def test_ckd_spectral_grid_construct_fix_mismatch(policy, expected):
 
 def test_ckd_spectral_grid_default():
     grid = CKDSpectralGrid.default()
-    expected_wcenters = np.arange(280.0, 2401.0, 10.0)
+    expected_wcenters = np.arange(250.0, 3126.0, 10.0)
     np.testing.assert_allclose(grid.wcenters.m, expected_wcenters)
     np.testing.assert_allclose(grid.wmins.m, expected_wcenters - 5.0)
     np.testing.assert_allclose(grid.wmaxs.m, expected_wcenters + 5.0)


### PR DESCRIPTION
# Description

This PR extends the canonical spectral range to match the range covered by most of out optical databases.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
