### PR TITLE
Use rich.table to display CLI information

### DIFF
--- a/src/eradiate/cli/_console.py
+++ b/src/eradiate/cli/_console.py
@@ -1,13 +1,42 @@
+from rich.box import Box
 from rich.console import Console
+from rich.table import Table
 
 console = Console(color_system=None)
 error_console = Console(stderr=True, color_system=None)
+
+BOX_COLON = Box(
+    "    \n"  # top
+    "  : \n"  # header row
+    "    \n"  # head/body separator
+    "  : \n"  # body row
+    "    \n"  # row separator
+    "    \n"  # foot separator
+    "  : \n"  # footer row
+    "    \n"  # bottom
+)
+
+
+def make_table(**kwargs) -> Table:
+    """Create a two-column key/value table with colon separator styling."""
+    t = Table(
+        show_header=False,
+        show_lines=False,
+        show_edge=False,
+        title_justify="left",
+        box=BOX_COLON,
+        **kwargs,
+    )
+    t.add_column("Item", justify="right", no_wrap=True)
+    t.add_column("Value", justify="left", overflow="fold")
+    return t
 
 
 def section(title, newline=True):
     if newline:
         console.print()
-    console.rule("── " + title, align="left")
+    console.print(title)
+    console.print("=" * len(title))
     console.print()
 
 

--- a/src/eradiate/cli/data.py
+++ b/src/eradiate/cli/data.py
@@ -6,7 +6,7 @@ import typer
 
 from eradiate import asset_manager, fresolver
 
-from ._console import message, section
+from ._console import console, make_table, message, section
 
 app = typer.Typer()
 
@@ -35,16 +35,18 @@ def main(ctx: typer.Context):
     if ctx.invoked_subcommand is None:
         asset_manager_info = asset_manager.info()
         section("Asset manager")
-        message(f"• Remote storage URL: {asset_manager_info['remote_url']}")
-        message(
-            f"• Asset cache location [{asset_manager_info['cache_size']:.3g~P}]: "
-            f"{asset_manager_info['cache_dir']}"
+        table = make_table()
+        table.add_row("Remote storage URL", str(asset_manager_info["remote_url"]))
+        table.add_row(
+            f"Asset cache [{asset_manager_info['cache_size']:.3g~P}]",
+            str(asset_manager_info["cache_dir"]),
         )
-        message(
-            f"• Unpacked asset location [{asset_manager_info['unpack_size']:.3g~P}]: "
-            f"{asset_manager_info['unpack_dir']}"
+        table.add_row(
+            f"Unpacked assets [{asset_manager_info['unpack_size']:.3g~P}]",
+            str(asset_manager_info["unpack_dir"]),
         )
-        message(f"• Installation location: {asset_manager_info['install_dir']}")
+        table.add_row("Installation location", str(asset_manager_info["install_dir"]))
+        console.print(table)
 
         fresolver_info = fresolver.info()
         section("File resolver")

--- a/src/eradiate/cli/sys_info.py
+++ b/src/eradiate/cli/sys_info.py
@@ -1,6 +1,8 @@
 import joseki  # noqa: F401  # Put import at top to mitigate undesired log output
 import typer
 
+from eradiate.cli._console import console, make_table
+
 app = typer.Typer()
 
 
@@ -11,7 +13,7 @@ def main():
     """
     import eradiate.util.sys_info
 
-    from ._console import message, section, warning
+    from ._console import section, warning
 
     warnings = eradiate.kernel.check_kernel()
 
@@ -21,43 +23,59 @@ def main():
         warning("• " + w)
 
     sys_info = eradiate.util.sys_info.show()
+
+    def _table():
+        return make_table()
+
     section("System")
-    message(f"CPU: {sys_info['cpu_info']}")
-    message(f"OS: {sys_info['os']}")
-    message(f"Python: {sys_info['python']}")
+    table = _table()
+    table.add_row("CPU", sys_info["cpu_info"])
+    table.add_row("OS", sys_info["os"])
+    table.add_row("Python", sys_info["python"])
+    console.print(table)
 
     section("Versions")
-    message(f"• eradiate {eradiate.__version__}")
-    message(f"• drjit {sys_info['drjit_version']}")
-    message(
-        f"• eradiate-mitsuba {sys_info['eradiate_mitsuba_version']} "
-        f"(based on mitsuba {sys_info['mitsuba_version']})"
+    table = _table()
+    table.add_row("eradiate", eradiate.__version__)
+    table.add_row("drjit", sys_info["drjit_version"])
+    table.add_row(
+        "eradiate-mitsuba",
+        f"{sys_info['eradiate_mitsuba_version']} "
+        f"(based on mitsuba {sys_info['mitsuba_version']})",
     )
-    message(f"• numpy {sys_info['numpy']}")
-    message(f"• scipy {sys_info['scipy']}")
-    message(f"• xarray {sys_info['xarray']}")
+    for package in ["numpy", "scipy", "xarray", "axsdb", "joseki"]:
+        table.add_row(package, sys_info[package])
 
     try:
         import mitsuba as mi
 
-        section("Available Mitsuba variants")
-        message("\n".join([f"• {variant}" for variant in mi.variants()]))
+        table.add_section()
+        table.add_row(
+            "Mitsuba variants", "\n".join([variant for variant in mi.variants()])
+        )
     except ImportError:
         pass
 
+    console.print(table)
+
     section("Configuration")
+    table = _table()
+
     for var in ["SOURCE_DIR"]:
         value = getattr(eradiate.config, var)
         var_repr = str(value)
-        message(f"• ERADIATE_{var.upper()}: {var_repr}")
+        table.add_row(f"ERADIATE_{var.upper()}", var_repr)
 
     loaded_settings_files = list(eradiate.config.settings._loaded_files)
     if loaded_settings_files:
-        message("• Loaded settings files:")
+        item = "Loaded settings files"
         for fname in loaded_settings_files:
-            message(f"  • {fname}")
+            table.add_row(item, fname)
+            item = ""
     else:
-        message("• Loaded setting files: <none>")
+        table.add_row("Loaded settings files", "<none>")
+
+    console.print(table)
 
 
 __doc__ = main.__doc__

--- a/src/eradiate/util/sys_info.py
+++ b/src/eradiate/util/sys_info.py
@@ -86,7 +86,7 @@ def show() -> dict:
     result["mitsuba_compiler"] = import_module("mitsuba.config").CXX_COMPILER
 
     # Python dependencies
-    for package in ["numpy", "scipy", "xarray"]:
+    for package in ["numpy", "scipy", "xarray", "axsdb", "joseki"]:
         try:
             mod = importlib.import_module(package)
             result[package] = mod.__version__


### PR DESCRIPTION
# Description

This commit updates the CLI terminal output to use Rich's table features and improve how information is displayed in narrow terminal windows.

We also add axsdb and joseki to the reported versions.

In practice, we go from this

```
❯ eradiate sys-info

── System ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

CPU: AMD Ryzen 9 5900X 12-Core Processor
OS: Ubuntu 24.04.4 LTS
Python: 3.10.19 | packaged by conda-forge | (main, Jan 26 2026, 23:45:08) [GCC 14.3.0]

── Versions ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

• eradiate 1.2.0.dev0
• drjit 1.2.0
• eradiate-mitsuba 0.4.3, not installed [DEV] (based on mitsuba 3.7.1)
• numpy 2.2.6
• scipy 1.15.3
• xarray 2025.6.1

── Available Mitsuba variants ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

• scalar_mono
• scalar_mono_double
• scalar_mono_polarized
• scalar_mono_polarized_double
• scalar_rgb
• scalar_spectral
• llvm_ad_rgb
• llvm_ad_spectral_polarized

── Configuration ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

• ERADIATE_SOURCE_DIR: /home/leroyv/Documents/src/rayference/rtm/eradiate
• Loaded setting files: <none>
```
to this
```
❯ eradiate sys-info

System
======

    CPU : AMD Ryzen 9 5900X 12-Core Processor
     OS : Ubuntu 24.04.4 LTS
 Python : 3.10.19 | packaged by conda-forge | (main, Jan 26 2026, 23:45:08) [GCC 14.3.0]

Versions
========

         eradiate : 1.2.0.dev0
            drjit : 1.2.0
 eradiate-mitsuba : 0.4.3, not installed [DEV] (based on mitsuba 3.7.1)
            numpy : 2.2.6
            scipy : 1.15.3
           xarray : 2025.6.1
            axsdb : 0.1.2
           joseki : 2.6.1

 Mitsuba variants : scalar_mono
                  : scalar_mono_double
                  : scalar_mono_polarized
                  : scalar_mono_polarized_double
                  : scalar_rgb
                  : scalar_spectral
                  : llvm_ad_rgb
                  : llvm_ad_spectral_polarized

Configuration
=============

   ERADIATE_SOURCE_DIR : /home/leroyv/Documents/src/rayference/rtm/eradiate
 Loaded settings files : <none>
```

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
