### PR TITLE
data: Add libRadtran aerosol importer

### DIFF
--- a/docs/reference_api/data.rst
+++ b/docs/reference_api/data.rst
@@ -5,6 +5,17 @@
 
 .. py:currentmodule:: eradiate.data
 
+Modules
+-------
+
+.. autosummary::
+   :toctree: generated/autosummary/
+
+   io
+
+Classes
+-------
+
 .. autosummary::
    :toctree: generated/autosummary/
 

--- a/docs/release_notes/v0.31.x.md
+++ b/docs/release_notes/v0.31.x.md
@@ -42,6 +42,7 @@ Read the following for migration instructions.
 * Added a {func}`.get_mode` getter that aims to replace {func}`.mode`
   ({ghpr}`486`). The {func}`.mode` getter remains available for compatibility.
 * Added the `tuber` 0.1 nm-resolution CKD database ({ghpr}`495`).
+* Added a converter for libRadtran's NetCDF aerosol data files ({ghpr}`499`).
 
 ### Changed
 

--- a/src/eradiate/data/__init__.pyi
+++ b/src/eradiate/data/__init__.pyi
@@ -1,3 +1,4 @@
+from . import io as io
 from ._asset_manager import AssetManager as AssetManager
 from ._asset_manager import asset_manager as asset_manager
 from ._file_resolver import FileResolver as FileResolver

--- a/src/eradiate/data/io.py
+++ b/src/eradiate/data/io.py
@@ -1,0 +1,252 @@
+"""
+Data loading, conversion and output components.
+"""
+
+from __future__ import annotations
+
+import warnings
+from typing import Literal
+
+import numpy as np
+import pint
+import pinttrs
+import xarray as xr
+
+from ..data import fresolver
+from ..typing import PathLike
+from ..units import unit_context_config as ucc
+from ..units import unit_registry as ureg
+
+
+def _convert_units(value: str):
+    if value == "per cent":
+        return "percent"
+    return value
+
+
+def load_aerosol_libradtran(
+    data: PathLike | xr.Dataset,
+    particle_shape: Literal["spherical", "spheroidal"] | None = None,
+    tolerance: dict[str, pint.Quantity | float] | None = None,
+    wbounds: tuple = (None, None),
+    **kwargs,
+) -> xr.Dataset:
+    """
+    Convert a libRadtran NetCDF aerosol file to the Eradiate aerosol data format.
+    Both effective radius and humidity-indexed data are supported.
+
+    Parameters
+    ----------
+    data : Dataset or path-like
+        A libRadtran NetCDF aerosol dataset. If a path is passed, it will be
+        resolved by the file resolver and tentatively loaded into memory.
+
+    particle_shape : {"spherical", "spheroidal"}, optional
+        The expected shape of the particle (this will tell the phase matrix
+        coefficients it should expect). If unset, the shape is inferred from the
+        input dataset.
+
+    reff, hum : float or quantity
+        For datasets with a humidity or effective radius dimension, the
+        coordinate point to select. By default, the nearest data point is
+        selected; tolerance can be adjusted using the ``tolerance`` parameter.
+        Quantities are accepted (see Notes for expected dimensions and
+        defaults). These parameters are optional if the dataset has only one
+        point on these dimensions.
+
+    wbounds : tuple, optional
+        Bounds to restrict the spectral domain where conversion is performed.
+        This parameter accepts a tuple with the minimum and maximum values
+        (use ``None`` to leave a bound open). Examples:
+        ``(300, 3000)``, ``(None, 3000)``, ``(0.3, 3) * ureg.micron``,
+        ``(None, 3 * ureg.micron)``.
+
+    tolerance : dict
+        A mapping that allows to specify a tolerance for nearest neighbour
+        lookup for relevant parameters. Units are applied with the same rules as
+        for the ``reff`` and ``hum`` parameters.
+
+    Returns
+    -------
+    Dataset
+
+    Notes
+    -----
+    .. list-table::
+        :widths: 1 2 2
+        :header-rows: 1
+
+        * - Parameter
+          - Dimension
+          - Default units
+        * - ``reff``
+          - Length
+          - μm
+        * - ``hum``
+          - Dimensionless (fraction)
+          - percent
+        * - ``wbounds``
+          - Wavelength
+          - ``ucc.get("wavelength")`` (usually, nm)
+
+    * The current implementation resamples the angular dimension at the
+      highest resolution to minimize the loss of information on phase matrix
+      coefficients.
+
+    * All conversion is done in memory: very large dataset might result in
+      massive converted data. In such case, an easy way to split the conversion
+      is to chunk it on the spectral dimension.
+    """
+    VARS_TO_DIMS = {"wavelen": "nlam", "reff": "nreff", "hum": "nhum"}
+    KWARG_TO_DEFAULT_UNITS = {
+        "w": ucc.get("wavelength"),
+        "hum": ureg.Unit("percent"),
+        "reff": ureg.Unit("micrometer"),
+    }
+
+    # Load aerosol component dataset
+    if not isinstance(data, xr.Dataset):
+        data = fresolver.load_dataset(data)
+
+    # Extract required variables
+    vars = ["phase", "ext", "ssa", "theta", "wavelen"]
+    for var in ["reff", "hum"]:
+        if var in data:
+            vars.append(var)
+    data = data[vars]
+
+    # Select on humidity and effective radius
+    if tolerance is None:
+        tolerance = {}
+
+    for kwarg in ["hum", "reff"]:
+        var = kwarg
+        if var not in data:
+            continue
+
+        da = data[var]
+        units = ureg.Unit(_convert_units(data[var].units))
+        default_units = KWARG_TO_DEFAULT_UNITS[kwarg]
+
+        if len(da) > 1:
+            if kwarg not in kwargs:
+                raise TypeError(
+                    f"load_aerosol_libradtran() is missing keyword argument '{kwarg}' "
+                    f"(allowed: {da.values})"
+                )
+            else:
+                kwarg_value = pinttrs.converters.ensure_units(
+                    np.atleast_1d(kwargs.pop(kwarg)), default_units=default_units
+                ).to(units)
+        else:
+            if kwarg not in kwargs:
+                kwarg_value = da.values * units
+            else:
+                kwarg_value = pinttrs.converters.ensure_units(
+                    np.atleast_1d(kwargs.pop(kwarg)), default_units=default_units
+                ).to(units)
+
+        sel_kwargs = {var: kwarg_value.m, "method": "nearest"}
+        if kwarg in tolerance:
+            sel_kwargs["tolerance"] = tolerance[kwarg]
+
+        data = data.swap_dims({VARS_TO_DIMS[var]: var})
+        data = data.sel(**sel_kwargs)
+        data = data.squeeze(var, drop=True)
+
+    if kwargs:
+        warnings.warn(
+            f"load_aerosol_libradtran() got unexpected keyword arguments {list(kwargs.keys())}, which were not used"
+        )
+
+    # Filter wavelengths if requested
+    wmin, wmax = wbounds
+    units = ureg.Unit(_convert_units(data["wavelen"].units))
+    default_units = KWARG_TO_DEFAULT_UNITS["w"]
+
+    if wmin is not None:
+        wmin = pinttrs.converters.ensure_units(wmin, default_units=default_units).m_as(
+            units
+        )
+        data = data.where(data["wavelen"] >= wmin).dropna("nlam", how="all")
+    if wmax is not None:
+        wmax = pinttrs.converters.ensure_units(wmax, default_units=default_units).m_as(
+            units
+        )
+        data = data.where(data["wavelen"] <= wmax).dropna("nlam", how="all")
+
+    wavelength = data["wavelen"].values * ureg(data["wavelen"].units)
+
+    # Phase function
+    if particle_shape is None:
+        if len(data["nphamat"] == 4):
+            particle_shape = "spherical"
+        elif len(data["nphamat"] == 6):
+            particle_shape = "spheroidal"
+        else:
+            raise ValueError("Could not detect particle shape type")
+
+    if particle_shape == "spherical":
+        ij_to_nphamat = {
+            (0, 0): 0,
+            (1, 1): 0,
+            (0, 1): 1,
+            (1, 0): 1,
+            (2, 2): 2,
+            (3, 3): 2,
+            (2, 3): 3,
+            (3, 2): 3,
+        }
+    elif particle_shape == "spheroidal":
+        ij_to_nphamat = {
+            (0, 0): 0,
+            (0, 1): 1,
+            (1, 0): 1,
+            (1, 1): 4,
+            (2, 2): 2,
+            (2, 3): 3,
+            (3, 2): 3,
+            (3, 3): 5,
+        }
+    else:
+        raise NotImplementedError(f"Unknown particle shape '{particle_shape}'")
+
+    # -- Create angular grid (highest resolution possible)
+    mus = np.cos(np.deg2rad(data["theta"].values.ravel()))
+    mus = mus[~np.isnan(mus)]
+    mus = np.unique(mus)
+
+    # -- Resample all phase matrix components and fill data array with shape
+    #    [wavelength, theta, i, j]
+    n_wavelength = len(wavelength)
+    n_theta = len(mus)
+    phase_np = np.zeros((n_wavelength, n_theta, 4, 4))
+
+    for i_wavelength in range(n_wavelength):
+        for (i, j), nphamat in ij_to_nphamat.items():
+            data_selected = data.isel(nlam=i_wavelength, nphamat=nphamat).dropna(
+                "nthetamax"
+            )
+            x = mus
+            xp = data_selected["theta"].values
+            xp = np.cos(np.deg2rad(data_selected["theta"].values)).ravel()
+            fp = data_selected["phase"].values
+            p = np.interp(x, xp, fp)
+            phase_np[i_wavelength, :, i, j] = p
+
+    # Populate Eradiate dataset with correct format
+    phase_eradiate = xr.Dataset(
+        data_vars={
+            "sigma_t": (["w"], data["ext"].values, {"units": "1/km"}),
+            "albedo": (["w"], data["ssa"].values, {"units": ""}),
+            "phase": (["w", "mu", "i", "j"], phase_np),
+        },
+        coords={
+            "w": ("w", wavelength.m_as("nm"), {"units": "nm"}),
+            "mu": ("mu", mus),
+            "i": ("i", range(4)),
+            "j": ("j", range(4)),
+        },
+    )
+
+    return phase_eradiate


### PR DESCRIPTION
# Description

This PR adds a converter for libRadtran NetCDF aerosol files. Both humidity and effective particle radius-indexed data files are supported. The function was tested with samples downloaded from the libRadtran archive and the IPRT samples.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
