### PR TITLE
[3DATM 2/7] Add the Ppr-v1 format for spatial variation of particles physical properties

### DIFF
--- a/docs/data/formats/aer.rst
+++ b/docs/data/formats/aer.rst
@@ -122,6 +122,64 @@ Normalization conventions
       * ``imom``
       * ``nmommax``
 
+.. _sec-data-formats-prt_v1:
+
+Prt v1 [``prt_v1``]
+--------------------
+
+Extension of ``aer_core_v2`` for particle properties. This data format
+indexes properties defined by ``aer_core_v2`` on two extra dimensions,
+``reff`` and ``veff``, the mean and variance of the particle size
+distribution, respectively. It shares the same normalization conventions
+as ``aer_core_v2``.
+
+Format
+    ``xarray.Dataset`` (in-memory), NetCDF (storage)
+
+Dimensions
+    * ``w``: radiation wavelength
+    * ``reff``: effective radius of the particles
+    * ``veff``: variance of the particles radii
+    * ``phamat``: nonzero coefficients in the phase matrix
+    * ``iangle``: angular data points
+    * ``imom``: Legendre coefficients for the (1,1) phase matrix component
+
+Coordinates
+    *When relevant, units are required and specified in the "units" metadata field.*
+
+    * ``w(w)``: float [length]: wavelength
+    * ``reff(reff)``: float [length]: effective radius
+    * ``veff(veff)``: float [—]: variance of particles radii
+    * ``phamat(phamat)``: str [—]: row and column indices of the phase matrix coefficient
+      (*e.g.* "11", "12", etc.)
+    * ``theta(w, reff, veff, iangle)``: float [angle]: scattering angle θ; NaN-padded beyond
+      ``nangles[iw, ireff, iveff]``
+    * ``mu(w, reff, veff, iangle)``: float [—]: value of cos θ; NaN-padded beyond 
+      ``nangles[iw, ireff, iveff]``
+
+Data variables
+    *When relevant, units are required and specified in the "units" metadata field.*
+
+    * ``ext(w, reff, veff)`` float [1 / length]: extinction coefficient per unit concentration
+    * ``ssa(w, reff, veff)`` float [—]: single-scattering albedo
+    * ``phase(phamat, w, reff, veff, iangle)`` float [1 / sr]: value of the phase matrix;
+      NaN-padded beyond ``nangles[iw, ireff, iveff]``
+    * ``nangles(w, reff, veff)`` int [—]: number of valid angular samples per wavelength,
+      reff and veff; must be consistent with the NaN padding of ``theta``, ``mu``, and 
+      ``phase``
+    * ``pmom(w, reff, veff, imom)`` float [—], optional: Legendre expansion coefficients
+      of the (1,1) phase matrix element; NaN-padded beyond ``nmom[iw, ireff, iveff]``
+    * ``nmom(w, reff, veff)`` int [—], required if ``pmom`` is present: number of valid
+      Legendre coefficients per wavelength; must be consistent with the NaN
+      padding of ``pmom``
+
+.. note::
+
+    * Data are sorted in ascending order of ``w``, ``reff``, ``veff`` and ``mu``
+    * ``reff`` and ``veff`` are regularly spaced
+    * ``phamat`` conventions (valid values, and their implication for
+      polarization and particle shape) are the same as ``aer_core_v2``
+
 .. _sec-data-formats-aer_v1:
 
 Aer v1 (legacy) [``aer_v1``]

--- a/docs/data/formats/profile.rst
+++ b/docs/data/formats/profile.rst
@@ -1,0 +1,47 @@
+Particle profile (Ppr)
+=======================
+
+.. _sec-data-formats-ppr_v1:
+
+Ppr v1 [``ppr_v1``]
+-------------------
+
+Sparse, per-voxel description of a spatially varying particle field.
+Typically used for clouds. Each entry describes one populated voxel: its
+grid cell indices, the local particle size distribution parameters, and the
+mass concentration used to scale optical properties looked up from a
+:ref:`Prt v1 <sec-data-formats-prt_v1>` dataset.
+
+The grid is described by the ``x_levels``/``y_levels``/``z_levels`` arrays of
+cell edges along each axis. The profile is defined on either a Cartesian
+coordinate system (``x_levels``/``y_levels`` in length units) or a spherical
+geocentric coordinate system (``x_levels``/``y_levels`` in angle units,
+representing azimuth/colatitude).
+
+Format
+    ``xarray.Dataset`` (in-memory), NetCDF (storage)
+
+Dimensions
+    * ``index``: flat, populated-voxel index
+
+Data variables
+    *When relevant, units are required and specified in the "units" metadata field.*
+
+    * ``x_levels`` float, 1-D [length or angle]: grid cell edges along the x
+      axis
+    * ``y_levels`` float, 1-D [length or angle]: grid cell edges along the y
+      axis
+    * ``z_levels`` float, 1-D [length]: grid cell edges along the z
+      (altitude) axis
+    * ``i_x(index)`` int [—]: index of the populated cell along the x axis,
+      0-based
+    * ``i_y(index)`` int [—]: index of the populated cell along the y axis,
+      0-based
+    * ``i_z(index)`` int [—]: index of the populated cell along the z axis,
+      0-based
+    * ``reff(index)`` float [length]: effective radius of the particle size
+      distribution
+    * ``veff(index)`` float [—]: effective variance of the particle size
+      distribution
+    * ``mass_concentration(index)`` float [mass / volume]: particle mass
+      concentration

--- a/docs/release_notes/v1.3.x.md
+++ b/docs/release_notes/v1.3.x.md
@@ -11,6 +11,8 @@
 * {class}`.ParticleProperties` can now load particle radiative property
   datasets in the new `prt_v1` format, which extends `aer_core_v2` with
   `r_eff`/`v_eff` support ({ghpr}`584`).
+* New `ppr_v1` data format for spatially varying particle profiles, like
+  clouds ({ghpr}`585`).
 
 ### Fixed
 

--- a/docs/release_notes/v1.3.x.md
+++ b/docs/release_notes/v1.3.x.md
@@ -8,6 +8,9 @@
   `<var>_srf` whenever variance computation is enabled. This makes
   noise-aware comparisons (*e.g.* {class}`.ZTest`) possible on band-integrated
   quantities ({ghpr}`595`).
+* {class}`.ParticleProperties` can now load particle radiative property
+  datasets in the new `prt_v1` format, which extends `aer_core_v2` with
+  `r_eff`/`v_eff` support ({ghpr}`584`).
 
 ### Fixed
 

--- a/pytest.toml
+++ b/pytest.toml
@@ -14,6 +14,8 @@ filterwarnings = [
   "ignore:.*utcnow.*:DeprecationWarning",
   # Ignore Skyfield ephemeris file handle warnings (expected behaviour)
   "ignore:.*de421.bsp.*:ResourceWarning",
+  # Remove when netCDF4 supports NumPy >= 2.5 (in-place reshape deprecated)
+  "ignore:Setting the shape on a NumPy array.*:DeprecationWarning",
 ]
 markers = ["unit", "system", "regression"]
 testpaths = ["tests"]

--- a/src/eradiate/data/convert.py
+++ b/src/eradiate/data/convert.py
@@ -64,6 +64,8 @@ def make_aer_core_v2(
     ext: pint.Quantity,
     ssa: pint.Quantity,
     phase: pint.Quantity,
+    reff: pint.Quantity | None = None,
+    veff: pint.Quantity | None = None,
     nangles: np.ndarray | None = None,
     pmom: np.ndarray | None = None,
     nmom: int | np.ndarray | None = None,
@@ -73,7 +75,8 @@ def make_aer_core_v2(
     check: Literal["none", "fast", "full"] | None = None,
 ) -> xr.Dataset:
     """
-    Create a new dataset in the Aer-Core v2 format.
+    Create a new dataset in the Aer-Core v2 format, or the Prt v1 format
+    when ``reff``/``veff`` are provided.
 
     Parameters
     ----------
@@ -84,46 +87,53 @@ def make_aer_core_v2(
         Phase matrix component list, shape (nphamat,).
 
     mu : quantity
-        Scattering angle cosine, shape (nw, nangle).
+        Scattering angle cosine, shape (nw, [nreff, nveff, ]nangle).
 
     theta : quantity
-        Scattering angle, shape (nw, nangle).
+        Scattering angle, shape (nw, [nreff, nveff, ]nangle).
 
     ext : quantity
-        Extinction coefficient, shape (nw,).
+        Extinction coefficient, shape (nw, [nreff, nveff]).
 
     ssa : quantity
-        Single-scattering albedo, shape (nw,).
+        Single-scattering albedo, shape (nw, [nreff, nveff]).
 
     phase : quantity
-        Phase matrix values, shape (nphamat, nw, nangle).
+        Phase matrix values, shape (nphamat, nw, [nreff, nveff, ]nangle).
         Integral normalized to 2 (*i.e.* ∫ p(μ) dμ = 2).
 
+    reff, veff : quantity, optional
+        Effective radius and variance grids, shape (nreff,) and (nveff,).
+        When set, the dataset is built in the Prt v1 format: all
+        other arrays gain the corresponding ``reff``/``veff`` dimensions,
+        between ``w`` and the angular/moment dimension. Both must be set
+        together, or neither.
+
     nangles : ndarray, optional
-        Number of valid angular samples per wavelength, shape (nw,), dtype int.
-        When provided, entries at indices ``>= nangles[iw]`` in ``mu``,
-        ``theta``, and ``phase`` must be NaN-padded.  The ``nangles`` dataset
-        variable is always written; if not provided, it is inferred by counting
-        non-NaN entries in the first phase matrix component.
+        Number of valid angular samples, shape (nw, [nreff, nveff]), dtype
+        int. When provided, entries beyond ``nangles`` in ``mu``, ``theta``,
+        and ``phase`` must be NaN-padded. The ``nangles`` dataset variable is
+        always written; if not provided, it is inferred by counting non-NaN
+        entries in the first phase matrix component.
 
     pmom : ndarray, optional
         Legendre polynomials for the (1,1) phase matrix element, shape
-        (nw, nimom).  If not provided, they are computed automatically from
-        ``phase`` and ``theta`` using :func:`.compute_pmom` with
-        ``coefficients=True``.
+        (nw, [nreff, nveff, ]nimom). If not provided, they are computed
+        automatically from ``phase`` and ``theta`` using
+        :func:`.compute_pmom` with ``coefficients=True``.
 
     nmom : int or ndarray, optional
-        Controls the number of Legendre polynomials.  The ``nmom`` dataset
+        Controls the number of Legendre polynomials. The ``nmom`` dataset
         variable is always written when ``pmom`` is present.
 
         * ``None`` (default) — when ``pmom`` is not provided, compute 129
           coefficients and store their count as a uniform ``nmom`` array;
-          when ``pmom`` is provided explicitly, infer per-wavelength counts
-          by counting non-NaN entries in the first phase matrix component,
-          consistent with the NaN-padding convention.
+          when ``pmom`` is provided explicitly, infer counts by counting
+          non-NaN entries in the first phase matrix component, consistent
+          with the NaN-padding convention.
         * ``int`` — scalar moment count; used as the target for automatic
           computation and stored as a uniform ``nmom`` array.
-        * ``ndarray`` shape ``(nw,)`` — per-wavelength count stored as-is.
+        * ``ndarray`` shape ``(nw, [nreff, nveff])`` — count stored as-is.
           ``pmom`` must be provided explicitly when ``nmom`` is an ndarray.
 
     grid_res : int, default: 3
@@ -146,13 +156,13 @@ def make_aer_core_v2(
 
         * ``None`` or ``"none"`` — no check (default).
         * ``"fast"`` — sampling-based check: validates a random 10 % of
-          wavelengths (at least one). Intended as a cheap guard during bulk
+          entries (at least one). Intended as a cheap guard during bulk
           production runs.
-        * ``"full"`` — validates every wavelength.
+        * ``"full"`` — validates every entry.
 
         A ``ValueError`` is raised if any sampled row is not strictly
         monotonically increasing in μ. Only the valid (non-NaN) portion of
-        each row is checked (bounded by ``nangles[iw]``).
+        each row is checked (bounded by ``nangles``).
 
     Returns
     -------
@@ -161,49 +171,57 @@ def make_aer_core_v2(
     Raises
     ------
     ValueError
-        If a value check fails, or if ``nmom`` is an ndarray but ``pmom`` is
-        not provided.
+        If a value check fails, if ``nmom`` is an ndarray but ``pmom`` is
+        not provided, or if only one of ``reff``/``veff`` is provided.
     """
+    if (reff is None) != (veff is None):
+        raise ValueError(
+            "make_aer_core_v2(): 'reff' and 'veff' must be provided together, "
+            "or not at all"
+        )
+    extra_dims = [] if reff is None else ["reff", "veff"]
+
     # nangles is always stored. Infer from the first phase matrix component when
-    # not provided: count non-NaN entries per wavelength.
+    # not provided: count non-NaN entries along the angular dimension.
     if nangles is None:
         nangles = _count_valid(phase.m[0])
 
     if check is not None and check != "none":
-        mu_vals = mu.m  # (nw, nangle)
-        nw_check = mu_vals.shape[0]
+        mu_vals = mu.m  # (nw, [nreff, nveff, ]nangle)
+        indices = list(np.ndindex(mu_vals.shape[:-1]))
 
         if check == "fast":
             rng = np.random.default_rng(seed=0)
-            n_sample = max(1, nw_check // 10)
-            iw_check = rng.choice(nw_check, size=n_sample, replace=False)
-        else:  # "full"
-            iw_check = np.arange(nw_check)
+            n_sample = max(1, len(indices) // 10)
+            indices = [
+                indices[i]
+                for i in rng.choice(len(indices), size=n_sample, replace=False)
+            ]
 
-        for iw in iw_check:
-            n = int(nangles[iw])
-            row = mu_vals[iw, :n]
+        for idx in indices:
+            n = int(nangles[idx])
+            row = mu_vals[idx][:n]
             if not np.all(np.diff(row) > 0):
                 raise ValueError(
                     f"make_aer_core_v2(): mu is not strictly ascending at "
-                    f"wavelength index {iw}. Sort the angular grid in ascending "
+                    f"index {idx}. Sort the angular grid in ascending "
                     "mu order before calling this function."
                 )
 
     if normalize:
-        phase_vals = phase.m.copy()  # (nphamat, nw, nangle)
-        mu_vals = mu.m  # (nw, nangle)
-        for iw in range(phase_vals.shape[1]):
-            n = int(nangles[iw])
-            mu_w = mu_vals[iw, :n]
-            p11_w = phase_vals[0, iw, :n]
-            integral = np.trapezoid(p11_w, mu_w)
+        phase_vals = phase.m.copy()  # (nphamat, nw, [nreff, nveff, ]nangle)
+        mu_vals = mu.m  # (nw, [nreff, nveff, ]nangle)
+        for idx in np.ndindex(mu_vals.shape[:-1]):
+            n = int(nangles[idx])
+            mu_pt = mu_vals[idx][:n]
+            phase_pt = phase_vals[(slice(None), *idx)]  # (nphamat, nangle)
+            integral = np.trapezoid(phase_pt[0, :n], mu_pt)
             if integral == 0.0:
                 raise ValueError(
-                    f"make_aer_core_v2(): p11 integrates to 0 at wavelength "
-                    f"index {iw}; cannot normalize."
+                    f"make_aer_core_v2(): p11 integrates to 0 at index "
+                    f"{idx}; cannot normalize."
                 )
-            phase_vals[:, iw, :n] *= 2.0 / integral
+            phase_pt[:, :n] *= 2.0 / integral
         phase = phase_vals * phase.u
 
     if pmom is None:
@@ -221,38 +239,38 @@ def make_aer_core_v2(
         # Compute pmom for p_11 (index 0) only.
         # mu in the dataset is ascending (-1 → +1), so theta is descending
         # (180° → 0°). compute_pmom() expects theta ascending (0° → 180°),
-        # so we reverse each per-wavelength slice.
-        theta_deg = theta.to("deg").magnitude  # (nw, nangle)
-        phase_vals = phase.m  # (nphamat, nw, nangle)
-        _nw = theta_deg.shape[0]
+        # so we reverse each slice.
+        theta_deg = theta.to("deg").magnitude  # (nw, [nreff, nveff, ]nangle)
+        phase_vals = phase.m  # (nphamat, nw, [nreff, nveff, ]nangle)
+        leading_shape = theta_deg.shape[:-1]
 
-        pmom = np.zeros((_nw, _nmom_scalar))
-        for iw in range(_nw):
-            n = int(nangles[iw])
-            theta_w = theta_deg[iw, :n][::-1]  # ascending 0° → 180°
-            phase_w = phase_vals[0, iw, :n][::-1]  # p_11 component
-            pmom[iw, :] = _compute_pmom(
-                theta_w,
-                phase_w,
+        pmom = np.zeros(leading_shape + (_nmom_scalar,))
+        for idx in np.ndindex(leading_shape):
+            n = int(nangles[idx])
+            theta_pt = theta_deg[idx][:n][::-1]  # ascending 0° → 180°
+            phase_pt = phase_vals[(0, *idx)][:n][::-1]  # p_11 component
+            pmom[idx] = _compute_pmom(
+                theta_pt,
+                phase_pt,
                 nmom=_nmom_scalar,
                 grid_res=grid_res,
                 coefficients=True,
                 check_normalization=True,
             )
-        nmom = np.full(_nw, _nmom_scalar, dtype=np.int32)
+        nmom = np.full(leading_shape, _nmom_scalar, dtype=np.int32)
 
     # nmom is always stored alongside pmom.
-    # Normalize any remaining scalar or inferred form to a per-wavelength array.
+    # Normalize any remaining scalar or inferred form to a per-entry array.
     if nmom is None:
-        # pmom was provided explicitly without nmom: count non-NaN entries per
-        # wavelength, consistent with the NaN-padding convention.
+        # pmom was provided explicitly without nmom: count non-NaN entries,
+        # consistent with the NaN-padding convention.
         nmom = _count_valid(pmom)
     elif isinstance(nmom, int):
-        nmom = np.full(len(w.m), nmom, dtype=np.int32)
+        nmom = np.full(np.shape(nangles), nmom, dtype=np.int32)
 
     data_vars = {
         "ext": (
-            "w",
+            ["w", *extra_dims],
             ext.m,
             {
                 "standard_name": "extinction_coefficient",
@@ -261,7 +279,7 @@ def make_aer_core_v2(
             },
         ),
         "ssa": (
-            "w",
+            ["w", *extra_dims],
             ssa.m,
             {
                 "standard_name": "single_scattering_albedo",
@@ -270,7 +288,7 @@ def make_aer_core_v2(
             },
         ),
         "phase": (
-            ["phamat", "w", "iangle"],
+            ["phamat", "w", *extra_dims, "iangle"],
             phase.m,
             {
                 "standard_name": "phase_matrix",
@@ -282,7 +300,7 @@ def make_aer_core_v2(
     }
 
     data_vars["nangles"] = (
-        "w",
+        ["w", *extra_dims],
         nangles,
         {
             "standard_name": "n_angular_samples",
@@ -291,7 +309,7 @@ def make_aer_core_v2(
     )
 
     data_vars["nmom"] = (
-        "w",
+        ["w", *extra_dims],
         nmom,
         {
             "standard_name": "n_legendre_polys",
@@ -300,7 +318,7 @@ def make_aer_core_v2(
     )
 
     data_vars["pmom"] = (
-        ["w", "imom"],
+        ["w", *extra_dims, "imom"],
         pmom,
         {
             "standard_name": "legendre_polys",
@@ -328,7 +346,7 @@ def make_aer_core_v2(
             },
         ),
         "mu": (
-            ["w", "iangle"],
+            ["w", *extra_dims, "iangle"],
             mu.m,
             {
                 "standard_name": "cos_scattering_angle",
@@ -337,7 +355,7 @@ def make_aer_core_v2(
             },
         ),
         "theta": (
-            ["w", "iangle"],
+            ["w", *extra_dims, "iangle"],
             theta.m,
             {
                 "standard_name": "scattering_angle",
@@ -347,7 +365,116 @@ def make_aer_core_v2(
         ),
     }
 
+    if reff is not None:
+        coords["reff"] = (
+            "reff",
+            reff.m,
+            {
+                "standard_name": "effective_radius",
+                "long_name": "effective radius",
+                "units": symbol(reff.u),
+            },
+        )
+        coords["veff"] = (
+            "veff",
+            veff.m,
+            {
+                "standard_name": "effective_variance",
+                "long_name": "effective variance",
+                "units": symbol(veff.u),
+            },
+        )
+
     return xr.Dataset(data_vars=data_vars, coords=coords, attrs=attrs or {})
+
+
+def _shared_attrs(datasets: list[xr.Dataset]) -> dict:
+    """Attrs common to all *datasets*, by key and value; the rest are dropped."""
+    ref_attrs = datasets[0].attrs
+    return {
+        key: value
+        for key, value in ref_attrs.items()
+        if all(ds.attrs.get(key, ref_attrs) == value for ds in datasets[1:])
+    }
+
+
+def concat_particles_veff(datasets: list[xr.Dataset]) -> xr.Dataset:
+    """
+    Concatenate several Prt v1 datasets along the ``veff`` dimension.
+
+    Parameters
+    ----------
+    datasets : list of xr.Dataset
+        Prt v1 datasets (as produced by :func:`make_aer_core_v2` with
+        ``reff``/``veff`` set), each with a ``reff``/``veff``-dimensioned
+        layout. Every dataset may cover one or several ``veff`` values. All
+        datasets must share the same ``w``, ``reff``, and ``phamat``
+        coordinates.
+
+    Returns
+    -------
+    xr.Dataset
+        Prt v1 dataset with a ``veff`` dimension spanning the concatenation
+        of all input datasets' ``veff`` values. ``iangle``/``imom`` are
+        padded to the largest size found across inputs. Only attrs common
+        to all input datasets are retained.
+
+    Raises
+    ------
+    ValueError
+        If the datasets do not share the same ``w``, ``reff``, or ``phamat``
+        coordinates.
+    """
+    ref = datasets[0]
+
+    for ds in datasets[1:]:
+        if not np.array_equal(ds["w"].values, ref["w"].values):
+            raise ValueError("All datasets must share the same 'w' coordinate.")
+        if not np.array_equal(ds["reff"].values, ref["reff"].values):
+            raise ValueError("All datasets must share the same 'reff' coordinate.")
+        if not np.array_equal(ds["phamat"].values, ref["phamat"].values):
+            raise ValueError("All datasets must share the same 'phamat' coordinate.")
+
+    n_iangle = max(ds.sizes["iangle"] for ds in datasets)
+    n_imom = max(ds.sizes["imom"] for ds in datasets)
+
+    def pad_last(a: np.ndarray, n: int) -> np.ndarray:
+        pad_width = [(0, 0)] * (a.ndim - 1) + [(0, n - a.shape[-1])]
+        return np.pad(a, pad_width, mode="constant", constant_values=np.nan)
+
+    mu = np.concatenate(
+        [pad_last(ds["mu"].values, n_iangle) for ds in datasets], axis=2
+    )
+    theta = np.concatenate(
+        [pad_last(ds["theta"].values, n_iangle) for ds in datasets], axis=2
+    )
+    phase = np.concatenate(
+        [pad_last(ds["phase"].values, n_iangle) for ds in datasets], axis=3
+    )
+    pmom = np.concatenate(
+        [pad_last(ds["pmom"].values, n_imom) for ds in datasets], axis=2
+    )
+    ext = np.concatenate([ds["ext"].values for ds in datasets], axis=2)
+    ssa = np.concatenate([ds["ssa"].values for ds in datasets], axis=2)
+    nangles = np.concatenate([ds["nangles"].values for ds in datasets], axis=2)
+    nmom = np.concatenate([ds["nmom"].values for ds in datasets], axis=2)
+    veff = np.concatenate([ds["veff"].values for ds in datasets])
+
+    return make_aer_core_v2(
+        w=to_quantity(ref["w"]),
+        phamat=list(ref["phamat"].values),
+        mu=mu * ureg(ref["mu"].attrs["units"]),
+        theta=theta * ureg(ref["theta"].attrs["units"]),
+        ext=ext * ureg(ref["ext"].attrs["units"]),
+        ssa=ssa * ureg(ref["ssa"].attrs["units"]),
+        phase=phase * ureg(ref["phase"].attrs["units"]),
+        reff=to_quantity(ref["reff"]),
+        veff=veff * ureg(ref["veff"].attrs["units"]),
+        nangles=nangles,
+        pmom=pmom,
+        nmom=nmom,
+        attrs=_shared_attrs(datasets),
+    )
 
 
 def aer_v1_to_aer_core_v2(

--- a/src/eradiate/radprops/_particles.py
+++ b/src/eradiate/radprops/_particles.py
@@ -19,15 +19,6 @@ from ..units import unit_registry as ureg
 from ..util.misc import summary_repr
 
 
-def _validate_shape(value: Any) -> str:
-    valid = {"spherical", "spheroidal"}
-    if value not in valid:
-        raise ValueError(
-            f"Unrecognized particle shape {value!r} (valid values are {valid})."
-        )
-    return value
-
-
 # TODO: If _rdp1d_log becomes a performance bottleneck (e.g. with grids up to
 #   10k points called frequently), consider rewriting the heap loop with Numba
 #   (@njit(cache=True)). The algorithm maps well to scalar JIT compilation and
@@ -284,6 +275,52 @@ class ParticleProperties:
         )
 
     @property
+    def has_size_distribution(self) -> bool:
+        """
+        Returns
+        -------
+        bool
+            ``True`` iff ``data`` has ``reff``/``veff`` dimensions (Part-Core
+            v1 format), ``False`` for a plain Aer-Core v2 dataset.
+        """
+        return "reff" in self.data.dims and "veff" in self.data.dims
+
+    def _resolve(
+        self, reff_idx: int | None, veff_idx: int | None
+    ) -> ParticleProperties:
+        """
+        Select a point on the ``reff``/``veff`` dimensions by index, if present.
+
+        Parameters
+        ----------
+        reff_idx, veff_idx : int or None
+            Index along the ``reff``/``veff`` dimensions. Both must be set
+            iff ``data`` has ``reff``/``veff`` dimensions.
+
+        Returns
+        -------
+        ParticleProperties
+            ``self`` if ``data`` has no ``reff``/``veff`` dimensions;
+            otherwise a new instance with those dimensions selected away.
+        """
+        if not self.has_size_distribution:
+            if reff_idx is not None or veff_idx is not None:
+                raise ValueError(
+                    "'reff_idx'/'veff_idx' were provided, but this dataset "
+                    "has no 'reff'/'veff' dimensions"
+                )
+            return self
+
+        if reff_idx is None or veff_idx is None:
+            raise ValueError(
+                "'reff_idx' and 'veff_idx' must both be provided: this "
+                "dataset has 'reff'/'veff' dimensions"
+            )
+
+        ds = self.data.isel(reff=reff_idx, veff=veff_idx, drop=True)
+        return ParticleProperties(ds)
+
+    @property
     def w(self) -> pint.Quantity:
         """
         Returns
@@ -353,7 +390,7 @@ class ParticleProperties:
             layout during interpolation, cached to minimize overhead.
         """
         if self._phase is None:
-            self._phase = self.data["phase"].transpose("phamat", "iangle", "w")
+            self._phase = self.data["phase"].transpose("phamat", "iangle", "w", ...)
         return self._phase
 
     @property
@@ -368,7 +405,7 @@ class ParticleProperties:
             if "pmom" not in self.data:
                 return None
             else:
-                self._pmom = self.data["pmom"].transpose("imom", "w")
+                self._pmom = self.data["pmom"].transpose("imom", "w", ...)
 
         return self._pmom
 
@@ -424,6 +461,16 @@ class ParticleProperties:
 
         return self._has_fixed_mu_grid
 
+    @staticmethod
+    def _broadcast_t(t: np.ndarray, reference: np.ndarray) -> np.ndarray:
+        """
+        Reshape a per-wavelength interpolation weight ``t`` (shape ``(nw,)``)
+        so that it broadcasts against ``reference`` (shape ``(nw, ...)``)
+        along its leading axis, instead of numpy's default trailing-axis
+        alignment.
+        """
+        return t.reshape(t.shape + (1,) * (reference.ndim - t.ndim))
+
     def eval_ext(self, w: pint.Quantity) -> pint.Quantity:
         """
         Evaluate the extinction coefficient at wavelength(s) ``w`` by plain
@@ -437,9 +484,15 @@ class ParticleProperties:
         Returns
         -------
         quantity
-            Extinction coefficient, same shape as ``w``.
+            Extinction coefficient. Shape ``(nw,)`` if ``data`` has no
+            ``reff``/``veff`` dimensions, ``(nw, nreff, nveff)`` otherwise.
         """
-        return np.interp(w, self.w, self.ext)
+        idx_l, idx_r, t = self._locate(w)
+        ext = self.ext.m
+        ext_l, ext_r = ext[idx_l], ext[idx_r]
+        t = self._broadcast_t(t, ext_l)
+        ext_interp = (1.0 - t) * ext_l + t * ext_r
+        return ext_interp * self.ext.units
 
     def eval_ssa(self, w: pint.Quantity) -> pint.Quantity:
         """
@@ -453,7 +506,8 @@ class ParticleProperties:
         Returns
         -------
         quantity
-            Dimensionless SSA, same shape as ``w``.
+            Dimensionless SSA. Shape ``(nw,)`` if ``data`` has no
+            ``reff``/``veff`` dimensions, ``(nw, nreff, nveff)`` otherwise.
 
         Notes
         -----
@@ -472,6 +526,7 @@ class ParticleProperties:
         ssa = self.ssa.m
         ext_l, ext_r = ext[idx_l], ext[idx_r]
         ssa_l, ssa_r = ssa[idx_l], ssa[idx_r]
+        t = self._broadcast_t(t, ext_l)
         ext_interp = (1.0 - t) * ext_l + t * ext_r
         linear = (1.0 - t) * ssa_l + t * ssa_r
         weighted = ((1.0 - t) * ext_l * ssa_l + t * ext_r * ssa_r) / np.where(
@@ -599,13 +654,14 @@ class ParticleProperties:
         self, w: pint.Quantity, n_mu: int | None = None
     ) -> tuple[np.ndarray, np.ndarray]:
         """
-        Evaluate the phase function at wavelength ``w`` by interpolation.
+        Evaluate the phase function at wavelength(s) ``w`` by interpolation.
 
         Parameters
         ----------
         w : quantity
-            Query wavelength (scalar only; array input raises ``ValueError``
-            because each wavelength can have a different angular grid).
+            Query wavelength(s); scalar or array. Each wavelength is
+            interpolated independently, since it may have a different
+            bracketing pair and thus a different union mu grid.
 
         n_mu : int, optional
             Number of output mu points. Defaults to ``2 * n_iangle``, where
@@ -617,10 +673,12 @@ class ParticleProperties:
         Returns
         -------
         mu : ndarray
-            Scattering angle cosines of the output grid, shape ``(n_mu,)``.
+            Scattering angle cosines of the output grid: shape ``(n_mu,)``
+            for a scalar ``w``, ``(nw, n_mu)`` for an array ``w``.
 
         phase : ndarray
-            Phase function values in sr⁻¹, shape ``(n_phamat, n_mu)``.
+            Phase function values in sr⁻¹: shape ``(n_phamat, n_mu)`` for a
+            scalar ``w``, ``(n_phamat, nw, n_mu)`` for an array ``w``.
 
         Notes
         -----
@@ -635,55 +693,58 @@ class ParticleProperties:
         interpolation preserves the piecewise-linear shape that Mitsuba uses
         during tabulated phase-function look-up, so no distortion is introduced.
         """
-        if not np.isscalar(w.m):
-            raise ValueError("eval_phase() only accepts a scalar wavelength")
+        is_scalar = np.isscalar(w.m)
+        w = np.atleast_1d(w)
 
         n_iangle = self.data.sizes["iangle"]
         if n_mu is None:
             n_mu = n_iangle if self.has_fixed_mu_grid else 2 * n_iangle
 
         # --- Step 1: bracket wavelengths and compute mixing weights ---
-        idx_l_arr, idx_r_arr, w0_arr, w1_arr, _ = self._bracket_and_weights(w)
-        idx_l = int(idx_l_arr[0])
-        idx_r = int(idx_r_arr[0])
-        w0 = float(w0_arr[0])
-        w1 = float(w1_arr[0])
+        idx_l, idx_r, w0, w1, _ = self._bracket_and_weights(w)
 
-        mu1, phase1 = self._get_mu_phase(idx_l)
-        mu2, phase2 = self._get_mu_phase(idx_r)
+        n_phamat = self.data.sizes["phamat"]
+        mu = np.empty((len(w), n_mu))
+        phase = np.empty((n_phamat, len(w), n_mu))
 
-        # --- Step 2: union mu grid ---
-        mu_union = np.union1d(mu1, mu2)
+        for i in range(len(w)):
+            mu1, phase1 = self._get_mu_phase(int(idx_l[i]))
+            mu2, phase2 = self._get_mu_phase(int(idx_r[i]))
 
-        # --- Step 3: resample both phase functions onto union grid ---
-        # interp1d expects (..., n) layout; phase is (n_phamat, nangles[w_idx])
-        phase1_union = interp1d(mu1, phase1, mu_union, bounds="clamp")
-        phase2_union = interp1d(mu2, phase2, mu_union, bounds="clamp")
+            # --- Step 2: union mu grid ---
+            mu_union = np.union1d(mu1, mu2)
 
-        # --- Step 4: scattering-weighted spectral interpolation ---
-        phase_union = w0 * phase1_union + w1 * phase2_union
+            # --- Step 3: resample both phase functions onto union grid ---
+            # interp1d expects (..., n) layout; phase is (n_phamat, nangles[w_idx])
+            phase1_union = interp1d(mu1, phase1, mu_union, bounds="clamp")
+            phase2_union = interp1d(mu2, phase2, mu_union, bounds="clamp")
 
-        # --- Step 5: bring to exactly n_mu points ---
-        n_union = len(mu_union)
+            # --- Step 4: scattering-weighted spectral interpolation ---
+            phase_union = w0[i] * phase1_union + w1[i] * phase2_union
 
-        if n_union > n_mu:
-            # Decimate: keep the most informative points in log space
-            keep = _rdp1d_log(mu_union, phase_union, n_mu)
-            mu_out = mu_union[keep]
-            phase_out = phase_union[:, keep]
+            # --- Step 5: bring to exactly n_mu points ---
+            n_union = len(mu_union)
 
-        elif n_union < n_mu:
-            # Upsample: insert midpoints into the largest gaps of the union grid.
-            # All original points are preserved, so the non-uniform  density near
-            # the forward-scattering peak is maintained.
-            mu_out = _upsample_mu(mu_union, n_mu)
-            phase_out = interp1d(mu_union, phase_union, mu_out, bounds="clamp")
+            if n_union > n_mu:
+                # Decimate: keep the most informative points in log space
+                keep = _rdp1d_log(mu_union, phase_union, n_mu)
+                mu[i] = mu_union[keep]
+                phase[:, i, :] = phase_union[:, keep]
 
-        else:
-            mu_out = mu_union
-            phase_out = phase_union
+            elif n_union < n_mu:
+                # Upsample: insert midpoints into the largest gaps of the union
+                # grid. All original points are preserved, so the non-uniform
+                # density near the forward-scattering peak is maintained.
+                mu[i] = _upsample_mu(mu_union, n_mu)
+                phase[:, i, :] = interp1d(mu_union, phase_union, mu[i], bounds="clamp")
 
-        return mu_out, phase_out
+            else:
+                mu[i] = mu_union
+                phase[:, i, :] = phase_union
+
+        if is_scalar:
+            return mu[0], phase[:, 0, :]
+        return mu, phase
 
     def eval_pmom(self, w: pint.Quantity, clip: bool = False) -> tuple[np.ndarray, int]:
         """

--- a/tests/01_unit/data/test_convert.py
+++ b/tests/01_unit/data/test_convert.py
@@ -9,6 +9,7 @@ import xarray as xr
 from eradiate import unit_registry as ureg
 from eradiate.data.convert import (
     aer_v1_to_aer_core_v2,
+    concat_particles_veff,
     libradtran_to_aer_core_v2,
     make_aer_core_v2,
 )
@@ -44,6 +45,80 @@ def _isotropic_args(
         "ext": np.ones(nw) * ureg("1/km"),
         "ssa": 0.9 * np.ones(nw) * ureg.dimensionless,
         "phase": np.full((1, nw, nangle), scale) * ureg("1/sr"),
+    }
+
+
+def _size_distribution_args(
+    nw: int = 2,
+    nreff: int = 2,
+    nveff: int = 2,
+    nangle: int = 5,
+    scale: float = 1.0,
+) -> dict:
+    """
+    Keyword args for make_aer_core_v2 with reff/veff dimensions.
+
+    Phase is a uniform isotropic p = scale (4π-normalized when scale=1) with
+    a shared ascending mu grid across the whole (w, reff, veff) grid. ext/ssa
+    take a distinct value at every (w, reff, veff) point.
+    """
+    mu_1d = np.linspace(-1.0, 1.0, nangle)
+    mu = np.tile(mu_1d, (nw, nreff, nveff, 1))
+    theta = np.degrees(np.arccos(mu))
+    phase = np.full((1, nw, nreff, nveff, nangle), scale)
+
+    ext = np.zeros((nw, nreff, nveff))
+    ssa = np.zeros((nw, nreff, nveff))
+    for ireff in range(nreff):
+        for iveff in range(nveff):
+            ext[:, ireff, iveff] = (ireff + 1) * (iveff + 1)
+            ssa[:, ireff, iveff] = 0.5 + 0.1 * ireff + 0.01 * iveff
+
+    return {
+        "w": np.linspace(400.0, 700.0, nw) * ureg.nm,
+        "phamat": ["11"],
+        "mu": mu * ureg.dimensionless,
+        "theta": theta * ureg.deg,
+        "ext": ext * ureg("1/km"),
+        "ssa": ssa * ureg.dimensionless,
+        "phase": phase * ureg("1/sr"),
+        "reff": np.linspace(5.0, 15.0, nreff) * ureg.micron,
+        "veff": np.linspace(0.05, 0.15, nveff) * ureg.dimensionless,
+    }
+
+
+def _size_distribution_padded_args(
+    nangles_grid: np.ndarray, nangle_max: int = 10
+) -> dict:
+    """
+    Keyword args for make_aer_core_v2 with reff/veff dimensions and a
+    varying, nan padded angle count per (w, reff, veff) point.
+    """
+    nreff, nveff = nangles_grid.shape
+    nw = 1
+    mu = np.full((nw, nreff, nveff, nangle_max), np.nan)
+    theta = np.full((nw, nreff, nveff, nangle_max), np.nan)
+    phase = np.full((1, nw, nreff, nveff, nangle_max), np.nan)
+
+    for ireff in range(nreff):
+        for iveff in range(nveff):
+            n = int(nangles_grid[ireff, iveff])
+            mu_row = np.linspace(-1.0, 1.0, n)
+            mu[0, ireff, iveff, :n] = mu_row
+            theta[0, ireff, iveff, :n] = np.degrees(np.arccos(mu_row))
+            phase[0, 0, ireff, iveff, :n] = 1.0
+
+    return {
+        "w": np.linspace(400.0, 700.0, nw) * ureg.nm,
+        "phamat": ["11"],
+        "mu": mu * ureg.dimensionless,
+        "theta": theta * ureg.deg,
+        "ext": np.ones((nw, nreff, nveff)) * ureg("1/km"),
+        "ssa": 0.9 * np.ones((nw, nreff, nveff)) * ureg.dimensionless,
+        "phase": phase * ureg("1/sr"),
+        "reff": np.linspace(5.0, 15.0, nreff) * ureg.micron,
+        "veff": np.linspace(0.05, 0.15, nveff) * ureg.dimensionless,
+        "nangles": nangles_grid.reshape(nw, nreff, nveff),
     }
 
 
@@ -334,6 +409,239 @@ class TestMakeAerCoreV2:
             args = _isotropic_args(nw=1, scale=0.0)
             with pytest.raises(ValueError, match="integrates to 0"):
                 make_aer_core_v2(**args, normalize=True)
+
+    class TestSizeDistribution:
+        """Tests for the reff/veff (Prt v1) dimensions in make_aer_core_v2()."""
+
+        def test_no_reff_veff_omits_dimensions(self):
+            """Without reff/veff, the dataset has no such dimensions (Aer-Core v2)."""
+            ds = make_aer_core_v2(**_isotropic_args())
+            assert "reff" not in ds.dims
+            assert "veff" not in ds.dims
+
+        def test_only_reff_raises(self):
+            """Providing reff without veff raises ValueError."""
+            args = _size_distribution_args()
+            del args["veff"]
+            with pytest.raises(ValueError, match="must be provided together"):
+                make_aer_core_v2(**args)
+
+        def test_only_veff_raises(self):
+            """Providing veff without reff raises ValueError."""
+            args = _size_distribution_args()
+            del args["reff"]
+            with pytest.raises(ValueError, match="must be provided together"):
+                make_aer_core_v2(**args)
+
+        def test_dimensions_and_shapes(self):
+            """ext/ssa/mu/theta/phase/nangles gain reff/veff dimensions."""
+            nw, nreff, nveff, nangle = 2, 3, 2, 5
+            ds = make_aer_core_v2(
+                **_size_distribution_args(
+                    nw=nw, nreff=nreff, nveff=nveff, nangle=nangle
+                )
+            )
+            assert ds["ext"].dims == ("w", "reff", "veff")
+            assert ds["ext"].shape == (nw, nreff, nveff)
+            assert ds["mu"].dims == ("w", "reff", "veff", "iangle")
+            assert ds["mu"].shape == (nw, nreff, nveff, nangle)
+            assert ds["phase"].dims == ("phamat", "w", "reff", "veff", "iangle")
+            assert ds["nangles"].shape == (nw, nreff, nveff)
+
+        def test_ext_ssa_values_at_each_point(self):
+            """ext/ssa are stored verbatim at every (w, reff, veff) point."""
+            args = _size_distribution_args()
+            ds = make_aer_core_v2(**args)
+            np.testing.assert_allclose(ds["ext"].values, args["ext"].m)
+            np.testing.assert_allclose(ds["ssa"].values, args["ssa"].m)
+
+        def test_nangles_inferred_at_each_point(self):
+            """nangles is inferred per (w, reff, veff) point when not provided."""
+            nw, nreff, nveff, nangle = 2, 2, 2, 5
+            ds = make_aer_core_v2(
+                **_size_distribution_args(
+                    nw=nw, nreff=nreff, nveff=nveff, nangle=nangle
+                )
+            )
+            np.testing.assert_array_equal(
+                ds["nangles"].values, np.full((nw, nreff, nveff), nangle)
+            )
+
+        def test_check_full_catches_unsorted_point(self):
+            """check='full' validates every (w, reff, veff) point, not just w."""
+            args = _size_distribution_args(nw=2, nreff=2, nveff=2)
+            mu_arr = args["mu"].m.copy()
+            mu_arr[1, 1, 0, :] = mu_arr[1, 1, 0, :][::-1]
+            args["mu"] = mu_arr * ureg.dimensionless
+            with pytest.raises(ValueError, match="strictly ascending"):
+                make_aer_core_v2(**args, check="full")
+
+        def test_fast_passes_on_sorted_grid(self):
+            """check='fast' runs over the full (w, reff, veff) index space without error."""
+            args = _size_distribution_args(nw=2, nreff=5, nveff=5)
+            make_aer_core_v2(**args, check="fast")
+
+        def test_fast_catches_unsorted_point_in_reff_veff_space(self):
+            """check='fast' samples over (w, reff, veff), not just w."""
+            nw, nreff, nveff = 2, 5, 5
+            args = _size_distribution_args(nw=nw, nreff=nreff, nveff=nveff)
+
+            # check='fast' reseeds to 0 on every call, so the sampled indices
+            # are reproducible; replicate that here to target one of them.
+            indices = list(np.ndindex((nw, nreff, nveff)))
+            rng = np.random.default_rng(seed=0)
+            n_sample = max(1, len(indices) // 10)
+            sampled = [
+                indices[i]
+                for i in rng.choice(len(indices), size=n_sample, replace=False)
+            ]
+
+            mu_arr = args["mu"].m.copy()
+            mu_arr[sampled[0]] = mu_arr[sampled[0]][::-1]
+            args["mu"] = mu_arr * ureg.dimensionless
+
+            with pytest.raises(ValueError, match="strictly ascending"):
+                make_aer_core_v2(**args, check="fast")
+
+        def test_nangles_varies_per_reff_veff_point(self):
+            """nangles can vary independently across (w, reff, veff) points."""
+            nangles_grid = np.array([[4, 7], [10, 3]])
+            args = _size_distribution_padded_args(nangles_grid)
+            ds = make_aer_core_v2(**args)
+            np.testing.assert_array_equal(ds["nangles"].values[0], nangles_grid)
+
+        def test_check_full_ignores_nan_tails_per_point(self):
+            """check='full' validates only the valid portion of each ragged row."""
+            nangles_grid = np.array([[4, 7], [10, 3]])
+            args = _size_distribution_padded_args(nangles_grid)
+            make_aer_core_v2(**args, check="full")
+
+        def test_check_full_raises_on_unsorted_valid_portion(self):
+            """check='full' raises if the valid part of a ragged row is unsorted."""
+            nangles_grid = np.array([[4, 7], [10, 3]])
+            args = _size_distribution_padded_args(nangles_grid)
+            mu_arr = args["mu"].m.copy()
+            n = int(nangles_grid[1, 0])
+            mu_arr[0, 1, 0, :n] = mu_arr[0, 1, 0, :n][::-1]
+            args["mu"] = mu_arr * ureg.dimensionless
+            with pytest.raises(ValueError, match="strictly ascending"):
+                make_aer_core_v2(**args, check="full")
+
+        def test_normalize_at_each_point(self):
+            """normalize=True enforces the integral convention at every point."""
+            args = _size_distribution_args(scale=4.0)
+            ds = make_aer_core_v2(**args, normalize=True)
+            mu = ds["mu"].values
+            phase = ds["phase"].values
+            for idx in np.ndindex(mu.shape[:-1]):
+                integral = np.trapezoid(phase[(0, *idx)], mu[idx])
+                np.testing.assert_allclose(integral, 2.0, rtol=1e-12)
+
+        def test_auto_pmom_at_each_point(self):
+            """Automatic pmom computation runs independently at every point."""
+            nw, nreff, nveff = 2, 2, 2
+            ds = make_aer_core_v2(
+                **_size_distribution_args(nw=nw, nreff=nreff, nveff=nveff), nmom=20
+            )
+            assert ds["pmom"].shape == (nw, nreff, nveff, 20)
+            # Isotropic phase: l=0 coefficient is 1, l>0 are ~0, everywhere.
+            np.testing.assert_allclose(ds["pmom"].values[..., 0], 1.0, rtol=1e-6)
+            np.testing.assert_allclose(ds["pmom"].values[..., 1:], 0.0, atol=1e-6)
+
+        def test_scalar_nmom_broadcasts_to_grid_shape(self):
+            """An int nmom broadcasts to the full (w, reff, veff) shape."""
+            nw, nreff, nveff = 2, 3, 2
+            ds = make_aer_core_v2(
+                **_size_distribution_args(nw=nw, nreff=nreff, nveff=nveff), nmom=64
+            )
+            assert ds["nmom"].shape == (nw, nreff, nveff)
+            np.testing.assert_array_equal(
+                ds["nmom"].values, np.full((nw, nreff, nveff), 64)
+            )
+
+        def test_explicit_pmom_stored_verbatim_per_point(self):
+            """Explicit pmom is stored as-is; nmom is inferred per (w, reff, veff) point."""
+            nw, nreff, nveff = 2, 2, 2
+            args = _size_distribution_args(nw=nw, nreff=nreff, nveff=nveff)
+            sentinel = np.full((nw, nreff, nveff, 10), 42.0)
+            ds = make_aer_core_v2(**args, pmom=sentinel)
+            np.testing.assert_array_equal(ds["pmom"].values, sentinel)
+            np.testing.assert_array_equal(
+                ds["nmom"].values, np.full((nw, nreff, nveff), 10)
+            )
+
+        def test_ndarray_nmom_stored_verbatim_per_point(self):
+            """An ndarray nmom is stored as-is per (w, reff, veff) point."""
+            nw, nreff, nveff = 2, 2, 2
+            args = _size_distribution_args(nw=nw, nreff=nreff, nveff=nveff)
+            nmom_grid = np.array([[[4, 7], [10, 3]], [[5, 8], [11, 4]]], dtype=np.int32)
+            pmom = np.full((nw, nreff, nveff, int(nmom_grid.max())), np.nan)
+            for idx in np.ndindex(nmom_grid.shape):
+                pmom[idx][: nmom_grid[idx]] = 1.0
+            ds = make_aer_core_v2(**args, pmom=pmom, nmom=nmom_grid)
+            np.testing.assert_array_equal(ds["nmom"].values, nmom_grid)
+
+
+class TestConcatParticlesVeff:
+    """Tests for concat_particles_veff()."""
+
+    def test_concatenates_veff_values(self):
+        """Combined dataset spans the union of both inputs' veff values."""
+        ds1 = make_aer_core_v2(**_size_distribution_args(nveff=1))
+        ds2 = make_aer_core_v2(**_size_distribution_args(nveff=1))
+        # Give ds2 a distinct veff value so the union is non-trivial.
+        ds2 = ds2.assign_coords(veff=("veff", ds2["veff"].values + 1.0))
+
+        combined = concat_particles_veff([ds1, ds2])
+
+        assert combined.sizes["veff"] == 2
+        np.testing.assert_allclose(
+            combined["veff"].values,
+            np.concatenate([ds1["veff"].values, ds2["veff"].values]),
+        )
+        np.testing.assert_allclose(
+            combined["ext"].isel(veff=0).values, ds1["ext"].isel(veff=0).values
+        )
+        np.testing.assert_allclose(
+            combined["ext"].isel(veff=1).values, ds2["ext"].isel(veff=0).values
+        )
+
+    def test_pads_mismatched_iangle(self):
+        """Datasets with different iangle sizes are NaN-padded to the max."""
+        ds1 = make_aer_core_v2(**_size_distribution_args(nveff=1, nangle=5))
+        ds2 = make_aer_core_v2(**_size_distribution_args(nveff=1, nangle=8))
+        ds2 = ds2.assign_coords(veff=("veff", ds2["veff"].values + 1.0))
+
+        combined = concat_particles_veff([ds1, ds2])
+
+        assert combined.sizes["iangle"] == 8
+        np.testing.assert_array_equal(
+            combined["nangles"].isel(veff=0).values,
+            np.full(combined["nangles"].isel(veff=0).shape, 5),
+        )
+        phase_v0 = combined["phase"].isel(veff=0).values
+        assert np.all(np.isnan(phase_v0[..., 5:]))
+        assert not np.any(np.isnan(phase_v0[..., :5]))
+        phase_v1 = combined["phase"].isel(veff=1).values
+        assert not np.any(np.isnan(phase_v1[..., :8]))
+
+    @pytest.mark.parametrize(
+        "override, match",
+        [
+            ({"w": np.array([401.0, 700.0]) * ureg.nm}, "'w' coordinate"),
+            ({"reff": np.array([6.0, 15.0]) * ureg.micron}, "'reff' coordinate"),
+            ({"phamat": ["12"]}, "'phamat' coordinate"),
+        ],
+    )
+    def test_mismatched_grid_raises(self, override, match):
+        """Datasets with different w/reff/phamat coordinates raise ValueError."""
+        ds1 = make_aer_core_v2(**_size_distribution_args(nveff=1))
+        args2 = {**_size_distribution_args(nveff=1), **override}
+        ds2 = make_aer_core_v2(**args2)
+        ds2 = ds2.assign_coords(veff=("veff", ds2["veff"].values + 1.0))
+
+        with pytest.raises(ValueError, match=match):
+            concat_particles_veff([ds1, ds2])
 
 
 class TestAerV1ToAerCoreV2:

--- a/tests/01_unit/radprops/test_particles.py
+++ b/tests/01_unit/radprops/test_particles.py
@@ -92,6 +92,67 @@ def make_single_w_dataset() -> xr.Dataset:
     )
 
 
+REFF = np.array([5.0, 15.0])  # micron
+VEFF = np.array([0.05, 0.15])  # dimensionless
+
+
+def make_size_distribution_dataset() -> xr.Dataset:
+    """
+    Build a minimal Prt v1-shaped dataset (``reff``/``veff`` dimensions
+    added to the Aer-Core v2 layout) for ``ParticleProperties``.
+
+    ``ext``/``ssa`` take a distinct value at every ``(w, reff, veff)`` grid
+    point, so index-based selection can be checked against known values. The
+    angular grid is shared across the whole grid: the ragged/union-grid
+    mechanics along ``w`` are already covered by other tests, so this dataset
+    only needs to exercise ``reff``/``veff`` selection.
+    """
+    n_w, n_reff, n_veff = len(W_NM), len(REFF), len(VEFF)
+
+    ext = np.zeros((n_w, n_reff, n_veff))
+    ssa = np.zeros((n_w, n_reff, n_veff))
+    for ireff in range(n_reff):
+        for iveff in range(n_veff):
+            ext[:, ireff, iveff] = EXT * (ireff + 1) * (iveff + 1)
+            ssa[:, ireff, iveff] = SSA * (1.0 - 0.05 * ireff - 0.01 * iveff)
+
+    mu_vals = np.tile(MU_1D, (n_w, n_reff, n_veff, 1))
+    theta_vals = np.degrees(np.arccos(mu_vals))
+    phase = np.tile(
+        _PHASE_DATA[:, :, np.newaxis, np.newaxis, :], (1, 1, n_reff, n_veff, 1)
+    )
+    nangles = np.full((n_w, n_reff, n_veff), len(MU_1D), dtype=np.int32)
+
+    return xr.Dataset(
+        {
+            "ext": (["w", "reff", "veff"], ext, {"units": "km^-1"}),
+            "ssa": (["w", "reff", "veff"], ssa, {"units": "dimensionless"}),
+            "mu": (
+                ["w", "reff", "veff", "iangle"],
+                mu_vals,
+                {"units": "dimensionless"},
+            ),
+            "theta": (
+                ["w", "reff", "veff", "iangle"],
+                theta_vals,
+                {"units": "degree"},
+            ),
+            "phase": (
+                ["phamat", "w", "reff", "veff", "iangle"],
+                phase,
+                {"units": "1/sr"},
+            ),
+            "nangles": (["w", "reff", "veff"], nangles),
+        },
+        coords={
+            "w": ("w", W_NM, {"units": "nm"}),
+            "reff": ("reff", REFF, {"units": "micron"}),
+            "veff": ("veff", VEFF, {"units": "dimensionless"}),
+            "phamat": ("phamat", ["11"]),
+        },
+    )
+
+
 @pytest.fixture
 def pp() -> ParticleProperties:
     return ParticleProperties(data=make_dataset())
@@ -200,6 +261,59 @@ class TestParticleProperties:
 
     def test_has_polarization(self, pp):
         assert pp.has_polarization is False
+
+    def test_has_size_distribution_false_for_aer_core_v2(self, pp):
+        assert pp.has_size_distribution is False
+
+    def test_has_size_distribution_true_for_prt_v1(self):
+        pp = ParticleProperties(data=make_size_distribution_dataset())
+        assert pp.has_size_distribution is True
+
+    class TestResolve:
+        def test_noop_on_aer_core_v2(self, pp):
+            """No 'reff'/'veff' dims and no indices given: returns self."""
+            assert pp._resolve(None, None) is pp
+
+        def test_raises_if_indices_given_on_aer_core_v2(self, pp):
+            with pytest.raises(ValueError, match="no 'reff'/'veff' dimensions"):
+                pp._resolve(0, 0)
+
+        def test_raises_if_indices_missing_on_prt_v1(self):
+            pp = ParticleProperties(data=make_size_distribution_dataset())
+            with pytest.raises(ValueError, match="must both be provided"):
+                pp._resolve(None, None)
+
+        def test_raises_if_only_one_index_given(self):
+            pp = ParticleProperties(data=make_size_distribution_dataset())
+            with pytest.raises(ValueError, match="must both be provided"):
+                pp._resolve(0, None)
+
+        @pytest.mark.parametrize("reff_idx", [0, 1])
+        @pytest.mark.parametrize("veff_idx", [0, 1])
+        def test_selects_correct_point(self, reff_idx, veff_idx):
+            """Resolved ext/ssa match a manual index selection on the source data."""
+            ds = make_size_distribution_dataset()
+            pp = ParticleProperties(data=ds)
+            resolved = pp._resolve(reff_idx, veff_idx)
+
+            assert resolved.has_size_distribution is False
+            np.testing.assert_allclose(
+                resolved.ext.m, ds["ext"].values[:, reff_idx, veff_idx]
+            )
+            np.testing.assert_allclose(
+                resolved.ssa.m, ds["ssa"].values[:, reff_idx, veff_idx]
+            )
+
+        def test_eval_ext_after_resolve(self):
+            """eval_ext on a resolved instance matches the manually selected point."""
+            ds = make_size_distribution_dataset()
+            pp = ParticleProperties(data=ds)
+            resolved = pp._resolve(1, 0)
+
+            w_idx = 1
+            expected = ds["ext"].values[w_idx, 1, 0]
+            result = resolved.eval_ext(W_NM[w_idx] * ureg.nm)
+            np.testing.assert_allclose(result.m, expected, rtol=1e-10)
 
     class TestLocate:
         @pytest.mark.parametrize(
@@ -330,6 +444,17 @@ class TestParticleProperties:
             expected = 0.5 * (EXT[0] + EXT[1])
             np.testing.assert_allclose(result.m, expected, rtol=1e-10)
 
+        def test_preserves_reff_veff_dims(self):
+            """On a Prt v1 dataset, result keeps the 'reff'/'veff' dimensions."""
+            ds = make_size_distribution_dataset()
+            pp = ParticleProperties(data=ds)
+            w = np.array([475.0, 625.0]) * ureg.nm  # midpoints of both segments
+            result = pp.eval_ext(w)
+
+            assert result.shape == (2, len(REFF), len(VEFF))
+            expected = 0.5 * (ds["ext"].values[[0, 1]] + ds["ext"].values[[1, 2]])
+            np.testing.assert_allclose(result.m, expected, rtol=1e-10)
+
     class TestEvalSsa:
         @pytest.mark.parametrize("idx", [0, 1, 2])
         def test_at_nodes(self, pp, idx):
@@ -360,12 +485,40 @@ class TestParticleProperties:
             expected = 0.5 * SSA[0] + 0.5 * SSA[1]
             np.testing.assert_allclose(result.m, expected, rtol=1e-10)
 
+        def test_preserves_reff_veff_dims(self):
+            """On a Prt v1 dataset, result keeps the 'reff'/'veff' dimensions,
+            with the extinction-weighted formula applied independently at
+            each (reff, veff) grid point."""
+            ds = make_size_distribution_dataset()
+            pp = ParticleProperties(data=ds)
+            w = np.array([475.0, 625.0]) * ureg.nm  # midpoints of both segments
+            result = pp.eval_ssa(w)
+
+            assert result.shape == (2, len(REFF), len(VEFF))
+
+            t = 0.5
+            for iw, (il, ir) in enumerate([(0, 1), (1, 2)]):
+                ext_l = ds["ext"].values[il]
+                ext_r = ds["ext"].values[ir]
+                ssa_l = ds["ssa"].values[il]
+                ssa_r = ds["ssa"].values[ir]
+                ext_interp = (1 - t) * ext_l + t * ext_r
+                expected = ((1 - t) * ext_l * ssa_l + t * ext_r * ssa_r) / ext_interp
+                np.testing.assert_allclose(result.m[iw], expected, rtol=1e-10)
+
     class TestEvalPhase:
-        def test_array_raises(self, pp):
-            """Array w input raises ValueError."""
-            w = np.array([400.0, 550.0]) * ureg.nm
-            with pytest.raises(ValueError, match="scalar"):
-                pp.eval_phase(w)
+        def test_array_matches_scalar_calls(self, pp):
+            """Array w input matches independent per-wavelength scalar calls."""
+            w = np.array([400.0, 475.0, 550.0]) * ureg.nm
+            mu_out, phase_out = pp.eval_phase(w)
+            assert mu_out.shape == (3, phase_out.shape[-1])
+            assert phase_out.shape[0] == 1
+            assert phase_out.shape[1] == 3
+
+            for i, w_scalar in enumerate(w):
+                mu_scalar, phase_scalar = pp.eval_phase(w_scalar)
+                np.testing.assert_allclose(mu_out[i], mu_scalar)
+                np.testing.assert_allclose(phase_out[:, i, :], phase_scalar)
 
         @pytest.mark.parametrize("w_nm", [400.0, 475.0, 550.0, 700.0])
         def test_fixed_grid_shape(self, pp, w_nm):

--- a/tests/03_regression/romc/test_het01.py
+++ b/tests/03_regression/romc/test_het01.py
@@ -20,7 +20,7 @@ def test_het01_brfpp(mode_mono_double, exp, dataset_regression):
 
     Simulation results are compared to a reference obtained with a prior
     version and validated with ROMC. Comparison is done with a z-test
-    with a threshold of 0.05.
+    with a threshold of 0.01.
     """
     result = eradiate.run(exp)
 
@@ -28,6 +28,6 @@ def test_het01_brfpp(mode_mono_double, exp, dataset_regression):
 
     dataset_regression.check(
         result,
-        ZTest(0.05, variable="radiance"),
+        ZTest(0.01, variable="radiance"),
         basename="het01_brfpp_ref",
     )


### PR DESCRIPTION
# Description

Introduce a new data format to describe the variation of a particles species in a 3D grid. This is a sparse data format. particles microphysical properties are stored alongside the concentration.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `next` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
