### PR TITLE
[Feature] Move post processing definitions to a separate package

### DIFF
--- a/docs/release_notes/v0.31.x.md
+++ b/docs/release_notes/v0.31.x.md
@@ -123,3 +123,5 @@ Read the following for migration instructions.
   of extras ({ghpr}`493`).
 * 🖥️ Factored CLI terminal display components into a module to avoid code
   duplication ({ghpr}`493`).
+* 🖥️ The postprocessing pipeline definitions were moved to a separate package
+  that can be referenced at driver construction {{ghpr}`506`}.

--- a/src/eradiate/experiments/_core.py
+++ b/src/eradiate/experiments/_core.py
@@ -740,7 +740,7 @@ class EarthObservationExperiment(Experiment, ABC):
         if isinstance(measure, (int, str)):
             measure = self.measures.resolve(measure)
         config = pl.config(measure, integrator=self.integrator)
-        return eradiate.pipelines.driver(config)
+        return eradiate.pipelines.driver(config, "eradiate.pipelines.definitions.core")
 
     def _pipeline_inputs(self, i_measure: int):
         # This convenience function collects pipeline inputs for a specific measure

--- a/src/eradiate/pipelines/__init__.py
+++ b/src/eradiate/pipelines/__init__.py
@@ -1,17 +1,9 @@
 """
-This module contains definitions for all post-processing pipeline operations.
-The implementation complies with the `Hamilton <https://hamilton.dagworks.io/>`_
-dataflow framework's specifications: the post-processing pipeline is modelled as
-a directed acyclic graph (DAG), and all post-processing operations are a node in
-that DAG.
-
-Eradiate uses advanced Hamilton features to mutate the pipeline based on
-configuration input. For example:
-
-* Node names reflect the processed physical quantity.
-* Viewing angles are only computed if the measure is distant.
-* Post-processing operations vary depending on the active mode. For example,
-  SRF weighted averaging is only performed in CKD modes.
+This module contains the infrastructure, definitions, and logic for all
+post-processing pipeline operations. The implementation complies with the
+`Hamilton <https://hamilton.dagworks.io/>`__ dataflow framework's specifications:
+the post-processing pipeline is modelled as a directed acyclic graph (DAG), and
+all post-processing operations are a node in that DAG.
 
 For clarity, the implementation is split as follows:
 

--- a/src/eradiate/pipelines/core.py
+++ b/src/eradiate/pipelines/core.py
@@ -88,7 +88,7 @@ def config(
     return result
 
 
-def driver(config: dict):
+def driver(config: dict, definition_module: str):
     """
     Create a Hamilton :class:`~hamilton.driver.Driver` instance using the
     specified configuration. The post-processing pipeline mutates defined on
@@ -99,6 +99,9 @@ def driver(config: dict):
     config : dict
         A configuration dictionary specifying various parameters
         (see :mod:`~eradiate.pipelines` for details).
+
+    definition_module : str
+        The module path to the Hamilton definitions.
 
     Returns
     -------
@@ -114,7 +117,7 @@ def driver(config: dict):
 
     # Instantiate the driver following the Generic result builder documentation
     # https://hamilton.dagworks.io/en/latest/reference/result-builders/Generic/
-    module = importlib.import_module("eradiate.pipelines.definitions")
+    module = importlib.import_module(definition_module)
     dict_builder = DictResult()
     adapter = SimplePythonGraphAdapter(dict_builder)
     drv = Driver(config, module, adapter=adapter)

--- a/src/eradiate/pipelines/definitions/__init__.py
+++ b/src/eradiate/pipelines/definitions/__init__.py
@@ -1,0 +1,40 @@
+"""
+This module contains definitions for all post-processing pipeline operations.
+The implementation complies with the `Hamilton <https://hamilton.dagworks.io/>`__
+dataflow framework's specifications: the post-processing pipeline is modelled as
+a directed acyclic graph (DAG), and all post-processing operations are a node in
+that DAG.
+
+Eradiate uses advanced Hamilton features to mutate the pipeline based on
+configuration input. For example:
+
+* Node names reflect the processed physical quantity.
+* Viewing angles are only computed if the measure is distant.
+* Post-processing operations vary depending on the active mode. For example,
+  SRF weighted averaging is only performed in CKD modes.
+
+New pipelines can be created by adding new definition modules to this package.
+
+For clarity, the implementation is split as follows:
+
+* :mod:`eradiate.pipelines.logic` provides the fundamental logic powering each
+  step of post-processing;
+* :mod:`eradiate.pipelines.definitions` contains the pipeline definition and is
+  intended to be consumed by the Hamilton driver constructor for pipeline
+  initialization;
+* :mod:`eradiate.pipelines.core` provides convenience entry points to facilitate
+  post-processing pipeline initialization.
+
+See Also
+--------
+
+* :class:`hamilton.driver.Driver`
+* `Hamilton's documentation on tags \
+  <https://hamilton.dagworks.io/en/latest/reference/decorators/tag/#tag>`_
+"""
+
+import lazy_loader
+
+__getattr__, __dir__, __all__ = lazy_loader.attach_stub(__name__, __file__)
+
+del lazy_loader

--- a/src/eradiate/pipelines/definitions/__init__.pyi
+++ b/src/eradiate/pipelines/definitions/__init__.pyi
@@ -1,0 +1,1 @@
+from . import core as core

--- a/src/eradiate/pipelines/definitions/core.py
+++ b/src/eradiate/pipelines/definitions/core.py
@@ -17,13 +17,13 @@ from hamilton.function_modifiers import (
     tag_outputs,
 )
 
-from . import logic
-from .._mode import modes
-from ..scenes.illumination import (
+from .. import logic
+from ..._mode import modes
+from ...scenes.illumination import (
     Illumination,
 )
-from ..spectral import SpectralResponseFunction
-from ..spectral.grid import SpectralGrid
+from ...spectral import SpectralResponseFunction
+from ...spectral.grid import SpectralGrid
 
 _MODE_IDS_CKD = set(modes(lambda x: x.is_ckd))
 


### PR DESCRIPTION
# Description

This PR aims at making the post processing pipeline more modular by having definitions placed in a subpackage inside the `pipeline` package. On top of this, the `eradiate.pipeline.driver()` function now *requires* a definition path. In practice this allows anyone creating a new experiment to create a new definition module and add it to the the definition package, whilst still reusing the current pipeline infrastructure.

# Checklist

- [X] The code follows the relevant coding guidelines
- [X] The code generates no new warnings
- [X] The code is appropriately documented
- [X] The code is tested to prove its function
- [X] The feature branch is rebased on the current state of the `main` branch
- [X] I updated the change log if relevant
- [X] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
