### PR TITLE
Use `stokes_moment` integrator instead of separate nested `stokes` and `moment`

### DIFF
--- a/docs/release_notes/v1.2.x.md
+++ b/docs/release_notes/v1.2.x.md
@@ -12,6 +12,7 @@
   an incorrect value for the ``absorption_data`` parameter ({ghpr}`566`).
 * {class}`.SolarIrradianceSpectrum` now accepts various datetime-like objects
   for its `datetime` argument ({ghpr}`572`).
+* Restored variance computation for all stokes components ({ghpr}`571`).
 
 ### Added
 

--- a/src/eradiate/experiments/_core.py
+++ b/src/eradiate/experiments/_core.py
@@ -714,7 +714,7 @@ class EarthObservationExperiment(Experiment, ABC):
         # Map bitmap names to result names
         mapping = {}
         if self.integrator.stokes:
-            stokes = ["S0", "S1", "S2", "S3"]
+            stokes = ["nested.S0", "nested.S1", "nested.S2", "nested.S3"]
             iquv = ["I", "Q", "U", "V"]
 
             for s, i in zip(stokes, iquv):

--- a/src/eradiate/pipelines/logic.py
+++ b/src/eradiate/pipelines/logic.py
@@ -715,7 +715,7 @@ def gather_bitmaps(
             coords = (
                 spectral_coords
                 if not calculate_stokes
-                else {**spectral_coords, "stokes": ["I"]}
+                else {**spectral_coords, "stokes": ["I", "Q", "U", "V"]}
             )
             sensor_data[f"{var_name}_m2_raw"].append(da_m2.expand_dims(dim=coords))
 
@@ -934,17 +934,7 @@ def moment2_to_variance(
     -----
     This function calculates the Monte-Carlo variance, which aggregates the variance
     of each sample. It thus needs to be divided by the spp.
-
-    In polarized mode (``calculate_stokes=True``), the m2 array only contains
-    the 'I' (intensity) component, while the expectation may contain the full
-    Stokes vector. The function automatically selects the 'I' component from
-    expectation when needed.
     """
-
-    # In polarized mode, m2 only contains the 'I' component
-    # Select it from expectation if it has a 'stokes' dimension
-    if calculate_stokes and "stokes" in expectation.dims:
-        expectation = expectation.sel(stokes=["I"])
 
     dims_m2 = set(m2.dims)
     dims_expectation = set(expectation.dims)

--- a/src/eradiate/scenes/integrators/_path_tracers.py
+++ b/src/eradiate/scenes/integrators/_path_tracers.py
@@ -87,16 +87,12 @@ class MonteCarloIntegrator(Integrator):
         # Build the kernel dict (children can override _build_kernel_dict)
         result = self._build_kernel_dict()
 
-        # Apply wrapping layers
-        if self.moment:
-            result = {"type": "moment", "nested": result}
-
-        # Important: the 'stokes' integrator has to come last because it needs
-        # sensor information
-        if self.stokes:
+        if self.stokes or self.moment:
             result = {
-                "type": "stokes",
-                "integrator": result,
+                "type": "stokes_moment",
+                "nested": result,
+                "use_stokes": self.stokes,
+                "use_moment": self.moment,
                 "meridian_align": self.meridian_align,
             }
 

--- a/tests/01_unit/pipelines/test_logic.py
+++ b/tests/01_unit/pipelines/test_logic.py
@@ -222,15 +222,12 @@ def test_01_gather_bitmaps(mode, experiment, gather_bitmaps):
     solar_angle_sizes = {"sza": 1, "saa": 1}
     film_sizes = {"y_index": 32, "x_index": 32}
     all_sizes = {**spectral_sizes, **film_sizes, **solar_angle_sizes}
+    all_sizes_pol = {**all_sizes, "stokes": 4}
 
     expected_sizes = {
         "spp": spectral_sizes,
-        "radiance_raw": all_sizes
-        if not mode.is_polarized
-        else {**all_sizes, "stokes": 4},
-        "radiance_m2_raw": all_sizes
-        if not mode.is_polarized
-        else {**all_sizes, "stokes": 1},
+        "radiance_raw": all_sizes if not mode.is_polarized else all_sizes_pol,
+        "radiance_m2_raw": all_sizes if not mode.is_polarized else all_sizes_pol,
     }
 
     for var, da in gather_bitmaps.items():  # noqa: F402

--- a/tests/01_unit/pipelines/test_logic.py
+++ b/tests/01_unit/pipelines/test_logic.py
@@ -226,8 +226,8 @@ def test_01_gather_bitmaps(mode, experiment, gather_bitmaps):
 
     expected_sizes = {
         "spp": spectral_sizes,
-        "radiance_raw": all_sizes if not mode.is_polarized else all_sizes_pol,
-        "radiance_m2_raw": all_sizes if not mode.is_polarized else all_sizes_pol,
+        "radiance_raw": all_sizes_pol if mode.is_polarized else all_sizes,
+        "radiance_m2_raw": all_sizes_pol if mode.is_polarized else all_sizes,
     }
 
     for var, da in gather_bitmaps.items():  # noqa: F402

--- a/tests/01_unit/scenes/integrators/test_path_tracers.py
+++ b/tests/01_unit/scenes/integrators/test_path_tracers.py
@@ -165,10 +165,10 @@ def test_stokes_construct(mode_mono_polarized_single, integrator_cls, kwargs):
     integrator = integrator_cls(**kwargs)
     mi_wrapper = check_scene_element(integrator, mi.SamplingIntegrator)
     assert (
-        "S0.R" in mi_wrapper.obj.aov_names()
-        and "S1.R" in mi_wrapper.obj.aov_names()
-        and "S2.R" in mi_wrapper.obj.aov_names()
-        and "S3.R" in mi_wrapper.obj.aov_names()
+        "nested.S0.R" in mi_wrapper.obj.aov_names()
+        and "nested.S1.R" in mi_wrapper.obj.aov_names()
+        and "nested.S2.R" in mi_wrapper.obj.aov_names()
+        and "nested.S3.R" in mi_wrapper.obj.aov_names()
     )
 
 
@@ -233,5 +233,4 @@ def test_stokes_moment_construct(mode_mono_polarized_single, integrator_cls, kwa
     check_scene_element(integrator, mi.SamplingIntegrator)
 
     kdict_template, _ = traverse(integrator)
-    assert kdict_template.data["type"] == "stokes"
-    assert kdict_template.data["integrator.type"] == "moment"
+    assert kdict_template.data["type"] == "stokes_moment"


### PR DESCRIPTION
# Description

Hello,
This PR enforces the use of the `stokes_moment` integrator when either the stokes components, the variance, or both elements are required as output. This change solves the nesting order constraint imposed by recent performance fixes in the stokes component. The pipeline had to be modified to process all stokes components again. The `stokes_moment` integrator tries to reproduce the AOV order and naming of the integrators it is derived from. There is an exception when only the Stokes vector is required, and the name of the nested integrator is preprended to the AOV i.e `nested.S0`. This change was also reflected in the processing changes.

The breaking unit tests were modified accordingly. All tests pass, including regression tests, and some IPRT cases were also run again.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `next` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
