### PR TITLE
[Feature] Experimental extremum structure interface

### DIFF
--- a/docs/release_notes/v1.2.x.md
+++ b/docs/release_notes/v1.2.x.md
@@ -16,3 +16,6 @@
 * Added {class}`.EOVolPathIntegrator` that implements the DDIS variance
   reduction technique from {cite:t}`Buras2011EfficientUnbiasedVariance`
   ({ghpr}`565`).
+* Added the `extremum_resolution` parameter to `AbstractHeterogeneousAtmosphere`,
+  which introduces local extremum structures to Eradiate, improving performance
+  for spherical shell atmosphere and future 3D volumes ({ghpr}`568`).

--- a/src/eradiate/scenes/atmosphere/_core.py
+++ b/src/eradiate/scenes/atmosphere/_core.py
@@ -379,6 +379,25 @@ class AbstractHeterogeneousAtmosphere(Atmosphere, ABC):
         init_type="bool, optional",
     )
 
+    extremum_resolution: tuple[int, int, int] = documented(
+        attrs.field(
+            default=(1, 1, 1),
+            validator=validators.is_vector3,
+        ),
+        doc="[EXPERIMENTAL] Resolution of the extremum structure. Applies to "
+        "both plane parallel and spherical shell geometries but the latter only "
+        "accepts a resolution greater than one along its radial dimension "
+        "(first dimension). Also note than in plane parallel the dimensions are "
+        "[x, y, z] and in spherical shell [r, theta, phi]. "
+        "The default value (1, 1, 1) falls back to a global majorant. In plane "
+        "parallel, set to (0,0,0) to trigger an adaptive search of the optimal"
+        "resolution. Note that this is an expensive search that triggers at "
+        "spectral update.",
+        type="tuple[int, int, int]",
+        init_type="tuple[int, int, int]",
+        default="(1,1,1)",
+    )
+
     def update(self) -> None:
         """
         Update internal state.
@@ -701,7 +720,6 @@ class AbstractHeterogeneousAtmosphere(Atmosphere, ABC):
                     ),
                     "to_world": to_world,
                     "filter_type": "nearest",
-                    "accel": False,
                 },
             }
 
@@ -753,7 +771,6 @@ class AbstractHeterogeneousAtmosphere(Atmosphere, ABC):
                             ),
                         ),
                         "filter_type": "nearest",
-                        "accel": False,
                     },
                     "to_world": to_world,
                     "rmin": volume_rmin,
@@ -778,6 +795,8 @@ class AbstractHeterogeneousAtmosphere(Atmosphere, ABC):
         result = {
             "type": medium,
             "has_spectral_extinction": (
+                # piecewise volpath currently only works with spectral extinction true
+                # hack fix by setting to True when we have a piecewise medium
                 (not get_mode().check(mi_color_mode="mono")) or (medium == "piecewise")
             ),
             **volumes,

--- a/src/eradiate/scenes/atmosphere/_core.py
+++ b/src/eradiate/scenes/atmosphere/_core.py
@@ -18,7 +18,9 @@ from ..core import (
 from ..geometry import PlaneParallelGeometry, SceneGeometry, SphericalShellGeometry
 from ..phase import PhaseFunction
 from ..shapes import Shape
+from ... import validators
 from ..._factory import Factory
+from ..._mode import get_mode
 from ...attrs import define, documented, get_doc
 from ...contexts import KernelContext
 from ...kernel import (
@@ -99,6 +101,25 @@ class Atmosphere(CompositeSceneElement, ABC):
         type=".SceneGeometry",
         init_type=".SceneGeometry or dict or str, optional",
         default='"plane_parallel"',
+    )
+
+    extremum_resolution: tuple[int, int, int] = documented(
+        attrs.field(
+            default=(1, 1, 1),
+            validator=validators.is_vector3,
+        ),
+        doc="[EXPERIMENTAL] Resolution of the extremum structure. Applies to "
+        "both plane parallel and spherical shell geometries but the latter only "
+        "accepts a resolution greater than one along its radial dimension "
+        "(first dimension). Also note than in plane parallel the dimensions are "
+        "[x, y, z] and in spherical shell [r, theta, phi]. "
+        "The default value (1, 1, 1) falls back to a global majorant. In plane "
+        "parallel, set to (0,0,0) to trigger an adaptive search of the optimal"
+        "resolution. Note that this is an expensive search that triggers at "
+        "spectral update.",
+        type="tuple[int, int, int]",
+        init_type="tuple[int, int, int]",
+        default="(1,1,1)",
     )
 
     # --------------------------------------------------------------------------
@@ -644,6 +665,9 @@ class AbstractHeterogeneousAtmosphere(Atmosphere, ABC):
     def _template_medium(self) -> dict:
         # Inherit docstring
 
+        extremum = None
+        sigma_t_id = f"{self.id}_sigma_t"
+
         if isinstance(self.geometry, PlaneParallelGeometry):
             to_world = self.geometry.atmosphere_volume_to_world
 
@@ -664,6 +688,7 @@ class AbstractHeterogeneousAtmosphere(Atmosphere, ABC):
                 },
                 "sigma_t": {
                     "type": "gridvolume",
+                    "id": sigma_t_id,
                     "grid": DictParameter(
                         lambda ctx: mi.VolumeGrid(
                             np.reshape(
@@ -676,8 +701,18 @@ class AbstractHeterogeneousAtmosphere(Atmosphere, ABC):
                     ),
                     "to_world": to_world,
                     "filter_type": "nearest",
+                    "accel": False,
                 },
             }
+
+            if medium == "heterogeneous":
+                if self.extremum_resolution != (1, 1, 1):
+                    extremum = {
+                        "type": "extremum_grid",
+                        "volume": {"type": "ref", "id": sigma_t_id},
+                        "resolution": self.extremum_resolution,
+                        "to_world": to_world,
+                    }
 
         elif isinstance(self.geometry, SphericalShellGeometry):
             volume_rmin = self.geometry.atmosphere_volume_rmin
@@ -704,6 +739,7 @@ class AbstractHeterogeneousAtmosphere(Atmosphere, ABC):
                 },
                 "sigma_t": {
                     "type": "sphericalcoordsvolume",
+                    "id": sigma_t_id,
                     "volume": {
                         "type": "gridvolume",
                         "grid": DictParameter(
@@ -717,11 +753,21 @@ class AbstractHeterogeneousAtmosphere(Atmosphere, ABC):
                             ),
                         ),
                         "filter_type": "nearest",
+                        "accel": False,
                     },
                     "to_world": to_world,
                     "rmin": volume_rmin,
                 },
             }
+
+            if self.extremum_resolution != (1, 1, 1):
+                extremum = {
+                    "type": "extremum_spherical",
+                    "volume": {"type": "ref", "id": sigma_t_id},
+                    "rmin": volume_rmin,
+                    "resolution": self.extremum_resolution,
+                    "to_world": to_world,
+                }
 
         else:
             raise ValueError(
@@ -731,6 +777,9 @@ class AbstractHeterogeneousAtmosphere(Atmosphere, ABC):
         # Create medium dictionary
         result = {
             "type": medium,
+            "has_spectral_extinction": (
+                (not get_mode().check(mi_color_mode="mono")) or (medium == "piecewise")
+            ),
             **volumes,
             # Note: "phase" is deliberately unset, this is left to the
             # Atmosphere.template property
@@ -738,6 +787,9 @@ class AbstractHeterogeneousAtmosphere(Atmosphere, ABC):
 
         if self.scale is not None:
             result["scale"] = self.scale
+
+        if extremum is not None:
+            result["extremum"] = extremum
 
         return result
 

--- a/tests/01_unit/scenes/atmosphere/test_heterogeneous.py
+++ b/tests/01_unit/scenes/atmosphere/test_heterogeneous.py
@@ -386,3 +386,58 @@ def test_heterogeneous_absorbing_mol_atm(
             f"Test parametrisation inconsistent. Expected 'absorbing_only' or "
             f"'scattering_only' (got {particle_radprops})"
         )
+
+
+@pytest.mark.parametrize("geometry", ["plane_parallel", "spherical_shell"])
+@pytest.mark.parametrize("force_majorant", [False, True])
+def test_heterogeneous_medium_type(
+    mode_mono, geometry, force_majorant, atmosphere_us_standard_mono
+):
+    atmosphere = HeterogeneousAtmosphere(
+        geometry=geometry,
+        molecular_atmosphere=atmosphere_us_standard_mono,
+        force_majorant=force_majorant,
+    )
+    template = atmosphere._template_medium
+
+    if geometry == "plane_parallel":
+        if force_majorant:
+            assert template["type"] == "heterogeneous"
+        else:
+            assert template["type"] == "piecewise"
+    elif geometry == "spherical_shell":
+        assert template["type"] == "heterogeneous"
+
+
+@pytest.mark.parametrize("geometry", ["plane_parallel", "spherical_shell"])
+@pytest.mark.parametrize("force_majorant", [False, True])
+def test_heterogenous_extremum_type(
+    mode_mono, geometry, force_majorant, atmosphere_us_standard_mono
+):
+    atmosphere = HeterogeneousAtmosphere(
+        geometry=geometry,
+        molecular_atmosphere=atmosphere_us_standard_mono,
+        force_majorant=force_majorant,
+        extremum_resolution=(1, 1, 1),
+    )
+
+    template = atmosphere._template_medium
+    assert "extremum" not in template
+
+    atmosphere = HeterogeneousAtmosphere(
+        geometry=geometry,
+        molecular_atmosphere=atmosphere_us_standard_mono,
+        force_majorant=force_majorant,
+        extremum_resolution=(1, 1, 12) if geometry == "plane_parallel" else (12, 1, 1),
+    )
+    template = atmosphere._template_medium
+
+    if geometry == "plane_parallel":
+        if force_majorant:
+            assert "extremum" in template
+            assert template["extremum"]["type"] == "extremum_grid"
+        else:
+            assert "extremum" not in template
+    elif geometry == "spherical_shell":
+        assert "extremum" in template
+        assert template["extremum"]["type"] == "extremum_spherical"


### PR DESCRIPTION
# Description

This PR includes an experimental interface for extremum structures. Extremum Structures are superstructures that are constructed from volumes (atmosphere and particle layer) to provide local upper and lower bounds of extinction coefficients. Using those local bounds drastically improves the performance of delta tracking in case of heterogeneous volumes with peaked density. 

While the kernel provides flexibility on the choice of structures in the form of plugins, the interface in Eradiate is more restrictive: the structure is tied to the geometry, namely `extremum_grid` for `plane_parallel` and `extremum_spherical` for `spherical_shell`. Since the two structures are based on grids, we expose `extremum_resolution` for both through the abstract heterogeneous interface. A few things to note:
- A resolution of (1,1,1), defaults to not describing an extremum. (future implementation might default to global implementations).
- The resolution will have different meaning for plane parallel (x, y, z) and spherical shell (r, theta, phi). The current implementation of `extremum_spherical` only accept `r` to be bigger than one and will throw otherwise.
- A resolution of (0,0,0) in plane parallel will trigger adaptive resolution search, which will find the optimal resolution. This will trigger at each spectral update.

Within this PR is also included a check to the kernel color mode that sets `has_spectral_extinction`. This is mostly for performance reasons as we can save on a few operations in non-spectral mode (order of magnitude of a 2 to 3%). Note also that the current implementation of extremum structures is not compatible with spectral extinction coefficients, which will be fixed in the next kernel update. This change unveiled that there might be some error in non-spectral integration of `piecewise` media. A fix should be done in a separate PR.

This is an experimental feature: 
- The interface is likely to change as new structures are introduced.
- There are incoming structural changes that will restrict the use of extremum structures to `eovolpath`.

A couple of unit tests were added to ensure the correct medium and extremum type are used.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
