### PR TITLE
BandSRF: Add central wavelength computation

### DIFF
--- a/docs/release_notes/v1.1.x.md
+++ b/docs/release_notes/v1.1.x.md
@@ -59,6 +59,10 @@
   ({ghpr}`543`).
 * 🖥️ The phase function of the {class}`.MolecularAtmosphere` class can now be
   forced to a user-defined value for debugging purposes ({ghpr}`550`).
+* The {class}`.BandSRF` class now provides a method to get the associated band
+  central wavelength ({ghpr}`560`).
+* Band-weighted output variables now have a `w_srf` scalar coordinate that
+  contains the central wavelength of the band ({ghpr}`560`).
 
 ### Fixed
 

--- a/src/eradiate/pipelines/logic.py
+++ b/src/eradiate/pipelines/logic.py
@@ -279,9 +279,29 @@ def apply_spectral_response(
 
     # Initialize storage (we want to keep all coordinate variables)
     result = xr.full_like(spectral_data, np.nan).isel(w=0, drop=True)
-    result.values = var_srf_int.values / srf_int.m_as(w_units)
 
     # Apply SRF to variable and store result
+    result.values = var_srf_int.values / srf_int.m_as(w_units)
+
+    if isinstance(srf, BandSRF):
+        # Add SRF central wavelength as a scalar coordinate
+        w_srf = srf.central_wavelength()
+        result = result.assign_coords(
+            {
+                "w_srf": (
+                    [],
+                    w_srf.m,
+                    {
+                        "standard_name": "central_wavelength",
+                        "long_name": "SRF central wavelength",
+                        "units": symbol(w_srf.u),
+                        "comment": "Relevant only for SRF-weighted variables",
+                    },
+                )
+            }
+        )
+
+    # Apply metadata
     attrs = spectral_values.attrs.copy()
     if "standard_name" in attrs:
         attrs["standard_name"] += "_srf"

--- a/src/eradiate/spectral/response.py
+++ b/src/eradiate/spectral/response.py
@@ -634,6 +634,21 @@ class BandSRF(SpectralResponseFunction):
         # Compute integral
         return spi.cumulative_trapezoid(values_m, w_m) * w_u
 
+    def central_wavelength(self) -> pint.Quantity:
+        """
+        Return central wavelength.
+
+        Returns
+        -------
+        pint.Quantity
+        """
+        b = BandSRF(
+            wavelengths=self.wavelengths, values=self.values * self.wavelengths.m
+        )
+        wmin, wmax = self.support()
+        w_units = self.wavelengths.u
+        return b.integrate(wmin, wmax) / self.integrate(wmin, wmax) * w_units
+
 
 def make_gaussian(*args, **kwargs) -> xr.Dataset:
     """

--- a/tests/01_unit/pipelines/test_logic.py
+++ b/tests/01_unit/pipelines/test_logic.py
@@ -319,12 +319,15 @@ def test_04_apply_spectral_response_main(
     assert set(result.dims) == expected_dims
 
     # Coordinate checks
-    expected_coords = set(raw.coords) - ({"w"} | {"bin_wmax", "bin_wmin"})
+    expected_coords = (set(raw.coords) | {"w_srf"}) - {"w", "bin_wmax", "bin_wmin"}
     assert set(result.coords) == expected_coords
 
     # The step adds an SRF-weighted variable
     assert apply_spectral_response.name == f"{var_name}_srf"
     assert np.all(apply_spectral_response.values > 0.0)
+
+    # The recorded central wavelength is correct
+    np.testing.assert_approx_equal(result["w_srf"].values, 559.84824506)
 
 
 @pytest.mark.parametrize("mode_id", ["ckd"])

--- a/tests/01_unit/spectral/test_response.py
+++ b/tests/01_unit/spectral/test_response.py
@@ -114,6 +114,17 @@ def test_band_srf():
     ).integrate_cumulative([400, 500, 550, 600, 700])
     np.testing.assert_equal(integral.m_as("nm"), [0, 25, 50, 50])
 
+    # Central wavelength
+    central_wavelength = BandSRF(
+        wavelengths=[500, 550, 600], values=[0, 1, 0]
+    ).central_wavelength()
+    np.testing.assert_allclose(central_wavelength, 550.0 * ureg.nm)
+
+    central_wavelength = BandSRF(
+        wavelengths=[500, 533, 567, 600], values=[0, 0.5, 1, 0]
+    ).central_wavelength()
+    np.testing.assert_allclose(central_wavelength, 555.666667 * ureg.nm)
+
     # Export to xarray
     da = BandSRF(wavelengths=[500, 550, 600], values=[0, 1, 0]).to_dataarray()
     expected = xr.DataArray(np.array([0, 1, 0]), coords={"w": [500, 550, 600]})

--- a/tests/01_unit/spectral/test_response.py
+++ b/tests/01_unit/spectral/test_response.py
@@ -7,128 +7,181 @@ from eradiate.spectral import SpectralResponseFunction
 from eradiate.spectral.response import BandSRF, DeltaSRF, UniformSRF
 
 
-def test_uniform_srf():
-    # Default constructor succeeds
-    assert UniformSRF() is not None
+class TestUniformSRF:
+    def test_construct(self):
+        assert UniformSRF() is not None
 
-    # Evaluation works as expected
-    srf = UniformSRF(400.0, 500.0, 1.0)
-    value = srf.eval([300, 400, 450, 500, 600]).m
-    expected = np.array([0.0, 1.0, 1.0, 1.0, 0.0])
-    np.testing.assert_array_equal(value, expected)
+    def test_eval(self):
+        srf = UniformSRF(400.0, 500.0, 1.0)
+        value = srf.eval([300, 400, 450, 500, 600]).m
+        expected = np.array([0.0, 1.0, 1.0, 1.0, 0.0])
+        np.testing.assert_array_equal(value, expected)
 
 
-def test_delta_srf():
-    # Construct from float
-    srf = DeltaSRF(0.55 * ureg.micron)
-    np.testing.assert_array_equal(
-        srf.wavelengths.m_as("nm"),
-        [550.0],
-        strict=True,
+class TestDeltaSRF:
+    @pytest.fixture(scope="class")
+    def srf(self):
+        yield DeltaSRF([440.0, 550.0, 660.0])
+
+    def test_construct_from_float(self):
+        srf = DeltaSRF(0.55 * ureg.micron)
+        np.testing.assert_array_equal(srf.wavelengths.m_as("nm"), [550.0], strict=True)
+
+    def test_construct_from_array(self):
+        srf = DeltaSRF([440.0, 550.0, 660.0])
+        np.testing.assert_array_equal(
+            srf.wavelengths.m_as("nm"), [440.0, 550.0, 660.0], strict=True
+        )
+
+    def test_eval_single_value(self, srf):
+        np.testing.assert_array_equal(
+            srf.eval(500.0).m_as("dimensionless"), 0.0, strict=True
+        )
+
+    def test_eval_multiple_values(self, srf):
+        np.testing.assert_array_equal(
+            srf.eval([500.0]).m_as("dimensionless"), [0.0], strict=True
+        )
+
+        np.testing.assert_array_equal(
+            srf.eval([440.0, 550.0, 660.0]).m_as("dimensionless"),
+            [0.0, 0.0, 0.0],
+            strict=True,
+        )
+
+
+class TestBandSRF:
+    @pytest.fixture(scope="class")
+    def srf(self):
+        yield BandSRF(wavelengths=[500, 550, 600], values=[0, 1, 0])
+
+    def test_construct(self):
+        # Construct without leading and trailing zeros
+        with pytest.warns(UserWarning):
+            BandSRF(wavelengths=[500, 550, 600], values=[1, 1, 1])
+
+        # Construct from ID
+        srf = BandSRF.from_id("sentinel_2a-msi-3")
+        np.testing.assert_array_equal(srf.support().m_as("nm"), [536.0, 583.0])
+
+    def test_eval_single_value(self, srf):
+        result = srf.eval(550.0).m_as("dimensionless")
+        np.testing.assert_array_equal(result, 1.0, strict=True)
+
+    def test_eval_multiple_values(self, srf):
+        result = srf.eval([400, 500, 525, 550, 575, 600, 700]).m
+        expected = [0.0, 0.0, 0.5, 1.0, 0.5, 0.0, 0.0]
+        np.testing.assert_array_equal(result, expected)
+
+    @pytest.mark.parametrize(
+        "wmin, wmax, expected",
+        [(500, 600, 50.0), (500, 550, 25.0), (525, 575, 37.5)],
     )
+    def test_integrate(self, srf, wmin, wmax, expected):
+        result = srf.integrate(wmin, wmax).m_as("nm")
+        np.testing.assert_equal(result, expected)
 
-    # Construct from array
-    srf = DeltaSRF([440.0, 550.0, 660.0])
-    np.testing.assert_array_equal(
-        srf.wavelengths.m_as("nm"),
-        [440.0, 550.0, 660.0],
-        strict=True,
+    @pytest.mark.parametrize(
+        "w, expected",
+        [
+            ([500, 550, 600], [25, 50]),
+            ([525, 550, 575], [18.75, 37.5]),
+            ([400, 500, 550, 600, 700], [0, 25, 50, 50]),
+        ],
     )
+    def test_integrate_cumulative(self, srf, w, expected):
+        result = srf.integrate_cumulative(w).m_as("nm")
+        np.testing.assert_array_equal(result, expected)
 
-    # Evaluate with single value
-    np.testing.assert_array_equal(
-        srf.eval(500.0).m_as("dimensionless"),
-        0.0,
-        strict=True,
+    @pytest.mark.parametrize(
+        "wavelengths, values, expected",
+        [
+            ([500, 550, 600], [0, 1, 0], 550.0),
+            ([0.500, 0.533, 0.567, 0.600] * ureg.um, [0, 0.5, 1, 0], 555.666667),
+        ],
     )
+    def test_central_wavelength(self, wavelengths, values, expected):
+        srf = BandSRF(wavelengths=wavelengths, values=values)
+        result = srf.central_wavelength().m_as("nm")
+        np.testing.assert_allclose(result, expected)
 
-    # Evaluate with multiple values
-    np.testing.assert_array_equal(
-        srf.eval([500.0]).m_as("dimensionless"),
-        [0.0],
-        strict=True,
+    def test_to_dataarray(self, srf):
+        result = srf.to_dataarray()
+        expected = xr.DataArray(srf.values.m, coords={"w": srf.wavelengths.m})
+        xr.testing.assert_equal(result, expected)
+
+    @pytest.mark.parametrize(
+        "wl_center, fwhm, cutoff, wl, pad, expected_srf, expected_w",
+        [
+            (
+                0.0,
+                1.0,
+                3.0,
+                np.linspace(-5, 5, 11),
+                False,
+                [0.0625, 1.0, 0.0625],
+                [-1.0, 0.0, 1.0],
+            ),
+            (
+                0.0,
+                3.0,
+                3.0,
+                np.linspace(-5, 5, 11),
+                False,
+                [0.0625, 0.291632, 0.734867, 1.0, 0.734867, 0.291632, 0.0625],
+                [-3.0, -2.0, -1.0, 0.0, 1.0, 2.0, 3.0],
+            ),
+            (
+                0.0,
+                1.0,
+                3.0,
+                np.linspace(-1, 1, 11),
+                False,
+                [
+                    0.0625,
+                    0.169576,
+                    0.368567,
+                    0.641713,
+                    0.895025,
+                    1.0,
+                    0.895025,
+                    0.641713,
+                    0.368567,
+                    0.169576,
+                    0.0625,
+                ],
+                np.linspace(-1, 1, 11),
+            ),
+            (
+                550.0,
+                1.0,
+                3.0,
+                None,
+                False,
+                [0.0625, 1.0, 0.0625],
+                [549.0, 550.0, 551.0],
+            ),
+            (
+                550.0,
+                1.0,
+                3.0,
+                None,
+                True,
+                [0.0, 0.0625, 1.0, 0.0625, 0.0],
+                [548.0, 549.0, 550.0, 551.0, 552.0],
+            ),
+        ],
     )
+    def test_gaussian(self, wl_center, fwhm, cutoff, wl, pad, expected_srf, expected_w):
+        if not pad:
+            with pytest.warns(UserWarning):
+                srf = BandSRF.gaussian(wl_center, fwhm, cutoff=cutoff, wl=wl, pad=pad)
+        else:
+            srf = BandSRF.gaussian(wl_center, fwhm, cutoff=cutoff, wl=wl, pad=pad)
 
-    np.testing.assert_array_equal(
-        srf.eval([440.0, 550.0, 660.0]).m_as("dimensionless"),
-        [0.0, 0.0, 0.0],
-        strict=True,
-    )
-
-
-def test_band_srf():
-    # Construct
-    srf = BandSRF(wavelengths=[500, 550, 600], values=[0, 1, 0])
-
-    # Construct without leading and trailing zeros
-    with pytest.warns(UserWarning):
-        BandSRF(wavelengths=[500, 550, 600], values=[1, 1, 1])
-
-    # Evaluate with single value
-    np.testing.assert_array_equal(
-        srf.eval(550.0).m_as("dimensionless"), 1.0, strict=True
-    )
-
-    # Evaluate with multiple values
-    values = srf.eval([400, 500, 525, 550, 575, 600, 700]).m
-    expected = [0.0, 0.0, 0.5, 1.0, 0.5, 0.0, 0.0]
-    np.testing.assert_array_equal(values, expected)
-
-    # Construct from ID
-    srf = BandSRF.from_id("sentinel_2a-msi-3")
-    np.testing.assert_array_equal(srf.support().m_as("nm"), [536.0, 583.0])
-
-    # Integrate
-    np.testing.assert_equal(
-        BandSRF(wavelengths=[500, 550, 600], values=[0, 1, 0])
-        .integrate(500, 600)
-        .m_as("nm"),
-        50.0,
-    )
-    np.testing.assert_equal(
-        BandSRF(wavelengths=[500, 550, 600], values=[0, 1, 0])
-        .integrate(500, 550)
-        .m_as("nm"),
-        25.0,
-    )
-    np.testing.assert_equal(
-        BandSRF(wavelengths=[500, 550, 600], values=[0, 1, 0])
-        .integrate(500, 550)
-        .m_as("nm"),
-        25.0,
-    )
-
-    # Integrate (cumulative)
-    integral = BandSRF(
-        wavelengths=[500, 550, 600], values=[0, 1, 0]
-    ).integrate_cumulative([500, 550, 600])
-    np.testing.assert_equal(integral.m_as("nm"), [25, 50])
-
-    integral = BandSRF(
-        wavelengths=[500, 550, 600], values=[0, 1, 0]
-    ).integrate_cumulative([525, 550, 575])
-    np.testing.assert_equal(integral.m_as("nm"), [18.75, 37.5])
-
-    integral = BandSRF(
-        wavelengths=[500, 550, 600], values=[0, 1, 0]
-    ).integrate_cumulative([400, 500, 550, 600, 700])
-    np.testing.assert_equal(integral.m_as("nm"), [0, 25, 50, 50])
-
-    # Central wavelength
-    central_wavelength = BandSRF(
-        wavelengths=[500, 550, 600], values=[0, 1, 0]
-    ).central_wavelength()
-    np.testing.assert_allclose(central_wavelength, 550.0 * ureg.nm)
-
-    central_wavelength = BandSRF(
-        wavelengths=[500, 533, 567, 600], values=[0, 0.5, 1, 0]
-    ).central_wavelength()
-    np.testing.assert_allclose(central_wavelength, 555.666667 * ureg.nm)
-
-    # Export to xarray
-    da = BandSRF(wavelengths=[500, 550, 600], values=[0, 1, 0]).to_dataarray()
-    expected = xr.DataArray(np.array([0, 1, 0]), coords={"w": [500, 550, 600]})
-    xr.testing.assert_equal(da, expected)
+        ds = srf.to_dataset()
+        np.testing.assert_allclose(ds.srf.data, expected_srf, rtol=1e-5)
+        np.testing.assert_allclose(ds.w.data, expected_w, rtol=1e-5)
 
 
 @pytest.mark.parametrize(
@@ -144,69 +197,3 @@ def test_band_srf():
 def test_convert(value, expected):
     converted = SpectralResponseFunction.convert(value)
     assert isinstance(converted, expected)
-
-
-@pytest.mark.parametrize(
-    "wl_center, fwhm, cutoff, wl, pad, expected_srf, expected_w",
-    [
-        (
-            0.0,
-            1.0,
-            3.0,
-            np.linspace(-5, 5, 11),
-            False,
-            [0.0625, 1.0, 0.0625],
-            [-1.0, 0.0, 1.0],
-        ),
-        (
-            0.0,
-            3.0,
-            3.0,
-            np.linspace(-5, 5, 11),
-            False,
-            [0.0625, 0.291632, 0.734867, 1.0, 0.734867, 0.291632, 0.0625],
-            [-3.0, -2.0, -1.0, 0.0, 1.0, 2.0, 3.0],
-        ),
-        (
-            0.0,
-            1.0,
-            3.0,
-            np.linspace(-1, 1, 11),
-            False,
-            [
-                0.0625,
-                0.169576,
-                0.368567,
-                0.641713,
-                0.895025,
-                1.0,
-                0.895025,
-                0.641713,
-                0.368567,
-                0.169576,
-                0.0625,
-            ],
-            np.linspace(-1, 1, 11),
-        ),
-        (550.0, 1.0, 3.0, None, False, [0.0625, 1.0, 0.0625], [549.0, 550.0, 551.0]),
-        (
-            550.0,
-            1.0,
-            3.0,
-            None,
-            True,
-            [0.0, 0.0625, 1.0, 0.0625, 0.0],
-            [548.0, 549.0, 550.0, 551.0, 552.0],
-        ),
-    ],
-)
-def test_band_srf_gaussian(wl_center, fwhm, cutoff, wl, pad, expected_srf, expected_w):
-    if pad is False:
-        with pytest.warns(UserWarning):
-            srf = BandSRF.gaussian(wl_center, fwhm, cutoff=cutoff, wl=wl, pad=pad)
-    else:
-        srf = BandSRF.gaussian(wl_center, fwhm, cutoff=cutoff, wl=wl, pad=pad)
-
-    ds = srf.to_dataset()
-    np.testing.assert_allclose(ds.srf.data, expected_srf, rtol=1e-5)
-    np.testing.assert_allclose(ds.w.data, expected_w, rtol=1e-5)


### PR DESCRIPTION
# Description

This PR adds an interface point to retrieve the central wavelength of a `BandSRF`:

```python
srf = BandSRF(...)
srf.central_wavelength()
```

For convenience, the post-processing pipeline also attaches a new `w_srf` **scalar** coordinate to SRF-weighted variables:
<img width="720" height="600" alt="image" src="https://github.com/user-attachments/assets/9e2d232f-f73d-4833-a642-957a69fb12f7" />

The choice of promoting it to a dimension coordinate is left to the user, in particular because, as a side effect, this coordinate will appear also for spectral variables, for which it is irrelevant. This is a limitation of xarray, which can be addressed only by changing more deeply the output data structure.

Now, we can concatenate two SRF-weighted variables as follows:
<img width="720" height="596" alt="image" src="https://github.com/user-attachments/assets/ccb0f634-4b90-4004-98b2-bab5bbc299a2" />

I also took the opportunity to refactor the SRF test suite.

Thanks to @pdevis for suggesting this feature.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
