### PR TITLE
[3DATM 3/7] Implement a coordinate system for 3D atmospheres

### DIFF
--- a/docs/data/formats/aer.rst
+++ b/docs/data/formats/aer.rst
@@ -122,6 +122,64 @@ Normalization conventions
       * ``imom``
       * ``nmommax``
 
+.. _sec-data-formats-prt_v1:
+
+Prt v1 [``prt_v1``]
+--------------------
+
+Extension of ``aer_core_v2`` for particle properties. This data format
+indexes properties defined by ``aer_core_v2`` on two extra dimensions,
+``reff`` and ``veff``, the mean and variance of the particle size
+distribution, respectively. It shares the same normalization conventions
+as ``aer_core_v2``.
+
+Format
+    ``xarray.Dataset`` (in-memory), NetCDF (storage)
+
+Dimensions
+    * ``w``: radiation wavelength
+    * ``reff``: effective radius of the particles
+    * ``veff``: variance of the particles radii
+    * ``phamat``: nonzero coefficients in the phase matrix
+    * ``iangle``: angular data points
+    * ``imom``: Legendre coefficients for the (1,1) phase matrix component
+
+Coordinates
+    *When relevant, units are required and specified in the "units" metadata field.*
+
+    * ``w(w)``: float [length]: wavelength
+    * ``reff(reff)``: float [length]: effective radius
+    * ``veff(veff)``: float [—]: variance of particles radii
+    * ``phamat(phamat)``: str [—]: row and column indices of the phase matrix coefficient
+      (*e.g.* "11", "12", etc.)
+    * ``theta(w, reff, veff, iangle)``: float [angle]: scattering angle θ; NaN-padded beyond
+      ``nangles[iw, ireff, iveff]``
+    * ``mu(w, reff, veff, iangle)``: float [—]: value of cos θ; NaN-padded beyond 
+      ``nangles[iw, ireff, iveff]``
+
+Data variables
+    *When relevant, units are required and specified in the "units" metadata field.*
+
+    * ``ext(w, reff, veff)`` float [1 / length]: extinction coefficient per unit concentration
+    * ``ssa(w, reff, veff)`` float [—]: single-scattering albedo
+    * ``phase(phamat, w, reff, veff, iangle)`` float [1 / sr]: value of the phase matrix;
+      NaN-padded beyond ``nangles[iw, ireff, iveff]``
+    * ``nangles(w, reff, veff)`` int [—]: number of valid angular samples per wavelength,
+      reff and veff; must be consistent with the NaN padding of ``theta``, ``mu``, and 
+      ``phase``
+    * ``pmom(w, reff, veff, imom)`` float [—], optional: Legendre expansion coefficients
+      of the (1,1) phase matrix element; NaN-padded beyond ``nmom[iw, ireff, iveff]``
+    * ``nmom(w, reff, veff)`` int [—], required if ``pmom`` is present: number of valid
+      Legendre coefficients per wavelength; must be consistent with the NaN
+      padding of ``pmom``
+
+.. note::
+
+    * Data are sorted in ascending order of ``w``, ``reff``, ``veff`` and ``mu``
+    * ``reff`` and ``veff`` are regularly spaced
+    * ``phamat`` conventions (valid values, and their implication for
+      polarization and particle shape) are the same as ``aer_core_v2``
+
 .. _sec-data-formats-aer_v1:
 
 Aer v1 (legacy) [``aer_v1``]

--- a/docs/data/formats/profile.rst
+++ b/docs/data/formats/profile.rst
@@ -1,0 +1,47 @@
+Particle profile (Ppr)
+=======================
+
+.. _sec-data-formats-ppr_v1:
+
+Ppr v1 [``ppr_v1``]
+-------------------
+
+Sparse, per-voxel description of a spatially varying particle field.
+Typically used for clouds. Each entry describes one populated voxel: its
+grid cell indices, the local particle size distribution parameters, and the
+mass concentration used to scale optical properties looked up from a
+:ref:`Prt v1 <sec-data-formats-prt_v1>` dataset.
+
+The grid is described by the ``x_levels``/``y_levels``/``z_levels`` arrays of
+cell edges along each axis. The profile is defined on either a Cartesian
+coordinate system (``x_levels``/``y_levels`` in length units) or a spherical
+geocentric coordinate system (``x_levels``/``y_levels`` in angle units,
+representing azimuth/colatitude).
+
+Format
+    ``xarray.Dataset`` (in-memory), NetCDF (storage)
+
+Dimensions
+    * ``index``: flat, populated-voxel index
+
+Data variables
+    *When relevant, units are required and specified in the "units" metadata field.*
+
+    * ``x_levels`` float, 1-D [length or angle]: grid cell edges along the x
+      axis
+    * ``y_levels`` float, 1-D [length or angle]: grid cell edges along the y
+      axis
+    * ``z_levels`` float, 1-D [length]: grid cell edges along the z
+      (altitude) axis
+    * ``i_x(index)`` int [—]: index of the populated cell along the x axis,
+      0-based
+    * ``i_y(index)`` int [—]: index of the populated cell along the y axis,
+      0-based
+    * ``i_z(index)`` int [—]: index of the populated cell along the z axis,
+      0-based
+    * ``reff(index)`` float [length]: effective radius of the particle size
+      distribution
+    * ``veff(index)`` float [—]: effective variance of the particle size
+      distribution
+    * ``mass_concentration(index)`` float [mass / volume]: particle mass
+      concentration

--- a/docs/reference_api/grid.rst
+++ b/docs/reference_api/grid.rst
@@ -1,0 +1,5 @@
+``eradiate.grid``
+=================
+
+.. automodule:: eradiate.grid
+   :members:

--- a/docs/reference_api/index.rst
+++ b/docs/reference_api/index.rst
@@ -74,6 +74,7 @@ Alphabetical list of modules
    exceptions
    experiments
    frame
+   grid
    kernel
    notebook
    pipelines

--- a/docs/reference_api/radprops.rst
+++ b/docs/reference_api/radprops.rst
@@ -19,7 +19,6 @@
    :recursive:
    :toctree: generated/autosummary/
 
-   ZGrid
    RadProfile
    ArrayRadProfile
    AtmosphereRadProfile

--- a/docs/release_notes/v1.3.x.md
+++ b/docs/release_notes/v1.3.x.md
@@ -25,6 +25,10 @@
 
 ### Internal changes
 
+* 🖥️ `ZGrid` is replaced throughout the atmosphere stack by the new
+  `grid.py` facility (`GridCoords`, `PlaneParallelGridCoords`,
+  `SphericalShellGridCoords`) and a `generate_gridvolume()` helper for
+  building kernel volumes ({ghpr}`586`).
 * 🖥️ Documentation now builds with Sphinx 9 and Python 3.11 ({ghpr}`580`).
 * 🖥️ Local docs build now mocks Mitsuba and Dr.Jit like the Read The Docs build
   does ({ghpr}`580`).

--- a/docs/release_notes/v1.3.x.md
+++ b/docs/release_notes/v1.3.x.md
@@ -11,6 +11,8 @@
 * {class}`.ParticleProperties` can now load particle radiative property
   datasets in the new `prt_v1` format, which extends `aer_core_v2` with
   `r_eff`/`v_eff` support ({ghpr}`584`).
+* New `ppr_v1` data format for spatially varying particle profiles, like
+  clouds ({ghpr}`585`).
 
 ### Fixed
 

--- a/docs/release_notes/v1.3.x.md
+++ b/docs/release_notes/v1.3.x.md
@@ -8,6 +8,9 @@
   `<var>_srf` whenever variance computation is enabled. This makes
   noise-aware comparisons (*e.g.* {class}`.ZTest`) possible on band-integrated
   quantities ({ghpr}`595`).
+* {class}`.ParticleProperties` can now load particle radiative property
+  datasets in the new `prt_v1` format, which extends `aer_core_v2` with
+  `r_eff`/`v_eff` support ({ghpr}`584`).
 
 ### Fixed
 

--- a/pytest.toml
+++ b/pytest.toml
@@ -14,6 +14,8 @@ filterwarnings = [
   "ignore:.*utcnow.*:DeprecationWarning",
   # Ignore Skyfield ephemeris file handle warnings (expected behaviour)
   "ignore:.*de421.bsp.*:ResourceWarning",
+  # Remove when netCDF4 supports NumPy >= 2.5 (in-place reshape deprecated)
+  "ignore:Setting the shape on a NumPy array.*:DeprecationWarning",
 ]
 markers = ["unit", "system", "regression"]
 testpaths = ["tests"]

--- a/src/eradiate/__init__.pyi
+++ b/src/eradiate/__init__.pyi
@@ -5,6 +5,7 @@ from . import converters as converters
 from . import data as data
 from . import experiments as experiments
 from . import frame as frame
+from . import grid as grid
 from . import kernel as kernel
 from . import notebook as notebook
 from . import pipelines as pipelines

--- a/src/eradiate/_repr_diagrams.py
+++ b/src/eradiate/_repr_diagrams.py
@@ -1,0 +1,740 @@
+"""SVG diagrams for GridCoords/SceneGeometry HTML reprs."""
+
+from __future__ import annotations
+
+import math
+import xml.etree.ElementTree as ET
+
+import pint
+
+from .units import unit_registry as ureg
+
+
+def _attrib(attrib: dict) -> dict[str, str]:
+    """Translate Python-friendly (underscored) attribute names to their SVG/CSS (hyphenated) form and stringify values, dropping ``None`` entries."""
+    return {k.replace("_", "-"): str(v) for k, v in attrib.items() if v is not None}
+
+
+def svg(width: float, height: float, *children: ET.Element, **attrib) -> ET.Element:
+    """Build an <svg> root sized to (width, height) with a matching viewBox."""
+    el = ET.Element(
+        "svg",
+        _attrib(
+            {
+                "width": f"{width}",
+                "height": f"{height}",
+                "viewBox": f"0 0 {width} {height}",
+                "xmlns": "http://www.w3.org/2000/svg",
+                **attrib,
+            }
+        ),
+    )
+    el.extend(children)
+    return el
+
+
+def g(*children: ET.Element, **attrib) -> ET.Element:
+    """Build a <g> group element."""
+    el = ET.Element("g", _attrib(attrib))
+    el.extend(children)
+    return el
+
+
+def line(x1: float, y1: float, x2: float, y2: float, **attrib) -> ET.Element:
+    """Build a <line> element."""
+    return ET.Element(
+        "line",
+        _attrib({"x1": f"{x1}", "y1": f"{y1}", "x2": f"{x2}", "y2": f"{y2}", **attrib}),
+    )
+
+
+def rect(x: float, y: float, width: float, height: float, **attrib) -> ET.Element:
+    """Build a <rect> element."""
+    return ET.Element(
+        "rect",
+        _attrib(
+            {
+                "x": f"{x}",
+                "y": f"{y}",
+                "width": f"{width}",
+                "height": f"{height}",
+                **attrib,
+            }
+        ),
+    )
+
+
+def circle(cx: float, cy: float, r: float, **attrib) -> ET.Element:
+    """Build a <circle> element."""
+    return ET.Element(
+        "circle", _attrib({"cx": f"{cx}", "cy": f"{cy}", "r": f"{r}", **attrib})
+    )
+
+
+def ellipse(cx: float, cy: float, rx: float, ry: float, **attrib) -> ET.Element:
+    """Build an <ellipse> element."""
+    return ET.Element(
+        "ellipse",
+        _attrib({"cx": f"{cx}", "cy": f"{cy}", "rx": f"{rx}", "ry": f"{ry}", **attrib}),
+    )
+
+
+def polygon(points: list[tuple[float, float]], **attrib) -> ET.Element:
+    """Build a <polygon> element from a sequence of (x, y) points."""
+    pts = " ".join(f"{x},{y}" for x, y in points)
+    return ET.Element("polygon", _attrib({"points": pts, **attrib}))
+
+
+def path(d: str, **attrib) -> ET.Element:
+    """Build a <path> element with the given path data."""
+    return ET.Element("path", _attrib({"d": d, **attrib}))
+
+
+def text(x: float, y: float, content: str, **attrib) -> ET.Element:
+    """Build a <text> element."""
+    el = ET.Element("text", _attrib({"x": f"{x}", "y": f"{y}", **attrib}))
+    el.text = content
+    return el
+
+
+def el(
+    tag: str, *children: ET.Element, text: str | None = None, **attrib
+) -> ET.Element:
+    """Build a generic (typically non-SVG, e.g. HTML) element with optional text content and children."""
+    node = ET.Element(tag, _attrib(attrib))
+    node.text = text
+    node.extend(children)
+    return node
+
+
+def tostring(node: ET.Element) -> str:
+    """Serialize an element tree to an XML string."""
+    return ET.tostring(node, encoding="unicode")
+
+
+def _division_fractions(
+    n_cells: int, *, max_shown: int = 5, gap_scale: float = 2.0
+) -> tuple[list[float], tuple[float, float] | None]:
+    """Division fractions for up to *max_shown* grid segments, plus the compressed-gap range (*gap_scale* times as wide as a regular cell) when *n_cells* exceeds *max_shown*."""
+    if n_cells <= 1:
+        return [], None
+    if n_cells <= max_shown:
+        return [i / n_cells for i in range(1, n_cells)], None
+
+    n_head = n_tail = 2
+    unit = 1.0 / (n_head + n_tail + gap_scale)
+    lines = [
+        unit,
+        2 * unit,
+        (2 + gap_scale) * unit,
+        (3 + gap_scale) * unit,
+    ]
+    gap = (2 * unit, (2 + gap_scale) * unit)
+    return lines, gap
+
+
+_AXIS_SCALES = (0.55, 1.0, 1.6)  # (small, medium, large) edge-length multipliers
+
+
+def _axis_scales(
+    span_x: pint.Quantity,
+    span_y: pint.Quantity,
+    span_z: pint.Quantity,
+    scales: tuple[float, float, float] = _AXIS_SCALES,
+) -> tuple[float, float, float]:
+    """Rank each axis by physical extent into one of 3 predefined *scales* (small/medium/large, ties share a scale, non-comparable axes default to medium)."""
+    spans = [span_x, span_y, span_z]
+    small, medium, large = scales
+
+    def _cmp(i: int, j: int) -> int | None:
+        try:
+            if spans[i] < spans[j]:
+                return -1
+            if spans[i] > spans[j]:
+                return 1
+            return 0
+        except pint.DimensionalityError:
+            return None
+
+    result = [medium, medium, medium]
+    for i in range(3):
+        others = [j for j in range(3) if j != i and _cmp(i, j) is not None]
+        if not others:
+            continue
+        is_min = all(_cmp(i, j) <= 0 for j in others)
+        is_max = all(_cmp(i, j) >= 0 for j in others)
+        if is_min and not is_max:
+            result[i] = small
+        elif is_max and not is_min:
+            result[i] = large
+    return tuple(result)
+
+
+def _format_extent(lo: pint.Quantity, hi: pint.Quantity) -> str:
+    return f"{lo:~P.4g} … {hi:~P.4g}"
+
+
+def _visual_fraction(
+    ratio: float, *, floor: float = 0.15, log_floor_ratio: float = 1e-6
+) -> float:
+    """Map a linear size ratio in (0, 1] to a visual fraction in [*floor*, 1] on a log scale."""
+    if ratio >= 1.0:
+        return 1.0
+    if ratio <= log_floor_ratio:
+        return floor
+    t = math.log10(ratio) / math.log10(log_floor_ratio)  # 0 at ratio=1, 1 at floor
+    return floor + (1.0 - t) * (1.0 - floor)
+
+
+def _add(
+    p: tuple[float, float], v: tuple[float, float], f: float = 1.0
+) -> tuple[float, float]:
+    return (p[0] + v[0] * f, p[1] + v[1] * f)
+
+
+def _pt(
+    origin: tuple[float, float],
+    va: tuple[float, float],
+    fa: float,
+    vb: tuple[float, float],
+    fb: float,
+) -> tuple[float, float]:
+    return _add(_add(origin, va, fa), vb, fb)
+
+
+def _cuboid_vertices(
+    p0: tuple[float, float],
+    ux: tuple[float, float],
+    uy: tuple[float, float],
+    uz: tuple[float, float],
+) -> tuple[
+    tuple[float, float],
+    tuple[float, float],
+    tuple[float, float],
+    tuple[float, float],
+    tuple[float, float],
+    tuple[float, float],
+]:
+    """The 6 remaining corners of a parallelepiped from its front-bottom-left corner and 3 edge vectors."""
+    p1 = _add(p0, ux)
+    p3 = _add(p0, uz)
+    p2 = _add(p1, uz)
+    p1b = _add(p1, uy)
+    p3b = _add(p3, uy)
+    p2b = _add(p2, uy)
+    return p1, p2, p3, p1b, p2b, p3b
+
+
+def _cuboid_faces(
+    p0: tuple[float, float],
+    p1: tuple[float, float],
+    p2: tuple[float, float],
+    p3: tuple[float, float],
+    p1b: tuple[float, float],
+    p2b: tuple[float, float],
+    p3b: tuple[float, float],
+    *,
+    stroke_width: float = 1.2,
+) -> list[ET.Element]:
+    """The cuboid's 3 visible (top, right, front) faces as filled, shaded polygons."""
+    stroke = "#1f3a52"
+    return [
+        polygon(
+            [p3, p2, p2b, p3b], fill="#a9c8e0", stroke=stroke, stroke_width=stroke_width
+        ),
+        polygon(
+            [p1, p2, p2b, p1b], fill="#2f5678", stroke=stroke, stroke_width=stroke_width
+        ),
+        polygon(
+            [p0, p1, p2, p3], fill="#4c78a8", stroke=stroke, stroke_width=stroke_width
+        ),
+    ]
+
+
+def cuboid(
+    n_x: int,
+    n_y: int,
+    n_z: int,
+    *,
+    scale_x: float = 1.0,
+    scale_y: float = 1.0,
+    scale_z: float = 1.0,
+) -> ET.Element:
+    """Isometric cuboid <svg> element with the cell grid drawn on its 3 visible faces and X/Y/Z edges labelled with their cell count."""
+    base_w, base_h = 106.6, 94.9  # front face size (X width, Z height) at scale 1
+    base_uy = (40.3, -27.3)  # depth direction/length (Y) at scale 1, screen space
+
+    W = base_w * scale_x
+    H = base_h * scale_z
+    uy = (base_uy[0] * scale_y, base_uy[1] * scale_y)
+    ux = (W, 0.0)
+    uz = (0.0, -H)
+
+    # Margins are fixed regardless of scale and the canvas grows/shrinks
+    # around them instead, so long axis labels (e.g. "z (n=2000000)") never
+    # clip.
+    left_margin, right_margin = 161.2, 88.4
+    top_pad, bottom_margin = 10.4, 46.8
+    p0 = (left_margin, top_pad + abs(uy[1]) + H)
+    canvas_w = left_margin + W + uy[0] + right_margin
+    canvas_h = top_pad + abs(uy[1]) + H + bottom_margin
+
+    p1, p2, p3, p1b, p2b, p3b = _cuboid_vertices(p0, ux, uy, uz)
+    faces = _cuboid_faces(p0, p1, p2, p3, p1b, p2b, p3b)
+
+    x_lines, x_gap = _division_fractions(n_x)
+    y_lines, y_gap = _division_fractions(n_y)
+    z_lines, z_gap = _division_fractions(n_z)
+
+    def _gridline(a: tuple[float, float], b: tuple[float, float]) -> ET.Element:
+        return line(*a, *b, stroke="white", stroke_opacity=0.65, stroke_width=0.8)
+
+    grid_lines = []
+    # Front face (X-Z): X divisions run bottom-to-top, Z divisions left-to-right.
+    for fx in x_lines:
+        grid_lines.append(_gridline(_pt(p0, ux, fx, uz, 0), _pt(p0, ux, fx, uz, 1)))
+    for fz in z_lines:
+        grid_lines.append(_gridline(_pt(p0, uz, fz, ux, 0), _pt(p0, uz, fz, ux, 1)))
+    # Top face (X-Y): X divisions continue into depth, Y divisions run across.
+    for fx in x_lines:
+        grid_lines.append(_gridline(_pt(p3, ux, fx, uy, 0), _pt(p3, ux, fx, uy, 1)))
+    for fy in y_lines:
+        grid_lines.append(_gridline(_pt(p3, uy, fy, ux, 0), _pt(p3, uy, fy, ux, 1)))
+    # Right face (Z-Y): Z divisions continue into depth, Y divisions run across.
+    for fz in z_lines:
+        grid_lines.append(_gridline(_pt(p1, uz, fz, uy, 0), _pt(p1, uz, fz, uy, 1)))
+    for fy in y_lines:
+        grid_lines.append(_gridline(_pt(p1, uy, fy, uz, 0), _pt(p1, uy, fy, uz, 1)))
+
+    def _ellipsis_dots(
+        origin: tuple[float, float],
+        axis_vec: tuple[float, float],
+        axis_frac: float,
+        other_vec: tuple[float, float],
+        other_frac: float,
+    ) -> list[ET.Element]:
+        cx, cy = _pt(origin, axis_vec, axis_frac, other_vec, other_frac)
+        norm = math.hypot(*axis_vec)
+        if norm == 0:
+            return []
+        dirx, diry = axis_vec[0] / norm, axis_vec[1] / norm
+        return [
+            circle(
+                cx + dirx * k * 4.03,
+                cy + diry * k * 4.03,
+                1.43,
+                fill="#16283a",
+            )
+            for k in (-1, 0, 1)
+        ]
+
+    ellipses = []
+    if x_gap:
+        ellipses += _ellipsis_dots(p0, ux, sum(x_gap) / 2, uz, 0.22)
+    if z_gap:
+        ellipses += _ellipsis_dots(p0, uz, sum(z_gap) / 2, ux, 0.8)
+    if y_gap:
+        ellipses += _ellipsis_dots(p3, uy, sum(y_gap) / 2, ux, 0.22)
+
+    label_attrib = {"font_family": "sans-serif", "font_size": "13.65px", "fill": "#555"}
+    labels = [
+        text(
+            (p0[0] + p1[0]) / 2,
+            p0[1] + 32.5,
+            f"x (n={n_x})",
+            text_anchor="middle",
+            **label_attrib,
+        ),
+        text(
+            p0[0] - 23.4,
+            (p0[1] + p3[1]) / 2,
+            f"z (n={n_z})",
+            text_anchor="end",
+            **label_attrib,
+        ),
+        text(
+            (p1[0] + p1b[0]) / 2 + 28.6,
+            (p1[1] + p1b[1]) / 2 + 16.9,
+            f"y (n={n_y})",
+            text_anchor="middle",
+            **label_attrib,
+        ),
+    ]
+
+    return svg(
+        canvas_w,
+        canvas_h,
+        *faces,
+        *grid_lines,
+        *ellipses,
+        *labels,
+        style="vertical-align:middle",
+    )
+
+
+def nested_cuboid(
+    domain_width: pint.Quantity,
+    grid_width: pint.Quantity,
+    grid_length: pint.Quantity,
+    ground: pint.Quantity,
+    toa: pint.Quantity,
+) -> ET.Element:
+    """Dashed outer wireframe cuboid (the geometry's full domain) with the grid's footprint drawn as a smaller solid cuboid nested inside."""
+    frac_w = _visual_fraction(
+        float((grid_width / domain_width).m_as(ureg.dimensionless))
+    )
+    frac_l = _visual_fraction(
+        float((grid_length / domain_width).m_as(ureg.dimensionless))
+    )
+
+    W, H = 169.0, 104.0
+    uy = (52.0, -33.8)
+    ux = (W, 0.0)
+    uz = (0.0, -H)
+
+    left_margin, right_margin = 78.0, 26.0
+    top_pad, bottom_margin = 15.6, 44.2
+    p0 = (left_margin, top_pad + abs(uy[1]) + H)
+    canvas_w = left_margin + W + uy[0] + right_margin
+    canvas_h = top_pad + abs(uy[1]) + H + bottom_margin
+
+    p1, p2, p3, p1b, p2b, p3b = _cuboid_vertices(p0, ux, uy, uz)
+
+    stroke = "#9aa5b1"
+    outer = [
+        line(*a, *b, stroke=stroke, stroke_width=1.2, stroke_dasharray="4,3")
+        for a, b in (
+            (p0, p1),
+            (p1, p2),
+            (p2, p3),
+            (p3, p0),
+            (p3, p3b),
+            (p2, p2b),
+            (p1, p1b),
+            (p0, _add(p0, uy)),
+            (p3b, p2b),
+            (p2b, p1b),
+        )
+    ]
+
+    inner_w, inner_h = W * frac_w, H  # full height: grid always spans ground..toa
+    inner_uy = (uy[0] * frac_l, uy[1] * frac_l)
+    inner_p0 = _add(p0, ux, (1 - frac_w) / 2.0)
+    inner_p0 = _add(inner_p0, uy, (1 - frac_l) / 2.0)
+    iux = (inner_w, 0.0)
+    iuz = (0.0, -inner_h)
+    ip1, ip2, ip3, ip1b, ip2b, ip3b = _cuboid_vertices(inner_p0, iux, inner_uy, iuz)
+    inner = _cuboid_faces(inner_p0, ip1, ip2, ip3, ip1b, ip2b, ip3b, stroke_width=1)
+
+    label_attrib = {"font_family": "sans-serif", "font_size": "13.65px", "fill": "#555"}
+    labels = [
+        text(
+            (p0[0] + p1[0]) / 2,
+            p0[1] + 32.5,
+            f"domain width {domain_width:~P.3g}",
+            text_anchor="middle",
+            **label_attrib,
+        ),
+        text(
+            p0[0] - 10.4,
+            p0[1] + 5.2,
+            f"{ground:~P.4g}",
+            text_anchor="end",
+            **label_attrib,
+        ),
+        text(
+            p3[0] - 10.4,
+            p3[1] + 5.2,
+            f"{toa:~P.4g}",
+            text_anchor="end",
+            **label_attrib,
+        ),
+    ]
+
+    diagram = svg(
+        canvas_w, canvas_h, *outer, *inner, *labels, style="vertical-align:middle"
+    )
+    caption = el(
+        "div",
+        text=f"grid footprint: {grid_width:~P.3g} × {grid_length:~P.3g}",
+        style="font-family:sans-serif;font-size:13.65px;color:#555",
+    )
+    return el("div", diagram, caption)
+
+
+def spherical_extent(
+    az_min: float,
+    az_max: float,
+    colat_min: float,
+    colat_max: float,
+    ground: pint.Quantity,
+    toa: pint.Quantity,
+) -> ET.Element:
+    """Polar plot (angle=azimuth, radius=colatitude) of the grid's angular coverage, plus an altitude bar."""
+    cx, cy, R = 109.2, 109.2, 93.6
+
+    def _polar(az_deg: float, colat_deg: float) -> tuple[float, float]:
+        r = R * (colat_deg / 180.0)
+        a = math.radians(az_deg - 90.0)
+        return (cx + r * math.cos(a), cy + r * math.sin(a))
+
+    fill = "#4c78a8"
+    stroke = "#1f3a52"
+    label_attrib = {"font_family": "sans-serif", "font_size": "13.65px", "fill": "#555"}
+
+    wedge_children = [
+        circle(
+            cx,
+            cy,
+            R,
+            fill="none",
+            stroke="#c3ccd4",
+            stroke_width=1,
+            stroke_dasharray="3,3",
+        ),
+        circle(
+            cx,
+            cy,
+            R * 0.5,
+            fill="none",
+            stroke="#e3e8ec",
+            stroke_width=0.8,
+            stroke_dasharray="2,3",
+        ),
+        circle(cx, cy, 1.82, fill="#9aa5b1"),
+    ]
+
+    full_azimuth = (az_max - az_min) >= 359.999
+    from_pole = colat_min <= 1e-3
+
+    if full_azimuth and from_pole:
+        r = R * (colat_max / 180.0)
+        wedge_children.append(
+            circle(
+                cx, cy, r, fill=fill, fill_opacity=0.8, stroke=stroke, stroke_width=1.2
+            )
+        )
+    elif full_azimuth:
+        r0 = R * (colat_min / 180.0)
+        r1 = R * (colat_max / 180.0)
+        wedge_children += [
+            circle(
+                cx, cy, r1, fill=fill, fill_opacity=0.8, stroke=stroke, stroke_width=1.2
+            ),
+            circle(cx, cy, r0, fill="white", stroke=stroke, stroke_width=1.2),
+        ]
+    else:
+        r0 = R * (colat_min / 180.0)
+        r1 = R * (colat_max / 180.0)
+        p_in0 = _polar(az_min, colat_min)
+        p_out0 = _polar(az_min, colat_max)
+        p_out1 = _polar(az_max, colat_max)
+        p_in1 = _polar(az_max, colat_min)
+        large_arc = 1 if (az_max - az_min) > 180 else 0
+        d = (
+            f"M{p_in0[0]},{p_in0[1]} "
+            f"L{p_out0[0]},{p_out0[1]} "
+            f"A{r1},{r1} 0 {large_arc} 1 {p_out1[0]},{p_out1[1]} "
+            f"L{p_in1[0]},{p_in1[1]} "
+            f"A{r0},{r0} 0 {large_arc} 0 {p_in0[0]},{p_in0[1]} Z"
+        )
+        wedge_children.append(
+            path(d, fill=fill, fill_opacity=0.8, stroke=stroke, stroke_width=1.2)
+        )
+
+    wedge_children += [
+        text(
+            cx,
+            cy + R + 26.0,
+            f"azimuth {az_min:g}-{az_max:g} deg",
+            text_anchor="middle",
+            **label_attrib,
+        ),
+        text(
+            cx,
+            cy + R + 44.2,
+            f"colatitude {colat_min:g}-{colat_max:g} deg",
+            text_anchor="middle",
+            **label_attrib,
+        ),
+    ]
+    wedge_svg = svg(
+        2 * cx, cy + R + 57.2, *wedge_children, style="vertical-align:middle"
+    )
+
+    bar_x, bar_w = 15.6, 20.8
+    bar_top, bar_bot = 18.2, cy + R - 26.0
+    bar_h = bar_bot - bar_top
+    bar_canvas_w, bar_canvas_h = 83.2, cy + R + 57.2
+    bar_mid_x, bar_mid_y = bar_x + bar_w / 2, (bar_top + bar_bot) / 2
+    bar_children = [
+        rect(
+            bar_x,
+            bar_top,
+            bar_w,
+            bar_h,
+            rx=2,
+            fill="#a9c8e0",
+            stroke=stroke,
+            stroke_width=1,
+        ),
+        text(
+            bar_mid_x,
+            bar_top - 7.8,
+            f"{toa:~P.4g}",
+            text_anchor="middle",
+            **label_attrib,
+        ),
+        text(
+            bar_mid_x,
+            bar_bot + 20.8,
+            f"{ground:~P.4g}",
+            text_anchor="middle",
+            **label_attrib,
+        ),
+        text(
+            bar_mid_x,
+            bar_mid_y,
+            "altitude",
+            text_anchor="middle",
+            transform=f"rotate(-90 {bar_mid_x} {bar_mid_y})",
+            **label_attrib,
+        ),
+    ]
+    bar_svg = svg(
+        bar_canvas_w, bar_canvas_h, *bar_children, style="vertical-align:middle"
+    )
+
+    return el(
+        "div",
+        el("div", wedge_svg),
+        el("div", bar_svg),
+        style="display:flex;align-items:flex-start;gap:8px",
+    )
+
+
+def grid_repr_html(grid) -> str | None:
+    from .grid import PlaneParallelGridCoords, SphericalShellGridCoords
+
+    # Never let a display helper break notebook rendering: fall back to
+    # the plain-text repr if anything goes wrong.
+    try:
+        if isinstance(grid, PlaneParallelGridCoords):
+            axes = [
+                ("x (width)", grid.edges_x),
+                ("y (length)", grid.edges_y),
+                ("z (altitude)", grid.levels),
+            ]
+        elif isinstance(grid, SphericalShellGridCoords):
+            axes = [
+                ("azimuth", grid.azimuths),
+                ("colatitude", grid.colatitudes),
+                ("z (altitude)", grid.levels),
+            ]
+        else:
+            return None
+
+        n_cells = [len(edges) - 1 for _, edges in axes]
+        spans = [abs(edges[-1] - edges[0]) for _, edges in axes]
+        scale_x, scale_y, scale_z = _axis_scales(*spans)
+        diagram = cuboid(*n_cells, scale_x=scale_x, scale_y=scale_y, scale_z=scale_z)
+
+        rows = [
+            el(
+                "tr",
+                el(
+                    "td",
+                    text=label,
+                    style="padding:2px 8px 2px 0;white-space:nowrap;font-weight:600",
+                ),
+                el(
+                    "td",
+                    text=_format_extent(edges[0], edges[-1]),
+                    style="padding:2px 8px 2px 0;white-space:nowrap;font-family:monospace",
+                ),
+                el(
+                    "td",
+                    text=str(n),
+                    style="padding:2px 0;text-align:right;white-space:nowrap",
+                ),
+            )
+            for (label, edges), n in zip(axes, n_cells)
+        ]
+
+        table = el(
+            "table",
+            el(
+                "thead",
+                el(
+                    "tr",
+                    el("th", text="axis", style="text-align:left;padding:0 8px 2px 0"),
+                    el(
+                        "th", text="extent", style="text-align:left;padding:0 8px 2px 0"
+                    ),
+                    el("th", text="cells", style="text-align:right;padding:0 0 2px 0"),
+                ),
+            ),
+            el("tbody", *rows),
+            style="border-collapse:collapse",
+        )
+
+        root = el(
+            "div",
+            el(
+                "div",
+                text=type(grid).__name__,
+                style="font-weight:600;margin-bottom:4px",
+            ),
+            el(
+                "div",
+                el("div", diagram),
+                table,
+                style="display:flex;align-items:center;gap:12px",
+            ),
+            style="font-size:1.17em",
+        )
+        return tostring(root)
+    except Exception:  # noqa: BLE001 — repr helper must never raise
+        return None
+
+
+def geometry_repr_html(geometry) -> str | None:
+    from .scenes.geometry import PlaneParallelGeometry, SphericalShellGeometry
+
+    # Never let a display helper break notebook rendering: fall back to
+    # the plain-text repr if anything goes wrong.
+    try:
+        if isinstance(geometry, PlaneParallelGeometry):
+            diagram = nested_cuboid(
+                geometry.width,
+                geometry.grid.total_width,
+                geometry.grid.total_length,
+                geometry.ground_altitude,
+                geometry.toa_altitude,
+            )
+        elif isinstance(geometry, SphericalShellGeometry):
+            grid = geometry.grid
+            diagram = spherical_extent(
+                grid.azimuths[0].m_as(ureg.deg),
+                grid.azimuths[-1].m_as(ureg.deg),
+                grid.colatitudes[0].m_as(ureg.deg),
+                grid.colatitudes[-1].m_as(ureg.deg),
+                geometry.ground_altitude,
+                geometry.toa_altitude,
+            )
+        else:
+            return None
+
+        root = el(
+            "div",
+            el(
+                "div",
+                text=type(geometry).__name__,
+                style="font-weight:600;margin-bottom:4px",
+            ),
+            el("div", diagram),
+            style="font-size:1.17em",
+        )
+        return tostring(root)
+    except Exception:  # noqa: BLE001 — repr helper must never raise
+        return None

--- a/src/eradiate/data/convert.py
+++ b/src/eradiate/data/convert.py
@@ -64,6 +64,8 @@ def make_aer_core_v2(
     ext: pint.Quantity,
     ssa: pint.Quantity,
     phase: pint.Quantity,
+    reff: pint.Quantity | None = None,
+    veff: pint.Quantity | None = None,
     nangles: np.ndarray | None = None,
     pmom: np.ndarray | None = None,
     nmom: int | np.ndarray | None = None,
@@ -73,7 +75,8 @@ def make_aer_core_v2(
     check: Literal["none", "fast", "full"] | None = None,
 ) -> xr.Dataset:
     """
-    Create a new dataset in the Aer-Core v2 format.
+    Create a new dataset in the Aer-Core v2 format, or the Prt v1 format
+    when ``reff``/``veff`` are provided.
 
     Parameters
     ----------
@@ -84,46 +87,53 @@ def make_aer_core_v2(
         Phase matrix component list, shape (nphamat,).
 
     mu : quantity
-        Scattering angle cosine, shape (nw, nangle).
+        Scattering angle cosine, shape (nw, [nreff, nveff, ]nangle).
 
     theta : quantity
-        Scattering angle, shape (nw, nangle).
+        Scattering angle, shape (nw, [nreff, nveff, ]nangle).
 
     ext : quantity
-        Extinction coefficient, shape (nw,).
+        Extinction coefficient, shape (nw, [nreff, nveff]).
 
     ssa : quantity
-        Single-scattering albedo, shape (nw,).
+        Single-scattering albedo, shape (nw, [nreff, nveff]).
 
     phase : quantity
-        Phase matrix values, shape (nphamat, nw, nangle).
+        Phase matrix values, shape (nphamat, nw, [nreff, nveff, ]nangle).
         Integral normalized to 2 (*i.e.* ∫ p(μ) dμ = 2).
 
+    reff, veff : quantity, optional
+        Effective radius and variance grids, shape (nreff,) and (nveff,).
+        When set, the dataset is built in the Prt v1 format: all
+        other arrays gain the corresponding ``reff``/``veff`` dimensions,
+        between ``w`` and the angular/moment dimension. Both must be set
+        together, or neither.
+
     nangles : ndarray, optional
-        Number of valid angular samples per wavelength, shape (nw,), dtype int.
-        When provided, entries at indices ``>= nangles[iw]`` in ``mu``,
-        ``theta``, and ``phase`` must be NaN-padded.  The ``nangles`` dataset
-        variable is always written; if not provided, it is inferred by counting
-        non-NaN entries in the first phase matrix component.
+        Number of valid angular samples, shape (nw, [nreff, nveff]), dtype
+        int. When provided, entries beyond ``nangles`` in ``mu``, ``theta``,
+        and ``phase`` must be NaN-padded. The ``nangles`` dataset variable is
+        always written; if not provided, it is inferred by counting non-NaN
+        entries in the first phase matrix component.
 
     pmom : ndarray, optional
         Legendre polynomials for the (1,1) phase matrix element, shape
-        (nw, nimom).  If not provided, they are computed automatically from
-        ``phase`` and ``theta`` using :func:`.compute_pmom` with
-        ``coefficients=True``.
+        (nw, [nreff, nveff, ]nimom). If not provided, they are computed
+        automatically from ``phase`` and ``theta`` using
+        :func:`.compute_pmom` with ``coefficients=True``.
 
     nmom : int or ndarray, optional
-        Controls the number of Legendre polynomials.  The ``nmom`` dataset
+        Controls the number of Legendre polynomials. The ``nmom`` dataset
         variable is always written when ``pmom`` is present.
 
         * ``None`` (default) — when ``pmom`` is not provided, compute 129
           coefficients and store their count as a uniform ``nmom`` array;
-          when ``pmom`` is provided explicitly, infer per-wavelength counts
-          by counting non-NaN entries in the first phase matrix component,
-          consistent with the NaN-padding convention.
+          when ``pmom`` is provided explicitly, infer counts by counting
+          non-NaN entries in the first phase matrix component, consistent
+          with the NaN-padding convention.
         * ``int`` — scalar moment count; used as the target for automatic
           computation and stored as a uniform ``nmom`` array.
-        * ``ndarray`` shape ``(nw,)`` — per-wavelength count stored as-is.
+        * ``ndarray`` shape ``(nw, [nreff, nveff])`` — count stored as-is.
           ``pmom`` must be provided explicitly when ``nmom`` is an ndarray.
 
     grid_res : int, default: 3
@@ -146,13 +156,13 @@ def make_aer_core_v2(
 
         * ``None`` or ``"none"`` — no check (default).
         * ``"fast"`` — sampling-based check: validates a random 10 % of
-          wavelengths (at least one). Intended as a cheap guard during bulk
+          entries (at least one). Intended as a cheap guard during bulk
           production runs.
-        * ``"full"`` — validates every wavelength.
+        * ``"full"`` — validates every entry.
 
         A ``ValueError`` is raised if any sampled row is not strictly
         monotonically increasing in μ. Only the valid (non-NaN) portion of
-        each row is checked (bounded by ``nangles[iw]``).
+        each row is checked (bounded by ``nangles``).
 
     Returns
     -------
@@ -161,49 +171,57 @@ def make_aer_core_v2(
     Raises
     ------
     ValueError
-        If a value check fails, or if ``nmom`` is an ndarray but ``pmom`` is
-        not provided.
+        If a value check fails, if ``nmom`` is an ndarray but ``pmom`` is
+        not provided, or if only one of ``reff``/``veff`` is provided.
     """
+    if (reff is None) != (veff is None):
+        raise ValueError(
+            "make_aer_core_v2(): 'reff' and 'veff' must be provided together, "
+            "or not at all"
+        )
+    extra_dims = [] if reff is None else ["reff", "veff"]
+
     # nangles is always stored. Infer from the first phase matrix component when
-    # not provided: count non-NaN entries per wavelength.
+    # not provided: count non-NaN entries along the angular dimension.
     if nangles is None:
         nangles = _count_valid(phase.m[0])
 
     if check is not None and check != "none":
-        mu_vals = mu.m  # (nw, nangle)
-        nw_check = mu_vals.shape[0]
+        mu_vals = mu.m  # (nw, [nreff, nveff, ]nangle)
+        indices = list(np.ndindex(mu_vals.shape[:-1]))
 
         if check == "fast":
             rng = np.random.default_rng(seed=0)
-            n_sample = max(1, nw_check // 10)
-            iw_check = rng.choice(nw_check, size=n_sample, replace=False)
-        else:  # "full"
-            iw_check = np.arange(nw_check)
+            n_sample = max(1, len(indices) // 10)
+            indices = [
+                indices[i]
+                for i in rng.choice(len(indices), size=n_sample, replace=False)
+            ]
 
-        for iw in iw_check:
-            n = int(nangles[iw])
-            row = mu_vals[iw, :n]
+        for idx in indices:
+            n = int(nangles[idx])
+            row = mu_vals[idx][:n]
             if not np.all(np.diff(row) > 0):
                 raise ValueError(
                     f"make_aer_core_v2(): mu is not strictly ascending at "
-                    f"wavelength index {iw}. Sort the angular grid in ascending "
+                    f"index {idx}. Sort the angular grid in ascending "
                     "mu order before calling this function."
                 )
 
     if normalize:
-        phase_vals = phase.m.copy()  # (nphamat, nw, nangle)
-        mu_vals = mu.m  # (nw, nangle)
-        for iw in range(phase_vals.shape[1]):
-            n = int(nangles[iw])
-            mu_w = mu_vals[iw, :n]
-            p11_w = phase_vals[0, iw, :n]
-            integral = np.trapezoid(p11_w, mu_w)
+        phase_vals = phase.m.copy()  # (nphamat, nw, [nreff, nveff, ]nangle)
+        mu_vals = mu.m  # (nw, [nreff, nveff, ]nangle)
+        for idx in np.ndindex(mu_vals.shape[:-1]):
+            n = int(nangles[idx])
+            mu_pt = mu_vals[idx][:n]
+            phase_pt = phase_vals[(slice(None), *idx)]  # (nphamat, nangle)
+            integral = np.trapezoid(phase_pt[0, :n], mu_pt)
             if integral == 0.0:
                 raise ValueError(
-                    f"make_aer_core_v2(): p11 integrates to 0 at wavelength "
-                    f"index {iw}; cannot normalize."
+                    f"make_aer_core_v2(): p11 integrates to 0 at index "
+                    f"{idx}; cannot normalize."
                 )
-            phase_vals[:, iw, :n] *= 2.0 / integral
+            phase_pt[:, :n] *= 2.0 / integral
         phase = phase_vals * phase.u
 
     if pmom is None:
@@ -221,38 +239,38 @@ def make_aer_core_v2(
         # Compute pmom for p_11 (index 0) only.
         # mu in the dataset is ascending (-1 → +1), so theta is descending
         # (180° → 0°). compute_pmom() expects theta ascending (0° → 180°),
-        # so we reverse each per-wavelength slice.
-        theta_deg = theta.to("deg").magnitude  # (nw, nangle)
-        phase_vals = phase.m  # (nphamat, nw, nangle)
-        _nw = theta_deg.shape[0]
+        # so we reverse each slice.
+        theta_deg = theta.to("deg").magnitude  # (nw, [nreff, nveff, ]nangle)
+        phase_vals = phase.m  # (nphamat, nw, [nreff, nveff, ]nangle)
+        leading_shape = theta_deg.shape[:-1]
 
-        pmom = np.zeros((_nw, _nmom_scalar))
-        for iw in range(_nw):
-            n = int(nangles[iw])
-            theta_w = theta_deg[iw, :n][::-1]  # ascending 0° → 180°
-            phase_w = phase_vals[0, iw, :n][::-1]  # p_11 component
-            pmom[iw, :] = _compute_pmom(
-                theta_w,
-                phase_w,
+        pmom = np.zeros(leading_shape + (_nmom_scalar,))
+        for idx in np.ndindex(leading_shape):
+            n = int(nangles[idx])
+            theta_pt = theta_deg[idx][:n][::-1]  # ascending 0° → 180°
+            phase_pt = phase_vals[(0, *idx)][:n][::-1]  # p_11 component
+            pmom[idx] = _compute_pmom(
+                theta_pt,
+                phase_pt,
                 nmom=_nmom_scalar,
                 grid_res=grid_res,
                 coefficients=True,
                 check_normalization=True,
             )
-        nmom = np.full(_nw, _nmom_scalar, dtype=np.int32)
+        nmom = np.full(leading_shape, _nmom_scalar, dtype=np.int32)
 
     # nmom is always stored alongside pmom.
-    # Normalize any remaining scalar or inferred form to a per-wavelength array.
+    # Normalize any remaining scalar or inferred form to a per-entry array.
     if nmom is None:
-        # pmom was provided explicitly without nmom: count non-NaN entries per
-        # wavelength, consistent with the NaN-padding convention.
+        # pmom was provided explicitly without nmom: count non-NaN entries,
+        # consistent with the NaN-padding convention.
         nmom = _count_valid(pmom)
     elif isinstance(nmom, int):
-        nmom = np.full(len(w.m), nmom, dtype=np.int32)
+        nmom = np.full(np.shape(nangles), nmom, dtype=np.int32)
 
     data_vars = {
         "ext": (
-            "w",
+            ["w", *extra_dims],
             ext.m,
             {
                 "standard_name": "extinction_coefficient",
@@ -261,7 +279,7 @@ def make_aer_core_v2(
             },
         ),
         "ssa": (
-            "w",
+            ["w", *extra_dims],
             ssa.m,
             {
                 "standard_name": "single_scattering_albedo",
@@ -270,7 +288,7 @@ def make_aer_core_v2(
             },
         ),
         "phase": (
-            ["phamat", "w", "iangle"],
+            ["phamat", "w", *extra_dims, "iangle"],
             phase.m,
             {
                 "standard_name": "phase_matrix",
@@ -282,7 +300,7 @@ def make_aer_core_v2(
     }
 
     data_vars["nangles"] = (
-        "w",
+        ["w", *extra_dims],
         nangles,
         {
             "standard_name": "n_angular_samples",
@@ -291,7 +309,7 @@ def make_aer_core_v2(
     )
 
     data_vars["nmom"] = (
-        "w",
+        ["w", *extra_dims],
         nmom,
         {
             "standard_name": "n_legendre_polys",
@@ -300,7 +318,7 @@ def make_aer_core_v2(
     )
 
     data_vars["pmom"] = (
-        ["w", "imom"],
+        ["w", *extra_dims, "imom"],
         pmom,
         {
             "standard_name": "legendre_polys",
@@ -328,7 +346,7 @@ def make_aer_core_v2(
             },
         ),
         "mu": (
-            ["w", "iangle"],
+            ["w", *extra_dims, "iangle"],
             mu.m,
             {
                 "standard_name": "cos_scattering_angle",
@@ -337,7 +355,7 @@ def make_aer_core_v2(
             },
         ),
         "theta": (
-            ["w", "iangle"],
+            ["w", *extra_dims, "iangle"],
             theta.m,
             {
                 "standard_name": "scattering_angle",
@@ -347,7 +365,116 @@ def make_aer_core_v2(
         ),
     }
 
+    if reff is not None:
+        coords["reff"] = (
+            "reff",
+            reff.m,
+            {
+                "standard_name": "effective_radius",
+                "long_name": "effective radius",
+                "units": symbol(reff.u),
+            },
+        )
+        coords["veff"] = (
+            "veff",
+            veff.m,
+            {
+                "standard_name": "effective_variance",
+                "long_name": "effective variance",
+                "units": symbol(veff.u),
+            },
+        )
+
     return xr.Dataset(data_vars=data_vars, coords=coords, attrs=attrs or {})
+
+
+def _shared_attrs(datasets: list[xr.Dataset]) -> dict:
+    """Attrs common to all *datasets*, by key and value; the rest are dropped."""
+    ref_attrs = datasets[0].attrs
+    return {
+        key: value
+        for key, value in ref_attrs.items()
+        if all(ds.attrs.get(key, ref_attrs) == value for ds in datasets[1:])
+    }
+
+
+def concat_particles_veff(datasets: list[xr.Dataset]) -> xr.Dataset:
+    """
+    Concatenate several Prt v1 datasets along the ``veff`` dimension.
+
+    Parameters
+    ----------
+    datasets : list of xr.Dataset
+        Prt v1 datasets (as produced by :func:`make_aer_core_v2` with
+        ``reff``/``veff`` set), each with a ``reff``/``veff``-dimensioned
+        layout. Every dataset may cover one or several ``veff`` values. All
+        datasets must share the same ``w``, ``reff``, and ``phamat``
+        coordinates.
+
+    Returns
+    -------
+    xr.Dataset
+        Prt v1 dataset with a ``veff`` dimension spanning the concatenation
+        of all input datasets' ``veff`` values. ``iangle``/``imom`` are
+        padded to the largest size found across inputs. Only attrs common
+        to all input datasets are retained.
+
+    Raises
+    ------
+    ValueError
+        If the datasets do not share the same ``w``, ``reff``, or ``phamat``
+        coordinates.
+    """
+    ref = datasets[0]
+
+    for ds in datasets[1:]:
+        if not np.array_equal(ds["w"].values, ref["w"].values):
+            raise ValueError("All datasets must share the same 'w' coordinate.")
+        if not np.array_equal(ds["reff"].values, ref["reff"].values):
+            raise ValueError("All datasets must share the same 'reff' coordinate.")
+        if not np.array_equal(ds["phamat"].values, ref["phamat"].values):
+            raise ValueError("All datasets must share the same 'phamat' coordinate.")
+
+    n_iangle = max(ds.sizes["iangle"] for ds in datasets)
+    n_imom = max(ds.sizes["imom"] for ds in datasets)
+
+    def pad_last(a: np.ndarray, n: int) -> np.ndarray:
+        pad_width = [(0, 0)] * (a.ndim - 1) + [(0, n - a.shape[-1])]
+        return np.pad(a, pad_width, mode="constant", constant_values=np.nan)
+
+    mu = np.concatenate(
+        [pad_last(ds["mu"].values, n_iangle) for ds in datasets], axis=2
+    )
+    theta = np.concatenate(
+        [pad_last(ds["theta"].values, n_iangle) for ds in datasets], axis=2
+    )
+    phase = np.concatenate(
+        [pad_last(ds["phase"].values, n_iangle) for ds in datasets], axis=3
+    )
+    pmom = np.concatenate(
+        [pad_last(ds["pmom"].values, n_imom) for ds in datasets], axis=2
+    )
+    ext = np.concatenate([ds["ext"].values for ds in datasets], axis=2)
+    ssa = np.concatenate([ds["ssa"].values for ds in datasets], axis=2)
+    nangles = np.concatenate([ds["nangles"].values for ds in datasets], axis=2)
+    nmom = np.concatenate([ds["nmom"].values for ds in datasets], axis=2)
+    veff = np.concatenate([ds["veff"].values for ds in datasets])
+
+    return make_aer_core_v2(
+        w=to_quantity(ref["w"]),
+        phamat=list(ref["phamat"].values),
+        mu=mu * ureg(ref["mu"].attrs["units"]),
+        theta=theta * ureg(ref["theta"].attrs["units"]),
+        ext=ext * ureg(ref["ext"].attrs["units"]),
+        ssa=ssa * ureg(ref["ssa"].attrs["units"]),
+        phase=phase * ureg(ref["phase"].attrs["units"]),
+        reff=to_quantity(ref["reff"]),
+        veff=veff * ureg(ref["veff"].attrs["units"]),
+        nangles=nangles,
+        pmom=pmom,
+        nmom=nmom,
+        attrs=_shared_attrs(datasets),
+    )
 
 
 def aer_v1_to_aer_core_v2(

--- a/src/eradiate/experiments/_helpers.py
+++ b/src/eradiate/experiments/_helpers.py
@@ -108,7 +108,7 @@ def check_geometry_atmosphere(
     """
 
     radprops_zbounds = atmosphere.radprops_profile.zbounds
-    geometry_zbounds = geometry.zgrid.levels[[0, -1]]
+    geometry_zbounds = geometry.grid.levels[[0, -1]]
     suggested_solution = (
         "Try to set the experiment geometry so that it does not go beyond "
         "the vertical extent of the molecular atmosphere."
@@ -117,8 +117,8 @@ def check_geometry_atmosphere(
         geometry_zbounds[1] > radprops_zbounds[1]
     ):
         raise ValueError(
-            "Attribtues 'geometry' and 'atmosphere' are incompatible: "
-            f"'geometry.zgrid' bounds ({geometry_zbounds}) go beyond the "
+            "Attributes 'geometry' and 'atmosphere' are incompatible: "
+            f"'geometry.grid' bounds ({geometry_zbounds}) go beyond the "
             f"bounds of 'atmosphere.radprops_profile.zbounds' ({radprops_zbounds}). "
             f"{suggested_solution}"
         )

--- a/src/eradiate/grid.py
+++ b/src/eradiate/grid.py
@@ -10,6 +10,7 @@ from pinttr.util import ensure_units
 
 from eradiate.kernel.transform import map_unit_cube
 
+from . import _repr_diagrams
 from .attrs import documented, frozen
 from .units import unit_context_config as ucc
 from .units import unit_context_kernel as uck
@@ -308,6 +309,9 @@ class GridCoords(ABC):
     @abstractmethod
     def to_world(self) -> mi.ScalarTransform4f:
         """Grid to_world"""
+
+    def _repr_html_(self) -> str | None:
+        return _repr_diagrams.grid_repr_html(self)
 
 
 @frozen(eq=False, init=False)

--- a/src/eradiate/grid.py
+++ b/src/eradiate/grid.py
@@ -1,0 +1,1170 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+import mitsuba as mi
+import numpy as np
+import pint
+import pinttr
+from pinttr.util import ensure_units
+
+from eradiate.kernel.transform import map_unit_cube
+
+from .attrs import documented, frozen
+from .units import unit_context_config as ucc
+from .units import unit_context_kernel as uck
+from .units import unit_registry as ureg
+
+
+@frozen(eq=False, init=False)
+class GridCoords(ABC):
+    """
+    Abstract coordinate grid for an atmosphere, expressed in 3 dimensions (X, Y and Z).
+
+    Eradiate's coordinate systems are made to conveniently locate objects
+    in a 3D scene. It does not map to an actual coordinate system used in
+    Earth Observation or to a specific projection explicitly.
+
+    Two coordinate systems are used internally, one for spherical shell
+    atmospheric geometries and another for plane parallel geometries.
+
+    Specializations of this class may implement their own logic to map their
+    coordinate system to one of the internal grid coordinates of Eradiate:
+
+    * Plane parallel: a local Cartesian frame
+      (X: local position [L], Y: local position [L], Z: altitude [L])
+    * Spherical shell: a geocentric spherical frame
+      (X: azimuth [dimensionless], Y: colatitude [dimensionless], Z: radius [L])
+
+    Notes
+    -----
+    * Instances are immutable.
+    * Instances are hashable by ID. This is required to allow for using them as
+      an argument of an LRU-cached function.
+    * This class is used as the argument of the ``eval()`` family of methods.
+    """
+
+    levels: pint.Quantity = documented(
+        pinttr.field(
+            units=ucc.deferred("length"),
+            on_setattr=None,
+        ),
+        type="pint.Quantity",
+        init_type="quantity or array-like",
+        doc="Grid node altitudes.\n\nUnit-enabled field (default: ``ucc['length']``).",
+    )
+
+    _layers: pint.Quantity = pinttr.field(
+        units=ucc.deferred("length"),
+        on_setattr=None,
+    )
+
+    _layer_height: pint.Quantity = pinttr.field(
+        units=ucc.deferred("length"),
+        on_setattr=None,
+    )
+
+    @_layer_height.validator
+    def _layer_height_validator(self, attribute, value):
+        if not np.isscalar(value.magnitude):
+            raise ValueError("layer height must be a scalar")
+
+    _total_height: pint.Quantity = pinttr.field(
+        units=ucc.deferred("length"),
+        on_setattr=None,
+    )
+
+    @staticmethod
+    def make_onedim_from_levels(levels: pint.Quantity):
+        """
+        Build a plane parallel 1D GridCoords using provided ``levels`` to
+        define the vertical extent and the horizontal extent comes from
+        Eradiate's default atmosphere width
+        """
+
+        ensure_units(levels, default_units=ucc.get("length"))
+
+        default = GridCoords.make_default()
+
+        return PlaneParallelGridCoords(
+            levels=levels,
+            edges_x=default.edges_x,
+            edges_y=default.edges_y,
+        )
+
+    @staticmethod
+    def make_onedim_arange(
+        top: pint.Quantity,
+        bottom: pint.Quantity,
+        step: pint.Quantity,
+        width: pint.Quantity,
+    ):
+        """
+        Build a plane parallel 1D GridCoords using ``width`` for horizontal
+        extents and the provided ``top`` and ``bottom`` altitude for the vertical coordinate.
+
+        Parameters
+        ----------
+        top
+            Top of the atmosphere altitude
+        bottom
+            Ground altitude
+        step
+            Regular layer height
+        width
+            Grid width
+
+        Returns
+        -------
+        PlaneParallelGridCoords
+            Constructed coords grid
+        """
+
+        ensure_units(top, default_units=ucc.get("length"))
+        ensure_units(bottom, default_units=ucc.get("length"))
+        ensure_units(width, default_units=ucc.get("length"))
+
+        levels = ureg.convert(
+            np.arange(
+                bottom.m_as(ureg.m), (top + step * 0.1).m_as(ureg.m), step.m_as(ureg.m)
+            ),
+            ureg.m,
+            ucc.get("length"),
+        )
+
+        return PlaneParallelGridCoords.from_extent_and_resolution(
+            levels=levels,
+            extent_x=width,
+            extent_y=width,
+            n_cells_x=1,
+            n_cells_y=1,
+        )
+
+    @staticmethod
+    def make_default():
+        """
+        Build the default plane parallel 1D GridCoords for Eradiate
+        atmospheres.
+
+        Bottom altitude is set to zero and top at 120 km. Each layer is 100m high.
+        The horizontal extent is 1e6 km.
+        """
+
+        bottom = 0.0 * ureg.km
+        top = 120.0 * ureg.km
+        step = 100.0 * ureg.m
+        width = 1e6 * ureg.km
+
+        return GridCoords.make_onedim_arange(top, bottom, step, width)
+
+    @classmethod
+    def convert(cls, value: t.Any) -> t.Any:
+        """
+        Convert dictionary type of parameters to a GridCoords.
+
+        Returns the default plane parallel ``GridCoords`` if value
+        is ``"plane_parallel_coords"``. If value is a ``pint.Quantity``,
+        attempts to construct a 1D atmosphere with the layer altitudes
+        contained in the quantity. If value is a ``np.ndarray``, interpret it
+        as an array of layer altitudes in meters.
+
+        If value is a dict, expects a ``"type"`` key with the value
+        ``"plane_parallel_coords"`` or ``"spherical_shell_geometry"``.
+        Other keys are passed to the relevant subclass constructor.
+
+        Parameters
+        ----------
+        value
+            ``str``, ``dict`` or ``pint.Quantity`` the parameter specification
+
+        Returns
+        -------
+        GridCoords
+            Constructed grid
+        """
+        if isinstance(value, str):
+            if value == "plane_parallel_coords":
+                return cls.make_default()
+            raise ValueError(f"No default factory for the type id {type}")
+        elif isinstance(value, dict):
+            value = value.copy()
+            value_t = value.pop("type")
+            if value_t == "plane_parallel_coords":
+                return PlaneParallelGridCoords(**value)
+            elif value_t == "spherical_shell_coords":
+                return SphericalShellGridCoords(**value)
+        elif isinstance(value, pint.Quantity):
+            return cls.make_onedim_from_levels(value)
+        elif isinstance(value, np.ndarray):
+            return cls.make_onedim_from_levels(value * ureg.m)
+
+        return value
+
+    @property
+    def layers(self) -> pint.Quantity:
+        """
+        Returns
+        -------
+        quantity
+            Vector of altitudes of layer centres.
+        """
+        return self._layers
+
+    @property
+    def layer_height(self) -> pint.Quantity:
+        """
+        Returns
+        -------
+        quantity
+            Layer height.
+        """
+        return self._layer_height
+
+    @property
+    def total_height(self) -> pint.Quantity:
+        """
+        Returns
+        -------
+        quantity
+            Total height covered by the altitude grid.
+        """
+        return self._total_height
+
+    @property
+    def n_levels(self) -> int:
+        """
+        Returns
+        -------
+        int
+            Number of levels (Z edges).
+        """
+        return len(self.levels)
+
+    @property
+    def n_layers(self) -> int:
+        """
+        Returns
+        -------
+        int
+            Number of layers (Z cells).
+        """
+        return len(self.layers)
+
+    @property
+    @abstractmethod
+    def cells_x(self) -> pint.Quantity:
+        raise NotImplementedError()
+
+    @property
+    @abstractmethod
+    def cells_y(self) -> pint.Quantity:
+        raise NotImplementedError()
+
+    @property
+    @abstractmethod
+    def n_cells_x(self) -> int:
+        """Number of cells in the X direction."""
+        raise NotImplementedError()
+
+    @property
+    @abstractmethod
+    def n_cells_y(self) -> int:
+        """Number of cells in the Y direction."""
+        raise NotImplementedError()
+
+    @property
+    @abstractmethod
+    def n_edges_x(self) -> int:
+        """Number of edges in the X direction."""
+        raise NotImplementedError()
+
+    @property
+    @abstractmethod
+    def n_edges_y(self) -> int:
+        """Number of edges in the Y direction."""
+        raise NotImplementedError()
+
+    @property
+    def n_cells_z(self) -> int:
+        """Number of cells in the Z direction (equal to number of layers)."""
+        return self.n_layers
+
+    @property
+    def n_edges_z(self) -> int:
+        """Number of edges in the Z direction (equal to number of levels)."""
+        return self.n_levels
+
+    @property
+    def shape(self) -> tuple[int, int, int]:
+        """Grid dimensions sizes, or numpy shape. (X, Y, Z) order."""
+        return (self.n_cells_x, self.n_cells_y, self.n_cells_z)
+
+    @property
+    def onedim(self) -> bool:
+        """Is this grid suitable for expressing properties of a 1D atmosphere."""
+        return self.n_cells_x == 1 and self.n_cells_y == 1
+
+    @property
+    @abstractmethod
+    def to_world(self) -> mi.ScalarTransform4f:
+        """Grid to_world"""
+
+
+@frozen(eq=False, init=False)
+class PlaneParallelGridCoords(GridCoords):
+    """
+    Plane parallel grid coordinates [``plane_parallel_coords``].
+
+    Implements the internal coordinate system for Eradiate plane parallel
+    geometries, using a local Cartesian reference frame.
+    (X: local position [L], Y: local position [L], Z: altitude [L])
+
+    The grid is regular: cells have uniform width in X and uniform length in Y,
+    but these two spacings are independent.
+    """
+
+    edges_x: pint.Quantity = documented(
+        pinttr.field(
+            units=ucc.deferred("length"),
+            on_setattr=None,
+        ),
+        type="pint.Quantity",
+        init_type="quantity or array-like",
+        doc="Grid node positions in the X direction.\n\nUnit-enabled field (default: ``ucc['length']``).",
+    )
+
+    edges_y: pint.Quantity = documented(
+        pinttr.field(
+            units=ucc.deferred("length"),
+            on_setattr=None,
+        ),
+        type="pint.Quantity",
+        init_type="quantity or array-like",
+        doc="Grid node positions in the Y direction.\n\nUnit-enabled field (default: ``ucc['length']``).",
+    )
+
+    _centers_x: pint.Quantity = pinttr.field(
+        units=ucc.deferred("length"),
+        on_setattr=None,
+    )
+
+    _centers_y: pint.Quantity = pinttr.field(
+        units=ucc.deferred("length"),
+        on_setattr=None,
+    )
+
+    _cell_width: pint.Quantity = pinttr.field(
+        units=ucc.deferred("length"),
+        on_setattr=None,
+    )
+
+    _cell_length: pint.Quantity = pinttr.field(
+        units=ucc.deferred("length"),
+        on_setattr=None,
+    )
+
+    _total_width: pint.Quantity = pinttr.field(
+        units=ucc.deferred("length"),
+        on_setattr=None,
+    )
+
+    _total_length: pint.Quantity = pinttr.field(
+        units=ucc.deferred("length"),
+        on_setattr=None,
+    )
+
+    def __rich_repr__(self):
+        yield "levels", self.levels
+        yield "layers", self.layers
+        yield "layer_height", self.layer_height
+        yield "total_height", self.total_height
+
+        yield "edges_x", self.edges_x
+        yield "centers_x", self.centers_x
+        yield "cell_width", self.cell_width
+        yield "total_width", self.total_width
+
+        yield "edges_y", self.edges_y
+        yield "centers_y", self.centers_y
+        yield "cell_length", self.cell_length
+        yield "total_length", self._total_length
+
+        yield "shape", self.shape
+
+    @_cell_width.validator
+    @_cell_length.validator
+    def _cell_extent_validator(self, attribute, value):
+        if not np.isscalar(value.magnitude):
+            raise ValueError("cell extent must be a scalar")
+
+    def __init__(
+        self,
+        levels: pint.Quantity,
+        edges_x: pint.Quantity,
+        edges_y: pint.Quantity,
+    ):
+        levels = ensure_units(levels, default_units=ucc.get("length"))
+        layer_height = np.diff(levels)
+        if not np.allclose(layer_height, layer_height[0]):
+            raise ValueError("levels must be regularly spaced")
+        layers = levels[:-1] + 0.5 * layer_height
+
+        edges_x = ensure_units(edges_x, default_units=ucc.get("length"))
+        edges_y = ensure_units(edges_y, default_units=ucc.get("length"))
+
+        def _centers_and_step(edges, axis):
+            step = np.diff(edges)
+            if not np.allclose(step, step[0]):
+                raise ValueError(f"edges_{axis} must be regularly spaced")
+            return edges[:-1] + 0.5 * step, step[0]
+
+        centers_x, cell_width = _centers_and_step(edges_x, "x")
+        centers_y, cell_length = _centers_and_step(edges_y, "y")
+
+        self.__attrs_init__(
+            levels=levels,
+            layers=layers,
+            layer_height=layer_height[0],
+            total_height=levels[-1] - levels[0],
+            edges_x=edges_x,
+            edges_y=edges_y,
+            centers_x=centers_x,
+            centers_y=centers_y,
+            cell_width=cell_width,
+            cell_length=cell_length,
+            total_width=edges_x[-1] - edges_x[0],
+            total_length=edges_y[-1] - edges_y[0],
+        )
+
+    @property
+    def to_world(self) -> mi.ScalarTransform4f:
+        """Grid to_world in cartesian coordinates"""
+        unit = uck.get("length")
+        return map_unit_cube(
+            self.edges_x.min().m_as(unit),
+            self.edges_x.max().m_as(unit),
+            self.edges_y.min().m_as(unit),
+            self.edges_y.max().m_as(unit),
+            self.levels.min().m_as(unit),
+            self.levels.max().m_as(unit),
+        )
+
+    @property
+    def centers_x(self) -> pint.Quantity:
+        """
+        Returns
+        -------
+        quantity
+            Vector of cell centre positions in the X direction.
+        """
+        return self._centers_x
+
+    @property
+    def centers_y(self) -> pint.Quantity:
+        """
+        Returns
+        -------
+        quantity
+            Vector of cell centre positions in the Y direction.
+        """
+        return self._centers_y
+
+    @property
+    def cell_width(self) -> pint.Quantity:
+        """
+        Returns
+        -------
+        quantity
+            Uniform cell width in the X direction.
+        """
+        return self._cell_width
+
+    @property
+    def cell_length(self) -> pint.Quantity:
+        """
+        Returns
+        -------
+        quantity
+            Uniform cell length in the Y direction.
+        """
+        return self._cell_length
+
+    @property
+    def total_width(self) -> pint.Quantity:
+        """
+        Returns
+        -------
+        quantity
+            Total extent of the grid in the X direction.
+        """
+        return self._total_width
+
+    @property
+    def total_length(self) -> pint.Quantity:
+        """
+        Returns
+        -------
+        quantity
+            Total extent of the grid in the Y direction.
+        """
+        return self._total_length
+
+    @property
+    def n_cells_x(self) -> int:
+        """Number of cells in the X direction."""
+        return len(self._centers_x)
+
+    @property
+    def n_cells_y(self) -> int:
+        """Number of cells in the Y direction."""
+        return len(self._centers_y)
+
+    @property
+    def n_edges_x(self) -> int:
+        """Number of edges in the X direction."""
+        return len(self.edges_x)
+
+    @property
+    def n_edges_y(self) -> int:
+        """Number of edges in the Y direction."""
+        return len(self.edges_y)
+
+    def __repr__(self) -> str:
+        return (
+            f"PlaneParallelGridCoords(\n"
+            f"  x: [{self.edges_x[0]:~P}, {self.edges_x[-1]:~P}], {self.n_cells_x} cells\n"
+            f"  y: [{self.edges_y[0]:~P}, {self.edges_y[-1]:~P}], {self.n_cells_y} cells\n"
+            f"  z: [{self.levels[0]:~P}, {self.levels[-1]:~P}], {self.n_layers} layers\n"
+            f")"
+        )
+
+    @staticmethod
+    def _make_centered_edges(extent: pint.Quantity, n_cells: int) -> pint.Quantity:
+        """Return regularly spaced edges centred at zero."""
+        half = extent / 2.0
+        return np.linspace(-half, half, n_cells + 1)
+
+    @staticmethod
+    def _cells_from_extent_and_size(
+        extent: pint.Quantity,
+        cell_size: pint.Quantity,
+        atol: pint.Quantity | None,
+    ) -> int:
+        """
+        Derive the number of cells fitting in *extent* given *cell_size*.
+
+        Parameters
+        ----------
+        extent
+            Total extent of the domain.
+        cell_size
+            Desired cell size.
+        atol
+            Absolute tolerance on the remainder. If ``None``, the remainder is
+            silently ignored and the floor count is returned. Otherwise a
+            ``ValueError`` is raised when the remainder exceeds *atol*.
+
+        Returns
+        -------
+        int
+            Number of cells.
+        """
+        ratio = extent / cell_size
+        n = int(np.floor(ratio.to("").magnitude))
+        remainder = (ratio.to("").magnitude - n) * cell_size
+        if atol is not None and remainder > atol:
+            raise ValueError(
+                f"extent {extent} is not a multiple of cell size {cell_size} "
+                f"within tolerance {atol} (remainder: {remainder})"
+            )
+        return n
+
+    @classmethod
+    def from_extent_and_resolution(
+        cls,
+        levels: pint.Quantity,
+        extent_x: pint.Quantity,
+        extent_y: pint.Quantity,
+        n_cells_x: int,
+        n_cells_y: int,
+    ) -> PlaneParallelGridCoords:
+        """
+        Construct from domain extents and cell counts, centred at the origin.
+
+        Parameters
+        ----------
+        levels
+            Altitude levels (Z edges).
+        extent_x
+            Total extent of the domain in the X direction.
+        extent_y
+            Total extent of the domain in the Y direction.
+        n_cells_x
+            Number of cells in the X direction.
+        n_cells_y
+            Number of cells in the Y direction.
+
+        Returns
+        -------
+        PlaneParallelGridCoords
+        """
+        extent_x = ensure_units(extent_x, default_units=ucc.get("length"))
+        extent_y = ensure_units(extent_y, default_units=ucc.get("length"))
+
+        edges_x = cls._make_centered_edges(extent_x, n_cells_x)
+        edges_y = cls._make_centered_edges(extent_y, n_cells_y)
+
+        return cls(levels=levels, edges_x=edges_x, edges_y=edges_y)
+
+    @classmethod
+    def from_extent_and_cell_size(
+        cls,
+        levels: pint.Quantity,
+        extent_x: pint.Quantity,
+        extent_y: pint.Quantity,
+        cell_width: pint.Quantity,
+        cell_length: pint.Quantity,
+        atol: pint.Quantity | None = None,
+    ) -> PlaneParallelGridCoords:
+        """
+        Construct from domain extents and cell sizes, centred at the origin.
+
+        The number of cells is derived from the extent and cell size. If the
+        extent is not an exact multiple of the cell size, the behaviour depends
+        on *atol*: if ``None``, the largest fitting number of cells is used;
+        otherwise a ``ValueError`` is raised when the remainder exceeds *atol*.
+
+        Parameters
+        ----------
+        levels
+            Altitude levels (Z edges).
+        extent_x
+            Total extent of the domain in the X direction.
+        extent_y
+            Total extent of the domain in the Y direction.
+        cell_width
+            Desired cell width in the X direction.
+        cell_length
+            Desired cell length in the Y direction.
+        atol
+            Absolute tolerance on the remainder extent. Unit-enabled.
+
+        Returns
+        -------
+        PlaneParallelGridCoords
+        """
+        extent_x = ensure_units(extent_x, default_units=ucc.get("length"))
+        extent_y = ensure_units(extent_y, default_units=ucc.get("length"))
+        cell_width = ensure_units(cell_width, default_units=ucc.get("length"))
+        cell_length = ensure_units(cell_length, default_units=ucc.get("length"))
+        if atol is not None:
+            atol = ensure_units(atol, default_units=ucc.get("length"))
+
+        n_cells_x = cls._cells_from_extent_and_size(extent_x, cell_width, atol)
+        n_cells_y = cls._cells_from_extent_and_size(extent_y, cell_length, atol)
+
+        edges_x = cls._make_centered_edges(extent_x, n_cells_x)
+        edges_y = cls._make_centered_edges(extent_y, n_cells_y)
+
+        return cls(levels=levels, edges_x=edges_x, edges_y=edges_y)
+
+    @classmethod
+    def from_cell_size_and_count(
+        cls,
+        levels: pint.Quantity,
+        cell_width: pint.Quantity,
+        cell_length: pint.Quantity,
+        n_cells_x: int,
+        n_cells_y: int,
+    ) -> PlaneParallelGridCoords:
+        """
+        Construct from cell sizes and counts, centred at the origin.
+
+        The domain extent is derived as ``cell_size * n_cells``.
+
+        Parameters
+        ----------
+        levels
+            Altitude levels (Z edges).
+        cell_width
+            Cell width in the X direction.
+        cell_length
+            Cell length in the Y direction.
+        n_cells_x
+            Number of cells in the X direction.
+        n_cells_y
+            Number of cells in the Y direction.
+
+        Returns
+        -------
+        PlaneParallelGridCoords
+        """
+        cell_width = ensure_units(cell_width, default_units=ucc.get("length"))
+        cell_length = ensure_units(cell_length, default_units=ucc.get("length"))
+
+        extent_x = cell_width * n_cells_x
+        extent_y = cell_length * n_cells_y
+
+        edges_x = cls._make_centered_edges(extent_x, n_cells_x)
+        edges_y = cls._make_centered_edges(extent_y, n_cells_y)
+
+        return cls(levels=levels, edges_x=edges_x, edges_y=edges_y)
+
+    def extended_by_cells(
+        self,
+        n_x: int,
+        n_y: int,
+    ) -> PlaneParallelGridCoords:
+        """
+        Extend the grid symmetrically by appending cells on each side.
+
+        The cell size is preserved. ``n_x`` cells are added on each side in X,
+        and ``n_y`` cells on each side in Y, so the total cell count grows by
+        ``2 * n_x`` and ``2 * n_y`` respectively.
+
+        Parameters
+        ----------
+        n_x
+            Number of cells to add on each side in the X direction.
+        n_y
+            Number of cells to add on each side in the Y direction.
+
+        Returns
+        -------
+        PlaneParallelGridCoords
+            New instance with extended edges.
+        """
+
+        def _extend(edges, step, n):
+            prepend = edges[0] - step * np.arange(n, 0, -1)
+            append = edges[-1] + step * np.arange(1, n + 1)
+            return np.concatenate([prepend, edges, append])
+
+        edges_x = _extend(self.edges_x, self.cell_width, n_x)
+        edges_y = _extend(self.edges_y, self.cell_length, n_y)
+
+        return self.__class__(levels=self.levels, edges_x=edges_x, edges_y=edges_y)
+
+    def extended_by_extent(
+        self,
+        extent_x: pint.Quantity,
+        extent_y: pint.Quantity,
+        atol: pint.Quantity | None = None,
+    ) -> PlaneParallelGridCoords:
+        """
+        Extend the grid symmetrically by a physical margin on each side.
+
+        The cell size is preserved. The number of cells added is derived from
+        the margin and cell size. If the margin is not an exact multiple of the
+        cell size, the behaviour depends on *atol*.
+
+        Parameters
+        ----------
+        extent_x
+            Physical margin to add on each side in the X direction.
+        extent_y
+            Physical margin to add on each side in the Y direction.
+        atol
+            Absolute tolerance on the remainder extent.
+
+        Returns
+        -------
+        PlaneParallelGridCoords
+            New instance with extended edges.
+        """
+        extent_x = ensure_units(extent_x, default_units=ucc.get("length"))
+        extent_y = ensure_units(extent_y, default_units=ucc.get("length"))
+        if atol is not None:
+            atol = ensure_units(atol, default_units=ucc.get("length"))
+
+        n_x = self._cells_from_extent_and_size(extent_x, self.cell_width, atol)
+        n_y = self._cells_from_extent_and_size(extent_y, self.cell_length, atol)
+
+        return self.extended_by_cells(n_x, n_y)
+
+    def resampled(
+        self,
+        n_cells_x: int,
+        n_cells_y: int,
+    ) -> PlaneParallelGridCoords:
+        """
+        Resample the grid to a new resolution, preserving the extent.
+
+        Parameters
+        ----------
+        n_cells_x
+            New number of cells in the X direction.
+        n_cells_y
+            New number of cells in the Y direction.
+
+        Returns
+        -------
+        PlaneParallelGridCoords
+            New instance with the same extent but different resolution.
+        """
+        edges_x = np.linspace(self.edges_x[0], self.edges_x[-1], n_cells_x + 1)
+        edges_y = np.linspace(self.edges_y[0], self.edges_y[-1], n_cells_y + 1)
+
+        return self.__class__(levels=self.levels, edges_x=edges_x, edges_y=edges_y)
+
+    def resampled_to_cell_size(
+        self,
+        cell_width: pint.Quantity,
+        cell_length: pint.Quantity,
+        atol: pint.Quantity | None = None,
+    ) -> PlaneParallelGridCoords:
+        """
+        Resample the grid to a new cell size, preserving the extent.
+
+        Parameters
+        ----------
+        cell_width
+            New cell width in the X direction.
+        cell_length
+            New cell length in the Y direction.
+        atol
+            Absolute tolerance on the remainder extent.
+
+        Returns
+        -------
+        PlaneParallelGridCoords
+            New instance with the same extent but different cell size.
+        """
+        cell_width = ensure_units(cell_width, default_units=ucc.get("length"))
+        cell_length = ensure_units(cell_length, default_units=ucc.get("length"))
+        if atol is not None:
+            atol = ensure_units(atol, default_units=ucc.get("length"))
+
+        n_cells_x = self._cells_from_extent_and_size(self.total_width, cell_width, atol)
+        n_cells_y = self._cells_from_extent_and_size(
+            self.total_length, cell_length, atol
+        )
+
+        return self.resampled(n_cells_x, n_cells_y)
+
+    def cropped(
+        self,
+        extent_x: pint.Quantity,
+        extent_y: pint.Quantity,
+    ) -> PlaneParallelGridCoords:
+        """
+        Crop the grid symmetrically to a smaller extent.
+
+        Snaps to the nearest existing edge inward. Raises if the requested
+        extent exceeds the current domain.
+
+        Parameters
+        ----------
+        extent_x
+            Target extent in the X direction.
+        extent_y
+            Target extent in the Y direction.
+
+        Returns
+        -------
+        PlaneParallelGridCoords
+            New instance with reduced extent.
+
+        Raises
+        ------
+        ValueError
+            If the requested extent exceeds the current domain in either
+            direction.
+        """
+        extent_x = ensure_units(extent_x, default_units=ucc.get("length"))
+        extent_y = ensure_units(extent_y, default_units=ucc.get("length"))
+
+        if extent_x > self.total_width:
+            raise ValueError(
+                f"requested extent_x {extent_x} exceeds current domain width {self.total_width}"
+            )
+        if extent_y > self.total_length:
+            raise ValueError(
+                f"requested extent_y {extent_y} exceeds current domain length {self.total_length}"
+            )
+
+        def _crop_edges(edges, n_drop):
+            return edges[n_drop : len(edges) - n_drop]
+
+        def _n_drop(total_cells, target_cells):
+            drop, remainder = divmod(total_cells - target_cells, 2)
+            if remainder != 0:
+                raise ValueError(
+                    f"cannot crop symmetrically: difference in cell count "
+                    f"({total_cells - target_cells}) is odd"
+                )
+            return drop
+
+        n_cells_x = self._cells_from_extent_and_size(
+            extent_x, self.cell_width, atol=None
+        )
+        n_cells_y = self._cells_from_extent_and_size(
+            extent_y, self.cell_length, atol=None
+        )
+
+        drop_x = _n_drop(self.n_cells_x, n_cells_x)
+        drop_y = _n_drop(self.n_cells_y, n_cells_y)
+
+        edges_x = _crop_edges(self.edges_x, drop_x)
+        edges_y = _crop_edges(self.edges_y, drop_y)
+
+        return self.__class__(levels=self.levels, edges_x=edges_x, edges_y=edges_y)
+
+    def centered(self) -> PlaneParallelGridCoords:
+        """
+        Return a new grid with the same cell size and count, centred at zero.
+
+        Returns
+        -------
+        PlaneParallelGridCoords
+            New instance centred at the origin.
+        """
+        edges_x = self._make_centered_edges(self.total_width, self.n_cells_x)
+        edges_y = self._make_centered_edges(self.total_length, self.n_cells_y)
+
+        return self.__class__(levels=self.levels, edges_x=edges_x, edges_y=edges_y)
+
+    def single_column(self) -> PlaneParallelGridCoords:
+        """
+        Collapse the grid to a single horizontal cell.
+
+        Useful when treating a 3D grid as a 1D vertical profile. The single
+        cell spans the full extent of the original grid.
+
+        Returns
+        -------
+        PlaneParallelGridCoords
+            New instance with a single cell in X and Y.
+        """
+        return self.__class__(
+            levels=self.levels,
+            edges_x=self.edges_x[[0, -1]],
+            edges_y=self.edges_y[[0, -1]],
+        )
+
+    @property
+    def cells_x(self):
+        return self.centers_x
+
+    @property
+    def cells_y(self):
+        return self.centers_y
+
+
+@frozen(eq=False, init=False)
+class SphericalShellGridCoords(GridCoords):
+    """
+    Spherical shell grid coordinates [``spherical_shell_coords``].
+
+    Implements the internal coordinate system for Eradiate spherical shell
+    atmospheric geometries, using a geocentric spherical convention.
+    (X: azimuth [dimensionless], Y: colatitude [dimensionless], Z: radius [L])
+
+    Both X and Y coordinates are dimensionless angles (radians in SI).
+    The grid is regular in both directions, and independently sized.
+    """
+
+    azimuths: pint.Quantity = documented(
+        pinttr.field(
+            units=ucc.deferred("angle"),
+            on_setattr=None,
+        ),
+        type="pint.Quantity",
+        init_type="quantity or array-like",
+        doc="Grid node azimuths (X edges).\n\nUnit-enabled field (default: ``ucc['angle']``).",
+    )
+
+    colatitudes: pint.Quantity = documented(
+        pinttr.field(
+            units=ucc.deferred("angle"),
+            on_setattr=None,
+        ),
+        type="pint.Quantity",
+        init_type="quantity or array-like",
+        doc="Grid node colatitudes (Y edges).\n\nUnit-enabled field (default: ``ucc['angle']``).",
+    )
+
+    _sectors: pint.Quantity = pinttr.field(
+        units=ucc.deferred("angle"),
+        on_setattr=None,
+    )
+
+    _bands: pint.Quantity = pinttr.field(
+        units=ucc.deferred("angle"),
+        on_setattr=None,
+    )
+
+    _sector_width: pint.Quantity = pinttr.field(
+        units=ucc.deferred("angle"),
+        on_setattr=None,
+    )
+
+    _band_width: pint.Quantity = pinttr.field(
+        units=ucc.deferred("angle"),
+        on_setattr=None,
+    )
+
+    @_sector_width.validator
+    @_band_width.validator
+    def _angular_extent_validator(self, attribute, value):
+        if not np.isscalar(value.magnitude):
+            raise ValueError("angular cell extent must be a scalar")
+
+    def __init__(
+        self,
+        levels: pint.Quantity,
+        azimuths: pint.Quantity,
+        colatitudes: pint.Quantity,
+    ):
+        levels = ensure_units(levels, default_units=ucc.get("length"))
+        layer_height = np.diff(levels)
+        if not np.allclose(layer_height, layer_height[0]):
+            raise ValueError("levels must be regularly spaced")
+        layers = levels[:-1] + 0.5 * layer_height
+
+        azimuths = ensure_units(azimuths, default_units=ucc.get("angle"))
+        colatitudes = ensure_units(colatitudes, default_units=ucc.get("angle"))
+
+        def _centers_and_step(edges, name):
+            step = np.diff(edges)
+            if not np.allclose(step, step[0]):
+                raise ValueError(f"{name} must be regularly spaced")
+            return edges[:-1] + 0.5 * step, step[0]
+
+        sectors, sector_width = _centers_and_step(azimuths, "azimuths")
+        bands, band_width = _centers_and_step(colatitudes, "colatitudes")
+
+        self.__attrs_init__(
+            levels=levels,
+            layers=layers,
+            layer_height=layer_height[0],
+            total_height=levels[-1] - levels[0],
+            azimuths=azimuths,
+            colatitudes=colatitudes,
+            sectors=sectors,
+            bands=bands,
+            sector_width=sector_width,
+            band_width=band_width,
+        )
+
+    @property
+    def sectors(self) -> pint.Quantity:
+        """
+        Returns
+        -------
+        quantity
+            Vector of azimuthal cell centres (X cells).
+        """
+        return self._sectors
+
+    @property
+    def bands(self) -> pint.Quantity:
+        """
+        Returns
+        -------
+        quantity
+            Vector of colatitudinal cell centres (Y cells).
+        """
+        return self._bands
+
+    @property
+    def sector_width(self) -> pint.Quantity:
+        """
+        Returns
+        -------
+        quantity
+            Uniform azimuthal cell width.
+        """
+        return self._sector_width
+
+    @property
+    def band_width(self) -> pint.Quantity:
+        """
+        Returns
+        -------
+        quantity
+            Uniform colatitudinal cell width.
+        """
+        return self._band_width
+
+    @property
+    def n_cells_x(self) -> int:
+        """Number of cells in the X (azimuthal) direction."""
+        return len(self._sectors)
+
+    @property
+    def n_cells_y(self) -> int:
+        """Number of cells in the Y (colatitudinal) direction."""
+        return len(self._bands)
+
+    @property
+    def n_edges_x(self) -> int:
+        """Number of edges in the X (azimuthal) direction."""
+        return len(self.azimuths)
+
+    @property
+    def n_edges_y(self) -> int:
+        """Number of edges in the Y (colatitudinal) direction."""
+        return len(self.colatitudes)
+
+    def __repr__(self) -> str:
+        return (
+            f"SphericalShellGridCoords(\n"
+            f"  azimuth:    [{self.azimuths[0]:~P}, {self.azimuths[-1]:~P}], {self.n_cells_x} sectors\n"
+            f"  colatitude: [{self.colatitudes[0]:~P}, {self.colatitudes[-1]:~P}], {self.n_cells_y} bands\n"
+            f"  z:          [{self.levels[0]:~P}, {self.levels[-1]:~P}], {self.n_layers} layers\n"
+            f")"
+        )
+
+    @property
+    def cells_x(self):
+        return self.sectors
+
+    @property
+    def cells_y(self):
+        return self.bands
+
+    @property
+    def to_world(self) -> mi.ScalarTransform4f:
+        """
+        Spherical grid to_world
+
+        This to_world is a portion of the unit cube representing
+        the complete extent of geocentric coordinate system.
+
+        This portion corresponds to the extent of the grid colatitudes,
+        azimuths and altitude.
+        """
+
+        phi_min = self.azimuths.min().m_as(ureg.rad)
+        phi_max = self.azimuths.max().m_as(ureg.rad)
+        theta_min = self.colatitudes.min().m_as(ureg.rad)
+        theta_max = self.colatitudes.max().m_as(ureg.rad)
+
+        # SphericalCoordsVolume outputs:
+        #   y = theta / pi        → colatitude normalized to [0, 1]
+        #   z = phi / (2*pi) + 0.5 → azimuth normalized to [0, 1]
+        return map_unit_cube(
+            xmin=0.0,
+            xmax=1.0,  # radius: always spans full [0, 1]
+            ymin=theta_min / np.pi,
+            ymax=theta_max / np.pi,
+            zmin=phi_min / (2 * np.pi) + 0.5,
+            zmax=phi_max / (2 * np.pi) + 0.5,
+        )
+
+    def __rich_repr__(self):
+        yield "levels", self.levels
+        yield "layers", self.layers
+        yield "layer_height", self.layer_height
+        yield "total_height", self.total_height
+
+        yield "azimuths", self.azimuths
+        yield "sectors", self.sectors
+        yield "sector_width", self.sector_width
+
+        yield "colatitudes", self.colatitudes
+        yield "bands", self.bands
+        yield "band_width", self.band_width
+
+        yield "shape", self.shape

--- a/src/eradiate/radprops/__init__.pyi
+++ b/src/eradiate/radprops/__init__.pyi
@@ -4,5 +4,4 @@ from ._absorption import get_default_absdb as get_default_absdb
 from ._array import ArrayRadProfile as ArrayRadProfile
 from ._atmosphere import AtmosphereRadProfile as AtmosphereRadProfile
 from ._core import RadProfile as RadProfile
-from ._core import ZGrid as ZGrid
 from ._particles import ParticleProperties as ParticleProperties

--- a/src/eradiate/radprops/_array.py
+++ b/src/eradiate/radprops/_array.py
@@ -12,8 +12,9 @@ import numpy as np
 import pint
 import xarray as xr
 
-from ._core import RadProfile, ZGrid, make_dataset
+from ._core import RadProfile, make_dataset
 from ..attrs import define, documented
+from ..grid import GridCoords
 from ..units import to_quantity
 from ..units import unit_registry as ureg
 
@@ -153,35 +154,32 @@ class ArrayRadProfile(RadProfile):
         raise NotImplementedError
 
     @property
-    def zgrid(self) -> ZGrid:
+    def grid(self) -> GridCoords:
         raise NotImplementedError
 
-    def eval_albedo_mono(self, w: pint.Quantity, zgrid: ZGrid) -> pint.Quantity:
+    def eval_albedo_mono(self, w: pint.Quantity, grid: GridCoords) -> pint.Quantity:
         # Inherit docstring
-        sigma_s = self.eval_sigma_s_mono(w, zgrid)
-        sigma_t = self.eval_sigma_t_mono(w, zgrid)
+        sigma_s = self.eval_sigma_s_mono(w, grid)
+        sigma_t = self.eval_sigma_t_mono(w, grid)
         return np.divide(
             sigma_s, sigma_t, where=sigma_t != 0.0, out=np.zeros_like(sigma_s)
         ).to("dimensionless")
 
     def eval_albedo_ckd(
-        self, w: pint.Quantity, g: float, zgrid: ZGrid
+        self, w: pint.Quantity, g: float, grid: GridCoords
     ) -> pint.Quantity:
-        sigma_s = self.eval_sigma_s_ckd(w=w, g=g, zgrid=zgrid)
-        sigma_t = self.eval_sigma_t_ckd(w=w, g=g, zgrid=zgrid)
+        sigma_s = self.eval_sigma_s_ckd(w=w, g=g, grid=grid)
+        sigma_t = self.eval_sigma_t_ckd(w=w, g=g, grid=grid)
         return np.divide(
             sigma_s, sigma_t, where=sigma_t != 0.0, out=np.zeros_like(sigma_s)
         ).to("dimensionless")
 
-    def eval_sigma_a_mono(self, w: pint.Quantity, zgrid: ZGrid) -> pint.Quantity:
-        # NOTE: this method accepts 'w'-arrays and is vectorized as far as
-        # each individual absorption dataset is concerned, namely when the
-        # wavelengths span multiple datasets we for-loop over them.
+    def eval_sigma_a_mono(self, w: pint.Quantity, grid: GridCoords) -> pint.Quantity:
         w = np.atleast_1d(w)
         if self.has_absorption and self.sigma_a is not None:
             values = self.sigma_a.interp(
                 coords={
-                    "z": zgrid.layers.m_as(self.sigma_a.z.attrs["units"]),
+                    "z": grid.layers.m_as(self.sigma_a.z.attrs["units"]),
                     "w": w.m_as(self.sigma_a.w.attrs["units"]),
                 },
                 method=self.interpolation_method,
@@ -191,24 +189,24 @@ class ArrayRadProfile(RadProfile):
             values = to_quantity(values)
             return values.squeeze()
         else:
-            return np.zeros((w.size, zgrid.n_layers)).squeeze() / ureg.km
+            return np.zeros((w.size, grid.n_layers)).squeeze() / ureg.km
 
     def eval_sigma_a_ckd(
-        self, w: pint.Quantity, g: float, zgrid: ZGrid
+        self, w: pint.Quantity, g: float, grid: GridCoords
     ) -> pint.Quantity:
         warnings.warn(
             "You are using ArrayRadProps in CKD mode, this is not standard "
             "behaviour and might provide erroneous results.",
             stacklevel=2,
         )
-        return self.eval_sigma_a_mono(w=w, zgrid=zgrid)
+        return self.eval_sigma_a_mono(w=w, grid=grid)
 
-    def eval_sigma_s_mono(self, w: pint.Quantity, zgrid: ZGrid) -> pint.Quantity:
+    def eval_sigma_s_mono(self, w: pint.Quantity, grid: GridCoords) -> pint.Quantity:
         w = np.atleast_1d(w)
         if self.has_scattering and self.sigma_s is not None:
             sigma_s = self.sigma_s.interp(
                 coords={
-                    "z": zgrid.layers.m_as(self.sigma_s.z.attrs["units"]),
+                    "z": grid.layers.m_as(self.sigma_s.z.attrs["units"]),
                     "w": w.m_as(self.sigma_s.w.attrs["units"]),
                 },
                 method=self.interpolation_method,
@@ -218,53 +216,53 @@ class ArrayRadProfile(RadProfile):
             sigma_s = to_quantity(sigma_s)
             return sigma_s.squeeze()
         else:
-            return np.zeros((1, zgrid.n_layers)) / ureg.km
+            return np.zeros((1, grid.n_layers)) / ureg.km
 
     def eval_sigma_s_ckd(
-        self, w: pint.Quantity, g: float, zgrid: ZGrid
+        self, w: pint.Quantity, g: float, grid: GridCoords
     ) -> pint.Quantity:
-        return self.eval_sigma_s_mono(w=w, zgrid=zgrid)
+        return self.eval_sigma_s_mono(w=w, grid=grid)
 
-    def eval_sigma_t_mono(self, w: pint.Quantity, zgrid: ZGrid) -> pint.Quantity:
-        sigma_a = self.eval_sigma_a_mono(w=w, zgrid=zgrid)
-        sigma_s = self.eval_sigma_s_mono(w=w, zgrid=zgrid)
+    def eval_sigma_t_mono(self, w: pint.Quantity, grid: GridCoords) -> pint.Quantity:
+        sigma_a = self.eval_sigma_a_mono(w=w, grid=grid)
+        sigma_s = self.eval_sigma_s_mono(w=w, grid=grid)
         return sigma_a + sigma_s
 
     def eval_sigma_t_ckd(
         self,
         w: pint.Quantity,
         g: float,
-        zgrid: ZGrid,
+        grid: GridCoords,
     ) -> pint.Quantity:
-        sigma_a = self.eval_sigma_a_ckd(w=w, g=g, zgrid=zgrid)
-        sigma_s = self.eval_sigma_s_ckd(w=w, g=g, zgrid=zgrid)
+        sigma_a = self.eval_sigma_a_ckd(w=w, g=g, grid=grid)
+        sigma_s = self.eval_sigma_s_ckd(w=w, g=g, grid=grid)
         return sigma_a + sigma_s
 
-    def eval_dataset_mono(self, w: pint.Quantity, zgrid: ZGrid) -> xr.Dataset:
+    def eval_dataset_mono(self, w: pint.Quantity, grid: GridCoords) -> xr.Dataset:
         return make_dataset(
             wavelength=w,
-            z_level=zgrid.levels,
-            z_layer=zgrid.layers,
-            sigma_a=self.eval_sigma_a_mono(w, zgrid),
-            sigma_s=self.eval_sigma_s_mono(w, zgrid),
+            z_level=grid.levels,
+            z_layer=grid.layers,
+            sigma_a=self.eval_sigma_a_mono(w, grid),
+            sigma_s=self.eval_sigma_s_mono(w, grid),
         ).squeeze()
 
     def eval_dataset_ckd(
         self,
         w: pint.Quantity,
         g: float,
-        zgrid: ZGrid,
+        grid: GridCoords,
     ) -> xr.Dataset:
         return make_dataset(
             wavelength=w,
-            z_level=zgrid.levels,
-            z_layer=zgrid.layers,
-            sigma_a=self.eval_sigma_a_ckd(w=w, g=g, zgrid=zgrid),
-            sigma_s=self.eval_sigma_s_ckd(w=w, g=g, zgrid=zgrid),
+            z_level=grid.levels,
+            z_layer=grid.layers,
+            sigma_a=self.eval_sigma_a_ckd(w=w, g=g, grid=grid),
+            sigma_s=self.eval_sigma_s_ckd(w=w, g=g, grid=grid),
         ).squeeze()
 
     def eval_depolarization_factor_mono(
-        self, w: pint.Quantity, zgrid: ZGrid
+        self, w: pint.Quantity, grid: GridCoords
     ) -> pint.Quantity:
         if self.has_scattering:
             if isinstance(self.rayleigh_depolarization, np.ndarray):
@@ -279,6 +277,6 @@ class ArrayRadProfile(RadProfile):
         self,
         w: pint.Quantity,
         g: float,
-        zgrid: ZGrid,
+        grid: GridCoords,
     ) -> pint.Quantity:
-        return self.eval_depolarization_factor_mono(w=w, zgrid=zgrid)
+        return self.eval_depolarization_factor_mono(w=w, grid=grid)

--- a/src/eradiate/radprops/_atmosphere.py
+++ b/src/eradiate/radprops/_atmosphere.py
@@ -12,10 +12,11 @@ from axsdb import AbsorptionDatabase
 from joseki.profiles.core import interp
 
 from ._absorption import get_default_absdb
-from ._core import RadProfile, ZGrid, make_dataset
+from ._core import RadProfile, make_dataset
 from .rayleigh import compute_sigma_s_air, depolarization_bates, depolarization_bodhaine
 from .. import converters
 from ..attrs import define, documented
+from ..grid import GridCoords
 from ..units import to_quantity
 from ..units import unit_registry as ureg
 from ..util.misc import cache_by_id, summary_repr
@@ -25,6 +26,45 @@ _THERMOPROPS_DEFAULT = {
     "z": np.linspace(0.0, 120.0, 121) * ureg.km,
     "additional_molecules": False,
 }
+
+
+def _validate_thermoprops_grid_shape(
+    thermoprops: xr.Dataset, grid: GridCoords
+) -> xr.Dataset:
+    """Check any 'x'/'y' dimensions of thermoprops against the render grid."""
+    horizontal_dims = set(thermoprops.dims) & {"x", "y"}
+    if not horizontal_dims:
+        return thermoprops
+
+    result = thermoprops.transpose(..., "z")
+    expected_sizes = {"x": grid.n_cells_x, "y": grid.n_cells_y}
+    for dim in horizontal_dims:
+        if result.sizes[dim] != expected_sizes[dim]:
+            raise ValueError(
+                f"thermoprops dimension '{dim}' has size {result.sizes[dim]}, "
+                f"expected {expected_sizes[dim]} to match the render grid"
+            )
+
+    return result
+
+
+def _average_adjacent_levels(values):
+    """
+    Average adjacent altitude levels (the last axis) into per-layer values,
+    then drop the leading axis (the wavelength axis) if it has size 1.
+    """
+    result = 0.5 * (values[..., 1:] + values[..., :-1])
+    return result[0] if result.shape[0] == 1 else result
+
+
+def _layers_from_levels(values: xr.DataArray) -> pint.Quantity:
+    """
+    Average adjacent altitude levels into per-layer values. ``values`` is
+    transposed so that ``w`` comes first and ``z`` last, whatever other
+    dimensions (e.g. ``x``, ``y``) sit in between and in whatever order they
+    originally came in.
+    """
+    return _average_adjacent_levels(to_quantity(values.transpose("w", ..., "z")))
 
 
 @define(eq=False)
@@ -123,13 +163,13 @@ class AtmosphereRadProfile(RadProfile):
         default="[0]",
     )
 
-    _zgrid: ZGrid | None = attrs.field(default=None, init=False)
+    _grid: GridCoords | None = attrs.field(default=None, init=False)
 
     def __attrs_post_init__(self):
         self.update()
 
     def update(self) -> None:
-        self._zgrid = ZGrid(levels=self.levels)
+        self._grid = GridCoords.make_default()
 
     @property
     def zbounds(self) -> tuple[pint.Quantity, pint.Quantity]:
@@ -141,127 +181,118 @@ class AtmosphereRadProfile(RadProfile):
         return to_quantity(self.thermoprops.z)
 
     @property
-    def zgrid(self) -> ZGrid:
+    def grid(self) -> GridCoords:
         # Inherit docstring
-        return self._zgrid
+        return self._grid
 
     @cache_by_id
-    def _thermoprops_interp(self, zgrid: ZGrid) -> xr.Dataset:
+    def _thermoprops_interp(self, grid: GridCoords) -> xr.Dataset:
         # Interpolate thermophysical profile on specified altitude grid
-        # Note: this value is cached so that repeated calls with the same zgrid
+        # Note: this value is cached so that repeated calls with the same grid
         #       won't trigger an unnecessary computation.
-        return interp(
+        result = interp(
             self.thermoprops,
-            z_new=zgrid.levels.m * ureg(str(zgrid.levels.units)),
+            z_new=grid.levels.m * ureg(str(grid.levels.units)),
             method={"default": "nearest"},  # TODO: revisit
         )
+        return _validate_thermoprops_grid_shape(result, grid)
 
-    def eval_albedo_mono(self, w: pint.Quantity, zgrid: ZGrid) -> pint.Quantity:
+    def eval_albedo_mono(self, w: pint.Quantity, grid: GridCoords) -> pint.Quantity:
         # Inherit docstring
-        sigma_s = self.eval_sigma_s_mono(w, zgrid)
-        sigma_t = self.eval_sigma_t_mono(w, zgrid)
+        sigma_s = self.eval_sigma_s_mono(w, grid)
+        sigma_t = self.eval_sigma_t_mono(w, grid)
         return np.divide(
             sigma_s, sigma_t, where=sigma_t != 0.0, out=np.zeros_like(sigma_s)
         ).to("dimensionless")
 
     def eval_albedo_ckd(
-        self, w: pint.Quantity, g: float, zgrid: ZGrid
+        self, w: pint.Quantity, g: float, grid: GridCoords
     ) -> pint.Quantity:
-        sigma_s = self.eval_sigma_s_ckd(w=w, g=g, zgrid=zgrid)
-        sigma_t = self.eval_sigma_t_ckd(w=w, g=g, zgrid=zgrid)
+        sigma_s = self.eval_sigma_s_ckd(w=w, g=g, grid=grid)
+        sigma_t = self.eval_sigma_t_ckd(w=w, g=g, grid=grid)
         return np.divide(
             sigma_s, sigma_t, where=sigma_t != 0.0, out=np.zeros_like(sigma_s)
         ).to("dimensionless")
 
-    def eval_sigma_a_mono(self, w: pint.Quantity, zgrid: ZGrid) -> pint.Quantity:
-        # NOTE: this method accepts 'w'-arrays and is vectorized as far as
-        # each individual absorption dataset is concerned, namely when the
-        # wavelengths span multiple datasets we for-loop over them.
+    def eval_sigma_a_mono(self, w: pint.Quantity, grid: GridCoords) -> pint.Quantity:
         w = np.atleast_1d(w)
         if self.has_absorption:
-            thermoprops = self._thermoprops_interp(zgrid)
-            values = self.absorption_data.eval_sigma_a_mono(w, thermoprops).transpose(
-                "w", "z"
-            )
-            values = to_quantity(values)
-            # We evaluated the
-            # project on altitude layers
-            return 0.5 * (values[:, 1:] + values[:, :-1]).squeeze()
+            thermoprops = self._thermoprops_interp(grid)
+            values = self.absorption_data.eval_sigma_a_mono(w, thermoprops)
+            return _layers_from_levels(values)
         else:
-            return np.zeros((w.size, zgrid.n_layers)).squeeze() / ureg.km
+            return np.zeros((w.size, grid.n_layers)).squeeze() / ureg.km
 
     def eval_sigma_a_ckd(
-        self, w: pint.Quantity, g: float, zgrid: ZGrid
+        self, w: pint.Quantity, g: float, grid: GridCoords
     ) -> pint.Quantity:
         w = np.atleast_1d(w)
         if self.has_absorption:
             values = self.absorption_data.eval_sigma_a_ckd(
-                w, g, self._thermoprops_interp(zgrid)
-            )  # axis order = (w, z)
-            values = to_quantity(values)
-
-            # Interpolate on altitude layers
-            return 0.5 * (values[:, 1:] + values[:, :-1]).squeeze()
+                w, g, self._thermoprops_interp(grid)
+            )
+            return _layers_from_levels(values)
         else:
-            return np.zeros((w.size, zgrid.n_layers)).squeeze() / ureg.km
+            return np.zeros((w.size, grid.n_layers)).squeeze() / ureg.km
 
-    def eval_sigma_s_mono(self, w: pint.Quantity, zgrid: ZGrid) -> pint.Quantity:
+    def eval_sigma_s_mono(self, w: pint.Quantity, grid: GridCoords) -> pint.Quantity:
         if self.has_scattering:
-            thermoprops = self._thermoprops_interp(zgrid)
+            w = np.atleast_1d(w)
+            thermoprops = self._thermoprops_interp(grid)
             sigma_s = compute_sigma_s_air(
                 wavelength=w,
                 number_density=to_quantity(thermoprops.n),
             )
             # project on altitude layers
-            return 0.5 * (sigma_s[1:] + sigma_s[:-1])
+            return _average_adjacent_levels(sigma_s)
         else:
-            return np.zeros((1, zgrid.n_layers)) / ureg.km
+            return np.zeros((1, grid.n_layers)) / ureg.km
 
     def eval_sigma_s_ckd(
-        self, w: pint.Quantity, g: float, zgrid: ZGrid
+        self, w: pint.Quantity, g: float, grid: GridCoords
     ) -> pint.Quantity:
-        return self.eval_sigma_s_mono(w=w, zgrid=zgrid)
+        return self.eval_sigma_s_mono(w=w, grid=grid)
 
-    def eval_sigma_t_mono(self, w: pint.Quantity, zgrid: ZGrid) -> pint.Quantity:
-        sigma_a = self.eval_sigma_a_mono(w=w, zgrid=zgrid)
-        sigma_s = self.eval_sigma_s_mono(w=w, zgrid=zgrid)
+    def eval_sigma_t_mono(self, w: pint.Quantity, grid: GridCoords) -> pint.Quantity:
+        sigma_a = self.eval_sigma_a_mono(w=w, grid=grid)
+        sigma_s = self.eval_sigma_s_mono(w=w, grid=grid)
         return sigma_a + sigma_s
 
     def eval_sigma_t_ckd(
         self,
         w: pint.Quantity,
         g: float,
-        zgrid: ZGrid,
+        grid: GridCoords,
     ) -> pint.Quantity:
-        sigma_a = self.eval_sigma_a_ckd(w=w, g=g, zgrid=zgrid)
-        sigma_s = self.eval_sigma_s_ckd(w=w, g=g, zgrid=zgrid)
+        sigma_a = self.eval_sigma_a_ckd(w=w, g=g, grid=grid)
+        sigma_s = self.eval_sigma_s_ckd(w=w, g=g, grid=grid)
         return sigma_a + sigma_s
 
-    def eval_dataset_mono(self, w: pint.Quantity, zgrid: ZGrid) -> xr.Dataset:
+    def eval_dataset_mono(self, w: pint.Quantity, grid: GridCoords) -> xr.Dataset:
         return make_dataset(
             wavelength=w,
-            z_level=zgrid.levels,
-            z_layer=zgrid.layers,
-            sigma_a=self.eval_sigma_a_mono(w, zgrid),
-            sigma_s=self.eval_sigma_s_mono(w, zgrid),
+            z_level=grid.levels,
+            z_layer=grid.layers,
+            sigma_a=self.eval_sigma_a_mono(w, grid),
+            sigma_s=self.eval_sigma_s_mono(w, grid),
         ).squeeze()
 
     def eval_dataset_ckd(
         self,
         w: pint.Quantity,
         g: float,
-        zgrid: ZGrid,
+        grid: GridCoords,
     ) -> xr.Dataset:
         return make_dataset(
             wavelength=w,
-            z_level=zgrid.levels,
-            z_layer=zgrid.layers,
-            sigma_a=self.eval_sigma_a_ckd(w=w, g=g, zgrid=zgrid),
-            sigma_s=self.eval_sigma_s_ckd(w=w, g=g, zgrid=zgrid),
+            z_level=grid.levels,
+            z_layer=grid.layers,
+            sigma_a=self.eval_sigma_a_ckd(w=w, g=g, grid=grid),
+            sigma_s=self.eval_sigma_s_ckd(w=w, g=g, grid=grid),
         ).squeeze()
 
     def eval_depolarization_factor_mono(
-        self, w: pint.Quantity, zgrid: ZGrid
+        self, w: pint.Quantity, grid: GridCoords
     ) -> pint.Quantity:
         if self.has_scattering:
             if isinstance(self.rayleigh_depolarization, np.ndarray):
@@ -272,12 +303,12 @@ class AtmosphereRadProfile(RadProfile):
                     return depolarization_bates(wavelength=w)
 
                 elif self.rayleigh_depolarization == "bodhaine":
-                    thermoprops = self._thermoprops_interp(zgrid)
+                    thermoprops = self._thermoprops_interp(grid)
                     depol = depolarization_bodhaine(
                         wavelength=w,
                         x_CO2=to_quantity(thermoprops.x_CO2),
                     )
-                    return 0.5 * (depol[1:] + depol[:-1])
+                    return 0.5 * (depol[..., 1:] + depol[..., :-1])
                 else:
                     raise NotImplementedError
 
@@ -291,6 +322,6 @@ class AtmosphereRadProfile(RadProfile):
         self,
         w: pint.Quantity,
         g: float,
-        zgrid: ZGrid,
+        grid: GridCoords,
     ) -> pint.Quantity:
-        return self.eval_depolarization_factor_mono(w=w, zgrid=zgrid)
+        return self.eval_depolarization_factor_mono(w=w, grid=grid)

--- a/src/eradiate/radprops/_core.py
+++ b/src/eradiate/radprops/_core.py
@@ -6,15 +6,12 @@ from functools import singledispatchmethod
 import attrs
 import numpy as np
 import pint
-import pinttrs
 import xarray as xr
-from pinttrs.util import ensure_units
 
 import eradiate
 
-from ..attrs import documented, frozen
+from ..grid import GridCoords
 from ..spectral.index import CKDSpectralIndex, MonoSpectralIndex, SpectralIndex
-from ..units import unit_context_config as ucc
 from ..units import unit_registry as ureg
 from ..util.misc import get_utcnow
 
@@ -82,74 +79,85 @@ def make_dataset(
             "('sigma_a', 'sigma_s') or ('sigma_t', 'albedo')."
         )
 
+    # sigma_a/sigma_s/sigma_t/albedo are shaped either (z_layer,) or, for a
+    # 3D atmosphere, (x, y, z_layer)
+    horizontal_shape = np.shape(sigma_a)[:-1]
+    dims = ("w",) + (("x", "y") if horizontal_shape else ()) + ("z_layer",)
+    shape = (1,) + horizontal_shape + (z_layer.size,)
+
+    coords = {
+        "z_level": (
+            "z_level",
+            z_level,
+            {
+                "standard_name": "level_altitude",
+                "units": "km",
+                "long_name": "level altitude",
+            },
+        ),
+        "z_layer": (
+            "z_layer",
+            z_layer,
+            {
+                "standard_name": "layer_altitude",
+                "units": "km",
+                "long_name": "layer altitude",
+            },
+        ),
+        "w": (
+            "w",
+            [wavelength],
+            {
+                "standard_name": "radiation_wavelength",
+                "units": "nm",
+                "long_name": "wavelength",
+            },
+        ),
+    }
+    if horizontal_shape:
+        coords["x"] = ("x", np.arange(horizontal_shape[0]))
+        coords["y"] = ("y", np.arange(horizontal_shape[1]))
+
     return xr.Dataset(
         data_vars={
             "sigma_a": (
-                ("w", "z_layer"),
-                sigma_a.reshape(1, z_layer.size),
-                dict(
-                    standard_name="absorption_coefficient",
-                    units="km^-1",
-                    long_name="absorption coefficient",
-                ),
+                dims,
+                sigma_a.reshape(shape),
+                {
+                    "standard_name": "absorption_coefficient",
+                    "units": "km^-1",
+                    "long_name": "absorption coefficient",
+                },
             ),
             "sigma_s": (
-                ("w", "z_layer"),
-                sigma_s.reshape(1, z_layer.size),
-                dict(
-                    standard_name="scattering_coefficient",
-                    units="km^-1",
-                    long_name="scattering coefficient",
-                ),
+                dims,
+                sigma_s.reshape(shape),
+                {
+                    "standard_name": "scattering_coefficient",
+                    "units": "km^-1",
+                    "long_name": "scattering coefficient",
+                },
             ),
             "sigma_t": (
-                ("w", "z_layer"),
-                sigma_t.reshape(1, z_layer.size),
-                dict(
-                    standard_name="extinction_coefficient",
-                    units="km^-1",
-                    long_name="extinction coefficient",
-                ),
+                dims,
+                sigma_t.reshape(shape),
+                {
+                    "standard_name": "extinction_coefficient",
+                    "units": "km^-1",
+                    "long_name": "extinction coefficient",
+                },
             ),
             "albedo": (
-                ("w", "z_layer"),
-                albedo.reshape(1, z_layer.size),
-                dict(
-                    standard_name="albedo",
-                    units="",
-                    long_name="albedo",
-                ),
+                dims,
+                albedo.reshape(shape),
+                {
+                    "standard_name": "albedo",
+                    "units": "",
+                    "long_name": "albedo",
+                },
             ),
         },
-        coords={
-            "z_level": (
-                "z_level",
-                z_level,
-                dict(
-                    standard_name="level_altitude",
-                    units="km",
-                    long_name="level altitude",
-                ),
-            ),
-            "z_layer": (
-                "z_layer",
-                z_layer,
-                dict(
-                    standard_name="layer_altitude",
-                    units="km",
-                    long_name="layer altitude",
-                ),
-            ),
-            "w": (
-                "w",
-                [wavelength],
-                dict(
-                    standard_name="radiation_wavelength",
-                    units="nm",
-                    long_name="wavelength",
-                ),
-            ),
-        },
+        coords=coords,
         attrs={
             "convention": "CF-1.8",
             "title": "Atmospheric monochromatic radiative properties",
@@ -160,113 +168,6 @@ def make_dataset(
             "references": "",
         },
     )
-
-
-@frozen(eq=False, init=False)
-class ZGrid:
-    """
-    A container for a regular altitude grid.
-
-    Notes
-    -----
-    * Instances are immutable.
-    * Instances are hashable by ID. This is required to allow for using them as
-      an argument of an LRU-cached function.
-    * This class is used as the argument of the ``eval()`` family of methods.
-    """
-
-    levels: pint.Quantity = documented(
-        pinttrs.field(
-            units=ucc.deferred("length"),
-            on_setattr=None,  # frozen instance: on_setattr must be disabled
-        ),
-        type="pint.Quantity",
-        init_type="quantity or array-like",
-        doc="Grid node altitudes.\n\nUnit-enabled field (default: ``ucc['length']``).",
-    )
-
-    _layers: pint.Quantity = pinttrs.field(
-        units=ucc.deferred("length"),
-        on_setattr=None,  # frozen instance: on_setattr must be disabled
-    )
-
-    _layer_height: pint.Quantity = pinttrs.field(
-        units=ucc.deferred("length"),
-        on_setattr=None,  # frozen instance: on_setattr must be disabled
-    )
-
-    @_layer_height.validator
-    def _layer_height_validator(self, attribute, value):
-        if not np.isscalar(value.magnitude):
-            raise ValueError("layer height must be a scalar")
-
-    _total_height: pint.Quantity = pinttrs.field(
-        units=ucc.deferred("length"),
-        on_setattr=None,  # frozen instance: on_setattr must be disabled
-    )
-
-    def __init__(self, levels: np.typing.ArrayLike):
-        levels = ensure_units(levels, default_units=ucc.get("length"))
-        layer_height = np.diff(levels)
-        if not np.allclose(layer_height, layer_height[0]):
-            raise ValueError("levels must be regularly spaced")
-        layers = levels[:-1] + 0.5 * layer_height
-        self.__attrs_init__(
-            levels=levels,
-            layers=layers,
-            layer_height=layer_height[0],
-            total_height=(levels.m[-1] - levels.m[0]) * levels.u,
-        )
-
-    @property
-    def layers(self) -> pint.Quantity:
-        """
-        Returns
-        -------
-        quantity
-            Vector of altitudes of layer centres.
-        """
-        return self._layers
-
-    @property
-    def layer_height(self) -> pint.Quantity:
-        """
-        Returns
-        -------
-        quantity
-            Layer height.
-        """
-        return self._layer_height
-
-    @property
-    def n_levels(self) -> int:
-        """
-        Returns
-        -------
-        int
-            Number of levels.
-        """
-        return len(self.levels)
-
-    @property
-    def n_layers(self) -> int:
-        """
-        Returns
-        -------
-        int
-            Number of layers.
-        """
-        return len(self.layers)
-
-    @property
-    def total_height(self) -> pint.Quantity:
-        """
-        Returns
-        -------
-        quantity
-            Total height covered by the altitude grid.
-        """
-        return self._total_height
 
 
 @attrs.define(eq=False)
@@ -283,21 +184,19 @@ class RadProfile(ABC):
         """
         Bounds of the z profile.
         """
-        pass
 
     @property
     @abstractmethod
-    def zgrid(self) -> ZGrid:
+    def grid(self) -> GridCoords:
         """
         Default altitude grid used for profile evaluation.
         """
-        pass
 
     @singledispatchmethod
     def eval_albedo(
         self,
         si: SpectralIndex,
-        zgrid: ZGrid | None = None,
+        grid: GridCoords | None = None,
     ) -> pint.Quantity:
         """
         Evaluate albedo at given spectral index.
@@ -307,7 +206,7 @@ class RadProfile(ABC):
         si : :class:`.SpectralIndex`
             Spectral index.
 
-        zgrid : .ZGrid, optional
+        grid : .GridCoords, optional
             The altitude grid for which the albedo is evaluated. If unset, a
             profile-specific default is used.
 
@@ -320,21 +219,21 @@ class RadProfile(ABC):
         raise NotImplementedError
 
     @eval_albedo.register(MonoSpectralIndex)
-    def _(self, si, zgrid: ZGrid) -> pint.Quantity:
-        return self.eval_albedo_mono(w=si.w, zgrid=zgrid).squeeze()
+    def _(self, si, grid: GridCoords) -> pint.Quantity:
+        return self.eval_albedo_mono(w=si.w, grid=grid)
 
     @eval_albedo.register(CKDSpectralIndex)
-    def _(self, si, zgrid: ZGrid) -> pint.Quantity:
-        return self.eval_albedo_ckd(w=si.w, g=si.g, zgrid=zgrid).squeeze()
+    def _(self, si, grid: GridCoords) -> pint.Quantity:
+        return self.eval_albedo_ckd(w=si.w, g=si.g, grid=grid)
 
-    def eval_albedo_mono(self, w: pint.Quantity, zgrid: ZGrid) -> pint.Quantity:
+    def eval_albedo_mono(self, w: pint.Quantity, grid: GridCoords) -> pint.Quantity:
         raise NotImplementedError
 
     def eval_albedo_ckd(
         self,
         w: pint.Quantity,
         g: float,
-        zgrid: ZGrid,
+        grid: GridCoords,
     ) -> pint.Quantity:
         raise NotImplementedError
 
@@ -342,7 +241,7 @@ class RadProfile(ABC):
     def eval_sigma_t(
         self,
         si: SpectralIndex,
-        zgrid: ZGrid | None = None,
+        grid: GridCoords | None = None,
     ) -> pint.Quantity:
         """
         Evaluate extinction coefficient at given spectral index.
@@ -352,7 +251,7 @@ class RadProfile(ABC):
         si : :class:`.SpectralIndex`
             Spectral index.
 
-        zgrid : .ZGrid, optional
+        grid : .GridCoords, optional
             The altitude grid for which the extinction coefficient is evaluated.
             If unset, a profile-specific default is used.
 
@@ -365,21 +264,21 @@ class RadProfile(ABC):
         raise NotImplementedError
 
     @eval_sigma_t.register(MonoSpectralIndex)
-    def _(self, si, zgrid: ZGrid) -> pint.Quantity:
-        return self.eval_sigma_t_mono(w=si.w, zgrid=zgrid).squeeze()
+    def _(self, si, grid: GridCoords) -> pint.Quantity:
+        return self.eval_sigma_t_mono(w=si.w, grid=grid)
 
     @eval_sigma_t.register(CKDSpectralIndex)
-    def _(self, si, zgrid: ZGrid) -> pint.Quantity:
-        return self.eval_sigma_t_ckd(w=si.w, g=si.g, zgrid=zgrid).squeeze()
+    def _(self, si, grid: GridCoords) -> pint.Quantity:
+        return self.eval_sigma_t_ckd(w=si.w, g=si.g, grid=grid)
 
-    def eval_sigma_t_mono(self, w: pint.Quantity, zgrid: ZGrid) -> pint.Quantity:
+    def eval_sigma_t_mono(self, w: pint.Quantity, grid: GridCoords) -> pint.Quantity:
         raise NotImplementedError
 
     def eval_sigma_t_ckd(
         self,
         w: pint.Quantity,
         g: float,
-        zgrid: ZGrid,
+        grid: GridCoords,
     ) -> pint.Quantity:
         raise NotImplementedError
 
@@ -387,7 +286,7 @@ class RadProfile(ABC):
     def eval_sigma_a(
         self,
         si: SpectralIndex,
-        zgrid: ZGrid | None = None,
+        grid: GridCoords | None = None,
     ) -> pint.Quantity:
         """
         Evaluate absorption coefficient at given spectral index.
@@ -397,7 +296,7 @@ class RadProfile(ABC):
         si : .SpectralIndex
             Spectral index.
 
-        zgrid : .ZGrid, optional
+        grid : .GridCoords, optional
             The altitude grid for which the absorption coefficient is evaluated.
             If unset, a profile-specific default is used.
 
@@ -410,17 +309,17 @@ class RadProfile(ABC):
         raise NotImplementedError
 
     @eval_sigma_a.register(MonoSpectralIndex)
-    def _(self, si, zgrid: ZGrid) -> pint.Quantity:
-        return self.eval_sigma_a_mono(w=si.w, zgrid=zgrid).squeeze()
+    def _(self, si, grid: GridCoords) -> pint.Quantity:
+        return self.eval_sigma_a_mono(w=si.w, grid=grid)
 
     @eval_sigma_a.register(CKDSpectralIndex)
-    def _(self, si, zgrid: ZGrid) -> pint.Quantity:
-        return self.eval_sigma_a_ckd(w=si.w, g=si.g, zgrid=zgrid).squeeze()
+    def _(self, si, grid: GridCoords) -> pint.Quantity:
+        return self.eval_sigma_a_ckd(w=si.w, g=si.g, grid=grid)
 
     def eval_sigma_a_mono(
         self,
         w: pint.Quantity,
-        zgrid: ZGrid,
+        grid: GridCoords,
     ) -> pint.Quantity:
         """
         Evaluate absorption coefficient spectrum in monochromatic mode.
@@ -431,7 +330,7 @@ class RadProfile(ABC):
         self,
         w: pint.Quantity,
         g: float,
-        zgrid: ZGrid,
+        grid: GridCoords,
     ) -> pint.Quantity:
         """
         Evaluate absorption coefficient spectrum in CKD modes.
@@ -442,7 +341,7 @@ class RadProfile(ABC):
     def eval_sigma_s(
         self,
         si: SpectralIndex,
-        zgrid: ZGrid | None = None,
+        grid: GridCoords | None = None,
     ) -> pint.Quantity:
         """
         Evaluate scattering coefficient at given spectral index.
@@ -452,7 +351,7 @@ class RadProfile(ABC):
         si : .SpectralIndex
             Spectral index.
 
-        zgrid : .ZGrid, optional
+        grid : .GridCoords, optional
             The altitude grid for which the scattering coefficient is evaluated.
             If unset, a profile-specific default is used.
 
@@ -465,18 +364,18 @@ class RadProfile(ABC):
         raise NotImplementedError
 
     @eval_sigma_s.register(MonoSpectralIndex)
-    def _(self, si, zgrid: ZGrid) -> pint.Quantity:
-        return self.eval_sigma_s_mono(w=si.w, zgrid=zgrid).squeeze()
+    def _(self, si, grid: GridCoords) -> pint.Quantity:
+        return self.eval_sigma_s_mono(w=si.w, grid=grid)
 
     @eval_sigma_s.register(CKDSpectralIndex)
-    def _(self, si, zgrid: ZGrid) -> pint.Quantity:
-        return self.eval_sigma_s_ckd(w=si.w, g=si.g, zgrid=zgrid).squeeze()
+    def _(self, si, grid: GridCoords) -> pint.Quantity:
+        return self.eval_sigma_s_ckd(w=si.w, g=si.g, grid=grid)
 
-    def eval_sigma_s_mono(self, w: pint.Quantity, zgrid: ZGrid) -> pint.Quantity:
+    def eval_sigma_s_mono(self, w: pint.Quantity, grid: GridCoords) -> pint.Quantity:
         raise NotImplementedError
 
     def eval_sigma_s_ckd(
-        self, w: pint.Quantity, g: float, zgrid: ZGrid
+        self, w: pint.Quantity, g: float, grid: GridCoords
     ) -> pint.Quantity:
         raise NotImplementedError
 
@@ -484,7 +383,7 @@ class RadProfile(ABC):
     def eval_depolarization_factor(
         self,
         si: SpectralIndex,
-        zgrid: ZGrid | None = None,
+        grid: GridCoords | None = None,
     ) -> pint.Quantity:
         """
         Evaluate depolarization factor at given spectral index.
@@ -494,7 +393,7 @@ class RadProfile(ABC):
         si : .SpectralIndex
             Spectral index.
 
-        zgrid : .ZGrid, optional
+        grid : .GridCoords, optional
             The altitude grid for which the depolarization factor is evaluated.
             If unset, a profile-specific default is used.
 
@@ -508,20 +407,20 @@ class RadProfile(ABC):
         raise NotImplementedError
 
     @eval_depolarization_factor.register(MonoSpectralIndex)
-    def _(self, si, zgrid: ZGrid) -> pint.Quantity:
-        return self.eval_depolarization_factor_mono(w=si.w, zgrid=zgrid)
+    def _(self, si, grid: GridCoords) -> pint.Quantity:
+        return self.eval_depolarization_factor_mono(w=si.w, grid=grid)
 
     @eval_depolarization_factor.register(CKDSpectralIndex)
-    def _(self, si, zgrid: ZGrid) -> pint.Quantity:
-        return self.eval_depolarization_factor_ckd(w=si.w, g=si.g, zgrid=zgrid)
+    def _(self, si, grid: GridCoords) -> pint.Quantity:
+        return self.eval_depolarization_factor_ckd(w=si.w, g=si.g, grid=grid)
 
     def eval_depolarization_factor_mono(
-        self, w: pint.Quantity, zgrid: ZGrid
+        self, w: pint.Quantity, grid: GridCoords
     ) -> pint.Quantity:
         raise NotImplementedError
 
     def eval_depolarization_factor_ckd(
-        self, w: pint.Quantity, g: float, zgrid: ZGrid
+        self, w: pint.Quantity, g: float, grid: GridCoords
     ) -> pint.Quantity:
         raise NotImplementedError
 
@@ -529,7 +428,7 @@ class RadProfile(ABC):
     def eval_dataset(
         self,
         si: SpectralIndex,
-        zgrid: ZGrid | None = None,
+        grid: GridCoords | None = None,
     ) -> xr.Dataset:
         """
         Evaluate radiative properties at given spectral index.
@@ -539,7 +438,7 @@ class RadProfile(ABC):
         si : :class:`.SpectralIndex`
             Spectral index.
 
-        zgrid : .ZGrid, optional
+        grid : .GridCoords, optional
             The altitude grid for which the radiative profile is evaluated.
             If unset, a profile-specific default is used.
 
@@ -551,20 +450,20 @@ class RadProfile(ABC):
         raise NotImplementedError
 
     @eval_dataset.register(MonoSpectralIndex)
-    def _(self, si, zgrid: ZGrid) -> xr.Dataset:
-        return self.eval_dataset_mono(w=si.w, zgrid=zgrid)
+    def _(self, si, grid: GridCoords) -> xr.Dataset:
+        return self.eval_dataset_mono(w=si.w, grid=grid)
 
     @eval_dataset.register(CKDSpectralIndex)
-    def _(self, si, zgrid: ZGrid) -> xr.Dataset:
-        return self.eval_dataset_ckd(w=si.w, g=si.g, zgrid=zgrid)
+    def _(self, si, grid: GridCoords) -> xr.Dataset:
+        return self.eval_dataset_ckd(w=si.w, g=si.g, grid=grid)
 
-    def eval_dataset_mono(self, w: pint.Quantity, zgrid: ZGrid) -> xr.Dataset:
+    def eval_dataset_mono(self, w: pint.Quantity, grid: GridCoords) -> xr.Dataset:
         raise NotImplementedError
 
     def eval_dataset_ckd(
         self,
         w: pint.Quantity,
         g: float,
-        zgrid: ZGrid,
+        grid: GridCoords,
     ) -> xr.Dataset:
         raise NotImplementedError

--- a/src/eradiate/radprops/_particles.py
+++ b/src/eradiate/radprops/_particles.py
@@ -19,15 +19,6 @@ from ..units import unit_registry as ureg
 from ..util.misc import summary_repr
 
 
-def _validate_shape(value: Any) -> str:
-    valid = {"spherical", "spheroidal"}
-    if value not in valid:
-        raise ValueError(
-            f"Unrecognized particle shape {value!r} (valid values are {valid})."
-        )
-    return value
-
-
 # TODO: If _rdp1d_log becomes a performance bottleneck (e.g. with grids up to
 #   10k points called frequently), consider rewriting the heap loop with Numba
 #   (@njit(cache=True)). The algorithm maps well to scalar JIT compilation and
@@ -284,6 +275,52 @@ class ParticleProperties:
         )
 
     @property
+    def has_size_distribution(self) -> bool:
+        """
+        Returns
+        -------
+        bool
+            ``True`` iff ``data`` has ``reff``/``veff`` dimensions (Part-Core
+            v1 format), ``False`` for a plain Aer-Core v2 dataset.
+        """
+        return "reff" in self.data.dims and "veff" in self.data.dims
+
+    def _resolve(
+        self, reff_idx: int | None, veff_idx: int | None
+    ) -> ParticleProperties:
+        """
+        Select a point on the ``reff``/``veff`` dimensions by index, if present.
+
+        Parameters
+        ----------
+        reff_idx, veff_idx : int or None
+            Index along the ``reff``/``veff`` dimensions. Both must be set
+            iff ``data`` has ``reff``/``veff`` dimensions.
+
+        Returns
+        -------
+        ParticleProperties
+            ``self`` if ``data`` has no ``reff``/``veff`` dimensions;
+            otherwise a new instance with those dimensions selected away.
+        """
+        if not self.has_size_distribution:
+            if reff_idx is not None or veff_idx is not None:
+                raise ValueError(
+                    "'reff_idx'/'veff_idx' were provided, but this dataset "
+                    "has no 'reff'/'veff' dimensions"
+                )
+            return self
+
+        if reff_idx is None or veff_idx is None:
+            raise ValueError(
+                "'reff_idx' and 'veff_idx' must both be provided: this "
+                "dataset has 'reff'/'veff' dimensions"
+            )
+
+        ds = self.data.isel(reff=reff_idx, veff=veff_idx, drop=True)
+        return ParticleProperties(ds)
+
+    @property
     def w(self) -> pint.Quantity:
         """
         Returns
@@ -353,7 +390,7 @@ class ParticleProperties:
             layout during interpolation, cached to minimize overhead.
         """
         if self._phase is None:
-            self._phase = self.data["phase"].transpose("phamat", "iangle", "w")
+            self._phase = self.data["phase"].transpose("phamat", "iangle", "w", ...)
         return self._phase
 
     @property
@@ -368,7 +405,7 @@ class ParticleProperties:
             if "pmom" not in self.data:
                 return None
             else:
-                self._pmom = self.data["pmom"].transpose("imom", "w")
+                self._pmom = self.data["pmom"].transpose("imom", "w", ...)
 
         return self._pmom
 
@@ -424,6 +461,16 @@ class ParticleProperties:
 
         return self._has_fixed_mu_grid
 
+    @staticmethod
+    def _broadcast_t(t: np.ndarray, reference: np.ndarray) -> np.ndarray:
+        """
+        Reshape a per-wavelength interpolation weight ``t`` (shape ``(nw,)``)
+        so that it broadcasts against ``reference`` (shape ``(nw, ...)``)
+        along its leading axis, instead of numpy's default trailing-axis
+        alignment.
+        """
+        return t.reshape(t.shape + (1,) * (reference.ndim - t.ndim))
+
     def eval_ext(self, w: pint.Quantity) -> pint.Quantity:
         """
         Evaluate the extinction coefficient at wavelength(s) ``w`` by plain
@@ -437,9 +484,15 @@ class ParticleProperties:
         Returns
         -------
         quantity
-            Extinction coefficient, same shape as ``w``.
+            Extinction coefficient. Shape ``(nw,)`` if ``data`` has no
+            ``reff``/``veff`` dimensions, ``(nw, nreff, nveff)`` otherwise.
         """
-        return np.interp(w, self.w, self.ext)
+        idx_l, idx_r, t = self._locate(w)
+        ext = self.ext.m
+        ext_l, ext_r = ext[idx_l], ext[idx_r]
+        t = self._broadcast_t(t, ext_l)
+        ext_interp = (1.0 - t) * ext_l + t * ext_r
+        return ext_interp * self.ext.units
 
     def eval_ssa(self, w: pint.Quantity) -> pint.Quantity:
         """
@@ -453,7 +506,8 @@ class ParticleProperties:
         Returns
         -------
         quantity
-            Dimensionless SSA, same shape as ``w``.
+            Dimensionless SSA. Shape ``(nw,)`` if ``data`` has no
+            ``reff``/``veff`` dimensions, ``(nw, nreff, nveff)`` otherwise.
 
         Notes
         -----
@@ -472,6 +526,7 @@ class ParticleProperties:
         ssa = self.ssa.m
         ext_l, ext_r = ext[idx_l], ext[idx_r]
         ssa_l, ssa_r = ssa[idx_l], ssa[idx_r]
+        t = self._broadcast_t(t, ext_l)
         ext_interp = (1.0 - t) * ext_l + t * ext_r
         linear = (1.0 - t) * ssa_l + t * ssa_r
         weighted = ((1.0 - t) * ext_l * ssa_l + t * ext_r * ssa_r) / np.where(
@@ -599,13 +654,14 @@ class ParticleProperties:
         self, w: pint.Quantity, n_mu: int | None = None
     ) -> tuple[np.ndarray, np.ndarray]:
         """
-        Evaluate the phase function at wavelength ``w`` by interpolation.
+        Evaluate the phase function at wavelength(s) ``w`` by interpolation.
 
         Parameters
         ----------
         w : quantity
-            Query wavelength (scalar only; array input raises ``ValueError``
-            because each wavelength can have a different angular grid).
+            Query wavelength(s); scalar or array. Each wavelength is
+            interpolated independently, since it may have a different
+            bracketing pair and thus a different union mu grid.
 
         n_mu : int, optional
             Number of output mu points. Defaults to ``2 * n_iangle``, where
@@ -617,10 +673,12 @@ class ParticleProperties:
         Returns
         -------
         mu : ndarray
-            Scattering angle cosines of the output grid, shape ``(n_mu,)``.
+            Scattering angle cosines of the output grid: shape ``(n_mu,)``
+            for a scalar ``w``, ``(nw, n_mu)`` for an array ``w``.
 
         phase : ndarray
-            Phase function values in sr⁻¹, shape ``(n_phamat, n_mu)``.
+            Phase function values in sr⁻¹: shape ``(n_phamat, n_mu)`` for a
+            scalar ``w``, ``(n_phamat, nw, n_mu)`` for an array ``w``.
 
         Notes
         -----
@@ -635,55 +693,58 @@ class ParticleProperties:
         interpolation preserves the piecewise-linear shape that Mitsuba uses
         during tabulated phase-function look-up, so no distortion is introduced.
         """
-        if not np.isscalar(w.m):
-            raise ValueError("eval_phase() only accepts a scalar wavelength")
+        is_scalar = np.isscalar(w.m)
+        w = np.atleast_1d(w)
 
         n_iangle = self.data.sizes["iangle"]
         if n_mu is None:
             n_mu = n_iangle if self.has_fixed_mu_grid else 2 * n_iangle
 
         # --- Step 1: bracket wavelengths and compute mixing weights ---
-        idx_l_arr, idx_r_arr, w0_arr, w1_arr, _ = self._bracket_and_weights(w)
-        idx_l = int(idx_l_arr[0])
-        idx_r = int(idx_r_arr[0])
-        w0 = float(w0_arr[0])
-        w1 = float(w1_arr[0])
+        idx_l, idx_r, w0, w1, _ = self._bracket_and_weights(w)
 
-        mu1, phase1 = self._get_mu_phase(idx_l)
-        mu2, phase2 = self._get_mu_phase(idx_r)
+        n_phamat = self.data.sizes["phamat"]
+        mu = np.empty((len(w), n_mu))
+        phase = np.empty((n_phamat, len(w), n_mu))
 
-        # --- Step 2: union mu grid ---
-        mu_union = np.union1d(mu1, mu2)
+        for i in range(len(w)):
+            mu1, phase1 = self._get_mu_phase(int(idx_l[i]))
+            mu2, phase2 = self._get_mu_phase(int(idx_r[i]))
 
-        # --- Step 3: resample both phase functions onto union grid ---
-        # interp1d expects (..., n) layout; phase is (n_phamat, nangles[w_idx])
-        phase1_union = interp1d(mu1, phase1, mu_union, bounds="clamp")
-        phase2_union = interp1d(mu2, phase2, mu_union, bounds="clamp")
+            # --- Step 2: union mu grid ---
+            mu_union = np.union1d(mu1, mu2)
 
-        # --- Step 4: scattering-weighted spectral interpolation ---
-        phase_union = w0 * phase1_union + w1 * phase2_union
+            # --- Step 3: resample both phase functions onto union grid ---
+            # interp1d expects (..., n) layout; phase is (n_phamat, nangles[w_idx])
+            phase1_union = interp1d(mu1, phase1, mu_union, bounds="clamp")
+            phase2_union = interp1d(mu2, phase2, mu_union, bounds="clamp")
 
-        # --- Step 5: bring to exactly n_mu points ---
-        n_union = len(mu_union)
+            # --- Step 4: scattering-weighted spectral interpolation ---
+            phase_union = w0[i] * phase1_union + w1[i] * phase2_union
 
-        if n_union > n_mu:
-            # Decimate: keep the most informative points in log space
-            keep = _rdp1d_log(mu_union, phase_union, n_mu)
-            mu_out = mu_union[keep]
-            phase_out = phase_union[:, keep]
+            # --- Step 5: bring to exactly n_mu points ---
+            n_union = len(mu_union)
 
-        elif n_union < n_mu:
-            # Upsample: insert midpoints into the largest gaps of the union grid.
-            # All original points are preserved, so the non-uniform  density near
-            # the forward-scattering peak is maintained.
-            mu_out = _upsample_mu(mu_union, n_mu)
-            phase_out = interp1d(mu_union, phase_union, mu_out, bounds="clamp")
+            if n_union > n_mu:
+                # Decimate: keep the most informative points in log space
+                keep = _rdp1d_log(mu_union, phase_union, n_mu)
+                mu[i] = mu_union[keep]
+                phase[:, i, :] = phase_union[:, keep]
 
-        else:
-            mu_out = mu_union
-            phase_out = phase_union
+            elif n_union < n_mu:
+                # Upsample: insert midpoints into the largest gaps of the union
+                # grid. All original points are preserved, so the non-uniform
+                # density near the forward-scattering peak is maintained.
+                mu[i] = _upsample_mu(mu_union, n_mu)
+                phase[:, i, :] = interp1d(mu_union, phase_union, mu[i], bounds="clamp")
 
-        return mu_out, phase_out
+            else:
+                mu[i] = mu_union
+                phase[:, i, :] = phase_union
+
+        if is_scalar:
+            return mu[0], phase[:, 0, :]
+        return mu, phase
 
     def eval_pmom(self, w: pint.Quantity, clip: bool = False) -> tuple[np.ndarray, int]:
         """

--- a/src/eradiate/scenes/_gridvolume.py
+++ b/src/eradiate/scenes/_gridvolume.py
@@ -1,0 +1,284 @@
+from __future__ import annotations
+
+from functools import partial
+from typing import Callable
+
+import mitsuba as mi
+import numpy as np
+
+from .geometry import (
+    PlaneParallelGeometry,
+    SceneGeometry,
+    SphericalShellGeometry,
+)
+from ..contexts import KernelContext
+from ..kernel import (
+    DictParameter,
+    KernelSceneParameterFlags,
+    SceneParameter,
+    SearchSceneParameter,
+)
+
+
+def _prepare_grid(
+    eval_grid, ctx, spectral_index, dtype, shape_xyz, extra_kwargs=None, units=None
+) -> np.ndarray:
+    """
+    Broadcasts the return value of the ``eval_grid`` callable onto the
+    requested ``shape_xyz``.
+
+    If shape_xyz is ``None``, the eval_grid returns one dimensional
+    properties corresponding to a 1D plane parallel atmosphere geometry.
+
+    Otherwise Scalars and 1-D z-column arrays are broadcast to ``shape_xyz``.
+    Any other shape mismatch raises a ``ValueError``.
+
+    Performs data type conversion of evaluated grids to ``dtype``. Optionally
+    performs units conversion to ``units``.
+
+    ``extra_kwargs`` are passed to eval_grid.
+
+    Returns
+    -------
+    np.ndarray
+        broadcasted evaluated array
+    """
+    grid = eval_grid(ctx.si if spectral_index else ctx, **extra_kwargs)
+    if units:
+        grid = grid.m_as(units)
+    grid = np.asarray(grid, dtype=dtype)
+    assert np.size(grid) > 0
+    if shape_xyz is None:
+        if np.squeeze(grid).ndim > 1:
+            raise ValueError(
+                "Evaluation of a non 1D grid for an undefined target shape "
+                f"Evaluated grid shape: {grid.shape} is not 1D. Could not "
+                "infer a grid volume shape."
+            )
+        return grid.reshape(1, 1, -1)
+    if grid.size == 1:
+        return np.broadcast_to(grid, shape_xyz)
+    elif np.squeeze(grid).shape == (shape_xyz[2],):
+        return np.broadcast_to(grid.reshape(1, 1, -1), shape_xyz)
+    if grid.shape != shape_xyz:
+        raise ValueError(f"Invalid grid shape, expected {shape_xyz}, got {grid.shape}")
+    return grid
+
+
+def make_volume_grid(
+    geometry: SceneGeometry,
+    ctx: KernelContext,
+    eval_grid=None,
+    dtype=None,
+    units=None,
+    spectral_index=True,
+    to_mi=True,
+    extra_dim=False,
+    extra_kwargs=None,
+) -> np.ndarray | mi.VolumeGrid:
+    """
+    Evaluate a grid function and reshape it to the layout expected by Mitsuba
+    for the given geometry.
+
+    Optionally append a trailing dimension and convert to a Mitsuba
+    ``VolumeGrid``.
+
+    Raises ``ValueError`` if geometry is None and the grid is not one dimensional.
+
+    For :class:`.PlaneParallelGeometry` the grid is transposed from
+    ``(x, y, z)`` to ``(z, y, x)``. For :class:`.SphericalShellGeometry` the
+    ``(x, y, z)`` layout is used as-is.
+
+    Returns
+    -------
+    Union[np.ndarray, mi.VolumeGrid]
+        Broadcasted and ordered VolumeGrid
+    """
+    shape = None
+    if geometry is not None:
+        shape = geometry.grid.shape
+    grid = _prepare_grid(
+        eval_grid,
+        ctx,
+        spectral_index,
+        dtype,
+        shape,
+        extra_kwargs=extra_kwargs,
+        units=units,
+    )
+    if isinstance(geometry, PlaneParallelGeometry):
+        grid = grid.T
+    if extra_dim:
+        grid = grid.reshape(*grid.shape, 1)
+    if to_mi:
+        return mi.VolumeGrid(grid)
+    return grid
+
+
+class _partial(partial):
+    """
+    A :class:`functools.partial` subclass with a human-readable ``__repr__``
+    and a ``get_bound_instance`` helper that returns the object to which
+    ``eval_grid`` is bound.
+    """
+
+    def __repr__(self):
+        instance = self.get_bound_instance()
+        if instance is None:
+            cls_name = None
+        else:
+            cls_name = instance.__class__.__name__
+        return f"partial({self.func.__name__}, {cls_name}, extra_parameters={list(self.keywords)})"
+
+    def get_bound_instance(self):
+        """Return the instance to which the ``eval_grid`` method is bound."""
+        return self.keywords["eval_grid"].__dict__.get("__self__", None)
+
+
+def _postprocess_template(
+    geometry: SceneGeometry,
+    partial_factory: Callable,
+    filter_type_kw: str,
+    wrap_mode_kw: str,
+) -> dict:
+    """
+    Build a Mitsuba kernel dict for a gridvolume plugin, wrapping it in a
+    ``sphericalcoordsvolume`` for :class:`.SphericalShellGeometry`.
+    """
+    gridvolume = {
+        "type": "gridvolume",
+        "grid": DictParameter(partial_factory),
+        "use_grid_bbox": True,
+        "filter_type": filter_type_kw,
+        "wrap_mode": wrap_mode_kw,
+    }
+    if geometry is not None:
+        to_world = geometry.grid.to_world
+        gridvolume["to_world"] = to_world
+    if isinstance(geometry, SphericalShellGeometry):
+        return {
+            "type": "sphericalcoordsvolume",
+            "volume": gridvolume,
+            "rmin": geometry.atmosphere_volume_rmin,
+            "to_world": geometry.atmosphere_volume_to_world,
+        }
+    return gridvolume
+
+
+def generate_gridvolume(
+    geometry: SceneGeometry | None,
+    eval_grid: Callable,
+    flag: KernelSceneParameterFlags | None = None,
+    search: SearchSceneParameter | None = None,
+    filter_type: str | None = None,
+    wrap_mode: str | None = None,
+    spectral_index: bool = True,
+    units=None,
+    dtype: type = np.float32,
+    extra_kwargs: dict | None = None,
+) -> dict | SceneParameter:
+    """
+    Generate a gridvolume kernel dict or a scene parameter update object.
+
+    When ``flag`` is ``None``, a Mitsuba kernel dict suitable for scene
+    construction is returned. When ``flag`` is set, a :class:`.SceneParameter`
+    intended for scene parameter updates is returned instead.
+
+    If geometry is None, the 1D plane parallel case is assumed and the Z
+    coordinate shape is inferred from the return value of ``eval_grid``.
+
+    Parameters
+    ----------
+    geometry : .SceneGeometry or NoneType
+        Scene geometry driving the grid shape and coordinate layout.
+
+    eval_grid : callable
+        A bound method returning the grid data. It must accept a
+        :class:`.KernelContext` (or spectral index if ``spectral_index`` is ``True``)
+        as its first argument, followed by any ``extra_kwargs``.
+
+        Expected return shape (in ``(x, y, z)`` order):
+
+        * ``()`` or ``(1,)`` — scalar, broadcast to full shape.
+        * ``(n_z,)`` — 1-D vertical profile, broadcast along x and y.
+        * ``(n_x, n_y, n_z)`` — full 3-D grid.
+
+    flag : object, optional
+        Update flag passed to :class:`.SceneParameter`. If ``None`` (default),
+        a kernel dict is returned.
+
+    search : .SearchSceneParameter, optional
+        Parameter lookup strategy forwarded to :class:`.SceneParameter`.
+        Only used when ``flag`` is set.
+
+    filter_type : str, optional
+        Mitsuba filter type string. Defaults to ``str(geometry.filter_type)``.
+
+    wrap_mode : str, optional
+        Mitsuba wrap mode string. Defaults to ``str(geometry.wrap_mode)``.
+
+    spectral_index : bool, optional, default: False
+        If ``True``, pass ``ctx.si`` instead of ``ctx`` to ``eval_grid``.
+
+    units : pint.Unit, optional
+    If set, convert grid values to these units before processing.
+
+    dtype : numpy.dtype, optional, default: numpy.float32
+        NumPy dtype of the resulting grid buffer.
+
+    extra_kwargs : dict, optional
+        Additional keyword arguments forwarded to ``eval_grid``.
+
+    Returns
+    -------
+    dict
+        Mitsuba kernel dict, when ``flag`` is ``None``.
+
+    .SceneParameter
+        Scene parameter update object, when ``flag`` is set.
+
+    Examples
+    --------
+    Generate a kernel dict for a plane-parallel scene:
+
+    .. code-block:: python
+
+        generate_gridvolume(geometry, my_component.eval_sigma_t)
+
+    Generate a scene parameter for spectral updates:
+
+    .. code-block:: python
+
+        generate_gridvolume(
+            geometry,
+            my_component.eval_sigma_t,
+            flag=UpdateFlags.SPECTRAL,
+            search=SearchSceneParameter(...),
+        )
+    """
+    pf = _partial(
+        make_volume_grid,
+        geometry,
+        eval_grid=eval_grid,
+        dtype=dtype,
+        units=units,
+        spectral_index=spectral_index,
+        extra_dim=flag is not None,
+        to_mi=flag is None,
+        extra_kwargs=extra_kwargs or {},
+    )
+    if flag is not None:
+        return SceneParameter(pf, flag, search=search)
+    if geometry is None:
+        filter_type = str(filter_type or "nearest")
+        wrap_mode = str(wrap_mode or "clamp")
+    else:
+        filter_type = str(filter_type or geometry.filter_type)
+        wrap_mode = str(wrap_mode or geometry.wrap_mode)
+
+    return _postprocess_template(
+        geometry,
+        pf,
+        filter_type,
+        wrap_mode,
+    )

--- a/src/eradiate/scenes/atmosphere/_core.py
+++ b/src/eradiate/scenes/atmosphere/_core.py
@@ -10,12 +10,19 @@ import pint
 import xarray as xr
 from axsdb import AbsorptionDatabase
 
+from eradiate.kernel._render import SearchSceneParameter
+
+from .._gridvolume import generate_gridvolume
 from ..core import (
     CompositeSceneElement,
     SceneElement,
     traverse,
 )
-from ..geometry import PlaneParallelGeometry, SceneGeometry, SphericalShellGeometry
+from ..geometry import (
+    PlaneParallelGeometry,
+    SceneGeometry,
+    SphericalShellGeometry,
+)
 from ..phase import PhaseFunction
 from ..shapes import Shape
 from ... import validators
@@ -23,13 +30,11 @@ from ..._factory import Factory
 from ..._mode import get_mode
 from ...attrs import define, documented, get_doc
 from ...contexts import KernelContext
+from ...grid import GridCoords
 from ...kernel import (
-    DictParameter,
     KernelSceneParameterFlags,
     SceneParameter,
-    SearchSceneParameter,
 )
-from ...radprops import ZGrid
 from ...spectral.index import SpectralIndex
 from ...units import symbol
 from ...units import unit_context_config as ucc
@@ -172,7 +177,6 @@ class Atmosphere(CompositeSceneElement, ABC):
         .PhaseFunction
             Phase function associated with the atmosphere.
         """
-        pass
 
     # --------------------------------------------------------------------------
     #                    Spatial and thermophysical properties
@@ -196,7 +200,6 @@ class Atmosphere(CompositeSceneElement, ABC):
         mfp : quantity
             Mean free path estimate.
         """
-        pass
 
     # --------------------------------------------------------------------------
     #                       Kernel dictionary generation
@@ -255,7 +258,6 @@ class Atmosphere(CompositeSceneElement, ABC):
             The phase function-related contribution to the kernel scene
             dictionary template for the atmosphere.
         """
-        pass
 
     @property
     @abstractmethod
@@ -267,7 +269,6 @@ class Atmosphere(CompositeSceneElement, ABC):
             The medium-related contribution to the kernel scene dictionary
             template for the atmosphere.
         """
-        pass
 
     @property
     def _template_shape(self) -> dict:
@@ -314,7 +315,6 @@ class Atmosphere(CompositeSceneElement, ABC):
             The phase function-related contribution to the parameter update map
             template for the atmosphere.
         """
-        pass
 
     @property
     @abstractmethod
@@ -326,7 +326,6 @@ class Atmosphere(CompositeSceneElement, ABC):
             The medium-related contribution to the parameter update map template
             for the atmosphere.
         """
-        pass
 
     @property
     def _params_shape(self) -> dict[str, SceneParameter]:
@@ -409,7 +408,6 @@ class AbstractHeterogeneousAtmosphere(Atmosphere, ABC):
         """
         Update internal state.
         """
-        pass
 
     # --------------------------------------------------------------------------
     #                    Spatial and thermophysical properties
@@ -435,7 +433,7 @@ class AbstractHeterogeneousAtmosphere(Atmosphere, ABC):
     def eval_radprops(
         self,
         si: SpectralIndex,
-        zgrid: ZGrid | None = None,
+        grid: GridCoords | None = None,
         optional_fields: bool = False,
     ) -> xr.Dataset:
         """
@@ -446,10 +444,10 @@ class AbstractHeterogeneousAtmosphere(Atmosphere, ABC):
         si : .SpectralIndex
             Spectral index.
 
-        zgrid : .ZGrid, optional
+        grid : .GridCoords, optional
             Altitude grid on which evaluation is performed. If unset, an
             instance-specific default is used
-            (see :meth:`zgrid <.AbstractHeterogeneousAtmosphere.zgrid>`).
+            (see :meth:`grid <.AbstractHeterogeneousAtmosphere.geometry.grid>`).
 
         optional_fields : bool, optional, default: False
             If ``True``, also output the absorption and scattering coefficients,
@@ -469,16 +467,18 @@ class AbstractHeterogeneousAtmosphere(Atmosphere, ABC):
 
             * ``z``: altitude.
         """
-        if zgrid is None:
-            zgrid = self.geometry.zgrid
+        if grid is None:
+            grid = self.geometry.grid
 
         sigma_units = ucc.get("collision_coefficient")
-        sigma_t = self.eval_sigma_t(si, zgrid).reshape(zgrid.layers.shape)
-        albedo = self.eval_albedo(si, zgrid).m_as(ureg.dimensionless)
+        sigma_t = self.eval_sigma_t(si, grid)
+        sigma_t = np.broadcast_to(sigma_t, grid.shape)
+        albedo = self.eval_albedo(si, grid).m_as(ureg.dimensionless)
+        albedo = np.broadcast_to(albedo, grid.shape)
 
         data_vars = {
             "sigma_t": (
-                "z_layer",
+                ("x_cells", "y_cells", "z_layer"),
                 sigma_t.m_as(sigma_units),
                 {
                     "units": f"{symbol(sigma_units)}",
@@ -487,7 +487,7 @@ class AbstractHeterogeneousAtmosphere(Atmosphere, ABC):
                 },
             ),
             "albedo": (
-                "z_layer",
+                ("x_cells", "y_cells", "z_layer"),
                 albedo,
                 {
                     "standard_name": "albedo",
@@ -501,7 +501,7 @@ class AbstractHeterogeneousAtmosphere(Atmosphere, ABC):
             data_vars.update(
                 {
                     "sigma_a": (
-                        "z_layer",
+                        ("x_cells", "y_cells", "z_layer"),
                         sigma_t.m_as(sigma_units) * (1.0 - albedo),
                         {
                             "units": f"{symbol(sigma_units)}",
@@ -510,7 +510,7 @@ class AbstractHeterogeneousAtmosphere(Atmosphere, ABC):
                         },
                     ),
                     "sigma_s": (
-                        "z_layer",
+                        ("x_cells", "y_cells", "z_layer"),
                         sigma_t.m_as(sigma_units) * albedo,
                         {
                             "units": f"{symbol(sigma_units)}",
@@ -524,21 +524,39 @@ class AbstractHeterogeneousAtmosphere(Atmosphere, ABC):
         return xr.Dataset(
             data_vars,
             coords={
+                "x_layer": (
+                    "x_layer",
+                    grid.cells_x.magnitude,
+                    {
+                        "units": f"{symbol(grid.cells_x.units)}",
+                        "standard_name": "cells_x",
+                        "long_name": "cells x position",
+                    },
+                ),
+                "y_layer": (
+                    "y_layer",
+                    grid.cells_y.magnitude,
+                    {
+                        "units": f"{symbol(grid.layers.units)}",
+                        "standard_name": "cells_y",
+                        "long_name": "cells y position",
+                    },
+                ),
                 "z_layer": (
                     "z_layer",
-                    zgrid.layers.magnitude,
+                    grid.layers.magnitude,
                     {
-                        "units": f"{symbol(zgrid.layers.units)}",
+                        "units": f"{symbol(grid.layers.units)}",
                         "standard_name": "layer_altitude",
                         "long_name": "layer altitude",
                     },
-                )
+                ),
             },
         )
 
     @abstractmethod
     def eval_albedo(
-        self, si: SpectralIndex, zgrid: ZGrid | None = None
+        self, si: SpectralIndex, grid: GridCoords | None = None
     ) -> pint.Quantity:
         """
         Evaluate albedo spectrum based on a spectral context. This method
@@ -550,10 +568,10 @@ class AbstractHeterogeneousAtmosphere(Atmosphere, ABC):
         si : :class:`.SpectralIndex`
             Spectral index.
 
-        zgrid : .ZGrid, optional
+        grid : .GridCoords, optional
             Altitude grid on which evaluation is performed. If unset, an
             instance-specific default is used
-            (see :meth:`zgrid <.AbstractHeterogeneousAtmosphere.zgrid>`).
+            (see :meth:`grid <.AbstractHeterogeneousAtmosphere.geometry.grid>`).
 
         Returns
         -------
@@ -561,11 +579,10 @@ class AbstractHeterogeneousAtmosphere(Atmosphere, ABC):
             Evaluated spectrum as an array with length equal to the number of
             layers.
         """
-        pass
 
     @abstractmethod
     def eval_sigma_t(
-        self, si: SpectralIndex, zgrid: ZGrid | None = None
+        self, si: SpectralIndex, grid: GridCoords | None = None
     ) -> pint.Quantity:
         """
         Evaluate extinction coefficient given a spectral context.
@@ -575,21 +592,20 @@ class AbstractHeterogeneousAtmosphere(Atmosphere, ABC):
         si : :class:`.SpectralIndex`
             Spectral index.
 
-        zgrid : .ZGrid, optional
+        grid : .GridCoords, optional
             Altitude grid on which evaluation is performed. If unset, an
             instance-specific default is used
-            (see :meth:`zgrid <.AbstractHeterogeneousAtmosphere.zgrid>`).
+            (see :meth:`grid <.AbstractHeterogeneousAtmosphere.geometry.grid>`).
 
         Returns
         -------
         quantity
             Particle layer extinction coefficient.
         """
-        pass
 
     @abstractmethod
     def eval_sigma_a(
-        self, si: SpectralIndex, zgrid: ZGrid | None = None
+        self, si: SpectralIndex, grid: GridCoords | None = None
     ) -> pint.Quantity:
         """
         Evaluate absorption coefficient given a spectral context.
@@ -599,21 +615,20 @@ class AbstractHeterogeneousAtmosphere(Atmosphere, ABC):
         si : :class:`.SpectralIndex`
             Spectral index.
 
-        zgrid : .ZGrid, optional
+        grid : .GridCoords, optional
             Altitude grid on which evaluation is performed. If unset, an
             instance-specific default is used
-            (see :meth:`zgrid <.AbstractHeterogeneousAtmosphere.zgrid>`).
+            (see :meth:`grid <.AbstractHeterogeneousAtmosphere.column.grid>`).
 
         Returns
         -------
         quantity
             Particle layer extinction coefficient.
         """
-        pass
 
     @abstractmethod
     def eval_sigma_s(
-        self, si: SpectralIndex, zgrid: ZGrid | None = None
+        self, si: SpectralIndex, grid: GridCoords | None = None
     ) -> pint.Quantity:
         """
         Evaluate scattering coefficient given a spectral context.
@@ -623,18 +638,16 @@ class AbstractHeterogeneousAtmosphere(Atmosphere, ABC):
         si : :class:`.SpectralIndex`
             Spectral index.
 
-        zgrid : .ZGrid, optional
+        grid : .GridCoords, optional
             Altitude grid on which evaluation is performed. If unset, an
             instance-specific default is used
-            (see :meth:`zgrid <.AbstractHeterogeneousAtmosphere.zgrid>`).
+            (see :meth:`grid <.AbstractHeterogeneousAtmosphere.geometry.grid>`).
 
         Returns
         -------
         quantity
             Particle layer scattering coefficient.
         """
-
-        pass
 
     def eval_transmittance(
         self,
@@ -666,12 +679,12 @@ class AbstractHeterogeneousAtmosphere(Atmosphere, ABC):
         try:
             sigma = eval_sigma[interaction](si=si)
         except KeyError as e:
-            raise ValueError(
+            raise TypeError(
                 f"invalid interaction type '{interaction}', "
                 f"supported: {list(eval_sigma.keys())}"
             ) from e
-        dz = np.diff(self.geometry.zgrid.levels)
-        tau = np.sum((sigma * dz).to("1"))
+        dz = np.diff(self.geometry.grid.levels)
+        tau = np.sum(np.multiply(sigma, dz).to("1"), axis=-1)
         return np.exp(-tau)
 
     def eval_transmittance_t(self, si: SpectralIndex) -> pint.Quantity:
@@ -692,109 +705,48 @@ class AbstractHeterogeneousAtmosphere(Atmosphere, ABC):
         # Inherit docstring
 
         extremum = None
+
+        volumes = {
+            "albedo": generate_gridvolume(
+                self.geometry,
+                self.eval_albedo,
+                units=ureg.dimensionless,
+                dtype=np.float64,
+            ),
+            "sigma_t": generate_gridvolume(
+                self.geometry,
+                self.eval_sigma_t,
+                units=uck.get("collision_coefficient"),
+                dtype=np.float64,
+            ),
+        }
         sigma_t_id = f"{self.id}_sigma_t"
 
-        if isinstance(self.geometry, PlaneParallelGeometry):
-            to_world = self.geometry.atmosphere_volume_to_world
-
-            medium = "eoheterogeneous" if self.force_majorant else "piecewise"
-            volumes = {
-                "albedo": {
-                    "type": "gridvolume",
-                    "grid": DictParameter(
-                        lambda ctx: mi.VolumeGrid(
-                            np.reshape(
-                                self.eval_albedo(ctx.si).m_as(ureg.dimensionless),
-                                (-1, 1, 1),
-                            ).astype(np.float32)
-                        ),
-                    ),
-                    "to_world": to_world,
-                    "filter_type": "nearest",
-                },
-                "sigma_t": {
-                    "type": "gridvolume",
-                    "id": sigma_t_id,
-                    "grid": DictParameter(
-                        lambda ctx: mi.VolumeGrid(
-                            np.reshape(
-                                self.eval_sigma_t(ctx.si).m_as(
-                                    uck.get("collision_coefficient")
-                                ),
-                                (-1, 1, 1),
-                            ).astype(np.float32)
-                        ),
-                    ),
-                    "to_world": to_world,
-                    "filter_type": "nearest",
-                },
-            }
-
-            if medium == "eoheterogeneous":
-                if self.extremum_resolution != (1, 1, 1):
-                    extremum = {
-                        "type": "extremum_grid",
-                        "volume": {"type": "ref", "id": sigma_t_id},
-                        "resolution": self.extremum_resolution,
-                        "to_world": to_world,
-                    }
-
-        elif isinstance(self.geometry, SphericalShellGeometry):
-            volume_rmin = self.geometry.atmosphere_volume_rmin
-            to_world = self.geometry.atmosphere_volume_to_world
-
+        if isinstance(self.geometry, SphericalShellGeometry):
             medium = "eoheterogeneous"
-            volumes = {
-                "albedo": {
-                    "type": "sphericalcoordsvolume",
-                    "volume": {
-                        "type": "gridvolume",
-                        "grid": DictParameter(
-                            lambda ctx: mi.VolumeGrid(
-                                np.reshape(
-                                    self.eval_albedo(ctx.si).m_as(ureg.dimensionless),
-                                    (1, 1, -1),
-                                ).astype(np.float32)
-                            ),
-                        ),
-                        "filter_type": "nearest",
-                    },
-                    "to_world": to_world,
-                    "rmin": volume_rmin,
-                },
-                "sigma_t": {
-                    "type": "sphericalcoordsvolume",
-                    "id": sigma_t_id,
-                    "volume": {
-                        "type": "gridvolume",
-                        "grid": DictParameter(
-                            lambda ctx: mi.VolumeGrid(
-                                np.reshape(
-                                    self.eval_sigma_t(ctx.si).m_as(
-                                        uck.get("collision_coefficient")
-                                    ),
-                                    (1, 1, -1),
-                                ).astype(np.float32)
-                            ),
-                        ),
-                        "filter_type": "nearest",
-                    },
-                    "to_world": to_world,
-                    "rmin": volume_rmin,
-                },
-            }
-
             if self.extremum_resolution != (1, 1, 1):
                 extremum = {
                     "type": "extremum_spherical",
                     "volume": {"type": "ref", "id": sigma_t_id},
-                    "rmin": volume_rmin,
+                    "rmin": self.geometry.atmosphere_volume_rmin,
                     "resolution": self.extremum_resolution,
-                    "to_world": to_world,
+                    "to_world": self.geometry.atmosphere_volume_to_world,
                 }
-
+        elif isinstance(self.geometry, PlaneParallelGeometry):
+            medium = (
+                "eoheterogeneous"
+                if self.force_majorant or not self.geometry.grid.onedim
+                else "piecewise"
+            )
+            if medium == "eoheterogeneous" and self.extremum_resolution != (1, 1, 1):
+                extremum = {
+                    "type": "extremum_grid",
+                    "volume": {"type": "ref", "id": sigma_t_id},
+                    "resolution": self.extremum_resolution,
+                    "to_world": self.geometry.atmosphere_volume_to_world,
+                }
         else:
-            raise ValueError(
+            raise TypeError(
                 f"unhandled scene geometry type '{type(self.geometry).__name__}'"
             )
 
@@ -812,6 +764,7 @@ class AbstractHeterogeneousAtmosphere(Atmosphere, ABC):
 
         if extremum is not None:
             result["extremum"] = extremum
+            result["sigma_t"]["id"] = sigma_t_id
 
         if medium == "eoheterogeneous":
             result["use_rrt"] = self.use_rrt
@@ -823,67 +776,42 @@ class AbstractHeterogeneousAtmosphere(Atmosphere, ABC):
     @property
     def _params_medium(self) -> dict[str, SceneParameter]:
         # Inherit docstring
+
         if isinstance(self.geometry, PlaneParallelGeometry):
-            return {
-                "albedo.data": SceneParameter(
-                    lambda ctx: np.reshape(
-                        self.eval_albedo(ctx.si).m_as(ureg.dimensionless),
-                        (-1, 1, 1, 1),
-                    ).astype(np.float32),
-                    KernelSceneParameterFlags.SPECTRAL,
-                    search=SearchSceneParameter(
-                        node_type=mi.Medium,
-                        node_id=self.medium_id,
-                        parameter_relpath="albedo.data",
-                    ),
-                ),
-                "sigma_t.data": SceneParameter(
-                    lambda ctx: np.reshape(
-                        self.eval_sigma_t(ctx.si).m_as(
-                            uck.get("collision_coefficient")
-                        ),
-                        (-1, 1, 1, 1),
-                    ).astype(np.float32),
-                    KernelSceneParameterFlags.SPECTRAL,
-                    search=SearchSceneParameter(
-                        node_type=mi.Medium,
-                        node_id=self.medium_id,
-                        parameter_relpath="sigma_t.data",
-                    ),
-                ),
-            }
-
+            albedo_key = "albedo.data"
+            sigma_t_key = "sigma_t.data"
         elif isinstance(self.geometry, SphericalShellGeometry):
-            return {
-                "albedo.volume.data": SceneParameter(
-                    lambda ctx: np.reshape(
-                        self.eval_albedo(ctx.si).m_as(ureg.dimensionless),
-                        (1, 1, -1, 1),
-                    ).astype(np.float32),
-                    KernelSceneParameterFlags.SPECTRAL,
-                    search=SearchSceneParameter(
-                        node_type=mi.Medium,
-                        node_id=self.medium_id,
-                        parameter_relpath="albedo.volume.data",
-                    ),
-                ),
-                "sigma_t.volume.data": SceneParameter(
-                    lambda ctx: np.reshape(
-                        self.eval_sigma_t(ctx.si).m_as(
-                            uck.get("collision_coefficient")
-                        ),
-                        (1, 1, -1, 1),
-                    ).astype(np.float32),
-                    KernelSceneParameterFlags.SPECTRAL,
-                    search=SearchSceneParameter(
-                        node_type=mi.Medium,
-                        node_id=self.medium_id,
-                        parameter_relpath="sigma_t.volume.data",
-                    ),
-                ),
-            }
-
-        else:  # Shouldn't happen, prevented by validator
+            albedo_key = "albedo.volume.data"
+            sigma_t_key = "sigma_t.volume.data"
+        else:
             raise ValueError(
                 f"unhandled scene geometry type '{type(self.geometry).__name__}'"
             )
+
+        albedo_search = SearchSceneParameter(
+            node_type=mi.Medium, node_id=self.medium_id, parameter_relpath=albedo_key
+        )
+        sigma_t_search = SearchSceneParameter(
+            node_type=mi.Medium, node_id=self.medium_id, parameter_relpath=sigma_t_key
+        )
+        albedo_grid = generate_gridvolume(
+            self.geometry,
+            self.eval_albedo,
+            units=ureg.dimensionless,
+            search=albedo_search,
+            flag=KernelSceneParameterFlags.SPECTRAL,
+            dtype=np.float64,
+        )
+        sigma_t_grid = generate_gridvolume(
+            self.geometry,
+            self.eval_sigma_t,
+            units=uck.get("collision_coefficient"),
+            search=sigma_t_search,
+            flag=KernelSceneParameterFlags.SPECTRAL,
+            dtype=np.float64,
+        )
+
+        return {
+            albedo_key: albedo_grid,
+            sigma_t_key: sigma_t_grid,
+        }

--- a/src/eradiate/scenes/atmosphere/_heterogeneous.py
+++ b/src/eradiate/scenes/atmosphere/_heterogeneous.py
@@ -6,12 +6,12 @@ from __future__ import annotations
 
 import logging
 from collections import abc as cabc
-from typing import TYPE_CHECKING
 
 import attrs
 import mitsuba as mi
 import numpy as np
 import pint
+from axsdb import AbsorptionDatabase
 
 from ._core import AbstractHeterogeneousAtmosphere, atmosphere_factory
 from ._molecular import MolecularAtmosphere
@@ -20,15 +20,12 @@ from ..core import traverse
 from ..phase import BlendPhaseFunction, PhaseFunction
 from ...attrs import define, documented
 from ...contexts import KernelContext
+from ...grid import GridCoords
 from ...kernel import SearchSceneParameter
-from ...radprops import ZGrid
 from ...spectral.index import SpectralIndex
 from ...units import unit_context_config as ucc
 from ...units import unit_registry as ureg
 from ...util.misc import cache_by_id
-
-if TYPE_CHECKING:
-    from axsdb import AbsorptionDatabase
 
 logger = logging.getLogger(__name__)
 
@@ -117,29 +114,12 @@ class HeterogeneousAtmosphere(AbstractHeterogeneousAtmosphere):
                 "scaled individually"
             )
 
-    _zgrid: ZGrid = documented(
-        attrs.field(
-            default=None,
-            converter=attrs.converters.optional(
-                lambda x: ZGrid(x) if not isinstance(x, ZGrid) else x
-            ),
-            validator=attrs.validators.optional(attrs.validators.instance_of(ZGrid)),
-            repr=False,
-        ),
-        doc="A high-resolution layer altitude mesh on which the radiative "
-        "properties of the components are interpolated. If unset, a default grid "
-        "with one layer per 100 m (or 10 layers if the atmosphere object "
-        "height is less than 100 m) is used.",
-        type=".ZGrid",
-        init_type=".ZGrid, optional",
-    )
-
     @property
     def components(self) -> list[MolecularAtmosphere | ParticleLayer]:
         """
         Returns
         -------
-        list of .AbstractHeterogeneousAtmosphere
+        list
             The list of all registered atmospheric components.
         """
         result = [self.molecular_atmosphere] if self.molecular_atmosphere else []
@@ -166,11 +146,6 @@ class HeterogeneousAtmosphere(AbstractHeterogeneousAtmosphere):
     # --------------------------------------------------------------------------
     #              Spatial extension and thermophysical properties
     # --------------------------------------------------------------------------
-
-    @property
-    def zgrid(self) -> ZGrid:
-        # Inherit docstring
-        return self._zgrid
 
     @property
     def bottom(self) -> pint.Quantity:
@@ -200,11 +175,11 @@ class HeterogeneousAtmosphere(AbstractHeterogeneousAtmosphere):
             return None
 
     def eval_albedo(
-        self, si: SpectralIndex, zgrid: ZGrid | None = None
+        self, si: SpectralIndex, grid: GridCoords | None = None
     ) -> pint.Quantity:
         # Inherit docstring
-        if zgrid is not None and zgrid is not self.geometry.zgrid:
-            raise ValueError("zgrid must be left unset or set to self.geometry.zgrid")
+        if grid is not None and grid is not self.geometry.grid:
+            raise ValueError("grid must be left unset or set to self.geometry.grid")
 
         units = ucc.get("collision_coefficient")
         sigma_s = self.eval_sigma_s(si).m_as(units)
@@ -216,45 +191,41 @@ class HeterogeneousAtmosphere(AbstractHeterogeneousAtmosphere):
 
     @cache_by_id
     def _eval_sigma_t_impl(self, si: SpectralIndex) -> pint.Quantity:
-        result = np.zeros((len(self.components), self.geometry.zgrid.n_layers))
         sigma_units = ucc.get("collision_coefficient")
-
-        # Evaluate extinction for current component
-        for i, component in enumerate(self.components):
-            result[i] = component.eval_sigma_t(si, self.geometry.zgrid).m_as(
-                sigma_units
+        result = []
+        for component in self.components:
+            cmp_result = component.eval_sigma_t(si, self.geometry.grid)
+            result.append(
+                np.broadcast_to(cmp_result.m_as(sigma_units), self.geometry.grid.shape)
             )
-
-        return result * sigma_units
+        return np.stack(result) * sigma_units
 
     def eval_sigma_t(
-        self, si: SpectralIndex, zgrid: ZGrid | None = None
+        self, si: SpectralIndex, grid: GridCoords | None = None
     ) -> pint.Quantity:
         # Inherit docstring
-        if zgrid is not None and zgrid is not self.geometry.zgrid:
-            raise ValueError("zgrid must be left unset or set to self.geometry.zgrid")
+        if grid is not None and grid is not self.geometry.grid:
+            raise ValueError("grid must be left unset or set to self.geometry.grid")
         return self._eval_sigma_t_impl(si).sum(axis=0)
 
     def eval_sigma_a(
-        self, si: SpectralIndex, zgrid: ZGrid | None = None
+        self, si: SpectralIndex, grid: GridCoords | None = None
     ) -> pint.Quantity:
         # Inherit docstring
-        if zgrid is not None and zgrid is not self.geometry.zgrid:
-            raise ValueError("zgrid must be left unset or set to self.geometry.zgrid")
+        if grid is not None and grid is not self.geometry.grid:
+            raise ValueError("grid must be left unset or set to self.geometry.grid")
         return self.eval_sigma_t(si) - self.eval_sigma_s(si)
 
     @cache_by_id
     def _eval_sigma_s_impl(self, si: SpectralIndex) -> pint.Quantity:
-        result = np.zeros((len(self.components), self.geometry.zgrid.n_layers))
         sigma_units = ucc.get("collision_coefficient")
-
-        # Evaluate scattering coefficient for current component
-        for i, component in enumerate(self.components):
-            result[i] = component.eval_sigma_s(si, self.geometry.zgrid).m_as(
-                sigma_units
+        result = []
+        for component in self.components:
+            cmp_result = component.eval_sigma_s(si, self.geometry.grid)
+            result.append(
+                np.broadcast_to(cmp_result.m_as(sigma_units), self.geometry.grid.shape)
             )
-
-        return result * sigma_units
+        return np.stack(result) * sigma_units
 
     def _eval_sigma_s_component(
         self, si: SpectralIndex, n_component: int
@@ -262,11 +233,11 @@ class HeterogeneousAtmosphere(AbstractHeterogeneousAtmosphere):
         return self._eval_sigma_s_impl(si)[n_component]
 
     def eval_sigma_s(
-        self, si: SpectralIndex, zgrid: ZGrid | None = None
+        self, si: SpectralIndex, grid: GridCoords | None = None
     ) -> pint.Quantity:
         # Inherit docstring
-        if zgrid is not None and zgrid is not self.geometry.zgrid:
-            raise ValueError("zgrid must be left unset or set to self.geometry.zgrid")
+        if grid is not None and grid is not self.geometry.grid:
+            raise ValueError("grid must be left unset or set to self.geometry.grid")
         return self._eval_sigma_s_impl(si).sum(axis=0)
 
     # --------------------------------------------------------------------------

--- a/src/eradiate/scenes/atmosphere/_molecular.py
+++ b/src/eradiate/scenes/atmosphere/_molecular.py
@@ -17,7 +17,8 @@ from ..phase import PhaseFunction, RayleighPhaseFunction, phase_function_factory
 from ... import converters
 from ...attrs import define, documented
 from ...contexts import KernelContext
-from ...radprops import AtmosphereRadProfile, RadProfile, ZGrid, get_default_absdb
+from ...grid import GridCoords
+from ...radprops import AtmosphereRadProfile, RadProfile, get_default_absdb
 from ...spectral.index import SpectralIndex
 from ...units import unit_registry as ureg
 from ...util.misc import summary_repr
@@ -254,47 +255,47 @@ class MolecularAtmosphere(AbstractHeterogeneousAtmosphere):
         return self._radprops_profile
 
     def eval_albedo(
-        self, si: SpectralIndex, zgrid: ZGrid | None = None
+        self, si: SpectralIndex, grid: GridCoords | None = None
     ) -> pint.Quantity:
         # Inherit docstring
         return self.radprops_profile.eval_albedo(
             si,
-            zgrid=self.geometry.zgrid if zgrid is None else zgrid,
+            grid=self.geometry.grid if grid is None else grid,
         )
 
     def eval_sigma_t(
-        self, si: SpectralIndex, zgrid: ZGrid | None = None
+        self, si: SpectralIndex, grid: GridCoords | None = None
     ) -> pint.Quantity:
         # Inherit docstring
         return self.radprops_profile.eval_sigma_t(
             si,
-            zgrid=self.geometry.zgrid if zgrid is None else zgrid,
+            grid=self.geometry.grid if grid is None else grid,
         )
 
     def eval_sigma_a(
-        self, si: SpectralIndex, zgrid: ZGrid | None = None, **kwargs
+        self, si: SpectralIndex, grid: GridCoords | None = None, **kwargs
     ) -> pint.Quantity:
         # Inherit docstring
         return self.radprops_profile.eval_sigma_a(
             si,
-            zgrid=self.geometry.zgrid if zgrid is None else zgrid,
+            grid=self.geometry.grid if grid is None else grid,
         )
 
     def eval_sigma_s(
-        self, si: SpectralIndex, zgrid: ZGrid | None = None
+        self, si: SpectralIndex, grid: GridCoords | None = None
     ) -> pint.Quantity:
         # Inherit docstring
         return self.radprops_profile.eval_sigma_s(
             si,
-            zgrid=self.geometry.zgrid if zgrid is None else zgrid,
+            grid=self.geometry.grid if grid is None else grid,
         )
 
     def eval_depolarization_factor(
-        self, si: SpectralIndex, zgrid: ZGrid | None = None
+        self, si: SpectralIndex, grid: GridCoords | None = None
     ) -> pint.Quantity:
         return self.radprops_profile.eval_depolarization_factor(
             si,
-            zgrid=self.geometry.zgrid if zgrid is None else zgrid,
+            grid=self.geometry.grid if grid is None else grid,
         )
 
     # --------------------------------------------------------------------------

--- a/src/eradiate/scenes/atmosphere/_particle_layer.py
+++ b/src/eradiate/scenes/atmosphere/_particle_layer.py
@@ -18,8 +18,9 @@ from ..core import traverse
 from ..phase import ParticlePhaseFunction
 from ...attrs import define, documented
 from ...contexts import KernelContext
+from ...grid import GridCoords
 from ...kernel import SceneParameter
-from ...radprops import ParticleProperties, ZGrid
+from ...radprops import ParticleProperties
 from ...spectral.index import (
     CKDSpectralIndex,
     MonoSpectralIndex,
@@ -235,7 +236,7 @@ class ParticleLayer(AbstractHeterogeneousAtmosphere):
     #                    Spatial and thermophysical properties
     # --------------------------------------------------------------------------
 
-    def eval_fractions(self, zgrid: ZGrid) -> np.ndarray:
+    def eval_fractions(self, grid: GridCoords) -> np.ndarray:
         """
         Compute the particle number fraction in the particle layer.
 
@@ -244,7 +245,7 @@ class ParticleLayer(AbstractHeterogeneousAtmosphere):
         ndarray
             Particle number fractions as a (n_layers,)-shaped array.
         """
-        x = (zgrid.layers - self.bottom) / (self.top - self.bottom)
+        x = (grid.layers - self.bottom) / (self.top - self.bottom)
         fractions = self.distribution(x.m_as(ureg.dimensionless))
         fractions /= np.sum(fractions)
         return fractions
@@ -258,17 +259,17 @@ class ParticleLayer(AbstractHeterogeneousAtmosphere):
     # --------------------------------------------------------------------------
 
     @cache_by_id
-    def _eval_albedo_impl(self, w: pint.Quantity, zgrid: ZGrid) -> pint.Quantity:
+    def _eval_albedo_impl(self, w: pint.Quantity, grid: GridCoords) -> pint.Quantity:
         # Return albedo from dataset (without accounting for bypass switches)
         # This routine is vectorized and returns an array of shape
         # (n_wavelengths, n_layers)
         pp = self.particle_properties
         albedo = pp.eval_ssa(w)
-        zmask = np.reshape(self.eval_fractions(zgrid) > 0, (1, -1))
+        zmask = np.reshape(self.eval_fractions(grid) > 0, (1, -1))
         return albedo * zmask
 
     @cache_by_id
-    def _eval_sigma_t_impl(self, w: pint.Quantity, zgrid: ZGrid) -> pint.Quantity:
+    def _eval_sigma_t_impl(self, w: pint.Quantity, grid: GridCoords) -> pint.Quantity:
         # Return extinction coefficient from dataset (without accounting
         # for bypass switches). This routine is vectorized and returns an
         # array of shape (n_wavelengths, n_layers)
@@ -285,55 +286,55 @@ class ParticleLayer(AbstractHeterogeneousAtmosphere):
         # Scatter this total OT to all layers
         # TODO: Make sure that axis order is consistent with other vectorized
         #  routines
-        fractions = self.eval_fractions(zgrid)
+        fractions = self.eval_fractions(grid)
         tau_layers = np.broadcast_to(
-            np.reshape(tau, (-1, 1)), (len(w), zgrid.n_layers)
+            np.reshape(tau, (-1, 1)), (len(w), grid.n_layers)
         ) * np.reshape(fractions, (1, -1))
 
         # Compute corresponding average coefficient
-        sigma_t = tau_layers / zgrid.layer_height
+        sigma_t = tau_layers / grid.layer_height
 
         return sigma_t
 
-    def _eval_sigma_a_impl(self, w: pint.Quantity, zgrid: ZGrid) -> pint.Quantity:
+    def _eval_sigma_a_impl(self, w: pint.Quantity, grid: GridCoords) -> pint.Quantity:
         # Return absorption coefficient from dataset (without accounting for
         # bypass switches). This routine is vectorized and returns an array of
         # shape (n_wavelengths, n_layers)
-        albedo = self._eval_albedo_impl(w, zgrid)
-        return self._eval_sigma_t_impl(w, zgrid) * (1.0 - albedo.m)
+        albedo = self._eval_albedo_impl(w, grid)
+        return self._eval_sigma_t_impl(w, grid) * (1.0 - albedo.m)
 
-    def _eval_sigma_s_impl(self, w: pint.Quantity, zgrid: ZGrid) -> pint.Quantity:
+    def _eval_sigma_s_impl(self, w: pint.Quantity, grid: GridCoords) -> pint.Quantity:
         # Return scattering coefficient from dataset (without accounting for
         # bypass switches). This routine is vectorized and returns an array of
         # shape (n_wavelengths, n_layers)
-        albedo = self._eval_albedo_impl(w, zgrid)
-        return self._eval_sigma_t_impl(w, zgrid) * albedo.m
+        albedo = self._eval_albedo_impl(w, grid)
+        return self._eval_sigma_t_impl(w, grid) * albedo.m
 
     @singledispatchmethod
     def eval_albedo(
-        self, si: SpectralIndex, zgrid: ZGrid | None = None
+        self, si: SpectralIndex, grid: GridCoords | None = None
     ) -> pint.Quantity:
         # Inherit docstring
         raise NotImplementedError
 
     @eval_albedo.register(MonoSpectralIndex)
-    def _(self, si, zgrid: ZGrid | None = None) -> pint.Quantity:
+    def _(self, si, grid: GridCoords | None = None) -> pint.Quantity:
         return self.eval_albedo_mono(
             w=si.w,
-            zgrid=self.geometry.zgrid if zgrid is None else zgrid,
+            grid=self.geometry.grid if grid is None else grid,
         )
 
     @eval_albedo.register(CKDSpectralIndex)
-    def _(self, si, zgrid: ZGrid | None = None) -> pint.Quantity:
+    def _(self, si, grid: GridCoords | None = None) -> pint.Quantity:
         return self.eval_albedo_ckd(
             w=si.w,
             g=si.g,
-            zgrid=self.geometry.zgrid if zgrid is None else zgrid,
+            grid=self.geometry.grid if grid is None else grid,
         )
 
-    def eval_albedo_mono(self, w: pint.Quantity, zgrid: ZGrid) -> pint.Quantity:
+    def eval_albedo_mono(self, w: pint.Quantity, grid: GridCoords) -> pint.Quantity:
         if self.has_absorption and self.has_scattering:
-            albedo = self._eval_albedo_impl(w, zgrid).squeeze()
+            albedo = self._eval_albedo_impl(w, grid).squeeze()
 
         elif self.has_absorption and not self.has_scattering:
             albedo = 0.0 * ureg.dimensionless
@@ -345,106 +346,106 @@ class ParticleLayer(AbstractHeterogeneousAtmosphere):
             raise RuntimeError
 
         # Albedo is constant vs spatial dimension
-        return np.full_like(zgrid.layers, albedo)
+        return np.full_like(grid.layers, albedo)
 
     def eval_albedo_ckd(
-        self, w: pint.Quantity, g: float, zgrid: ZGrid
+        self, w: pint.Quantity, g: float, grid: GridCoords
     ) -> pint.Quantity:
-        return self.eval_albedo_mono(w=w, zgrid=zgrid)
+        return self.eval_albedo_mono(w=w, grid=grid)
 
     @singledispatchmethod
     def eval_sigma_t(
-        self, si: SpectralIndex, zgrid: ZGrid | None = None
+        self, si: SpectralIndex, grid: GridCoords | None = None
     ) -> pint.Quantity:
         # Inherit docstring
         raise NotImplementedError
 
     @eval_sigma_t.register(MonoSpectralIndex)
-    def _(self, si, zgrid: ZGrid | None = None) -> pint.Quantity:
+    def _(self, si, grid: GridCoords | None = None) -> pint.Quantity:
         return self.eval_sigma_t_mono(
-            w=si.w, zgrid=self.geometry.zgrid if zgrid is None else zgrid
+            w=si.w, grid=self.geometry.grid if grid is None else grid
         )
 
     @eval_sigma_t.register(CKDSpectralIndex)
-    def _(self, si, zgrid: ZGrid | None = None) -> pint.Quantity:
+    def _(self, si, grid: GridCoords | None = None) -> pint.Quantity:
         return self.eval_sigma_t_ckd(
-            w=si.w, g=si.g, zgrid=self.geometry.zgrid if zgrid is None else zgrid
+            w=si.w, g=si.g, grid=self.geometry.grid if grid is None else grid
         )
 
-    def eval_sigma_t_mono(self, w: pint.Quantity, zgrid: ZGrid) -> pint.Quantity:
-        result = self._eval_sigma_t_impl(w, zgrid).squeeze()
+    def eval_sigma_t_mono(self, w: pint.Quantity, grid: GridCoords) -> pint.Quantity:
+        result = self._eval_sigma_t_impl(w, grid).squeeze()
 
         if self.has_absorption and self.has_scattering:
             return result
 
         elif not self.has_absorption and self.has_scattering:
-            return result - self._eval_sigma_a_impl(w, zgrid).squeeze()
+            return result - self._eval_sigma_a_impl(w, grid).squeeze()
 
         elif self.has_absorption and not self.has_scattering:
-            return result - self._eval_sigma_s_impl(w, zgrid).squeeze()
+            return result - self._eval_sigma_s_impl(w, grid).squeeze()
 
         raise RuntimeError
 
     def eval_sigma_t_ckd(
-        self, w: pint.Quantity, g: float, zgrid: ZGrid
+        self, w: pint.Quantity, g: float, grid: GridCoords
     ) -> pint.Quantity:
-        return self.eval_sigma_t_mono(w=w, zgrid=zgrid)
+        return self.eval_sigma_t_mono(w=w, grid=grid)
 
     @singledispatchmethod
     def eval_sigma_a(
-        self, si: SpectralIndex, zgrid: ZGrid | None = None
+        self, si: SpectralIndex, grid: GridCoords | None = None
     ) -> pint.Quantity:
         # Inherit docstring
         raise NotImplementedError
 
     @eval_sigma_a.register(MonoSpectralIndex)
-    def _(self, si, zgrid: ZGrid | None = None) -> pint.Quantity:
+    def _(self, si, grid: GridCoords | None = None) -> pint.Quantity:
         return self.eval_sigma_a_mono(
-            w=si.w, zgrid=self.geometry.zgrid if zgrid is None else zgrid
+            w=si.w, grid=self.geometry.grid if grid is None else grid
         )
 
     @eval_sigma_a.register(CKDSpectralIndex)
-    def _(self, si, zgrid: ZGrid | None = None) -> pint.Quantity:
+    def _(self, si, grid: GridCoords | None = None) -> pint.Quantity:
         return self.eval_sigma_a_ckd(
-            w=si.w, g=si.g, zgrid=self.geometry.zgrid if zgrid is None else zgrid
+            w=si.w, g=si.g, grid=self.geometry.grid if grid is None else grid
         )
 
-    def eval_sigma_a_mono(self, w: pint.Quantity, zgrid: ZGrid) -> pint.Quantity:
-        value = self._eval_sigma_a_impl(w, zgrid).squeeze()
+    def eval_sigma_a_mono(self, w: pint.Quantity, grid: GridCoords) -> pint.Quantity:
+        value = self._eval_sigma_a_impl(w, grid).squeeze()
         return value if self.has_absorption else np.zeros_like(value) * value.units
 
     def eval_sigma_a_ckd(
-        self, w: pint.Quantity, g: float, zgrid: ZGrid
+        self, w: pint.Quantity, g: float, grid: GridCoords
     ) -> pint.Quantity:
-        return self.eval_sigma_a_mono(w, zgrid)
+        return self.eval_sigma_a_mono(w, grid)
 
     @singledispatchmethod
     def eval_sigma_s(
-        self, si: SpectralIndex, zgrid: ZGrid | None = None
+        self, si: SpectralIndex, grid: GridCoords | None = None
     ) -> pint.Quantity:
         # Inherit docstring
         raise NotImplementedError
 
     @eval_sigma_s.register(MonoSpectralIndex)
-    def _(self, si, zgrid: ZGrid | None = None) -> pint.Quantity:
+    def _(self, si, grid: GridCoords | None = None) -> pint.Quantity:
         return self.eval_sigma_s_mono(
-            w=si.w, zgrid=self.geometry.zgrid if zgrid is None else zgrid
+            w=si.w, grid=self.geometry.grid if grid is None else grid
         )
 
     @eval_sigma_s.register(CKDSpectralIndex)
-    def _(self, si, zgrid: ZGrid | None = None) -> pint.Quantity:
+    def _(self, si, grid: GridCoords | None = None) -> pint.Quantity:
         return self.eval_sigma_s_ckd(
-            w=si.w, g=si.g, zgrid=self.geometry.zgrid if zgrid is None else zgrid
+            w=si.w, g=si.g, grid=self.geometry.grid if grid is None else grid
         )
 
-    def eval_sigma_s_mono(self, w: pint.Quantity, zgrid: ZGrid) -> pint.Quantity:
-        value = self._eval_sigma_s_impl(w, zgrid).squeeze()
+    def eval_sigma_s_mono(self, w: pint.Quantity, grid: GridCoords) -> pint.Quantity:
+        value = self._eval_sigma_s_impl(w, grid).squeeze()
         return value if self.has_scattering else np.zeros_like(value) * value.units
 
     def eval_sigma_s_ckd(
-        self, w: pint.Quantity, g: float, zgrid: ZGrid
+        self, w: pint.Quantity, g: float, grid: GridCoords
     ) -> pint.Quantity:
-        return self.eval_sigma_s_mono(w, zgrid)
+        return self.eval_sigma_s_mono(w, grid)
 
     # --------------------------------------------------------------------------
     #                       Kernel dictionary generation

--- a/src/eradiate/scenes/geometry.py
+++ b/src/eradiate/scenes/geometry.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import typing as t
 from abc import ABC, abstractmethod
+from enum import Enum
 
 import attrs
 import mitsuba as mi
@@ -12,11 +13,28 @@ import pinttrs
 from .shapes import CuboidShape, RectangleShape, Shape, SphereShape
 from ..attrs import define, documented
 from ..constants import EARTH_RADIUS
+from ..grid import GridCoords, SphericalShellGridCoords
 from ..kernel import map_cube, map_unit_cube
-from ..radprops import ZGrid
 from ..units import unit_context_config as ucc
 from ..units import unit_context_kernel as uck
 from ..units import unit_registry as ureg
+
+
+class WrapMode(Enum):
+    CLAMP = 0
+    REPEAT = 1
+    MIRROR = 2
+
+    def __str__(self):
+        return self.name.lower()
+
+
+class FilterType(Enum):
+    TRILINEAR = 0
+    NEAREST = 1
+
+    def __str__(self) -> str:
+        return self.name.lower()
 
 
 @define
@@ -26,74 +44,103 @@ class SceneGeometry(ABC):
 
     Warnings
     --------
-    If a ``zgrid`` value is passed to the constructor (instead of letting
-    the constructor set it automatically), its extent must be
-    [``ground_altitude``, ``toa_altitude``]. The constructor will raise
-    a :class:`ValueError` otherwise.
+    If a ``grid`` value is passed to the constructor together with explicit
+    ``ground_altitude`` and/or ``toa_altitude`` values, its extent must be
+    [``ground_altitude``, ``toa_altitude``]. The constructor will raise a
+    :class:`ValueError` otherwise. If ``ground_altitude`` and/or
+    ``toa_altitude`` are left unset, they are instead derived from the
+    ``grid`` extent.
     """
 
-    toa_altitude: pint.Quantity = documented(
-        pinttrs.field(default=120.0 * ureg.km, units=ucc.deferred("length")),
-        doc="Top-of-atmosphere level altitude. "
+    toa_altitude: pint.Quantity | None = documented(
+        pinttrs.field(default=None, units=ucc.deferred("length")),
+        doc="Top-of-atmosphere level altitude. If unset, defaults to the "
+        "``grid`` top level when ``grid`` is set, and to 120 km otherwise. "
         'Unit-enabled field (default: ``ucc["length"]``).',
         default="120 km",
         type="pint.Quantity",
-        init_type="float or quantity",
+        init_type="float or quantity, optional",
     )
 
-    ground_altitude: pint.Quantity = documented(
-        pinttrs.field(default=0.0 * ureg.km, units=ucc.deferred("length")),
-        doc="Baseline ground altitude. "
+    ground_altitude: pint.Quantity | None = documented(
+        pinttrs.field(default=None, units=ucc.deferred("length")),
+        doc="Baseline ground altitude. If unset, defaults to the ``grid`` "
+        "bottom level when ``grid`` is set, and to 0 km otherwise. "
         'Unit-enabled field (default: ``ucc["length"]``).',
         default="0 km",
         type="pint.Quantity",
-        init_type="float or quantity",
+        init_type="float or quantity, optional",
     )
 
-    zgrid: ZGrid = documented(
+    grid: GridCoords = documented(
         attrs.field(
             default=None,
             converter=attrs.converters.optional(
-                lambda x: ZGrid(x) if not isinstance(x, ZGrid) else x
+                lambda x: GridCoords.convert(x) if not isinstance(x, GridCoords) else x
             ),
-            validator=attrs.validators.optional(attrs.validators.instance_of(ZGrid)),
+            validator=attrs.validators.optional(
+                attrs.validators.instance_of(GridCoords)
+            ),
         ),
         doc="The altitude mesh on which the radiative properties of "
         "heterogeneous atmosphere components are evaluated. "
         "If unset, a default grid with one layer per 100 m (or 10 layers if "
         "the atmosphere object height is less than 100 m) is used.",
-        type=".ZGrid",
-        init_type=".ZGrid, quantity or ndarray, optional",
+        type=".GridCoords",
+        init_type=".GridCoords, quantity or ndarray, optional",
+    )
+
+    filter_type: FilterType = documented(
+        attrs.field(
+            default=FilterType.NEAREST,
+            converter=FilterType,
+            validator=attrs.validators.instance_of(FilterType),
+            kw_only=True,
+        ),
+        doc="Volume filter type.",
+        default="FilterType.NEAREST",
+        type=".FilterType",
+        init_type=".FilterType",
+    )
+
+    wrap_mode: WrapMode = documented(
+        attrs.field(
+            default=WrapMode.CLAMP,
+            converter=WrapMode,
+            validator=attrs.validators.instance_of(WrapMode),
+            kw_only=True,
+        ),
+        doc="Volume wrap mode.",
+        default="WrapMode.CLAMP",
+        type=".WrapMode",
+        init_type=".WrapMode",
     )
 
     def __attrs_post_init__(self) -> None:
-        # Set altitude grid
-        if self.zgrid is None:
-            bottom = self.ground_altitude.m_as(ureg.m)
-            top = self.toa_altitude.m_as(ureg.m)
-            step = min(100.0, (top - bottom) / 10.0)
-            self.zgrid = ZGrid(
-                ureg.convert(
-                    np.arange(bottom, top + step * 0.1, step),
-                    ureg.m,
-                    ucc.get("length"),
-                )
-            )
-
-        else:
-            grid_bottom = self.zgrid.levels[0]
-            if not np.isclose(grid_bottom, self.ground_altitude):
+        # Resolve ground_altitude and toa_altitude
+        if self.grid is not None:
+            grid_bottom = self.grid.levels[0]
+            if self.ground_altitude is None:
+                self.ground_altitude = grid_bottom
+            elif not np.isclose(grid_bottom, self.ground_altitude):
                 raise ValueError(
-                    "zgrid bottom must match ground_altitude; "
+                    "grid bottom must match ground_altitude; "
                     f"expected {self.ground_altitude}, got {grid_bottom}"
                 )
 
-            grid_top = self.zgrid.levels[-1]
-            if not np.isclose(grid_top, self.toa_altitude):
+            grid_top = self.grid.levels[-1]
+            if self.toa_altitude is None:
+                self.toa_altitude = grid_top
+            elif not np.isclose(grid_top, self.toa_altitude):
                 raise ValueError(
-                    "zgrid top must match toa_altitude; "
+                    "grid top must match toa_altitude; "
                     f"expected {self.toa_altitude}, got {grid_top}"
                 )
+        else:
+            if self.ground_altitude is None:
+                self.ground_altitude = 0.0 * ureg.km
+            if self.toa_altitude is None:
+                self.toa_altitude = 120.0 * ureg.km
 
     @classmethod
     def convert(cls, value: t.Any) -> t.Any:
@@ -146,7 +193,6 @@ class SceneGeometry(ABC):
         :class:`.Shape`: Stencil of the participating medium representing the
         atmosphere.
         """
-        pass
 
     @property
     @abstractmethod
@@ -156,7 +202,6 @@ class SceneGeometry(ABC):
             coordinates to world coordinates for heterogeneous atmosphere
             components.
         """
-        pass
 
     @property
     @abstractmethod
@@ -164,7 +209,13 @@ class SceneGeometry(ABC):
         """
         :class:`.Shape` : Shape representing the surface.
         """
-        pass
+
+    @property
+    def bbox(self):
+        """
+        :class:`eradiate.scenes.core.BoundingBox` : Bounding box of the geometry
+        """
+        return self.atmosphere_shape.bbox
 
 
 @define
@@ -211,6 +262,16 @@ class PlaneParallelGeometry(SceneGeometry):
     @property
     def surface_shape(self) -> RectangleShape:
         return RectangleShape.surface(altitude=self.ground_altitude, width=self.width)
+
+    def __attrs_post_init__(self) -> None:
+        super().__attrs_post_init__()
+
+        if self.grid is None:
+            bottom = self.ground_altitude
+            top = self.toa_altitude
+            step = min(100.0 * ureg.m, (top - bottom) / 10.0)
+
+            self.grid = GridCoords.make_onedim_arange(top, bottom, step, self.width)
 
 
 @define
@@ -263,3 +324,20 @@ class SphericalShellGeometry(SceneGeometry):
         return SphereShape.surface(
             altitude=self.ground_altitude, planet_radius=self.planet_radius
         )
+
+    def __attrs_post_init__(self) -> None:
+        super().__attrs_post_init__()
+
+        if self.grid is None:
+            bottom = self.ground_altitude.m_as(ureg.m)
+            top = self.toa_altitude.m_as(ureg.m)
+            step = min(100.0, (top - bottom) / 10.0)
+            self.grid = SphericalShellGridCoords(
+                levels=ureg.convert(
+                    np.arange(bottom, top + step * 0.1, step),
+                    ureg.m,
+                    ucc.get("length"),
+                ),
+                azimuths=np.asarray([0.0, 360.0]) * ureg.degree,
+                colatitudes=np.asarray([0.0, 180.0]) * ureg.degree,
+            )

--- a/src/eradiate/scenes/geometry.py
+++ b/src/eradiate/scenes/geometry.py
@@ -11,6 +11,7 @@ import pint
 import pinttrs
 
 from .shapes import CuboidShape, RectangleShape, Shape, SphereShape
+from .. import _repr_diagrams
 from ..attrs import define, documented
 from ..constants import EARTH_RADIUS
 from ..grid import GridCoords, SphericalShellGridCoords
@@ -216,6 +217,9 @@ class SceneGeometry(ABC):
         :class:`eradiate.scenes.core.BoundingBox` : Bounding box of the geometry
         """
         return self.atmosphere_shape.bbox
+
+    def _repr_html_(self) -> str | None:
+        return _repr_diagrams.geometry_repr_html(self)
 
 
 @define

--- a/src/eradiate/test_tools/test_cases/ocean.py
+++ b/src/eradiate/test_tools/test_cases/ocean.py
@@ -128,7 +128,7 @@ def create_ocean_grasp(water_body_reflectance, wind_speed, has_atmosphere=False)
         ],
         "geometry": {
             "type": "plane_parallel",
-            "zgrid": np.arange(0, 40 + 0.1, 0.1) * ureg.km,
+            "grid": np.arange(0, 40 + 0.1, 0.1) * ureg.km,
             "toa_altitude": 40 * ureg.km,
         },
         "atmosphere": atmosphere,

--- a/tests/01_unit/data/test_convert.py
+++ b/tests/01_unit/data/test_convert.py
@@ -9,6 +9,7 @@ import xarray as xr
 from eradiate import unit_registry as ureg
 from eradiate.data.convert import (
     aer_v1_to_aer_core_v2,
+    concat_particles_veff,
     libradtran_to_aer_core_v2,
     make_aer_core_v2,
 )
@@ -44,6 +45,80 @@ def _isotropic_args(
         "ext": np.ones(nw) * ureg("1/km"),
         "ssa": 0.9 * np.ones(nw) * ureg.dimensionless,
         "phase": np.full((1, nw, nangle), scale) * ureg("1/sr"),
+    }
+
+
+def _size_distribution_args(
+    nw: int = 2,
+    nreff: int = 2,
+    nveff: int = 2,
+    nangle: int = 5,
+    scale: float = 1.0,
+) -> dict:
+    """
+    Keyword args for make_aer_core_v2 with reff/veff dimensions.
+
+    Phase is a uniform isotropic p = scale (4π-normalized when scale=1) with
+    a shared ascending mu grid across the whole (w, reff, veff) grid. ext/ssa
+    take a distinct value at every (w, reff, veff) point.
+    """
+    mu_1d = np.linspace(-1.0, 1.0, nangle)
+    mu = np.tile(mu_1d, (nw, nreff, nveff, 1))
+    theta = np.degrees(np.arccos(mu))
+    phase = np.full((1, nw, nreff, nveff, nangle), scale)
+
+    ext = np.zeros((nw, nreff, nveff))
+    ssa = np.zeros((nw, nreff, nveff))
+    for ireff in range(nreff):
+        for iveff in range(nveff):
+            ext[:, ireff, iveff] = (ireff + 1) * (iveff + 1)
+            ssa[:, ireff, iveff] = 0.5 + 0.1 * ireff + 0.01 * iveff
+
+    return {
+        "w": np.linspace(400.0, 700.0, nw) * ureg.nm,
+        "phamat": ["11"],
+        "mu": mu * ureg.dimensionless,
+        "theta": theta * ureg.deg,
+        "ext": ext * ureg("1/km"),
+        "ssa": ssa * ureg.dimensionless,
+        "phase": phase * ureg("1/sr"),
+        "reff": np.linspace(5.0, 15.0, nreff) * ureg.micron,
+        "veff": np.linspace(0.05, 0.15, nveff) * ureg.dimensionless,
+    }
+
+
+def _size_distribution_padded_args(
+    nangles_grid: np.ndarray, nangle_max: int = 10
+) -> dict:
+    """
+    Keyword args for make_aer_core_v2 with reff/veff dimensions and a
+    varying, nan padded angle count per (w, reff, veff) point.
+    """
+    nreff, nveff = nangles_grid.shape
+    nw = 1
+    mu = np.full((nw, nreff, nveff, nangle_max), np.nan)
+    theta = np.full((nw, nreff, nveff, nangle_max), np.nan)
+    phase = np.full((1, nw, nreff, nveff, nangle_max), np.nan)
+
+    for ireff in range(nreff):
+        for iveff in range(nveff):
+            n = int(nangles_grid[ireff, iveff])
+            mu_row = np.linspace(-1.0, 1.0, n)
+            mu[0, ireff, iveff, :n] = mu_row
+            theta[0, ireff, iveff, :n] = np.degrees(np.arccos(mu_row))
+            phase[0, 0, ireff, iveff, :n] = 1.0
+
+    return {
+        "w": np.linspace(400.0, 700.0, nw) * ureg.nm,
+        "phamat": ["11"],
+        "mu": mu * ureg.dimensionless,
+        "theta": theta * ureg.deg,
+        "ext": np.ones((nw, nreff, nveff)) * ureg("1/km"),
+        "ssa": 0.9 * np.ones((nw, nreff, nveff)) * ureg.dimensionless,
+        "phase": phase * ureg("1/sr"),
+        "reff": np.linspace(5.0, 15.0, nreff) * ureg.micron,
+        "veff": np.linspace(0.05, 0.15, nveff) * ureg.dimensionless,
+        "nangles": nangles_grid.reshape(nw, nreff, nveff),
     }
 
 
@@ -334,6 +409,239 @@ class TestMakeAerCoreV2:
             args = _isotropic_args(nw=1, scale=0.0)
             with pytest.raises(ValueError, match="integrates to 0"):
                 make_aer_core_v2(**args, normalize=True)
+
+    class TestSizeDistribution:
+        """Tests for the reff/veff (Prt v1) dimensions in make_aer_core_v2()."""
+
+        def test_no_reff_veff_omits_dimensions(self):
+            """Without reff/veff, the dataset has no such dimensions (Aer-Core v2)."""
+            ds = make_aer_core_v2(**_isotropic_args())
+            assert "reff" not in ds.dims
+            assert "veff" not in ds.dims
+
+        def test_only_reff_raises(self):
+            """Providing reff without veff raises ValueError."""
+            args = _size_distribution_args()
+            del args["veff"]
+            with pytest.raises(ValueError, match="must be provided together"):
+                make_aer_core_v2(**args)
+
+        def test_only_veff_raises(self):
+            """Providing veff without reff raises ValueError."""
+            args = _size_distribution_args()
+            del args["reff"]
+            with pytest.raises(ValueError, match="must be provided together"):
+                make_aer_core_v2(**args)
+
+        def test_dimensions_and_shapes(self):
+            """ext/ssa/mu/theta/phase/nangles gain reff/veff dimensions."""
+            nw, nreff, nveff, nangle = 2, 3, 2, 5
+            ds = make_aer_core_v2(
+                **_size_distribution_args(
+                    nw=nw, nreff=nreff, nveff=nveff, nangle=nangle
+                )
+            )
+            assert ds["ext"].dims == ("w", "reff", "veff")
+            assert ds["ext"].shape == (nw, nreff, nveff)
+            assert ds["mu"].dims == ("w", "reff", "veff", "iangle")
+            assert ds["mu"].shape == (nw, nreff, nveff, nangle)
+            assert ds["phase"].dims == ("phamat", "w", "reff", "veff", "iangle")
+            assert ds["nangles"].shape == (nw, nreff, nveff)
+
+        def test_ext_ssa_values_at_each_point(self):
+            """ext/ssa are stored verbatim at every (w, reff, veff) point."""
+            args = _size_distribution_args()
+            ds = make_aer_core_v2(**args)
+            np.testing.assert_allclose(ds["ext"].values, args["ext"].m)
+            np.testing.assert_allclose(ds["ssa"].values, args["ssa"].m)
+
+        def test_nangles_inferred_at_each_point(self):
+            """nangles is inferred per (w, reff, veff) point when not provided."""
+            nw, nreff, nveff, nangle = 2, 2, 2, 5
+            ds = make_aer_core_v2(
+                **_size_distribution_args(
+                    nw=nw, nreff=nreff, nveff=nveff, nangle=nangle
+                )
+            )
+            np.testing.assert_array_equal(
+                ds["nangles"].values, np.full((nw, nreff, nveff), nangle)
+            )
+
+        def test_check_full_catches_unsorted_point(self):
+            """check='full' validates every (w, reff, veff) point, not just w."""
+            args = _size_distribution_args(nw=2, nreff=2, nveff=2)
+            mu_arr = args["mu"].m.copy()
+            mu_arr[1, 1, 0, :] = mu_arr[1, 1, 0, :][::-1]
+            args["mu"] = mu_arr * ureg.dimensionless
+            with pytest.raises(ValueError, match="strictly ascending"):
+                make_aer_core_v2(**args, check="full")
+
+        def test_fast_passes_on_sorted_grid(self):
+            """check='fast' runs over the full (w, reff, veff) index space without error."""
+            args = _size_distribution_args(nw=2, nreff=5, nveff=5)
+            make_aer_core_v2(**args, check="fast")
+
+        def test_fast_catches_unsorted_point_in_reff_veff_space(self):
+            """check='fast' samples over (w, reff, veff), not just w."""
+            nw, nreff, nveff = 2, 5, 5
+            args = _size_distribution_args(nw=nw, nreff=nreff, nveff=nveff)
+
+            # check='fast' reseeds to 0 on every call, so the sampled indices
+            # are reproducible; replicate that here to target one of them.
+            indices = list(np.ndindex((nw, nreff, nveff)))
+            rng = np.random.default_rng(seed=0)
+            n_sample = max(1, len(indices) // 10)
+            sampled = [
+                indices[i]
+                for i in rng.choice(len(indices), size=n_sample, replace=False)
+            ]
+
+            mu_arr = args["mu"].m.copy()
+            mu_arr[sampled[0]] = mu_arr[sampled[0]][::-1]
+            args["mu"] = mu_arr * ureg.dimensionless
+
+            with pytest.raises(ValueError, match="strictly ascending"):
+                make_aer_core_v2(**args, check="fast")
+
+        def test_nangles_varies_per_reff_veff_point(self):
+            """nangles can vary independently across (w, reff, veff) points."""
+            nangles_grid = np.array([[4, 7], [10, 3]])
+            args = _size_distribution_padded_args(nangles_grid)
+            ds = make_aer_core_v2(**args)
+            np.testing.assert_array_equal(ds["nangles"].values[0], nangles_grid)
+
+        def test_check_full_ignores_nan_tails_per_point(self):
+            """check='full' validates only the valid portion of each ragged row."""
+            nangles_grid = np.array([[4, 7], [10, 3]])
+            args = _size_distribution_padded_args(nangles_grid)
+            make_aer_core_v2(**args, check="full")
+
+        def test_check_full_raises_on_unsorted_valid_portion(self):
+            """check='full' raises if the valid part of a ragged row is unsorted."""
+            nangles_grid = np.array([[4, 7], [10, 3]])
+            args = _size_distribution_padded_args(nangles_grid)
+            mu_arr = args["mu"].m.copy()
+            n = int(nangles_grid[1, 0])
+            mu_arr[0, 1, 0, :n] = mu_arr[0, 1, 0, :n][::-1]
+            args["mu"] = mu_arr * ureg.dimensionless
+            with pytest.raises(ValueError, match="strictly ascending"):
+                make_aer_core_v2(**args, check="full")
+
+        def test_normalize_at_each_point(self):
+            """normalize=True enforces the integral convention at every point."""
+            args = _size_distribution_args(scale=4.0)
+            ds = make_aer_core_v2(**args, normalize=True)
+            mu = ds["mu"].values
+            phase = ds["phase"].values
+            for idx in np.ndindex(mu.shape[:-1]):
+                integral = np.trapezoid(phase[(0, *idx)], mu[idx])
+                np.testing.assert_allclose(integral, 2.0, rtol=1e-12)
+
+        def test_auto_pmom_at_each_point(self):
+            """Automatic pmom computation runs independently at every point."""
+            nw, nreff, nveff = 2, 2, 2
+            ds = make_aer_core_v2(
+                **_size_distribution_args(nw=nw, nreff=nreff, nveff=nveff), nmom=20
+            )
+            assert ds["pmom"].shape == (nw, nreff, nveff, 20)
+            # Isotropic phase: l=0 coefficient is 1, l>0 are ~0, everywhere.
+            np.testing.assert_allclose(ds["pmom"].values[..., 0], 1.0, rtol=1e-6)
+            np.testing.assert_allclose(ds["pmom"].values[..., 1:], 0.0, atol=1e-6)
+
+        def test_scalar_nmom_broadcasts_to_grid_shape(self):
+            """An int nmom broadcasts to the full (w, reff, veff) shape."""
+            nw, nreff, nveff = 2, 3, 2
+            ds = make_aer_core_v2(
+                **_size_distribution_args(nw=nw, nreff=nreff, nveff=nveff), nmom=64
+            )
+            assert ds["nmom"].shape == (nw, nreff, nveff)
+            np.testing.assert_array_equal(
+                ds["nmom"].values, np.full((nw, nreff, nveff), 64)
+            )
+
+        def test_explicit_pmom_stored_verbatim_per_point(self):
+            """Explicit pmom is stored as-is; nmom is inferred per (w, reff, veff) point."""
+            nw, nreff, nveff = 2, 2, 2
+            args = _size_distribution_args(nw=nw, nreff=nreff, nveff=nveff)
+            sentinel = np.full((nw, nreff, nveff, 10), 42.0)
+            ds = make_aer_core_v2(**args, pmom=sentinel)
+            np.testing.assert_array_equal(ds["pmom"].values, sentinel)
+            np.testing.assert_array_equal(
+                ds["nmom"].values, np.full((nw, nreff, nveff), 10)
+            )
+
+        def test_ndarray_nmom_stored_verbatim_per_point(self):
+            """An ndarray nmom is stored as-is per (w, reff, veff) point."""
+            nw, nreff, nveff = 2, 2, 2
+            args = _size_distribution_args(nw=nw, nreff=nreff, nveff=nveff)
+            nmom_grid = np.array([[[4, 7], [10, 3]], [[5, 8], [11, 4]]], dtype=np.int32)
+            pmom = np.full((nw, nreff, nveff, int(nmom_grid.max())), np.nan)
+            for idx in np.ndindex(nmom_grid.shape):
+                pmom[idx][: nmom_grid[idx]] = 1.0
+            ds = make_aer_core_v2(**args, pmom=pmom, nmom=nmom_grid)
+            np.testing.assert_array_equal(ds["nmom"].values, nmom_grid)
+
+
+class TestConcatParticlesVeff:
+    """Tests for concat_particles_veff()."""
+
+    def test_concatenates_veff_values(self):
+        """Combined dataset spans the union of both inputs' veff values."""
+        ds1 = make_aer_core_v2(**_size_distribution_args(nveff=1))
+        ds2 = make_aer_core_v2(**_size_distribution_args(nveff=1))
+        # Give ds2 a distinct veff value so the union is non-trivial.
+        ds2 = ds2.assign_coords(veff=("veff", ds2["veff"].values + 1.0))
+
+        combined = concat_particles_veff([ds1, ds2])
+
+        assert combined.sizes["veff"] == 2
+        np.testing.assert_allclose(
+            combined["veff"].values,
+            np.concatenate([ds1["veff"].values, ds2["veff"].values]),
+        )
+        np.testing.assert_allclose(
+            combined["ext"].isel(veff=0).values, ds1["ext"].isel(veff=0).values
+        )
+        np.testing.assert_allclose(
+            combined["ext"].isel(veff=1).values, ds2["ext"].isel(veff=0).values
+        )
+
+    def test_pads_mismatched_iangle(self):
+        """Datasets with different iangle sizes are NaN-padded to the max."""
+        ds1 = make_aer_core_v2(**_size_distribution_args(nveff=1, nangle=5))
+        ds2 = make_aer_core_v2(**_size_distribution_args(nveff=1, nangle=8))
+        ds2 = ds2.assign_coords(veff=("veff", ds2["veff"].values + 1.0))
+
+        combined = concat_particles_veff([ds1, ds2])
+
+        assert combined.sizes["iangle"] == 8
+        np.testing.assert_array_equal(
+            combined["nangles"].isel(veff=0).values,
+            np.full(combined["nangles"].isel(veff=0).shape, 5),
+        )
+        phase_v0 = combined["phase"].isel(veff=0).values
+        assert np.all(np.isnan(phase_v0[..., 5:]))
+        assert not np.any(np.isnan(phase_v0[..., :5]))
+        phase_v1 = combined["phase"].isel(veff=1).values
+        assert not np.any(np.isnan(phase_v1[..., :8]))
+
+    @pytest.mark.parametrize(
+        "override, match",
+        [
+            ({"w": np.array([401.0, 700.0]) * ureg.nm}, "'w' coordinate"),
+            ({"reff": np.array([6.0, 15.0]) * ureg.micron}, "'reff' coordinate"),
+            ({"phamat": ["12"]}, "'phamat' coordinate"),
+        ],
+    )
+    def test_mismatched_grid_raises(self, override, match):
+        """Datasets with different w/reff/phamat coordinates raise ValueError."""
+        ds1 = make_aer_core_v2(**_size_distribution_args(nveff=1))
+        args2 = {**_size_distribution_args(nveff=1), **override}
+        ds2 = make_aer_core_v2(**args2)
+        ds2 = ds2.assign_coords(veff=("veff", ds2["veff"].values + 1.0))
+
+        with pytest.raises(ValueError, match=match):
+            concat_particles_veff([ds1, ds2])
 
 
 class TestAerV1ToAerCoreV2:

--- a/tests/01_unit/experiments/test_atmosphere.py
+++ b/tests/01_unit/experiments/test_atmosphere.py
@@ -52,7 +52,7 @@ def test_atmosphere_experiment_extra_objects(mode_mono):
     assert isinstance(exp.extra_objects["reference_surface"], RectangleShape)
     mi_wrapper = check_scene_element(exp.scene, mi.Scene, ctx=exp.context_init())
     assert mi_wrapper.obj.shapes()[2].id() == "reference_surface"
-    assert "reference_surface.bsdf.reflectance.value" in mi_wrapper.parameters.keys()
+    assert "reference_surface.bsdf.reflectance.value" in mi_wrapper.parameters
 
 
 def test_atmosphere_experiment_construct_measures(modes_all_double):
@@ -107,7 +107,7 @@ def test_atmosphere_experiment_kernel_dict(mode_mono):
         mi.ScalarTransform4f().scale([21000, 21000, 1]).matrix,
     )
     # -- Atmosphere is part of the scene
-    assert "shape_atmosphere" in set(shape.id() for shape in mi_wrapper.obj.shapes())
+    assert "shape_atmosphere" in {shape.id() for shape in mi_wrapper.obj.shapes()}
     # -- Measure gets no external medium assigned
     assert all(sensor.get_medium() is None for sensor in mi_wrapper.obj.sensors())
 
@@ -128,9 +128,7 @@ def test_atmosphere_experiment_kernel_dict(mode_mono):
         mi.ScalarTransform4f().scale([5e8, 5e8, 1]).matrix,
     )
     # -- Atmosphere is not part of the scene
-    assert "shape_atmosphere" not in set(
-        shape.id() for shape in mi_wrapper.obj.shapes()
-    )
+    assert "shape_atmosphere" not in {shape.id() for shape in mi_wrapper.obj.shapes()}
     # -- Measures get no external medium assigned
     assert all(sensor.get_medium() is None for sensor in mi_wrapper.obj.sensors())
 
@@ -253,12 +251,12 @@ def test_atmosphere_experiment_custom_atmosphere(mode_ckd, atmosphere_cams_lybia
     Test that the AtmosphereExperiment can deal with a custom atmosphere (CAMS).
     """
     # Create a geometry compatible with the molecular atmosphere
-    zgrid = to_quantity(atmosphere_cams_lybia4_ckd["thermoprops"].z)
+    grid = to_quantity(atmosphere_cams_lybia4_ckd["thermoprops"].z)
     geometry = {
         "type": "spherical_shell",
-        "zgrid": zgrid,
-        "toa_altitude": zgrid[-1],
-        "ground_altitude": zgrid[0],
+        "grid": grid,
+        "toa_altitude": grid[-1],
+        "ground_altitude": grid[0],
     }
 
     # Create simple scene

--- a/tests/01_unit/radprops/test_array.py
+++ b/tests/01_unit/radprops/test_array.py
@@ -24,7 +24,7 @@ def test_data():
 
 
 def test_array(modes_all_mono, test_data):
-    zgrid = eradiate.scenes.geometry.ZGrid(np.linspace(0, 1000, 11))
+    grid = eradiate.grid.GridCoords.convert(np.linspace(0, 1000, 11))
     si = eradiate.spectral.SpectralIndex.new(w=550 * ureg.nm)
 
     array_radprofile = ArrayRadProfile(
@@ -35,15 +35,15 @@ def test_array(modes_all_mono, test_data):
         interpolation_method="nearest",
     )
 
-    sigma_s = array_radprofile.eval_sigma_s(si, zgrid)
-    sigma_a = array_radprofile.eval_sigma_s(si, zgrid)
+    sigma_s = array_radprofile.eval_sigma_s(si, grid)
+    sigma_a = array_radprofile.eval_sigma_s(si, grid)
 
     assert np.all(sigma_a.m_as("1/m") == test_data.isel(w=0).values)
     assert np.all(sigma_s.m_as("1/m") == test_data.isel(w=0).values)
 
 
 def test_resample_array(modes_all_mono, test_data):
-    zgrid = eradiate.scenes.geometry.ZGrid(np.linspace(0, 1000, 21))
+    grid = eradiate.grid.GridCoords.convert(np.linspace(0, 1000, 21))
     si = eradiate.spectral.SpectralIndex.new(w=550 * ureg.nm)
 
     array_radprofile = ArrayRadProfile(
@@ -57,8 +57,8 @@ def test_resample_array(modes_all_mono, test_data):
         },
     )
 
-    sigma_s = array_radprofile.eval_sigma_s(si, zgrid)
-    sigma_a = array_radprofile.eval_sigma_s(si, zgrid)
+    sigma_s = array_radprofile.eval_sigma_s(si, grid)
+    sigma_a = array_radprofile.eval_sigma_s(si, grid)
 
     gt = np.repeat(test_data.isel(w=0).values, 2)
     assert np.all(sigma_a.m_as("1/m") == gt)
@@ -66,7 +66,7 @@ def test_resample_array(modes_all_mono, test_data):
 
 
 def test_array_zeros(modes_all_mono, test_data):
-    zgrid = eradiate.scenes.geometry.ZGrid(np.linspace(0, 1000, 11))
+    grid = eradiate.grid.GridCoords.convert(np.linspace(0, 1000, 11))
     si = eradiate.spectral.SpectralIndex.new(w=550 * ureg.nm)
 
     array_sigma_a = ArrayRadProfile(
@@ -77,8 +77,8 @@ def test_array_zeros(modes_all_mono, test_data):
         interpolation_method="nearest",
     )
 
-    sigma_s = array_sigma_a.eval_sigma_s(si, zgrid)
-    sigma_a = array_sigma_a.eval_sigma_a(si, zgrid)
+    sigma_s = array_sigma_a.eval_sigma_s(si, grid)
+    sigma_a = array_sigma_a.eval_sigma_a(si, grid)
 
     assert np.all(sigma_a.m_as("1/m") == test_data.isel(w=0).values)
     assert np.all(sigma_s.m_as("1/m") == np.zeros(10))
@@ -91,8 +91,8 @@ def test_array_zeros(modes_all_mono, test_data):
         interpolation_method="nearest",
     )
 
-    sigma_s = array_sigma_s.eval_sigma_s(si, zgrid)
-    sigma_a = array_sigma_s.eval_sigma_a(si, zgrid)
+    sigma_s = array_sigma_s.eval_sigma_s(si, grid)
+    sigma_a = array_sigma_s.eval_sigma_a(si, grid)
 
     assert np.all(sigma_a.m_as("1/m") == np.zeros(10))
     assert np.all(sigma_s.m_as("1/m") == test_data.isel(w=0).values)

--- a/tests/01_unit/radprops/test_particles.py
+++ b/tests/01_unit/radprops/test_particles.py
@@ -92,6 +92,67 @@ def make_single_w_dataset() -> xr.Dataset:
     )
 
 
+REFF = np.array([5.0, 15.0])  # micron
+VEFF = np.array([0.05, 0.15])  # dimensionless
+
+
+def make_size_distribution_dataset() -> xr.Dataset:
+    """
+    Build a minimal Prt v1-shaped dataset (``reff``/``veff`` dimensions
+    added to the Aer-Core v2 layout) for ``ParticleProperties``.
+
+    ``ext``/``ssa`` take a distinct value at every ``(w, reff, veff)`` grid
+    point, so index-based selection can be checked against known values. The
+    angular grid is shared across the whole grid: the ragged/union-grid
+    mechanics along ``w`` are already covered by other tests, so this dataset
+    only needs to exercise ``reff``/``veff`` selection.
+    """
+    n_w, n_reff, n_veff = len(W_NM), len(REFF), len(VEFF)
+
+    ext = np.zeros((n_w, n_reff, n_veff))
+    ssa = np.zeros((n_w, n_reff, n_veff))
+    for ireff in range(n_reff):
+        for iveff in range(n_veff):
+            ext[:, ireff, iveff] = EXT * (ireff + 1) * (iveff + 1)
+            ssa[:, ireff, iveff] = SSA * (1.0 - 0.05 * ireff - 0.01 * iveff)
+
+    mu_vals = np.tile(MU_1D, (n_w, n_reff, n_veff, 1))
+    theta_vals = np.degrees(np.arccos(mu_vals))
+    phase = np.tile(
+        _PHASE_DATA[:, :, np.newaxis, np.newaxis, :], (1, 1, n_reff, n_veff, 1)
+    )
+    nangles = np.full((n_w, n_reff, n_veff), len(MU_1D), dtype=np.int32)
+
+    return xr.Dataset(
+        {
+            "ext": (["w", "reff", "veff"], ext, {"units": "km^-1"}),
+            "ssa": (["w", "reff", "veff"], ssa, {"units": "dimensionless"}),
+            "mu": (
+                ["w", "reff", "veff", "iangle"],
+                mu_vals,
+                {"units": "dimensionless"},
+            ),
+            "theta": (
+                ["w", "reff", "veff", "iangle"],
+                theta_vals,
+                {"units": "degree"},
+            ),
+            "phase": (
+                ["phamat", "w", "reff", "veff", "iangle"],
+                phase,
+                {"units": "1/sr"},
+            ),
+            "nangles": (["w", "reff", "veff"], nangles),
+        },
+        coords={
+            "w": ("w", W_NM, {"units": "nm"}),
+            "reff": ("reff", REFF, {"units": "micron"}),
+            "veff": ("veff", VEFF, {"units": "dimensionless"}),
+            "phamat": ("phamat", ["11"]),
+        },
+    )
+
+
 @pytest.fixture
 def pp() -> ParticleProperties:
     return ParticleProperties(data=make_dataset())
@@ -200,6 +261,59 @@ class TestParticleProperties:
 
     def test_has_polarization(self, pp):
         assert pp.has_polarization is False
+
+    def test_has_size_distribution_false_for_aer_core_v2(self, pp):
+        assert pp.has_size_distribution is False
+
+    def test_has_size_distribution_true_for_prt_v1(self):
+        pp = ParticleProperties(data=make_size_distribution_dataset())
+        assert pp.has_size_distribution is True
+
+    class TestResolve:
+        def test_noop_on_aer_core_v2(self, pp):
+            """No 'reff'/'veff' dims and no indices given: returns self."""
+            assert pp._resolve(None, None) is pp
+
+        def test_raises_if_indices_given_on_aer_core_v2(self, pp):
+            with pytest.raises(ValueError, match="no 'reff'/'veff' dimensions"):
+                pp._resolve(0, 0)
+
+        def test_raises_if_indices_missing_on_prt_v1(self):
+            pp = ParticleProperties(data=make_size_distribution_dataset())
+            with pytest.raises(ValueError, match="must both be provided"):
+                pp._resolve(None, None)
+
+        def test_raises_if_only_one_index_given(self):
+            pp = ParticleProperties(data=make_size_distribution_dataset())
+            with pytest.raises(ValueError, match="must both be provided"):
+                pp._resolve(0, None)
+
+        @pytest.mark.parametrize("reff_idx", [0, 1])
+        @pytest.mark.parametrize("veff_idx", [0, 1])
+        def test_selects_correct_point(self, reff_idx, veff_idx):
+            """Resolved ext/ssa match a manual index selection on the source data."""
+            ds = make_size_distribution_dataset()
+            pp = ParticleProperties(data=ds)
+            resolved = pp._resolve(reff_idx, veff_idx)
+
+            assert resolved.has_size_distribution is False
+            np.testing.assert_allclose(
+                resolved.ext.m, ds["ext"].values[:, reff_idx, veff_idx]
+            )
+            np.testing.assert_allclose(
+                resolved.ssa.m, ds["ssa"].values[:, reff_idx, veff_idx]
+            )
+
+        def test_eval_ext_after_resolve(self):
+            """eval_ext on a resolved instance matches the manually selected point."""
+            ds = make_size_distribution_dataset()
+            pp = ParticleProperties(data=ds)
+            resolved = pp._resolve(1, 0)
+
+            w_idx = 1
+            expected = ds["ext"].values[w_idx, 1, 0]
+            result = resolved.eval_ext(W_NM[w_idx] * ureg.nm)
+            np.testing.assert_allclose(result.m, expected, rtol=1e-10)
 
     class TestLocate:
         @pytest.mark.parametrize(
@@ -330,6 +444,17 @@ class TestParticleProperties:
             expected = 0.5 * (EXT[0] + EXT[1])
             np.testing.assert_allclose(result.m, expected, rtol=1e-10)
 
+        def test_preserves_reff_veff_dims(self):
+            """On a Prt v1 dataset, result keeps the 'reff'/'veff' dimensions."""
+            ds = make_size_distribution_dataset()
+            pp = ParticleProperties(data=ds)
+            w = np.array([475.0, 625.0]) * ureg.nm  # midpoints of both segments
+            result = pp.eval_ext(w)
+
+            assert result.shape == (2, len(REFF), len(VEFF))
+            expected = 0.5 * (ds["ext"].values[[0, 1]] + ds["ext"].values[[1, 2]])
+            np.testing.assert_allclose(result.m, expected, rtol=1e-10)
+
     class TestEvalSsa:
         @pytest.mark.parametrize("idx", [0, 1, 2])
         def test_at_nodes(self, pp, idx):
@@ -360,12 +485,40 @@ class TestParticleProperties:
             expected = 0.5 * SSA[0] + 0.5 * SSA[1]
             np.testing.assert_allclose(result.m, expected, rtol=1e-10)
 
+        def test_preserves_reff_veff_dims(self):
+            """On a Prt v1 dataset, result keeps the 'reff'/'veff' dimensions,
+            with the extinction-weighted formula applied independently at
+            each (reff, veff) grid point."""
+            ds = make_size_distribution_dataset()
+            pp = ParticleProperties(data=ds)
+            w = np.array([475.0, 625.0]) * ureg.nm  # midpoints of both segments
+            result = pp.eval_ssa(w)
+
+            assert result.shape == (2, len(REFF), len(VEFF))
+
+            t = 0.5
+            for iw, (il, ir) in enumerate([(0, 1), (1, 2)]):
+                ext_l = ds["ext"].values[il]
+                ext_r = ds["ext"].values[ir]
+                ssa_l = ds["ssa"].values[il]
+                ssa_r = ds["ssa"].values[ir]
+                ext_interp = (1 - t) * ext_l + t * ext_r
+                expected = ((1 - t) * ext_l * ssa_l + t * ext_r * ssa_r) / ext_interp
+                np.testing.assert_allclose(result.m[iw], expected, rtol=1e-10)
+
     class TestEvalPhase:
-        def test_array_raises(self, pp):
-            """Array w input raises ValueError."""
-            w = np.array([400.0, 550.0]) * ureg.nm
-            with pytest.raises(ValueError, match="scalar"):
-                pp.eval_phase(w)
+        def test_array_matches_scalar_calls(self, pp):
+            """Array w input matches independent per-wavelength scalar calls."""
+            w = np.array([400.0, 475.0, 550.0]) * ureg.nm
+            mu_out, phase_out = pp.eval_phase(w)
+            assert mu_out.shape == (3, phase_out.shape[-1])
+            assert phase_out.shape[0] == 1
+            assert phase_out.shape[1] == 3
+
+            for i, w_scalar in enumerate(w):
+                mu_scalar, phase_scalar = pp.eval_phase(w_scalar)
+                np.testing.assert_allclose(mu_out[i], mu_scalar)
+                np.testing.assert_allclose(phase_out[:, i, :], phase_scalar)
 
         @pytest.mark.parametrize("w_nm", [400.0, 475.0, 550.0, 700.0])
         def test_fixed_grid_shape(self, pp, w_nm):

--- a/tests/01_unit/radprops/test_zgrid.py
+++ b/tests/01_unit/radprops/test_zgrid.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 from eradiate import unit_registry as ureg
-from eradiate.radprops import ZGrid
+from eradiate.grid import GridCoords
 
 
 @pytest.mark.parametrize(
@@ -13,23 +13,23 @@ from eradiate.radprops import ZGrid
     ],
     ids=["pint", "unitless"],
 )
-def test_zgrid_all(levels):
-    zgrid = ZGrid(levels=levels)
+def test_grid_all(levels):
+    grid = GridCoords.convert(levels)
 
     np.testing.assert_array_equal(
-        zgrid.levels.m_as("km"), [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100]
+        grid.levels.m_as("km"), [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100]
     )
-    assert zgrid.n_levels == 11
+    assert grid.n_levels == 11
 
     np.testing.assert_array_equal(
-        zgrid.layers.m_as("km"), [5, 15, 25, 35, 45, 55, 65, 75, 85, 95]
+        grid.layers.m_as("km"), [5, 15, 25, 35, 45, 55, 65, 75, 85, 95]
     )
-    assert zgrid.n_layers == 10
+    assert grid.n_layers == 10
 
-    assert zgrid.layer_height == 10 * ureg.km
-    assert zgrid.total_height == 100 * ureg.km
+    assert grid.layer_height == 10 * ureg.km
+    assert grid.total_height == 100 * ureg.km
 
 
-def test_zgrid_fails():
+def test_grid_fails():
     with pytest.raises(ValueError, match="levels must be regularly spaced"):
-        ZGrid([0, 1, 3])
+        GridCoords.convert(np.asarray([0, 1, 3]))

--- a/tests/01_unit/scenes/atmosphere/test_heterogeneous.py
+++ b/tests/01_unit/scenes/atmosphere/test_heterogeneous.py
@@ -6,7 +6,6 @@ import eradiate
 from eradiate import unit_context_config as ucc
 from eradiate import unit_registry as ureg
 from eradiate.contexts import KernelContext
-from eradiate.radprops import ZGrid
 from eradiate.scenes.atmosphere import (
     HeterogeneousAtmosphere,
     ParticleLayer,
@@ -122,7 +121,7 @@ def test_heterogeneous_multi_ckd(mode_ckd, geometry, atmosphere_us_standard_ckd)
     """
     # Construct succeeds
     atmosphere = HeterogeneousAtmosphere(
-        geometry={"type": geometry, "zgrid": np.linspace(0, 120, 121) * ureg.km},
+        geometry={"type": geometry, "grid": np.linspace(0, 120, 121) * ureg.km},
         molecular_atmosphere=atmosphere_us_standard_ckd,
         particle_layers=[ParticleLayer() for _ in range(2)],
     )
@@ -147,12 +146,12 @@ def test_heterogeneous_mix_collision_coefficients(modes_all_double, field):
     mixed = HeterogeneousAtmosphere(
         geometry={
             "type": "plane_parallel",
-            "zgrid": np.linspace(0, 120, 1201) * ureg.km,
+            "grid": np.linspace(0, 120, 1201) * ureg.km,
         },
         particle_layers=[component_1, component_2, component_3],
     )
     ctx = KernelContext()
-    zgrid = mixed.geometry.zgrid
+    grid = mixed.geometry.grid
 
     # Evaluate all profiles on the container's altitude grid
     radprofiles = {}
@@ -164,7 +163,7 @@ def test_heterogeneous_mix_collision_coefficients(modes_all_double, field):
         ("mixed", mixed),
     ]:
         radprofiles[component] = atmosphere.eval_radprops(
-            ctx.si, zgrid, optional_fields=True
+            ctx.si, grid, optional_fields=True
         )
 
     collision_coefficient = {}
@@ -175,22 +174,22 @@ def test_heterogeneous_mix_collision_coefficients(modes_all_double, field):
             z_units = ureg.Unit(radprofile.coords["z_layer"].attrs["units"])
 
             field_units = ureg(radprofile.data_vars["sigma_a"].attrs["units"])
-            values[component] = (
-                float(
-                    radprofile.data_vars[field].interp(
-                        z_layer=float(z.m_as(z_units)),
-                        kwargs={"fill_value": 0.0},
-                        method="nearest",
-                    )
+            val = (
+                radprofile.data_vars[field]
+                .interp(
+                    z_layer=float(z.m_as(z_units)),
+                    kwargs={"fill_value": 0.0},
+                    method="nearest",
                 )
-                * field_units
+                .squeeze()
             )
+            values[component] = float(val) * field_units
 
         collision_coefficient[z.m] = values
 
     components = sorted(set(radprofiles.keys()) - {"mixed"})
 
-    for z in collision_coefficient.keys():
+    for z in collision_coefficient:
         total = collision_coefficient[z]["mixed"]
         expected = sum(collision_coefficient[z][component] for component in components)
         np.testing.assert_allclose(
@@ -212,7 +211,7 @@ def test_heterogeneous_mix_weights(
             "type": "plane_parallel",
             "ground_altitude": 0.0 * ureg.km,
             "toa_altitude": 100.0 * ureg.km,
-            "zgrid": ZGrid(np.linspace(0, 100, 101) * ureg.km),
+            "grid": np.linspace(0, 100, 101) * ureg.km,
         }
     )
 
@@ -237,9 +236,9 @@ def test_heterogeneous_mix_weights(
     # Weights should be non-zero over the first 50 km, and 0 above
     # (all to the molecular component)
     weights = np.squeeze(mi_params["weight.data"])
-    assert len(weights) == geometry.zgrid.n_layers
+    assert len(weights) == geometry.grid.n_layers
 
-    middle = np.argwhere(geometry.zgrid.layers <= 50.0 * ureg.km).max() + 1
+    middle = np.argwhere(geometry.grid.layers <= 50.0 * ureg.km).max() + 1
 
     assert np.all((weights[:middle] > 0.0) & (weights[:middle] < 1.0))
     assert np.all(weights[middle:] == 0.0)
@@ -269,8 +268,8 @@ def test_heterogeneous_mix_weights(
     weight_1 = np.squeeze(mi_wrapper.parameters["weight.data"])
     weight_2 = np.squeeze(mi_wrapper.parameters["phase_1.weight.data"])
 
-    middle = np.argwhere(geometry.zgrid.layers <= 50.0 * ureg.km).max() + 1
-    fourfive = np.argwhere(geometry.zgrid.layers <= 80.0 * ureg.km).max() + 1
+    middle = np.argwhere(geometry.grid.layers <= 50.0 * ureg.km).max() + 1
+    fourfive = np.argwhere(geometry.grid.layers <= 80.0 * ureg.km).max() + 1
 
     assert np.all(weight_1[:middle] == 0.0)
     assert np.all(weight_1[middle:] == 1.0)
@@ -299,7 +298,7 @@ def test_heterogeneous_mix_weights(
     )
     mi_wrapper = check_scene_element(mixed.phase, mi.PhaseFunction)
     weights = np.squeeze(mi_wrapper.parameters["weight.data"])
-    middle = np.argwhere(geometry.zgrid.layers <= 50.0 * ureg.km).max() + 1
+    middle = np.argwhere(geometry.grid.layers <= 50.0 * ureg.km).max() + 1
 
     assert np.all(weights[:middle] == 0.0)
     assert np.all(weights[middle:] == 0.5)
@@ -358,7 +357,7 @@ def test_heterogeneous_absorbing_mol_atm(
         particle_layers=particle_layer,
         geometry={
             "type": "spherical_shell",  # arbitrary
-            "zgrid": np.linspace(0, 120, 121) * ureg.km,
+            "grid": np.linspace(0, 120, 121) * ureg.km,
         },
     )
 
@@ -367,8 +366,8 @@ def test_heterogeneous_absorbing_mol_atm(
     weights = np.squeeze(mi_wrapper.parameters["weight.volume.data"])
 
     # Extract phase function weights
-    inside_particle_layer = (atmosphere.geometry.zgrid.layers >= pl_bottom) & (
-        atmosphere.geometry.zgrid.layers <= pl_top
+    inside_particle_layer = (atmosphere.geometry.grid.layers >= pl_bottom) & (
+        atmosphere.geometry.grid.layers <= pl_top
     )
 
     # Outside the particle layer, the phase function weight should be zero.

--- a/tests/01_unit/scenes/atmosphere/test_molecular_atmosphere.py
+++ b/tests/01_unit/scenes/atmosphere/test_molecular_atmosphere.py
@@ -5,11 +5,18 @@ import numpy as np
 import numpy.testing as npt
 import pint
 import pytest
+import xarray as xr
 
 import eradiate
 from eradiate import unit_registry as ureg
 from eradiate.contexts import KernelContext
 from eradiate.exceptions import DataError
+from eradiate.grid import PlaneParallelGridCoords
+from eradiate.radprops._atmosphere import (
+    _average_adjacent_levels,
+    _layers_from_levels,
+    _validate_thermoprops_grid_shape,
+)
 from eradiate.scenes.atmosphere import MolecularAtmosphere
 from eradiate.scenes.core import Scene, traverse
 from eradiate.spectral import CKDSpectralIndex, SpectralIndex
@@ -174,4 +181,58 @@ def test_molecular_atmosphere_depolarization(mode_ckd):
     template, _ = traverse(atmosphere)
     assert template.render(KernelContext(si=si))
     assert isinstance(depol, pint.Quantity)
-    assert len(depol) == atmosphere.geometry.zgrid.n_layers
+    assert len(depol) == atmosphere.geometry.grid.n_layers
+
+
+def _make_grid(n_cells_x, n_cells_y):
+    return PlaneParallelGridCoords(
+        edges_x=np.linspace(-1.0, 1.0, n_cells_x + 1) * ureg.km,
+        edges_y=np.linspace(-1.0, 1.0, n_cells_y + 1) * ureg.km,
+        levels=np.linspace(0.0, 5.0, 6) * ureg.km,
+    )
+
+
+def test_validate_thermoprops_grid_shape_z_only_passthrough():
+    ds = xr.Dataset({"n": (["z"], np.arange(5.0))})
+    assert _validate_thermoprops_grid_shape(ds, _make_grid(3, 7)) is ds
+
+
+@pytest.mark.parametrize(
+    "n_cells_x, n_cells_y, match",
+    [(3, 3, "'x'"), (2, 5, "'y'")],
+)
+def test_validate_thermoprops_grid_shape_mismatch_raises(n_cells_x, n_cells_y, match):
+    ds = xr.Dataset({"n": (["x", "y", "z"], np.zeros((2, 3, 5)))})
+    with pytest.raises(ValueError, match=match):
+        _validate_thermoprops_grid_shape(ds, _make_grid(n_cells_x, n_cells_y))
+
+
+def test_average_adjacent_levels_generalizes_to_xyz():
+    # dims: (w=1, x=2, y=3, z=5) -- leading w dropped, z averaged into layers
+    raw = np.zeros((1, 2, 3, 5))
+    for i in range(2):
+        for j in range(3):
+            for k in range(5):
+                raw[0, i, j, k] = 100 * i + 10 * j + k
+
+    result = _average_adjacent_levels(raw)
+
+    assert result.shape == (2, 3, 4)
+    expected = 0.5 * (raw[0, :, :, 1:] + raw[0, :, :, :-1])
+    np.testing.assert_allclose(result, expected)
+
+
+def test_layers_from_levels_generalizes_to_scrambled_xyz():
+    # dims deliberately scrambled: z is not adjacent to w, and x/y precede it
+    raw = np.zeros((2, 1, 3, 5))
+    for i in range(2):
+        for j in range(3):
+            for k in range(5):
+                raw[i, 0, j, k] = 100 * i + 10 * j + k
+    values = xr.DataArray(raw, dims=["x", "w", "y", "z"], attrs={"units": "km^-1"})
+
+    result = _layers_from_levels(values)
+
+    assert result.shape == (2, 3, 4)
+    expected = 0.5 * (raw[:, 0, :, 1:] + raw[:, 0, :, :-1])
+    np.testing.assert_allclose(result.m_as("km^-1"), expected)

--- a/tests/01_unit/scenes/atmosphere/test_particle_layer.py
+++ b/tests/01_unit/scenes/atmosphere/test_particle_layer.py
@@ -5,7 +5,8 @@ import xarray as xr
 
 from eradiate import KernelContext, fresolver
 from eradiate import unit_registry as ureg
-from eradiate.radprops import ParticleProperties, ZGrid
+from eradiate.grid import GridCoords
+from eradiate.radprops import ParticleProperties
 from eradiate.scenes.atmosphere import ParticleLayer, UniformParticleDistribution
 from eradiate.scenes.core import traverse
 from eradiate.spectral.index import SpectralIndex
@@ -228,8 +229,8 @@ class TestParticleLayer:
         ds = layer.eval_radprops(si)
         expected_data_vars = ["sigma_t", "albedo"]
         expected_coords = ["z_layer"]
-        assert all([coord in ds.coords for coord in expected_coords]) and all(
-            [var in ds.data_vars for var in expected_data_vars]
+        assert all(coord in ds.coords for coord in expected_coords) and all(
+            var in ds.data_vars for var in expected_data_vars
         )
 
     @pytest.mark.parametrize(
@@ -248,7 +249,7 @@ class TestParticleLayer:
         # and check it matches the input tau_ref
         si = SpectralIndex.new(w=layer.w_ref)
         radprops = layer.eval_radprops(si)
-        delta_z = layer.geometry.zgrid.layer_height
+        delta_z = layer.geometry.grid.layer_height
 
         with xr.set_options(keep_attrs=True):
             tau = to_quantity(radprops.sigma_t.sum()) * delta_z
@@ -290,14 +291,16 @@ class TestParticleLayer:
         n_wavelengths = 3
         n_layers = 10
         wavelengths = np.linspace(500.0, 1500.0, n_wavelengths) * ureg.nm
-        zgrid = ZGrid(np.linspace(0, 5, n_layers + 1) * ureg.km)
+        grid = GridCoords.make_onedim_from_levels(
+            np.linspace(0, 5, n_layers + 1) * ureg.km
+        )
 
         layer = ParticleLayer(
             particle_properties=ds,
             geometry={
                 "type": "plane_parallel",
-                "toa_altitude": zgrid.levels[-1],
-                "zgrid": zgrid,
+                "toa_altitude": grid.levels[-1],
+                "grid": grid,
             },
             bottom=bottom,
             top=top,
@@ -308,11 +311,11 @@ class TestParticleLayer:
 
         # Compute layer optical thickness at current wavelengths based on sigma_t
         # evaluation routine
-        sigma_t = layer._eval_sigma_t_impl(wavelengths, layer.geometry.zgrid)
+        sigma_t = layer._eval_sigma_t_impl(wavelengths, layer.geometry.grid)
         assert sigma_t.units.is_compatible_with(ureg("m**-1"))
         assert sigma_t.shape == (n_wavelengths, n_layers)
         # -- Integrate sigma_t * dz vs space coordinate using rectangle method
-        tau = np.sum(sigma_t * layer.geometry.zgrid.layer_height, axis=1)
+        tau = np.sum(sigma_t * layer.geometry.grid.layer_height, axis=1)
 
         # Manually compute extinction at running and reference wavelengths
         w_units = ureg(ds["w"].attrs["units"])
@@ -388,13 +391,13 @@ class TestParticleLayer:
                 has_absorption=has_absorption,
                 has_scattering=has_scattering,
             )
-            zgrid = particle_layer.geometry.zgrid
+            grid = particle_layer.geometry.grid
             w = 550.0 * ureg.nm
 
             for field in ["albedo", "sigma_t", "sigma_a", "sigma_s"]:
                 expected_value = expected[field]
                 method = f"eval_{field}_mono"
-                result = getattr(particle_layer, method)(w, zgrid)
+                result = getattr(particle_layer, method)(w, grid)
 
                 if isinstance(expected_value, pint.Quantity):
                     np.testing.assert_allclose(
@@ -415,7 +418,7 @@ class TestParticleLayer:
                     )
 
                 elif expected_value == "sigma_t":
-                    expected_value = particle_layer.eval_sigma_t_mono(w, zgrid)
+                    expected_value = particle_layer.eval_sigma_t_mono(w, grid)
                     np.testing.assert_allclose(
                         result.m_as(expected_value.units),
                         expected_value.m,

--- a/tests/03_regression/romc/test_het01.py
+++ b/tests/03_regression/romc/test_het01.py
@@ -20,7 +20,7 @@ def test_het01_brfpp(mode_mono_double, exp, dataset_regression):
 
     Simulation results are compared to a reference obtained with a prior
     version and validated with ROMC. Comparison is done with a z-test
-    with a threshold of 0.05.
+    with a threshold of 0.01.
     """
     result = eradiate.run(exp)
 
@@ -28,6 +28,6 @@ def test_het01_brfpp(mode_mono_double, exp, dataset_regression):
 
     dataset_regression.check(
         result,
-        ZTest(0.05, variable="radiance"),
+        ZTest(0.01, variable="radiance"),
         basename="het01_brfpp_ref",
     )


### PR DESCRIPTION
# Description

Implement a coordinate system for gridded atmospheres and adapt the codebase to this new feature. The `GridCoords` interface effectively replaces the `ZGrid` class, introducing many small mechanical changes in the codebase. This abstraction indexes the extent of the 3D space where the atmospheric data and optical properties are defined. It generalizes `ZGrid` to 3 dimensions.

Two subclasses of `GridCoords`, `PlaneParallelGridCoords` and `SphericalShellGridCoords`, implement a Cartesian and a geocentric coordinate system respectively.

The `Geometry` keeps the same role of defining the shape of the atmosphere volume, but the different components are now mapped on the `GridCoords` subregion of the shape. The `Geometry` subclasses are updated to introduce wrap mode parametrization, although this feature is not implemented yet (see #589).

A new set of tools is proposed to facilitate the configuration of a mitsuba `GridVolume` instances from a `Geometry` instance and its associated `GridCoords`.

Lastly, to support end user manipulation of these coordinates, a small visualization tool is proposed for notebook cells. This module is implemented in pure SVG without any external library, and only output a few diagrams representing the grids or atmosphere. This allows a fast render time for interactive sessions.

Here is an example representation of a default 1D grid in Eradiate:
<img width="726" height="166" alt="image" src="https://github.com/user-attachments/assets/752035c2-6894-4404-b150-141f1976b422" />

The scale is not realistic. Only 3 different sizes can be assigned to an axis, and sizes are attributed by order of length of the axes' extent. In the example above, the default coordinate grid is 120km high, and both X and Y extents are the same size at 5e6 km and thus represented with the same size. Thus this representation is only a convenient visual cue to help debugging or configuring a scene.

Here is an example with another narrower grid geometry:
<img width="592" height="235" alt="image" src="https://github.com/user-attachments/assets/c9c120d6-2e17-4e14-a155-dcbc4f7cca4b" />

For `Geometry` instances, a similar visualization uses a logarithmic scale to represent the extent of the inner grid compared to the atmosphere's shape:
<img width="341" height="225" alt="image" src="https://github.com/user-attachments/assets/725bb306-8395-47ce-9880-3897e9ee13d4" />

Another representation is used for spherical geometries:
<img width="264" height="261" alt="image" src="https://github.com/user-attachments/assets/06b5f819-7c6b-4549-86c1-45503072b32e" />

Note that although these representations are implemented in this PR, the actual wrap mode support is implemented in the subsequent #589. Using a grid smaller than the atmosphere shape at this stage is undefined behavior.

Examples taken from https://github.com/eradiate/eradiate-tutorials/pull/5

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `next` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
