### PR TITLE
`SolarIrradiance`: Support datetime-like objects

### DIFF
--- a/docs/release_notes/v1.2.x.md
+++ b/docs/release_notes/v1.2.x.md
@@ -10,14 +10,16 @@
 
 * Improved error messages when initializing a {class}`.MolecularAtmosphere` with
   an incorrect value for the ``absorption_data`` parameter ({ghpr}`566`).
+* {class}`.SolarIrradianceSpectrum` now accepts various datetime-like objects
+  for its `datetime` argument ({ghpr}`572`).
 
 ### Added
 
 * Added {class}`.EOVolPathIntegrator` that implements the DDIS variance
   reduction technique from {cite:t}`Buras2011EfficientUnbiasedVariance`
   ({ghpr}`565`).
-* Added the `extremum_resolution` parameter to `AbstractHeterogeneousAtmosphere`,
+* Added the `extremum_resolution` parameter to {class}`.AbstractHeterogeneousAtmosphere`,
   which introduces local extremum structures to Eradiate, improving performance
   for spherical shell atmosphere and future 3D volumes ({ghpr}`568`).
-* Added residual ratio tracking transmittance estimation, accesible through the
-  `use_rrt` parameter in the `Atmosphere` interface ({ghpr`569`}).
+* Added residual ratio tracking transmittance estimation, accessible through the
+  `use_rrt` parameter in the {class}`.Atmosphere` interface ({ghpr}`569`).

--- a/src/eradiate/scenes/spectra/_solar_irradiance.py
+++ b/src/eradiate/scenes/spectra/_solar_irradiance.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import attrs
 import numpy as np
+import pandas as pd
 import pint
 import xarray as xr
 
@@ -49,6 +50,19 @@ def _datetime_converter(x: Any):
             )
             raise
 
+        # datetime instances pass through
+        if isinstance(x, datetime.datetime):
+            return x
+
+        # Pandas: convert to datetime
+        if isinstance(x, pd.Timestamp):
+            return x.to_pydatetime()
+
+        # Numpy: convert to datetime
+        if isinstance(x, np.datetime64):
+            return pd.Timestamp(x).to_pydatetime()
+
+        # Fallback: try to parse a string
         return dateutil.parser.parse(x)
 
 
@@ -149,24 +163,21 @@ class SolarIrradianceSpectrum(Spectrum):
         doc="Arbitrary scaling factor. This scaling factor is applied in "
         "addition to the datetime-based scaling controlled by the *datetime* "
         "parameter.",
-        type="float or datetime",
-        init_type="float or datetime or str",
+        type="float",
+        init_type="float",
         default="1.0",
     )
 
     datetime: datetime.datetime | None = documented(
-        attrs.field(
-            default=None,
-            converter=_datetime_converter,
-        ),
+        attrs.field(default=None, converter=_datetime_converter),
         type="datetime or None",
-        init_type="datetime or str, optional",
+        init_type="pandas.Timestamp or numpy.datetime64 or datetime or str, optional",
         doc="Date for which the spectrum is to be evaluated. An ISO "
         "string can be passed and will be interpreted by "
         ":meth:`dateutil.parser.parse`. This parameter scales the irradiance "
         "spectrum to account for the seasonal variation of the Earth-Sun "
         "distance. This scaling is applied in addition to the arbitrary "
-        "scaling controlled by the *scale* parameter.",
+        "scaling controlled by the ``scale`` parameter.",
     )
 
     def _scale_earth_sun_distance(self) -> float:
@@ -235,6 +246,13 @@ class SolarIrradianceSpectrum(Spectrum):
             # Solar irradiance spectra in Eradiate).
             return (1.0 / distance_au) ** 2
 
+    def _scale_total(self) -> float:
+        """
+        Return the full scaling value, factoring in both manual and
+        datetime-based scaling.
+        """
+        return self.scale * self._scale_earth_sun_distance()
+
     def eval_mono(self, w: pint.Quantity) -> pint.Quantity:
         # Inherit docstring
 
@@ -247,7 +265,7 @@ class SolarIrradianceSpectrum(Spectrum):
         if np.any(np.isnan(irradiance.magnitude)):
             raise ValueError("interpolation of solar irradiance dataset returned nan")
 
-        result = irradiance * self.scale * self._scale_earth_sun_distance()
+        result = irradiance * self._scale_total()
 
         # Squeeze result if input was scalar
         return result.squeeze() if np.isscalar(w.magnitude) else result

--- a/tests/01_unit/scenes/spectra/test_solar_irradiance.py
+++ b/tests/01_unit/scenes/spectra/test_solar_irradiance.py
@@ -1,5 +1,8 @@
+import datetime
+
 import mitsuba as mi
 import numpy as np
+import pandas as pd
 import pytest
 
 import eradiate
@@ -95,14 +98,19 @@ class TestSolarIrradianceSpectrum:
             == s.eval_mono(550.0 * ureg.nm) * 10.0
         )
 
-    def test_datetime(self, mode_mono):
-        s = SolarIrradianceSpectrum(dataset="thuillier_2003")
+    @pytest.mark.parametrize(
+        "dt",
+        [
+            "2021-11-18",
+            datetime.datetime(2021, 11, 18),
+            pd.Timestamp("2021-11-18"),
+            np.datetime64("2021-11-18"),
+        ],
+        ids=["str", "datetime", "pandas_timestamp", "numpy_datetime64"],
+    )
+    def test_datetime(self, mode_mono, dt):
+        """Various datetime-like objects can be used to scale the spectrum."""
+        s = SolarIrradianceSpectrum(dataset="thuillier_2003", datetime=dt)
 
-        # We can also use a datetime to scale the spectrum
-        s_scaled_datetime = SolarIrradianceSpectrum(
-            dataset="thuillier_2003", datetime="2021-11-18"
-        )
-        assert np.isclose(
-            s_scaled_datetime.eval_mono(550.0 * ureg.nm),
-            s.eval_mono(550.0 * ureg.nm) / 0.98854537**2,
-        )
+        assert isinstance(s.datetime, datetime.datetime)
+        assert np.isclose(s._scale_total(), 1.0 / 0.98854537**2)

--- a/tests/01_unit/scenes/spectra/test_solar_irradiance.py
+++ b/tests/01_unit/scenes/spectra/test_solar_irradiance.py
@@ -12,96 +12,97 @@ from eradiate.test_tools.types import check_scene_element
 from eradiate.units import PhysicalQuantity
 
 
-@pytest.mark.parametrize(
-    "tested, expected",
-    [
-        ({}, "SolarIrradianceSpectrum"),
-        ({"dataset": "doesnt_exist"}, DataError),
-        ({"dataset": "thuillier_2003"}, "SolarIrradianceSpectrum"),
-        ({"dataset": "solar_irradiance/thuillier_2003.nc"}, "SolarIrradianceSpectrum"),
-        (
-            {"dataset": load_dataset("solar_irradiance/thuillier_2003.nc")},
-            "SolarIrradianceSpectrum",
-        ),
-    ],
-    ids=[
-        "no_args",
-        "dataset_doesnt_exist",
-        "dataset_keyword",
-        "dataset_path",
-        "dataset_xarray",
-    ],
-)
-def test_solar_irradiance_construct(mode_mono, tested, expected):
-    if expected == "SolarIrradianceSpectrum":
+class TestSolarIrradianceSpectrum:
+    @pytest.mark.parametrize(
+        "tested, expected",
+        [
+            ({}, "SolarIrradianceSpectrum"),
+            ({"dataset": "doesnt_exist"}, DataError),
+            ({"dataset": "thuillier_2003"}, "SolarIrradianceSpectrum"),
+            (
+                {"dataset": "solar_irradiance/thuillier_2003.nc"},
+                "SolarIrradianceSpectrum",
+            ),
+            (
+                {"dataset": load_dataset("solar_irradiance/thuillier_2003.nc")},
+                "SolarIrradianceSpectrum",
+            ),
+        ],
+        ids=[
+            "no_args",
+            "dataset_doesnt_exist",
+            "dataset_keyword",
+            "dataset_path",
+            "dataset_xarray",
+        ],
+    )
+    def test_construct(self, mode_mono, tested, expected):
+        if expected == "SolarIrradianceSpectrum":
+            s = SolarIrradianceSpectrum(**tested)
+            assert s.quantity is PhysicalQuantity.IRRADIANCE
+
+        elif issubclass(expected, Exception):
+            with pytest.raises(expected):
+                SolarIrradianceSpectrum(**tested)
+
+        else:
+            raise RuntimeError
+
+    @pytest.mark.parametrize(
+        "tested",
+        [
+            {},
+            {"scale": 2.0},
+            {"dataset": "thuillier_2003"},
+        ],
+        ids=[
+            "no_args",
+            "scale",
+            "thuillier_spectrum",
+        ],
+    )
+    def test_kernel_dict(self, mode_mono, tested):
         s = SolarIrradianceSpectrum(**tested)
-        assert s.quantity is PhysicalQuantity.IRRADIANCE
+        check_scene_element(s, mi.Texture)
 
-    elif issubclass(expected, Exception):
-        with pytest.raises(expected):
-            SolarIrradianceSpectrum(**tested)
+    def test_eval(self, modes_all_double):
+        # Irradiance is correctly interpolated in mono mode
+        s = SolarIrradianceSpectrum(dataset="thuillier_2003")
 
-    else:
-        raise RuntimeError
+        si = SpectralIndex.new(w=550.0 * ureg.nm)
+        expected = 1.87938 * ureg.W / ureg.m**2 / ureg.nm  # computed manually
 
+        assert np.allclose(s.eval(si), expected)
 
-@pytest.mark.parametrize(
-    "tested",
-    [
-        {},
-        {"scale": 2.0},
-        {"dataset": "thuillier_2003"},
-    ],
-    ids=[
-        "no_args",
-        "scale",
-        "thuillier_spectrum",
-    ],
-)
-def test_solar_irradiance_kernel_dict(mode_mono, tested):
-    s = SolarIrradianceSpectrum(**tested)
-    check_scene_element(s, mi.Texture)
+        # Eval raises out of the supported spectral range
+        if eradiate.mode().is_mono:
+            with pytest.raises(ValueError):
+                s.eval(SpectralIndex.new(w=1.0 * ureg.km))
 
+        elif eradiate.mode().is_ckd:
+            pass
 
-def test_solar_irradiance_eval(modes_all_double):
-    # Irradiance is correctly interpolated in mono mode
-    s = SolarIrradianceSpectrum(dataset="thuillier_2003")
+        else:
+            assert False
 
-    si = SpectralIndex.new(w=550.0 * ureg.nm)
-    expected = 1.87938 * ureg.W / ureg.m**2 / ureg.nm  # computed manually
+    def test_scale(self, mode_mono):
+        s = SolarIrradianceSpectrum(dataset="thuillier_2003")
 
-    assert np.allclose(s.eval(si), expected)
+        # We can scale the spectrum using a float
+        s_scaled_float = SolarIrradianceSpectrum(dataset="thuillier_2003", scale=10.0)
+        assert (
+            s_scaled_float.eval_mono(550.0 * ureg.nm)
+            == s.eval_mono(550.0 * ureg.nm) * 10.0
+        )
 
-    # Eval raises out of the supported spectral range
-    if eradiate.mode().is_mono:
-        with pytest.raises(ValueError):
-            s.eval(SpectralIndex.new(w=1.0 * ureg.km))
+    def test_datetime(self, mode_mono):
+        s = SolarIrradianceSpectrum(dataset="thuillier_2003")
 
-    elif eradiate.mode().is_ckd:
-        pass
-
-    else:
-        assert False
-
-
-def test_solar_irradiance_scale(mode_mono):
-    s = SolarIrradianceSpectrum(dataset="thuillier_2003")
-
-    # We can scale the spectrum using a float
-    s_scaled_float = SolarIrradianceSpectrum(dataset="thuillier_2003", scale=10.0)
-    assert (
-        s_scaled_float.eval_mono(550.0 * ureg.nm) == s.eval_mono(550.0 * ureg.nm) * 10.0
-    )
-
-
-def test_solar_irradiance_datetime(mode_mono):
-    s = SolarIrradianceSpectrum(dataset="thuillier_2003")
-
-    # We can also use a datetime to scale the spectrum
-    s_scaled_datetime = SolarIrradianceSpectrum(
-        dataset="thuillier_2003", datetime="2021-11-18"
-    )
-    assert np.isclose(
-        s_scaled_datetime.eval_mono(550.0 * ureg.nm),
-        s.eval_mono(550.0 * ureg.nm) / 0.98854537**2,
-    )
+        # We can also use a datetime to scale the spectrum
+        s_scaled_datetime = SolarIrradianceSpectrum(
+            dataset="thuillier_2003", datetime="2021-11-18"
+        )
+        assert np.isclose(
+            s_scaled_datetime.eval_mono(550.0 * ureg.nm),
+            s.eval_mono(550.0 * ureg.nm) / 0.98854537**2,
+        )


### PR DESCRIPTION
# Description

This PR updates `SolarIrradianceSpectrum`'s `datetime` attribute to support conversion of various datetime-like types. Now, the following types are accepted:

* `datetime.datetime`: Pivot data type, used internally for storage.
* `str`: ISO format string specification, parsed with `dateutil` as a `datetime.datetime`.
* `pd.Timestamp`: Pandas's own datetime type, converted to `datetime.datetime`.
* `np.datetime64`: NumPy's own datetime type, converted to `datetime.datetime`.

I also refactored the unit tests to use classes for scoping (new preferred pattern).

Closes #570.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
