### PR TITLE
Fix SolarIrradianceSpectrum.datetime not supporting datetime objects

### DIFF
--- a/src/eradiate/scenes/spectra/_solar_irradiance.py
+++ b/src/eradiate/scenes/spectra/_solar_irradiance.py
@@ -50,7 +50,7 @@ def _datetime_converter(x: Any):
             raise
         if isinstance(x, datetime.datetime):
             return x
-            
+
         return dateutil.parser.parse(x)
 
 

--- a/src/eradiate/scenes/spectra/_solar_irradiance.py
+++ b/src/eradiate/scenes/spectra/_solar_irradiance.py
@@ -48,7 +48,9 @@ def _datetime_converter(x: Any):
                 "See instructions on https://rhodesmill.org/skyfield/."
             )
             raise
-
+        if isinstance(x, datetime.datetime):
+            return x
+            
         return dateutil.parser.parse(x)
 
 

--- a/tests/01_unit/scenes/spectra/test_solar_irradiance.py
+++ b/tests/01_unit/scenes/spectra/test_solar_irradiance.py
@@ -1,6 +1,7 @@
 import mitsuba as mi
 import numpy as np
 import pytest
+import datetime
 
 import eradiate
 from eradiate import unit_registry as ureg
@@ -43,6 +44,13 @@ def test_solar_irradiance_construct(mode_mono, tested, expected):
 
     else:
         raise RuntimeError
+
+def test_solar_irradiance_datetime():
+    dt = datetime.datetime(2011, 11, 11, 11, 11, 11)
+    s = SolarIrradianceSpectrum(datetime=dt) # init with datetime object 
+    assert s.datetime == dt, "Cannot initialize SolarIrradianceSpectrum with a datetime object"
+    s = SolarIrradianceSpectrum(datetime="2011-11-11 11:11:11") # init with string
+    assert s.datetime == dt, "Cannot initialize SolarIrradianceSpectrum with a datetime string"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Description

Fixes the bug where `SolarIrradianceSpectrum.datetime` can only be initialised with a string and not also a `datetime` object (as suggested in the docs)

I also added a test for the correct parsing of datetime

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [ ] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
