### PR TITLE
Residual Ratio Tracking control parameter and user warning guard

### DIFF
--- a/docs/references.bib
+++ b/docs/references.bib
@@ -347,6 +347,21 @@
   url          = {http://rgl.epfl.ch/publications/NimierDavidVicini2019Mitsuba2},
   shortjournal = {ACM Trans. Graph.}
 }
+@article{Novak2014Residual,
+	title = {Residual ratio tracking for estimating attenuation in participating media},
+	volume = {33},
+	issn = {0730-0301, 1557-7368},
+	url = {https://dl.acm.org/doi/10.1145/2661229.2661292},
+	doi = {10.1145/2661229.2661292},
+	language = {en},
+	number = {6},
+	urldate = {2023-06-17},
+	journal = {ACM Transactions on Graphics},
+	author = {Novák, Jan and Selle, Andrew and Jarosz, Wojciech},
+	month = nov,
+	year = {2014},
+	pages = {1--11},
+}
 @article{Peck1972DispersionAir,
   title        = {Dispersion of air},
   author       = {E.R. Peck and K. Reeder},

--- a/docs/release_notes/v1.2.x.md
+++ b/docs/release_notes/v1.2.x.md
@@ -19,3 +19,5 @@
 * Added the `extremum_resolution` parameter to `AbstractHeterogeneousAtmosphere`,
   which introduces local extremum structures to Eradiate, improving performance
   for spherical shell atmosphere and future 3D volumes ({ghpr}`568`).
+* Added residual ratio tracking transmittance estimation, accesible through the
+  `use_rrt` parameter in the `Atmosphere` interface.

--- a/src/eradiate/experiments/_atmosphere.py
+++ b/src/eradiate/experiments/_atmosphere.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import typing as t
+import warnings
 
 import attrs
 
@@ -14,6 +15,7 @@ from ._helpers import (
 )
 from ..attrs import AUTO, define, documented
 from ..scenes.atmosphere import (
+    AbstractHeterogeneousAtmosphere,
     Atmosphere,
     HeterogeneousAtmosphere,
     HomogeneousAtmosphere,
@@ -166,6 +168,18 @@ class AtmosphereExperiment(EarthObservationExperiment):
         """
         Ensures that the integrator is compatible with the atmosphere and geometry.
         """
+        if isinstance(self.atmosphere, AbstractHeterogeneousAtmosphere):
+            if (
+                self.atmosphere.extremum_resolution != (1, 1, 1)
+                and not self.integrator.extremum_compatible
+            ):
+                warnings.warn(
+                    UserWarning(
+                        "Extremum structures are not compatible with "
+                        f"{type(self.integrator).__name__} and will be ignored."
+                    )
+                )
+
         piecewise_compatible, msg = check_piecewise_compatible(
             self.geometry, self.atmosphere
         )

--- a/src/eradiate/experiments/_canopy_atmosphere.py
+++ b/src/eradiate/experiments/_canopy_atmosphere.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import typing as t
+import warnings
 
 import attrs
 
@@ -16,6 +17,7 @@ from ._helpers import (
 from .. import validators
 from ..attrs import AUTO, define, documented
 from ..scenes.atmosphere import (
+    AbstractHeterogeneousAtmosphere,
     Atmosphere,
     HeterogeneousAtmosphere,
     HomogeneousAtmosphere,
@@ -213,6 +215,18 @@ class CanopyAtmosphereExperiment(EarthObservationExperiment):
         """
         Ensures that the integrator is compatible with the atmosphere and geometry.
         """
+        if isinstance(self.atmosphere, AbstractHeterogeneousAtmosphere):
+            if (
+                self.atmosphere.extremum_resolution != (1, 1, 1)
+                and not self.integrator.extremum_compatible
+            ):
+                warnings.warn(
+                    UserWarning(
+                        "Extremum structures are not compatible with "
+                        f"{type(self.integrator).__name__} and will be ignored."
+                    )
+                )
+
         piecewise_compatible, pw_msg = check_piecewise_compatible(
             self.geometry, self.atmosphere
         )

--- a/src/eradiate/experiments/_dem.py
+++ b/src/eradiate/experiments/_dem.py
@@ -15,6 +15,7 @@ from ._helpers import (
 )
 from ..attrs import AUTO, define, documented
 from ..scenes.atmosphere import (
+    AbstractHeterogeneousAtmosphere,
     Atmosphere,
     HeterogeneousAtmosphere,
     HomogeneousAtmosphere,
@@ -179,6 +180,18 @@ class DEMExperiment(EarthObservationExperiment):
         """
         Ensures that the integrator is compatible with the atmosphere and geometry.
         """
+        if isinstance(self.atmosphere, AbstractHeterogeneousAtmosphere):
+            if (
+                self.atmosphere.extremum_resolution != (1, 1, 1)
+                and not self.integrator.extremum_compatible
+            ):
+                warnings.warn(
+                    UserWarning(
+                        "Extremum structures are not compatible with "
+                        f"{type(self.integrator).__name__} and will be ignored."
+                    )
+                )
+
         piecewise_compatible, msg = check_piecewise_compatible(
             self.geometry, self.atmosphere
         )

--- a/src/eradiate/scenes/atmosphere/_core.py
+++ b/src/eradiate/scenes/atmosphere/_core.py
@@ -103,23 +103,18 @@ class Atmosphere(CompositeSceneElement, ABC):
         default='"plane_parallel"',
     )
 
-    extremum_resolution: tuple[int, int, int] = documented(
+    use_residual_ratio_tracking: bool = documented(
         attrs.field(
-            default=(1, 1, 1),
-            validator=validators.is_vector3,
+            default=True,
+            kw_only=True,
+            converter=bool,
+            validator=attrs.validators.instance_of(bool),
         ),
-        doc="[EXPERIMENTAL] Resolution of the extremum structure. Applies to "
-        "both plane parallel and spherical shell geometries but the latter only "
-        "accepts a resolution greater than one along its radial dimension "
-        "(first dimension). Also note than in plane parallel the dimensions are "
-        "[x, y, z] and in spherical shell [r, theta, phi]. "
-        "The default value (1, 1, 1) falls back to a global majorant. In plane "
-        "parallel, set to (0,0,0) to trigger an adaptive search of the optimal"
-        "resolution. Note that this is an expensive search that triggers at "
-        "spectral update.",
-        type="tuple[int, int, int]",
-        init_type="tuple[int, int, int]",
-        default="(1,1,1)",
+        doc="If set to true, uses residual ratio tracking to estimate transmittance "
+        "for non-analytical media. Otherwise, falls back to ratio tracking. "
+        "Residual ratio tracking generally reduces variance and can improve "
+        "performance for high optical thickness.",
+        type="bool",
     )
 
     # --------------------------------------------------------------------------
@@ -809,6 +804,9 @@ class AbstractHeterogeneousAtmosphere(Atmosphere, ABC):
 
         if extremum is not None:
             result["extremum"] = extremum
+
+        if medium == "heterogeneous":
+            result["use_rrt"] = self.use_residual_ratio_tracking
 
         return result
 

--- a/src/eradiate/scenes/atmosphere/_core.py
+++ b/src/eradiate/scenes/atmosphere/_core.py
@@ -103,15 +103,16 @@ class Atmosphere(CompositeSceneElement, ABC):
         default='"plane_parallel"',
     )
 
-    use_residual_ratio_tracking: bool = documented(
+    use_rrt: bool = documented(
         attrs.field(
             default=True,
             kw_only=True,
             converter=bool,
             validator=attrs.validators.instance_of(bool),
         ),
-        doc="If set to true, uses residual ratio tracking to estimate transmittance "
-        "for non-analytical media. Otherwise, falls back to ratio tracking. "
+        doc="If set to true, prescribe the use of residual ratio tracking to "
+        "estimate transmittance for integrators that allow it. "
+        "Otherwise, falls back to ratio tracking. "
         "Residual ratio tracking generally reduces variance and can improve "
         "performance for high optical thickness.",
         type="bool",
@@ -806,7 +807,7 @@ class AbstractHeterogeneousAtmosphere(Atmosphere, ABC):
             result["extremum"] = extremum
 
         if medium == "heterogeneous":
-            result["use_rrt"] = self.use_residual_ratio_tracking
+            result["use_rrt"] = self.use_rrt
 
         return result
 

--- a/src/eradiate/scenes/integrators/_path_tracers.py
+++ b/src/eradiate/scenes/integrators/_path_tracers.py
@@ -44,6 +44,16 @@ class MonteCarloIntegrator(Integrator):
     )
 
     @property
+    def extremum_compatible(self):
+        """
+        Returns
+        -------
+        bool
+            Flags whether the integrator can consume extremum structures.
+        """
+        return False
+
+    @property
     def kernel_type(self) -> str:
         raise NotImplementedError
 
@@ -131,6 +141,12 @@ class EOVolPathIntegrator(MonteCarloIntegrator):
     It supports multiple scattering, accounts for volume interactions, and
     implements the DDIS variance reduction method as described by
     :cite:t:`Buras2011EfficientUnbiasedVariance`.
+
+    It also supports the use of extremum structures and the estimation of
+    transmittance through residual ratio tracking :cite:`Novak2014Residual`.
+    The former can improve performance in heterogeneous atmosphere, and the
+    latter improves variance (and sometimes performance) induced from
+    transmittance estimation.
     """
 
     rr_depth: int = documented(
@@ -165,6 +181,10 @@ class EOVolPathIntegrator(MonteCarloIntegrator):
         "emitter as incident direction. Set to <0. to deactivate.",
         type="float",
     )
+
+    @property
+    def extremum_compatible(self):
+        return True
 
     @property
     def kernel_type(self) -> str:


### PR DESCRIPTION
# Description

Hello,
This PR adds a user parameter to control which algorithm is used to estimate the transmittance. This parameter is part of the Atmosphere interface as it applies to the medium in Mistuba. Note however that only the `EOVolpathIntegrator` currently consumes this parameter.

The PR also adds a user warning when specifiying an `extremum_resolution` with an incompatible integrator. Note that the simulation will pursue and will just ignore the parameter.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
