### PR TITLE
SolarIrradianceSpectrum: More explicit data error exception message

### DIFF
--- a/docs/release_notes/v0.31.x.md
+++ b/docs/release_notes/v0.31.x.md
@@ -108,6 +108,8 @@ Read the following for migration instructions.
   channels ({ghpr}`501`).
 * The {class}`.ParticleLayer` class can now use aerosol property datasets with a
   single wavelength ({ghpr}`502`).
+* Improved the error message when failing to load a solar irradiance spectrum
+  ({ghpr}`507`).
 
 ### Internal changes
 

--- a/src/eradiate/spectral/index.py
+++ b/src/eradiate/spectral/index.py
@@ -213,7 +213,7 @@ class CKDSpectralIndex(SpectralIndex):
 
     @property
     def formatted_repr(self) -> str:
-        return f"{self.w:g~P}:{self.g:g}"
+        return f"{self.w:g~P}:{self.g:.3f}"
 
     @property
     def as_hashable(self) -> t.Tuple[float, float]:


### PR DESCRIPTION
# Description

This PR improves the solar irradiance spectrum loading error message to help users figure out what to do *e.g.* when the `"coddington-2021"` dataset is not found.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
