### PR TITLE
Decouple test reporting from Robot Framework

### DIFF
--- a/.github/actions/save-ci-logs/action.yml
+++ b/.github/actions/save-ci-logs/action.yml
@@ -9,28 +9,28 @@ runs:
       uses: actions/upload-artifact@v4
       with:
         name: log_html
-        path: ./log.html
+        path: ./reports/log.html
     - name: Save HTML report
       if: always()
       uses: actions/upload-artifact@v4
       with:
         name: report_html
-        path: ./report.html
+        path: ./reports/report.html
     - name: Save PDF log
       if: always()
       uses: actions/upload-artifact@v4
       with:
         name: log_pdf
-        path: ./log.pdf
+        path: ./reports/log.pdf
     - name: Save PDF report
       if: always()
       uses: actions/upload-artifact@v4
       with:
         name: report_pdf
-        path: ./report.pdf
+        path: ./reports/report.pdf
     - name: Save test outputs
       if: always()
       uses: actions/upload-artifact@v4
       with:
         name: output_xml
-        path: ./output.xml
+        path: ./reports/output.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,13 +55,13 @@ jobs:
           eradiate sys-info
       - name: Run fast tests
         run: |
-          pytest -p robotframework --robot-tagstatinclude unit --robot-tagstatinclude system --robot-tagstatinclude regression --robot-tagstatinclude slow -m "not slow" ./tests
+          pytest -p robotframework -m "not slow" ./tests
       - name: Robot report
         if: always()
         run: |
-          rebot --tagstatinclude unit --tagstatinclude system --tagstatinclude regression --tagstatinclude slow --expandkeywords name:* ./output.xml
-          chrome --no-sandbox --virtual-time-budget=10000 --headless --print-to-pdf=./log.pdf    ./log.html    --no-pdf-header-footer
-          chrome --no-sandbox --virtual-time-budget=10000 --headless --print-to-pdf=./report.pdf ./report.html --no-pdf-header-footer
+          rebot --outputdir reports --tagstatinclude unit --tagstatinclude system --tagstatinclude regression --tagstatinclude slow --expandkeywords name:* ./reports/output.xml
+          chrome --no-sandbox --virtual-time-budget=10000 --headless --print-to-pdf=./reports/log.pdf    ./reports/log.html    --no-pdf-header-footer
+          chrome --no-sandbox --virtual-time-budget=10000 --headless --print-to-pdf=./reports/report.pdf ./reports/report.html --no-pdf-header-footer
       - uses: ./.github/actions/save-ci-logs
 
   report:
@@ -83,11 +83,11 @@ jobs:
           eradiate sys-info
       - name: Run all tests
         run: |
-          pytest -p robotframework --plot --robot-tagstatinclude unit --robot-tagstatinclude system --robot-tagstatinclude regression --robot-tagstatinclude slow ./tests
+          pytest -p robotframework --plot ./tests
       - name: Robot report
         if: always()
         run: |
-          rebot --tagstatinclude unit --tagstatinclude system --tagstatinclude regression --tagstatinclude slow --expandkeywords name:* ./output.xml
-          chrome --no-sandbox --virtual-time-budget=10000 --headless --print-to-pdf=./log.pdf    ./log.html    --no-pdf-header-footer
-          chrome --no-sandbox --virtual-time-budget=10000 --headless --print-to-pdf=./report.pdf ./report.html --no-pdf-header-footer
+          rebot --outputdir reports --tagstatinclude unit --tagstatinclude system --tagstatinclude regression --tagstatinclude slow --expandkeywords name:* ./reports/output.xml
+          chrome --no-sandbox --virtual-time-budget=10000 --headless --print-to-pdf=./reports/log.pdf    ./reports/log.html    --no-pdf-header-footer
+          chrome --no-sandbox --virtual-time-budget=10000 --headless --print-to-pdf=./reports/report.pdf ./reports/report.html --no-pdf-header-footer
       - uses: ./.github/actions/save-ci-logs

--- a/docs/reference_api/test_tools.rst
+++ b/docs/reference_api/test_tools.rst
@@ -15,7 +15,6 @@
 
    sample_eval_pdf_bsdf
 
-
 ``eradiate.test_tools.regression``
 ----------------------------------
 
@@ -34,6 +33,19 @@
    PairedStudentTTest
    ZTest
    SidakTTest
+
+``eradiate.test_tools.report``
+------------------------------
+
+.. automodule:: eradiate.test_tools.report
+
+.. currentmodule:: eradiate.test_tools.report
+
+.. autosummary::
+   :toctree: generated/autosummary/
+
+   figure_to_html
+   ReportLogger
 
 ``eradiate.test_tools.test_cases``
 ----------------------------------

--- a/docs/release_notes/v1.3.x.md
+++ b/docs/release_notes/v1.3.x.md
@@ -5,6 +5,8 @@
 ### Fixed
 
 * 🖥️ Fixed multiple breakages after a development environment update ({ghpr}`578`).
+* {class}`.RegressionTest` no longer raises when initialized with plotting
+  enabled and no reference data ({ghpr}`582`).
 
 ### Internal changes
 
@@ -22,3 +24,11 @@
 * 🖥️ The codebase and tooling were adjusted to better comply with the
   [Scientific Python Library Development Guide](https://learn.scientific-python.org/development/)
   ({ghpr}`583`).
+* 🖥️ Test code no longer depends directly on Robot ({ghpr}`582`).
+* 🖥️ Report messages are now routed through {class}`.ReportLogger`, which falls
+  back to standard logging when Robot is not installed ({ghpr}`582`).
+* 🖥️ Robot Framework is no longer a docs dependency ({ghpr}`582`).
+* 🖥️ Test report products (`output.xml`, `log.html`, `report.html` and PDF
+  renders) are now written to the `reports/` directory ({ghpr}`582`).
+* 🖥️ Move `figure_to_html()` from `test_tools.regression` to `test_tools.report`
+  ({ghpr}`582`).

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,7 +6,7 @@ aenum==3.1.17
     # via eradiate (pyproject.toml)
 alabaster==1.0.0
     # via sphinx
-annotated-doc==0.0.4
+annotated-doc==0.0.5
     # via typer
 anyio==4.14.2
     # via
@@ -92,11 +92,11 @@ docutils==0.22.4
     #   pybtex-docutils
     #   sphinx
     #   sphinxcontrib-bibtex
-dynaconf==3.3.3
+dynaconf==3.3.4
     # via eradiate (pyproject.toml)
 executing==2.2.1
     # via stack-data
-fastjsonschema==2.22.0
+fastjsonschema==2.22.1
     # via nbformat
 flexcache==0.3
     # via pint
@@ -410,8 +410,6 @@ rich==15.0.0
     # via
     #   eradiate (pyproject.toml)
     #   typer
-robotframework==7.4.2
-    # via eradiate (pyproject.toml:docs)
 roman-numerals==4.1.0
     # via sphinx
 rpds-py==2026.6.3
@@ -539,7 +537,7 @@ uri-template==1.3.0
     # via jsonschema
 urllib3==2.7.0
     # via requests
-uvicorn==0.51.0
+uvicorn==0.52.0
     # via sphinx-autobuild
 watchfiles==1.2.0
     # via sphinx-autobuild

--- a/pixi.lock
+++ b/pixi.lock
@@ -1885,7 +1885,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ed/c9/d7977eaacb9df673210491da99e6a247e93df98c715fc43fd136ce1d3d33/arrow-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ee/5a/73e2959af1b97fd5d556f9a8bdba017be23ceeef731869d5eaa0a753d5a3/watchfiles-1.2.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ef/35/fd2385b15f6d814f1801bcbd3d54b4c61a1bfc3a1a0fe023dc15551c5fe4/robotframework-7.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ef/af/4fbc8cab944db5d21b7e2a5b8e9211a03a79852b1157e2c102fcc61ac440/pandocfilters-1.5.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f3/71/8c002223e873a870f5c41dc69b0a7c922301123e4a31d5d01ecb700aef77/jupyter_server-2.20.0-py3-none-any.whl
@@ -2077,7 +2076,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ed/c9/d7977eaacb9df673210491da99e6a247e93df98c715fc43fd136ce1d3d33/arrow-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ef/35/fd2385b15f6d814f1801bcbd3d54b4c61a1bfc3a1a0fe023dc15551c5fe4/robotframework-7.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ef/af/4fbc8cab944db5d21b7e2a5b8e9211a03a79852b1157e2c102fcc61ac440/pandocfilters-1.5.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f3/71/8c002223e873a870f5c41dc69b0a7c922301123e4a31d5d01ecb700aef77/jupyter_server-2.20.0-py3-none-any.whl
@@ -2306,7 +2304,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ed/c9/d7977eaacb9df673210491da99e6a247e93df98c715fc43fd136ce1d3d33/arrow-1.4.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ef/35/fd2385b15f6d814f1801bcbd3d54b4c61a1bfc3a1a0fe023dc15551c5fe4/robotframework-7.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ef/af/4fbc8cab944db5d21b7e2a5b8e9211a03a79852b1157e2c102fcc61ac440/pandocfilters-1.5.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f3/71/8c002223e873a870f5c41dc69b0a7c922301123e4a31d5d01ecb700aef77/jupyter_server-2.20.0-py3-none-any.whl
@@ -2498,7 +2495,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ed/a1/e29995109e455dc8eff8d0fac6ae509be39561318a7cfeac5d33ad029213/charset_normalizer-3.4.9-cp311-cp311-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/ed/c9/d7977eaacb9df673210491da99e6a247e93df98c715fc43fd136ce1d3d33/arrow-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ef/35/fd2385b15f6d814f1801bcbd3d54b4c61a1bfc3a1a0fe023dc15551c5fe4/robotframework-7.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ef/af/4fbc8cab944db5d21b7e2a5b8e9211a03a79852b1157e2c102fcc61ac440/pandocfilters-1.5.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f2/b7/b7a1695d7af36f521fb11e80d6d3adbd744f73b921859bd3c2a2c0dc706f/rpds_py-2026.6.3-cp311-cp311-win_amd64.whl
@@ -21637,11 +21633,6 @@ packages:
   version: 2026.6.17
   sha256: 2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db
   requires_python: '>=3.7'
-- pypi: https://files.pythonhosted.org/packages/ef/35/fd2385b15f6d814f1801bcbd3d54b4c61a1bfc3a1a0fe023dc15551c5fe4/robotframework-7.4.2-py3-none-any.whl
-  name: robotframework
-  version: 7.4.2
-  sha256: 6e80f84cdc997bdde2abb6b729ac3531457ecf6d2e41abfb87a541877ab367bf
-  requires_python: '>=3.8'
 - pypi: https://files.pythonhosted.org/packages/ef/45/615f5babd880b4bd7d405cc0dc348234c5ffb6ed1ea33e152ede08b2072d/rich-14.3.2-py3-none-any.whl
   name: rich
   version: 14.3.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,6 @@ docs = [
   "nbsphinx>=0.9.0",
   "ipython", # Required for syntax highlighting in notebooks
   "pytest", # Required for pytest-related function docs
-  "robotframework", # Required for robot-related function docs
   "seaborn",
   "sphinx>=9.0",
   "sphinxcontrib-bibtex>=2.0",
@@ -177,39 +176,13 @@ test-cov-quick = { cmd = """
     --cov-report=json \
     --cov-report=term-missing
 """ }
-test-report = { cmd = """
-  pytest -p robotframework \
-    --robot-tagstatinclude unit \
-    --robot-tagstatinclude system \
-    --robot-tagstatinclude regression \
-    --robot-tagstatinclude slow \
-    --plot
-""" }
-test-unit-report = { cmd = """
-  pytest -p robotframework \
-    --robot-tagstatinclude unit \
-    --robot-tagstatinclude slow -m unit \
-    --plot""" }
-test-system-report = { cmd = """
-  pytest -p robotframework \
-    --robot-tagstatinclude system \
-    --robot-tagstatinclude slow -m system \
-    --plot
-""" }
-test-regression-report = { cmd = """
-  pytest -p robotframework \
-    --robot-tagstatinclude regression \
-    --robot-tagstatinclude slow -m regression \
-    --plot
-""" }
-test-slow-report = { cmd = """
-  pytest -p robotframework \
-    --robot-tagstatinclude unit \
-    --robot-tagstatinclude system \
-    --robot-tagstatinclude regression \
-    --robot-tagstatinclude slow -m slow \
-    --plot
-""" }
+# Default Robot Framework options (output directory, tag statistics) are set
+# by the pytest_robot_modify_options hook in tests/conftest.py
+test-report = { cmd = "pytest -p robotframework --plot" }
+test-unit-report = { cmd = "pytest -p robotframework -m unit --plot" }
+test-system-report = { cmd = "pytest -p robotframework -m system --plot" }
+test-regression-report = { cmd = "pytest -p robotframework -m regression --plot" }
+test-slow-report = { cmd = "pytest -p robotframework -m slow --plot" }
 
 [tool.pixi.feature.docs.tasks]
 # Docs build

--- a/resources/regression_testing_framework_benchmark/test_regression.py
+++ b/resources/regression_testing_framework_benchmark/test_regression.py
@@ -2,21 +2,27 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 import xarray as xr
-from robot.api import logger
 
 import eradiate
-import eradiate.test_tools.regression as tt
+from eradiate.test_tools.regression import (
+    Chi2Test,
+    IndependentStudentTTest,
+    PairedStudentTTest,
+    SidakTTest,
+    ZTest,
+)
+from eradiate.test_tools.report import figure_to_html, report_logger
 from eradiate.test_tools.test_cases.rami4atm import (
     create_rami4atm_hom00_bla_sd2s_m03_z30a000_brfpp,
 )
 from eradiate.test_tools.util import append_doc
 
 test_types = {
-    "t_test": tt.IndependentStudentTTest,
-    "paired_t_test": tt.PairedStudentTTest,
-    "z_test": tt.ZTest,
-    "chi2": tt.Chi2Test,
-    "sidak_t_test": tt.SidakTTest,
+    "t_test": IndependentStudentTTest,
+    "paired_t_test": PairedStudentTTest,
+    "z_test": ZTest,
+    "chi2": Chi2Test,
+    "sidak_t_test": SidakTTest,
 }
 
 
@@ -116,9 +122,9 @@ def test_t_test_static_var(
 
     passed, p_value = test._evaluate(diagnostic_chart=True)
 
-    logger.info(f"p-value: {p_value}; threshold: {threshold}")
-    logger.info(f"mean_ref: {mean_ref}; mean_obs: {mean_obs}")
-    logger.info(f"std_ref: {std_ref}; std_obs: {std_obs}")
+    report_logger.info(f"p-value: {p_value}; threshold: {threshold}")
+    report_logger.info(f"mean_ref: {mean_ref}; mean_obs: {mean_obs}")
+    report_logger.info(f"std_ref: {std_ref}; std_obs: {std_obs}")
 
     assert passed == accept
 
@@ -189,7 +195,7 @@ def test_z_test_static_var(
         ),
     )
 
-    test = tt.ZTest(
+    test = ZTest(
         name="z-test",
         reference=ref_ds,
         value=obs_ds,
@@ -198,12 +204,12 @@ def test_z_test_static_var(
         threshold=threshold,
     )
 
-    logger.info(f"Expecting Z-test to pass: {accept}", also_console=True)
+    report_logger.info(f"Expecting Z-test to pass: {accept}")
     passed, p_value = test._evaluate(diagnostic_chart=True)
-    logger.info(f"Z-test did pass: {passed}", also_console=True)
-    logger.info(f"min p-value: {p_value}; threshold: {threshold}", also_console=True)
-    logger.info(f"mean_ref: {mean_ref}; mean_obs: {mean_obs}", also_console=True)
-    logger.info(f"std_obs: {std_obs}", also_console=True)
+    report_logger.info(f"Z-test did pass: {passed}")
+    report_logger.info(f"min p-value: {p_value}; threshold: {threshold}")
+    report_logger.info(f"mean_ref: {mean_ref}; mean_obs: {mean_obs}")
+    report_logger.info(f"std_obs: {std_obs}")
 
     if passed != accept:
         fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(8, 4))
@@ -220,9 +226,9 @@ def test_z_test_static_var(
 
         plt.legend()
 
-        chart = tt.figure_to_html(plt.gcf())
+        chart = figure_to_html(plt.gcf())
         plt.close()
-        logger.info(chart, html=True)
+        report_logger.html(chart)
 
     assert passed == accept
 
@@ -263,8 +269,8 @@ def test_stats_same_simulation(mode_ckd_double, test_type, spp):
     exp1.integrator.moment = True
     result = eradiate.run(exp1, spp=spp)
 
-    logger.info("Displaying test dataset")
-    logger.info(result._repr_html_(), html=True)
+    report_logger.info("Displaying test dataset")
+    report_logger.html(result._repr_html_())
 
     r1np = result.radiance.sum(dim="w").squeeze().values
     s1np = np.sqrt(result.radiance_var.sum(dim="w").squeeze().values)
@@ -275,11 +281,13 @@ def test_stats_same_simulation(mode_ckd_double, test_type, spp):
     plt.xlabel("vza [degree]")
     plt.ylabel(f"radiance [{result.radiance_srf.attrs['units']}]")
     plt.legend()
-    chart = tt.figure_to_html(plt.gcf())
+    chart = figure_to_html(plt.gcf())
     plt.close()
-    logger.info(chart, html=True)
+    report_logger.html(chart)
 
-    logger.info("The test should pass, even considering a large significance level")
+    report_logger.info(
+        "The test should pass, even considering a large significance level"
+    )
 
     test = test_types[test_type](
         name="type_I_error_test",
@@ -291,8 +299,8 @@ def test_stats_same_simulation(mode_ckd_double, test_type, spp):
     )
 
     passed, p_value = test._evaluate()
-    logger.info(f"Test passed: {passed}")
-    logger.info(f"P-value: {p_value}")
+    report_logger.info(f"Test passed: {passed}")
+    report_logger.info(f"P-value: {p_value}")
 
     assert passed
 
@@ -338,15 +346,15 @@ def test_stats_same_setup(mode_ckd_double, test_type, spp1, spp2):
     exp1.integrator.moment = True
     result1 = eradiate.run(exp1, spp=spp1)
 
-    logger.info("Displaying test values dataset")
-    logger.info(result1._repr_html_(), html=True)
+    report_logger.info("Displaying test values dataset")
+    report_logger.html(result1._repr_html_())
 
     exp2 = create_rami4atm_hom00_bla_sd2s_m03_z30a000_brfpp()
     exp2.integrator.moment = True
     result2 = eradiate.run(exp2, spp=spp2)
 
-    logger.info("Displaying test reference dataset")
-    logger.info(result2._repr_html_(), html=True)
+    report_logger.info("Displaying test reference dataset")
+    report_logger.html(result2._repr_html_())
 
     r1np = result1.radiance.sum(dim="w").squeeze().values
     r2np = result2.radiance.sum(dim="w").squeeze().values
@@ -360,11 +368,13 @@ def test_stats_same_setup(mode_ckd_double, test_type, spp1, spp2):
     plt.xlabel("vza [degree]")
     plt.ylabel(f"radiance [{result1.radiance_srf.attrs['units']}]")
     plt.legend()
-    chart = tt.figure_to_html(plt.gcf())
+    chart = figure_to_html(plt.gcf())
     plt.close()
-    logger.info(chart, html=True)
+    report_logger.html(chart)
 
-    logger.info("The test should pass, even considering a large significance level")
+    report_logger.info(
+        "The test should pass, even considering a large significance level"
+    )
 
     test = test_types[test_type](
         name="type_I_error_test",
@@ -376,7 +386,7 @@ def test_stats_same_setup(mode_ckd_double, test_type, spp1, spp2):
     )
 
     passed, p_value = test._evaluate(diagnostic_chart=True)
-    logger.info(f"Test passed: {passed}")
+    report_logger.info(f"Test passed: {passed}")
 
     assert passed
 

--- a/src/eradiate/test_tools/fixtures/__init__.py
+++ b/src/eradiate/test_tools/fixtures/__init__.py
@@ -32,15 +32,6 @@ def plugin_checker(request):
 
 
 @pytest.fixture
-def has_robot(plugin_checker):
-    """
-    Fixture that returns ``True`` iff the robotframework plugin is loaded and
-    enabled in the current session.
-    """
-    return plugin_checker("robotframework")
-
-
-@pytest.fixture
 def absorption_database_error_handler_config():
     """
     Error handler configuration for absorption coefficient interpolation.

--- a/src/eradiate/test_tools/regression.py
+++ b/src/eradiate/test_tools/regression.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import os
 from abc import ABC, abstractmethod
-from io import StringIO
 from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar
 
@@ -13,8 +12,8 @@ import numpy as np
 import scipy.stats as spstats
 import xarray as xr
 from numpy.typing import ArrayLike
-from robot.api import logger
 
+from .report import ReportLogger, figure_to_html, report_logger
 from ..attrs import define, documented
 from ..typing import PathLike
 from ..util.misc import summary_repr
@@ -117,49 +116,6 @@ def regression_test_plots(
     return fig, axes
 
 
-def figure_to_html(fig: plt.Figure) -> str:
-    """
-    Render a figure in HTML format
-
-    Returns a string containing the rendered HTML. The root tag is a <svg> one.
-
-    Parameters
-    ----------
-    fig : plt.Figure
-        Matplotlib figure to render in HTML.
-
-    Returns
-    -------
-    str
-        Rendered HTML <svg> tag with styling.
-    """
-
-    str_i = StringIO()
-    fig.savefig(str_i, format="svg", transparent=True, bbox_inches="tight")
-    fig.canvas.draw_idle()
-    svg = str_i.getvalue()
-
-    # Include some CSS in the SVG to render nicely in Robot report's dark and
-    # light modes
-    return "\n".join(
-        [
-            "<svg",
-            'version="1.1"',
-            'baseProfile="full"',
-            'width="810" height="540" viewBox="0 0 810 540"'
-            'xmlns="http://www.w3.org/2000/svg">',
-            "<style>",
-            "    path {",
-            "        fill: var(--text-color);",
-            "        stroke: var(--text-color);",
-            "    }",
-            "</style>",
-            svg,
-            "</svg>",
-        ]
-    )
-
-
 def reference_converter(value: PathLike | xr.Dataset | None) -> xr.Dataset | None:
     """
     A converter for handling the reference data attribute.
@@ -198,11 +154,11 @@ def reference_converter(value: PathLike | xr.Dataset | None) -> xr.Dataset | Non
         return value
 
     if isinstance(value, (str, os.PathLike, bytes)):
-        logger.info(f'Looking up "{str(value)}" on disk', also_console=True)
+        report_logger.info(f'Looking up "{str(value)}" on disk')
         from .. import fresolver
 
         fname = fresolver.resolve(value)
-        logger.info(f"Resolved path: {fname}", also_console=True)
+        report_logger.info(f"Resolved path: {fname}")
 
         if not fname.exists():
             return None
@@ -287,14 +243,24 @@ class RegressionTest(ABC):
         init_type="bool",
     )
 
+    logger: ReportLogger = documented(
+        attrs.field(kw_only=True, default=report_logger, repr=False, eq=False),
+        doc="Logger used to send messages and HTML fragments to the test report. "
+        "Note that the ``reference`` field converter always reports through "
+        "the default logger, since it runs before the instance exists.",
+        type=":class:`.ReportLogger`",
+        init_type=":class:`.ReportLogger`, optional",
+        default=":data:`.report_logger`",
+    )
+
     def __attrs_pre_init__(self):
         if self.METRIC_NAME is None:
             raise TypeError(f"Unsupported test type {type(self).__name__}")
 
     def __attrs_post_init__(self):
         if self.plot:
-            if (
-                "w" in self.reference[self.variable]
+            if self.reference is not None and (
+                "w" in self.reference[self.variable].dims
                 and self.reference[self.variable].w.size > 1
             ):
                 raise ValueError(
@@ -303,7 +269,7 @@ class RegressionTest(ABC):
                     "Please disable the 'plot' option."
                 )
             if (
-                "w" in self.value[self.variable]
+                "w" in self.value[self.variable].dims
                 and self.value[self.variable].w.size > 1
             ):
                 raise ValueError(
@@ -326,7 +292,7 @@ class RegressionTest(ABC):
             Result of the test criterion comparison.
         """
 
-        logger.info(f"Regression test {self.name} results:", also_console=True)
+        self.logger.info(f"Regression test {self.name} results:")
 
         fname = self.name
         ext = ".nc"
@@ -338,10 +304,9 @@ class RegressionTest(ABC):
         # if no valid reference is found, store the results as new ref and fail
         # the test
         if not self.reference:
-            logger.info(
+            self.logger.info(
                 "No reference data found. Storing test results to "
-                f"{fname_reference}. This can be the new reference.",
-                also_console=True,
+                f"{fname_reference}. This can be the new reference."
             )
             self._archive(self.value, fname_reference)
             self._plot(metric_value=None, noref=True)
@@ -358,23 +323,17 @@ class RegressionTest(ABC):
                     f"Variable: {self.variable}",
                 ]
             )
-            logger.info(msg, also_console=True)
+            self.logger.info(msg)
 
         except Exception as e:
-            logger.info(
-                "An exception occurred during test evaluation!", also_console=True
-            )
+            self.logger.info("An exception occurred during test evaluation!")
             self._plot(noref=False, metric_value=None)
             raise e
 
         # we got a metric: report the results in the archive directory
-        logger.info(
-            f"Saving current output dataset to {fname_result}", also_console=True
-        )
+        self.logger.info(f"Saving current output dataset to {fname_result}")
         self._archive(self.value, fname_result)
-        logger.info(
-            f"Saving reference dataset locally to {fname_reference}", also_console=True
-        )
+        self.logger.info(f"Saving reference dataset locally to {fname_reference}")
         self._archive(self.reference, fname_reference)
         self._plot(noref=False, metric_value=metric_value)
 
@@ -441,8 +400,8 @@ class RegressionTest(ABC):
             figure, _ = self._plot_ref(metric_value)
 
         html_svg = figure_to_html(figure)
-        logger.info(html_svg, html=True, also_console=False)
-        logger.info(f"Saving PNG report chart to {fname_plot}", also_console=True)
+        self.logger.html(html_svg)
+        self.logger.info(f"Saving PNG report chart to {fname_plot}")
 
         plt.savefig(fname_plot)
         plt.close()
@@ -492,7 +451,7 @@ class RegressionTest(ABC):
         Create an additional plot to display more technical information about
         the test metrics and decision process. The diagnostic plot can help the
         user debug a failing test, or to assess the test power and significance.
-        This plot is output directly to the robotframework report.
+        This plot is output directly to the test report.
 
         Parameters:
         -----------
@@ -628,7 +587,7 @@ class AbstractStudentTTest(RegressionTest):
         chart = figure_to_html(fig)
         plt.close(fig)
 
-        logger.info(chart, html=True)
+        self.logger.html(chart)
 
 
 @define
@@ -701,12 +660,12 @@ class IndependentStudentTTest(AbstractStudentTTest):
         if diagnostic_chart:
             self._plot_diagnostic(dof=dof, t_prim=t_prim)
 
-        logger.info(f"bias    = {bias_mean}", also_console=True)
-        logger.info(f"s_p     = {s_p}", also_console=True)
-        logger.info(f"t'      = {t_prim}", also_console=True)
-        logger.info(f"dof     = {dof}", also_console=True)
-        logger.info(f"p-value = {p_value}", also_console=True)
-        logger.info(f"alpha   = {self.threshold}", also_console=True)
+        self.logger.info(f"bias    = {bias_mean}")
+        self.logger.info(f"s_p     = {s_p}")
+        self.logger.info(f"t'      = {t_prim}")
+        self.logger.info(f"dof     = {dof}")
+        self.logger.info(f"p-value = {p_value}")
+        self.logger.info(f"alpha   = {self.threshold}")
 
         return passed, p_value
 
@@ -787,12 +746,12 @@ class PairedStudentTTest(AbstractStudentTTest):
         if diagnostic_chart:
             self._plot_diagnostic(dof=dof, t_prim=t_prim)
 
-        logger.info(f"bias     = {D_mean}", also_console=True)
-        logger.info(f"var mean = {var_D_mean}", also_console=True)
-        logger.info(f"t'       = {t_prim}", also_console=True)
-        logger.info(f"dof      = {dof}", also_console=True)
-        logger.info(f"p-value  = {p_value}", also_console=True)
-        logger.info(f"alpha    = {self.threshold}", also_console=True)
+        self.logger.info(f"bias     = {D_mean}")
+        self.logger.info(f"var mean = {var_D_mean}")
+        self.logger.info(f"t'       = {t_prim}")
+        self.logger.info(f"dof      = {dof}")
+        self.logger.info(f"p-value  = {p_value}")
+        self.logger.info(f"alpha    = {self.threshold}")
 
         return passed, p_value
 
@@ -847,7 +806,7 @@ class ZTest(RegressionTest):
         chart = figure_to_html(fig)
         plt.close(fig)
 
-        logger.info(chart, html=True)
+        self.logger.html(chart)
 
     def _evaluate(self, diagnostic_chart=False) -> tuple[bool, float]:
         variable_var = self.variable + "_var"
@@ -881,14 +840,13 @@ class ZTest(RegressionTest):
         if diagnostic_chart:
             self._plot_diagnostic(z=z)
 
-        logger.info(f"min p-value = {min(p_values)}", also_console=True)
-        logger.info(f"max p-value = {max(p_values)}", also_console=True)
-        logger.info(
-            f"n passed    = {np.count_nonzero(accept_null)}/{int(0.9975 * result_np.size)}",
-            also_console=True,
+        self.logger.info(f"min p-value = {min(p_values)}")
+        self.logger.info(f"max p-value = {max(p_values)}")
+        self.logger.info(
+            f"n passed    = {np.count_nonzero(accept_null)}/{int(0.9975 * result_np.size)}"
         )
-        logger.info(f"alpha_1     = {self.threshold}", also_console=True)
-        logger.info(f"alpha_0     = {alpha_0}", also_console=True)
+        self.logger.info(f"alpha_1     = {self.threshold}")
+        self.logger.info(f"alpha_0     = {alpha_0}")
 
         return passed, min(p_values)
 
@@ -939,6 +897,9 @@ class SidakTTest(RegressionTest):
             T-statistic for each pair of measurements
         """
 
+        if not self.plot:
+            return
+
         fig, ax = plt.subplots()
         ax.grid()
         ax2 = ax.twinx()
@@ -959,7 +920,7 @@ class SidakTTest(RegressionTest):
         chart = figure_to_html(fig)
         plt.close(fig)
 
-        logger.info(chart, html=True)
+        self.logger.html(chart)
 
     def _evaluate(self, diagnostic_chart=False) -> tuple[bool, float]:
         variable_var = self.variable + "_var"
@@ -999,13 +960,12 @@ class SidakTTest(RegressionTest):
         if diagnostic_chart:
             self._plot_diagnostic(t_prim=t_prim)
 
-        logger.info(f"min p-value = {min(p_values)}", also_console=True)
-        logger.info(f"max p-value = {max(p_values)}", also_console=True)
-        logger.info(
-            f"n passed    = {np.count_nonzero(accept_null)}/{int(0.9975 * result_np.size)}",
-            also_console=True,
+        self.logger.info(f"min p-value = {min(p_values)}")
+        self.logger.info(f"max p-value = {max(p_values)}")
+        self.logger.info(
+            f"n passed    = {np.count_nonzero(accept_null)}/{int(0.9975 * result_np.size)}"
         )
-        logger.info(f"alpha_1     = {self.threshold}", also_console=True)
-        logger.info(f"alpha_0     = {alpha_0}", also_console=True)
+        self.logger.info(f"alpha_1     = {self.threshold}")
+        self.logger.info(f"alpha_0     = {alpha_0}")
 
         return passed, min(p_values)

--- a/src/eradiate/test_tools/report.py
+++ b/src/eradiate/test_tools/report.py
@@ -1,0 +1,134 @@
+"""
+Test report logging.
+
+This module provides an abstraction layer that routes logging messages to
+reporting infrastructure if available, and falls back to standard logging
+otherwise.
+
+The current reporting backend is Robot Framework. These components make it
+possible to change it in the future.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+from io import StringIO
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import matplotlib.pyplot as plt
+
+_logger = logging.getLogger(__name__)
+
+
+def figure_to_html(fig: plt.Figure) -> str:
+    """
+    Render a figure in HTML format
+
+    Returns a string containing the rendered HTML. The root tag is a <svg> one.
+
+    Parameters
+    ----------
+    fig : plt.Figure
+        Matplotlib figure to render in HTML.
+
+    Returns
+    -------
+    str
+        Rendered HTML <svg> tag with styling.
+    """
+
+    str_i = StringIO()
+    fig.savefig(str_i, format="svg", transparent=True, bbox_inches="tight")
+    fig.canvas.draw_idle()
+    svg = str_i.getvalue()
+
+    # Include some CSS in the SVG to render nicely in the test report's dark
+    # and light modes
+    return "\n".join(
+        [
+            "<svg",
+            'version="1.1"',
+            'baseProfile="full"',
+            'width="810" height="540" viewBox="0 0 810 540"',
+            'xmlns="http://www.w3.org/2000/svg">',
+            "<style>",
+            "    path {",
+            "        fill: var(--text-color);",
+            "        stroke: var(--text-color);",
+            "    }",
+            "</style>",
+            svg,
+            "</svg>",
+        ]
+    )
+
+
+class ReportLogger:
+    """
+    Send messages and HTML fragments to the active test report.
+
+    Parameters
+    ----------
+    use_robot : bool, optional
+        If ``True``, forward messages to the Robot Framework logger; if
+        ``False``, fall back to standard :mod:`logging`. If unset, the Robot
+        Framework backend is selected iff the :mod:`robot` package is
+        importable.
+
+    Notes
+    -----
+    The Robot Framework logger is safe to call outside of a Robot run (messages
+    are then simply not recorded), so backend selection only depends on package
+    availability, not on whether report generation is active.
+    """
+
+    def __init__(self, use_robot: bool | None = None):
+        if use_robot is None:
+            use_robot = importlib.util.find_spec("robot") is not None
+
+        # Any object with a robot.api.logger-compatible info() method works
+        self._robot: Any = None
+
+        if use_robot:
+            from robot.api import logger as robot_logger
+
+            self._robot = robot_logger
+
+    def info(self, msg: str) -> None:
+        """
+        Log an informational message to the test report and the console.
+
+        Parameters
+        ----------
+        msg : str
+            Message to log.
+        """
+        if self._robot is not None:
+            self._robot.info(msg, also_console=True)
+        else:
+            _logger.info(msg)
+
+    def html(self, fragment: str) -> None:
+        """
+        Embed an HTML fragment in the test report.
+
+        Parameters
+        ----------
+        fragment : str
+            HTML fragment to embed (e.g. an ``<svg>`` chart or an xarray HTML
+            repr).
+
+        Notes
+        -----
+        If no report backend is active, the fragment is discarded.
+        """
+        if self._robot is not None:
+            self._robot.info(fragment, html=True, also_console=False)
+        else:
+            _logger.debug("Discarding HTML report fragment (no report backend)")
+
+
+#: Default report logger instance, used when no specific instance is injected.
+report_logger = ReportLogger()

--- a/tests/01_unit/test_tools/test_regression.py
+++ b/tests/01_unit/test_tools/test_regression.py
@@ -2,37 +2,32 @@ import numpy as np
 import pytest
 import xarray as xr
 
-import eradiate.test_tools.regression as tt
-
-
-@pytest.mark.parametrize(
-    "cls, name",
-    [
-        (tt.RMSETest, "rmse"),
-        (tt.Chi2Test, "chi2"),
-        (tt.IndependentStudentTTest, "independent_t-test"),
-        (tt.PairedStudentTTest, "paired_t-test"),
-        (tt.ZTest, "z-test"),
-    ],
-    ids=["rmse", "chi2", "independent_t-test", "paired_t-test", "z-test"],
+from eradiate.test_tools.regression import (
+    Chi2Test,
+    IndependentStudentTTest,
+    PairedStudentTTest,
+    RMSETest,
+    ZTest,
 )
-def test_instantiate(cls, name):
-    # instantiate the test with reasonable defaults
-    assert cls(
-        name=name,
-        archive_dir="tests/",
-        value=xr.Dataset(),
-        reference=xr.Dataset(),
-        threshold=0.05,
-        plot=False,
+from eradiate.test_tools.report import ReportLogger
+
+
+class TestRegression:
+    @pytest.mark.parametrize(
+        "cls, name",
+        [
+            (RMSETest, "rmse"),
+            (Chi2Test, "chi2"),
+            (IndependentStudentTTest, "independent_t-test"),
+            (PairedStudentTTest, "paired_t-test"),
+            (ZTest, "z-test"),
+        ],
+        ids=["rmse", "chi2", "independent_t-test", "paired_t-test", "z-test"],
     )
-
-
-def test_instantiate_fail():
-    # assert all arguments except reference are needed
-    # only one subclass of RegressionTest (Chi2Test) is tested
-    with pytest.raises(TypeError):
-        assert tt.Chi2Test(
+    def test_instantiate(self, cls, name):
+        # instantiate the test with reasonable defaults
+        assert cls(
+            name=name,
             archive_dir="tests/",
             value=xr.Dataset(),
             reference=xr.Dataset(),
@@ -40,178 +35,303 @@ def test_instantiate_fail():
             plot=False,
         )
 
-    with pytest.raises(TypeError):
-        tt.Chi2Test(
-            name="chi2",
-            value=xr.Dataset(),
-            reference=xr.Dataset(),
-            threshold=0.05,
-            plot=False,
-        )
-
-    with pytest.raises(TypeError):
-        tt.Chi2Test(
-            name="chi2",
-            archive_dir="tests/",
-            reference=xr.Dataset(),
-            threshold=0.05,
-            plot=False,
-        )
-
-    with pytest.raises(TypeError):
-        tt.Chi2Test(
-            name="chi2",
-            archive_dir="tests/",
-            value=xr.Dataset(),
-            reference=xr.Dataset(),
-            plot=False,
-        )
-
-    assert tt.Chi2Test(
-        name="chi2",
-        archive_dir="tests/",
-        value=xr.Dataset(),
-        threshold=0.05,
-        plot=False,
+    @pytest.mark.parametrize(
+        "missing",
+        ["none", "name", "archive_dir", "value", "threshold", "plot"],
     )
-
-
-def test_reference_converter(tmp_path):
-    # test proper handling of missing and unreadable reference
-
-    # file does not exist
-    assert (
-        tt.Chi2Test(
-            name="chi2",
-            archive_dir="tests/",
-            value=xr.Dataset(),
-            threshold=0.05,
-            reference="./this/file/doesnot.exist",
-            plot=False,
-        ).reference
-        is None
-    )
-
-    # wrong file type
-    with pytest.raises(
-        ValueError,
-        match="did not find a match in any of xarray's currently installed IO backends",
-    ):
-        tempfile = tmp_path / "hello.txt"
-        tempfile.write_text("test")
-
-        tt.Chi2Test(
-            name="chi2",
-            archive_dir="tests/",
-            value=xr.Dataset(),
-            threshold=0.05,
-            reference=tempfile,
-            plot=False,
-        )
-
-    # wrong data type
-    with pytest.raises(ValueError, match="Reference must be provided as a Dataset"):
-        tt.Chi2Test(
-            name="chi2",
-            archive_dir="tests/",
-            value=xr.Dataset(),
-            threshold=0.05,
-            reference=np.zeros(25),
-            plot=False,
-        )
-
-
-def test_rmse_evaluate():
-    # test the computation of the RMSE value from given data.
-    # we give the dataset some wrong data fields to ensure the right
-    # data is used
-
-    result = np.random.rand(50)
-    ref = np.random.rand(50)
-
-    result_da = xr.DataArray(result)
-    ref_da = xr.DataArray(ref)
-
-    result_ds = xr.Dataset(
-        data_vars={
-            "brf": result_da,
-            "stuff": result_da * 0.1,
-            "wrong": result_da * 123.0,
+    def test_instantiate_fail(self, missing):
+        # assert all arguments except reference are needed
+        # only one subclass of RegressionTest (Chi2Test) is tested
+        kwargs = {
+            "name": "chi2",
+            "archive_dir": "tests/",
+            "value": xr.Dataset(),
+            "threshold": 0.05,
+            "plot": False,
         }
-    )
-    ref_ds = xr.Dataset(
-        data_vars={"brf": ref_da, "stuff": ref_da * 0.2, "wrong": ref_da * 321.0}
-    )
 
-    rmse_ref = np.linalg.norm(result - ref) / np.sqrt(len(ref))
+        if missing in kwargs:
+            kwargs.pop(missing)
+            with pytest.raises(TypeError):
+                Chi2Test(**kwargs)
 
-    test = tt.RMSETest(
-        name="rmse",
-        value=result_ds,
-        reference=ref_ds,
-        variable="brf",
-        archive_dir="tests/",
-        threshold=0.05,
-        plot=False,
-    )
+        else:
+            Chi2Test(**kwargs)
 
-    _, rmse = test._evaluate()
+    def test_reference_converter(self, tmp_path):
+        # test proper handling of missing and unreadable reference
 
-    assert rmse == rmse_ref
+        # file does not exist
+        assert (
+            Chi2Test(
+                name="chi2",
+                archive_dir="tests/",
+                value=xr.Dataset(),
+                threshold=0.05,
+                reference="./this/file/doesnot.exist",
+                plot=False,
+            ).reference
+            is None
+        )
+
+        # wrong file type
+        with pytest.raises(
+            ValueError,
+            match="did not find a match in any of xarray's currently installed IO backends",
+        ):
+            tempfile = tmp_path / "hello.txt"
+            tempfile.write_text("test")
+
+            Chi2Test(
+                name="chi2",
+                archive_dir="tests/",
+                value=xr.Dataset(),
+                threshold=0.05,
+                reference=tempfile,
+                plot=False,
+            )
+
+        # wrong data type
+        with pytest.raises(ValueError, match="Reference must be provided as a Dataset"):
+            Chi2Test(
+                name="chi2",
+                archive_dir="tests/",
+                value=xr.Dataset(),
+                threshold=0.05,
+                reference=np.zeros(25),
+                plot=False,
+            )
 
 
-def test_chi2_evaluate(mode_mono):
-    # test the computation of the Chi squared value from given data.
-    # we give the dataset some wrong data fields to ensure the right
-    # data is used
+class TestEvaluate:
+    def test_rmse(self):
+        # test the computation of the RMSE value from given data.
+        # we give the dataset some wrong data fields to ensure the right
+        # data is used
 
-    import mitsuba as mi
+        result = np.random.rand(50)
+        ref = np.random.rand(50)
 
-    result_np = np.random.rand(50)
-    ref_np = np.random.rand(50)
+        result_da = xr.DataArray(result)
+        ref_da = xr.DataArray(ref)
 
-    histo_bins = np.linspace(ref_np.min(), ref_np.max(), 20)
-    histo_ref = np.histogram(ref_np, histo_bins)[0]
-    histo_res = np.histogram(result_np, histo_bins)[0]
+        result_ds = xr.Dataset(
+            data_vars={
+                "brf": result_da,
+                "stuff": result_da * 0.1,
+                "wrong": result_da * 123.0,
+            }
+        )
+        ref_ds = xr.Dataset(
+            data_vars={"brf": ref_da, "stuff": ref_da * 0.2, "wrong": ref_da * 321.0}
+        )
 
-    # sorting both histograms following the ascending frequencies in
-    # the reference. Algorithm from:
-    # https://stackoverflow.com/questions/9764298/how-to-sort-two-lists-which-reference-each-other-in-the-exact-same-way
-    histo_ref_sorted, histo_res_sorted = zip(
-        *sorted(zip(histo_ref, histo_res), key=lambda x: x[0])
-    )
+        rmse_ref = np.linalg.norm(result - ref) / np.sqrt(len(ref))
 
-    from mitsuba.math_py import rlgamma
+        test = RMSETest(
+            name="rmse",
+            value=result_ds,
+            reference=ref_ds,
+            variable="brf",
+            archive_dir="tests/",
+            threshold=0.05,
+            plot=False,
+        )
 
-    chi2val, dof, pooled_in, pooled_out = mi.math.chi2(
-        histo_res_sorted, histo_ref_sorted, 5
-    )
-    p_value_ref = 1.0 - rlgamma(dof / 2.0, chi2val / 2.0)
+        _, rmse = test._evaluate()
 
-    result_da = xr.DataArray(result_np)
-    ref_da = xr.DataArray(ref_np)
+        assert rmse == rmse_ref
 
-    result_ds = xr.Dataset(
-        data_vars={
-            "brf": result_da,
-            "stuff": result_da * 0.1,
-            "wrong": result_da * 123.0,
-        }
-    )
-    ref_ds = xr.Dataset(
-        data_vars={"brf": ref_da, "stuff": ref_da * 0.2, "wrong": ref_da * 321.0}
-    )
+    def test_chi2(self, mode_mono):
+        # test the computation of the Chi squared value from given data.
+        # we give the dataset some wrong data fields to ensure the right
+        # data is used
 
-    test = tt.Chi2Test(
-        name="chi2",
-        value=result_ds,
-        reference=ref_ds,
-        variable="brf",
-        archive_dir="tests/",
-        threshold=0.05,
-        plot=False,
-    )
+        import mitsuba as mi
 
-    _, p_value = test._evaluate()
+        result_np = np.random.rand(50)
+        ref_np = np.random.rand(50)
 
-    assert p_value == p_value_ref
+        histo_bins = np.linspace(ref_np.min(), ref_np.max(), 20)
+        histo_ref = np.histogram(ref_np, histo_bins)[0]
+        histo_res = np.histogram(result_np, histo_bins)[0]
+
+        # sorting both histograms following the ascending frequencies in
+        # the reference. Algorithm from:
+        # https://stackoverflow.com/questions/9764298/how-to-sort-two-lists-which-reference-each-other-in-the-exact-same-way
+        histo_ref_sorted, histo_res_sorted = zip(
+            *sorted(zip(histo_ref, histo_res), key=lambda x: x[0])
+        )
+
+        from mitsuba.math_py import rlgamma
+
+        chi2val, dof, pooled_in, pooled_out = mi.math.chi2(
+            histo_res_sorted, histo_ref_sorted, 5
+        )
+        p_value_ref = 1.0 - rlgamma(dof / 2.0, chi2val / 2.0)
+
+        result_da = xr.DataArray(result_np)
+        ref_da = xr.DataArray(ref_np)
+
+        result_ds = xr.Dataset(
+            data_vars={
+                "brf": result_da,
+                "stuff": result_da * 0.1,
+                "wrong": result_da * 123.0,
+            }
+        )
+        ref_ds = xr.Dataset(
+            data_vars={"brf": ref_da, "stuff": ref_da * 0.2, "wrong": ref_da * 321.0}
+        )
+
+        test = Chi2Test(
+            name="chi2",
+            value=result_ds,
+            reference=ref_ds,
+            variable="brf",
+            archive_dir="tests/",
+            threshold=0.05,
+            plot=False,
+        )
+
+        _, p_value = test._evaluate()
+
+        assert p_value == p_value_ref
+
+
+class TestRegressionReport:
+    """
+    These tests check reporting infrastructure integration in the regression
+    testing components.
+    """
+
+    class ReportLoggerSpy(ReportLogger):
+        """
+        Report logger that records messages and HTML fragments for assertions
+        while forwarding them to the active report backend. Content sent
+        through this spy therefore shows up in the generated test report and
+        can be inspected visually.
+        """
+
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.messages = []
+            self.fragments = []
+
+        def info(self, msg):
+            self.messages.append(msg)
+            super().info(msg)
+
+        def html(self, fragment):
+            self.fragments.append(fragment)
+            super().html(fragment)
+
+    @pytest.fixture
+    def spy(self):
+        return self.ReportLoggerSpy()
+
+    @staticmethod
+    def make_dataset(values, vza):
+        return xr.Dataset(
+            {"brf": ("vza", values)},
+            coords={"vza": ("vza", vza)},
+        )
+
+    @pytest.fixture
+    def datasets(self):
+        vza = np.linspace(-75.0, 75.0, 11)
+        ref = np.linspace(0.1, 0.2, 11)
+        result = ref + 1e-3
+        return self.make_dataset(result, vza), self.make_dataset(ref, vza)
+
+    def test_messages(self, tmp_path, datasets, spy):
+        """
+        A regression test sends its diagnostic messages to the injected
+        report logger and archives result and reference datasets.
+        """
+        result, ref = datasets
+
+        test = RMSETest(
+            name="rmse-pass",
+            value=result,
+            reference=ref,
+            variable="brf",
+            threshold=1.0,
+            archive_dir=tmp_path,
+            plot=False,
+            logger=spy,
+        )
+
+        assert test.run()
+        assert any("Metric value: rmse" in msg for msg in spy.messages)
+        assert not spy.fragments  # No plot requested
+        assert (tmp_path / "rmse-pass-result.nc").exists()
+        assert (tmp_path / "rmse-pass-ref.nc").exists()
+
+    def test_failure(self, tmp_path, datasets, spy):
+        """
+        A failing regression test reports through the same channel.
+        """
+        result, ref = datasets
+
+        test = RMSETest(
+            name="rmse-fail",
+            value=result,
+            reference=ref,
+            variable="brf",
+            threshold=0.0,
+            archive_dir=tmp_path,
+            plot=False,
+            logger=spy,
+        )
+
+        assert not test.run()
+        assert any("Test did not pass" in msg for msg in spy.messages)
+
+    def test_plot(self, tmp_path, datasets, spy):
+        """
+        With plotting enabled, the comparison chart is embedded in the report
+        as an SVG fragment and saved to the archive directory as a PNG file
+        """
+        result, ref = datasets
+
+        test = RMSETest(
+            name="rmse-plot",
+            value=result,
+            reference=ref,
+            variable="brf",
+            threshold=1.0,
+            archive_dir=tmp_path,
+            plot=True,
+            logger=spy,
+        )
+
+        assert test.run()
+        assert len(spy.fragments) == 1
+        assert spy.fragments[0].startswith("<svg")
+        assert (tmp_path / "rmse-plot.png").exists()
+
+    def test_noref(self, tmp_path, datasets, spy):
+        """
+        Without reference data, the test fails, stores the result as a new
+        reference candidate, says so in the report and embeds a plot of the
+        reference candidate
+        """
+        result, _ = datasets
+
+        test = RMSETest(
+            name="rmse-noref",
+            value=result,
+            reference=None,
+            variable="brf",
+            threshold=1.0,
+            archive_dir=tmp_path,
+            plot=True,
+            logger=spy,
+        )
+
+        assert not test.run()
+        assert any("No reference data found" in msg for msg in spy.messages)
+        assert (tmp_path / "rmse-noref-ref.nc").exists()
+        assert len(spy.fragments) == 1
+        assert spy.fragments[0].startswith("<svg")

--- a/tests/01_unit/test_tools/test_report.py
+++ b/tests/01_unit/test_tools/test_report.py
@@ -1,0 +1,95 @@
+"""
+Tests for the test report logging system.
+"""
+
+import logging
+
+import matplotlib.pyplot as plt
+import pytest
+
+from eradiate.test_tools.report import ReportLogger, figure_to_html, report_logger
+
+
+def test_figure_to_html():
+    """
+    The HTML rendering of a figure is a self-contained <svg> fragment with
+    theme-aware styling.
+    """
+    fig, _ = plt.subplots()
+    html = figure_to_html(fig)
+    plt.close(fig)
+
+    assert html.startswith("<svg")
+    assert html.rstrip().endswith("</svg>")
+    assert "var(--text-color)" in html
+    # Attributes of the wrapping <svg> tag must be separated
+    assert 'viewBox="0 0 810 540"\nxmlns="http://www.w3.org/2000/svg">' in html
+
+
+class TestReportLogger:
+    """
+    Test report infrastructure tests.
+    """
+
+    class RobotLoggerStub:
+        """
+        Robot Framework logger stand-in that records calls.
+        """
+
+        def __init__(self):
+            self.calls = []
+
+        def info(self, msg, **kwargs):
+            self.calls.append((msg, kwargs))
+
+    def test_logging_fallback(self, caplog):
+        """
+        Without the Robot backend, messages go to standard logging and HTML
+        fragments are discarded silently.
+        """
+        logger = ReportLogger(use_robot=False)
+
+        with caplog.at_level(logging.INFO, logger="eradiate.test_tools.report"):
+            logger.info("hello report")
+            logger.html("<svg></svg>")
+
+        assert "hello report" in caplog.text
+        assert "<svg></svg>" not in caplog.text
+
+    def test_robot_delegation(self):
+        """
+        With the Robot backend, messages and HTML fragments are forwarded to
+        the Robot logger with the expected flags.
+        """
+        pytest.importorskip("robot")
+
+        # Exercise the Robot backend selection, then substitute a stub to
+        # capture the forwarded calls
+        logger = ReportLogger(use_robot=True)
+        assert logger._robot is not None
+        logger._robot = stub = self.RobotLoggerStub()
+
+        logger.info("message")
+        logger.html("<b>fragment</b>")
+
+        assert stub.calls == [
+            ("message", {"also_console": True}),
+            ("<b>fragment</b>", {"html": True, "also_console": False}),
+        ]
+
+    def test_smoke(self):
+        """
+        Send a message and a chart through the default report logger. This test
+        always passes: its purpose is to leave one known entry in the generated
+        test report (e.g. ``reports/log.html``) so that the reporting pipeline
+        can be checked end-to-end by visual inspection. Without an active report
+        backend, both calls are no-ops.
+        """
+        fig, ax = plt.subplots()
+        ax.plot([0.0, 1.0], [0.0, 1.0])
+
+        report_logger.info(
+            "Report smoke test: this message should appear in the test report"
+        )
+        report_logger.html(figure_to_html(fig))
+        plt.close(fig)

--- a/tests/02_system/test_atmosphere_rpv.py
+++ b/tests/02_system/test_atmosphere_rpv.py
@@ -6,10 +6,10 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 import xarray as xr
-from robot.api import logger
 
 import eradiate
 from eradiate import unit_registry as ureg
+from eradiate.test_tools.report import report_logger
 
 
 @pytest.mark.parametrize("illumination_azimuth", [0.0, 30.0, 120.0, 210.0, 300.0])
@@ -683,7 +683,7 @@ def test_rpv_vs_lambertian(
         )
         ax.set_title(title)
 
-        logger.info(f"Saving figure to {fname_plot}", also_console=True)
+        report_logger.info(f"Saving figure to {fname_plot}")
         fig.savefig(fname_plot, dpi=200, bbox_inches="tight")
         plt.close()
 

--- a/tests/03_regression/atmospheres/test_rpv_afgl1986_continental.py
+++ b/tests/03_regression/atmospheres/test_rpv_afgl1986_continental.py
@@ -1,8 +1,8 @@
 import pytest
-from robot.api import logger
 
 import eradiate
 from eradiate.test_tools.regression import ZTest
+from eradiate.test_tools.report import report_logger
 from eradiate.test_tools.test_cases.atmospheres import (
     create_rpv_afgl1986_continental_brfpp,
 )
@@ -28,7 +28,7 @@ def test_rpv_afgl1986_continental_brfpp(
     0.05.
     """
     result = eradiate.run(exp, spp=10000)
-    logger.info(result._repr_html_(), html=True)
+    report_logger.html(result._repr_html_())
 
     test = ZTest(
         name=f"{session_timestamp:%Y%m%d-%H%M%S}-rpv_afgl1986_continental.nc",

--- a/tests/03_regression/integrators/test_eovolpath_canopy.py
+++ b/tests/03_regression/integrators/test_eovolpath_canopy.py
@@ -1,7 +1,6 @@
-from robot.api import logger
-
 import eradiate
 from eradiate.test_tools.regression import ZTest, reference_converter
+from eradiate.test_tools.report import report_logger
 from eradiate.test_tools.test_cases.integrators import (
     create_eovolpath_canopy,
     create_volpath_canopy,
@@ -38,7 +37,7 @@ def test_eovolpath_canopy(
         spp = int(1e4)
 
     result = eradiate.run(exp, spp=spp)
-    logger.info(result._repr_html_(), html=True)
+    report_logger.html(result._repr_html_())
 
     test = ZTest(
         name=f"{session_timestamp:%Y%m%d-%H%M%S}-eovolpath_canopy.nc",

--- a/tests/03_regression/integrators/test_eovolpath_surface.py
+++ b/tests/03_regression/integrators/test_eovolpath_surface.py
@@ -1,7 +1,6 @@
-from robot.api import logger
-
 import eradiate
 from eradiate.test_tools.regression import ZTest, reference_converter
+from eradiate.test_tools.report import report_logger
 from eradiate.test_tools.test_cases.integrators import (
     create_eovolpath_surface,
     create_volpath_surface,
@@ -38,7 +37,7 @@ def test_eovolpath_surface(
         spp = int(1e4)
 
     result = eradiate.run(exp, spp=spp)
-    logger.info(result._repr_html_(), html=True)
+    report_logger.html(result._repr_html_())
 
     test = ZTest(
         name=f"{session_timestamp:%Y%m%d-%H%M%S}-eovolpath_surface.nc",

--- a/tests/03_regression/rami4atm/test_rami4atm_benchmark.py
+++ b/tests/03_regression/rami4atm/test_rami4atm_benchmark.py
@@ -1,10 +1,10 @@
 import numpy as np
 import pytest
-from robot.api import logger
 
 import eradiate
 from eradiate import fresolver
 from eradiate.test_tools.regression import SidakTTest
+from eradiate.test_tools.report import report_logger
 from eradiate.test_tools.test_cases import rami4atm
 
 cases = [c for c in rami4atm.registry if c != "hom00_bla_a00s_m04_z30a000_brfpp"]
@@ -30,7 +30,7 @@ def test_rami4atm_hom00_bla_a00s_m04_z30a000_brfpp(mode_ckd_double, artefact_dir
     _, (exp,) = rami4atm.create_rami4atm_toa("hom00_bla_a00s_m04_z30a000_brfpp", 1000)
 
     result = eradiate.run(exp)
-    logger.info(result._repr_html_(), html=True)
+    report_logger.html(result._repr_html_())
     assert np.allclose(result.brf_srf, 0.0)
 
 
@@ -54,15 +54,15 @@ def test_rami4atm(mode_ckd_double, case, artefact_dir):
     raw_results = [eradiate.run(exp) for exp in exps]
 
     result = postprocess(raw_results, srf)
-    logger.info(result._repr_html_(), html=True)
+    report_logger.html(result._repr_html_())
 
     reference = fresolver.load_dataset(
         f"tests/regression_test_references/rami4atm/{case}-ref.nc"
     )
-    logger.info(reference._repr_html_(), html=True)
+    report_logger.html(reference._repr_html_())
 
     for variable in variables:
-        logger.info(f"Testing {variable}")
+        report_logger.info(f"Testing {variable}")
 
         test = test_ctor(
             name=case,

--- a/tests/03_regression/romc/test_het01.py
+++ b/tests/03_regression/romc/test_het01.py
@@ -1,8 +1,8 @@
 import pytest
-from robot.api import logger
 
 import eradiate
 from eradiate.test_tools.regression import ZTest
+from eradiate.test_tools.report import report_logger
 from eradiate.test_tools.test_cases.romc import create_het01_brfpp
 from eradiate.test_tools.util import append_doc
 
@@ -26,7 +26,7 @@ def test_het01_brfpp(
     """
     result = eradiate.run(exp)
 
-    logger.info(result._repr_html_(), html=True)
+    report_logger.html(result._repr_html_())
 
     test = ZTest(
         name=f"{session_timestamp:%Y%m%d-%H%M%S}-het01.nc",

--- a/tests/03_regression/romc/test_het04.py
+++ b/tests/03_regression/romc/test_het04.py
@@ -1,8 +1,8 @@
 import pytest
-from robot.api import logger
 
 import eradiate
 from eradiate.test_tools.regression import ZTest
+from eradiate.test_tools.report import report_logger
 from eradiate.test_tools.test_cases.romc import create_het04a1_brfpp
 from eradiate.test_tools.util import append_doc
 
@@ -26,8 +26,8 @@ def test_het04a1_brfpp(
     """
     result = eradiate.run(exp)
 
-    logger.info("Result data:")
-    logger.info(result._repr_html_(), html=True)
+    report_logger.info("Result data:")
+    report_logger.html(result._repr_html_())
 
     test = ZTest(
         name=f"{session_timestamp:%Y%m%d-%H%M%S}-het04.nc",

--- a/tests/03_regression/romc/test_het06.py
+++ b/tests/03_regression/romc/test_het06.py
@@ -1,8 +1,8 @@
 import pytest
-from robot.api import logger
 
 import eradiate
 from eradiate.test_tools.regression import ZTest
+from eradiate.test_tools.report import report_logger
 from eradiate.test_tools.test_cases.romc import create_het06_brfpp
 from eradiate.test_tools.util import append_doc
 
@@ -26,7 +26,7 @@ def test_het06_brfpp(
     """
     result = eradiate.run(exp)
 
-    logger.info(result._repr_html_(), html=True)
+    report_logger.html(result._repr_html_())
 
     test = ZTest(
         name=f"{session_timestamp:%Y%m%d-%H%M%S}-het06.nc",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -99,6 +99,21 @@ def pytest_configure(config):
     logging.getLogger("joseki").setLevel(logging.WARNING)
 
 
+# The robotframework plugin is disabled by default (see addopts); optionalhook
+# avoids a validation error when the hook spec is not registered
+@pytest.hookimpl(optionalhook=True)
+def pytest_robot_modify_options(options, session):
+    """
+    Project defaults for Robot Framework report generation. Explicit
+    ``--robot-*`` command-line options take precedence.
+    """
+    if options.get("outputdir", ".") == ".":
+        options["outputdir"] = "reports"
+
+    if not options.get("tagstatinclude"):
+        options["tagstatinclude"] = ["unit", "system", "regression", "slow"]
+
+
 # ------------------------------------------------------------------------------
 #                            Pre-process helpers
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
# Description

Merge after #583.

This PR introduces `eradiate.test_tools.report.ReportLogger`, an abstraction over report message/plot logging that uses Robot's logger when installed and falls back to standard logging otherwise. `RegressionTest` now takes an injectable logger instead of importing `robot.api` directly, and all test files that logged through Robot do the same. 

This opens the door to removing the robotframework dependency and swapping it for different infrastructure for HTML and PDF report generation. This is not foreseen in the short term, but given the relatively precarious maintenance status of the contributed pytest-robotframework project (single maintainer), we better be ready to react if our report code stops working.

Also:

- Set default Robot options (output directory, tag statistics) via the `pytest_robot_modify_options` hook in `tests/conftest.py`, simplifying the pixi report tasks and CI accordingly; report products now go to the `reports/` directory.
- Removed robotframework from the docs dependency group.
- Fixed a `RegressionTest` crash when `plot=True` and `reference` is `None`.
- Added reporting unit tests (also for integration into `RegressionTest` framework).
- Refactored `RegressionTest` unit tests for maintainability (added class scopes).

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
