### PR TITLE
[enhancement] Refactor scene traversal by moving it to the kernel, allowing support for traversal of multiple parents.

### DIFF
--- a/docs/release_notes/v1.3.x.md
+++ b/docs/release_notes/v1.3.x.md
@@ -32,3 +32,4 @@
   renders) are now written to the `reports/` directory ({ghpr}`582`).
 * 🖥️ Move `figure_to_html()` from `test_tools.regression` to `test_tools.report`
   ({ghpr}`582`).
+* 🖥️ Move traversal logic of the mitsuba scene in the kernel code ({ghpr}`593`).

--- a/src/eradiate/kernel/_render.py
+++ b/src/eradiate/kernel/_render.py
@@ -5,9 +5,7 @@ import typing as t
 import warnings
 
 import attrs
-import drjit as dr
 import mitsuba as mi
-from mitsuba.python.util import SceneParameters as _MitsubaSceneParameters
 from tqdm.auto import tqdm
 
 from ._kernel_dict import KernelSceneParameterMap
@@ -92,8 +90,8 @@ class MitsubaObjectWrapper:
         attrs.field(
             default=None,
             repr=lambda x: (
-                "SceneParameters[...]"
-                if x.__class__.__name__ == "SceneParameters"
+                f"{x.__class__.__name__}[...]"
+                if isinstance(x, mi.SceneParameters)
                 else str(None)
             ),
         ),
@@ -144,44 +142,6 @@ class MitsubaObjectWrapper:
                     keys.append(name)
 
             self.parameters.keep(keys)
-
-
-class SceneParameters(_MitsubaSceneParameters):
-    def __init__(self, properties=None, hierarchy=None, aliases=None):
-        super().__init__(properties, hierarchy)
-        self.aliases = aliases if aliases is not None else {}
-
-    def set_dirty(self, key: str):
-        # Inherit docstring
-
-        value, _, node, flags = self.properties[key]
-
-        is_nondifferentiable = flags & mi.ParamFlags.NonDifferentiable.value
-        if is_nondifferentiable and dr.grad_enabled(value):
-            mi.Log(
-                mi.LogLevel.Warn,
-                f"Parameter '{key}' is marked as non-differentiable but has "
-                "gradients enabled, unexpected results may occur!",
-            )
-
-        node_key = key  # Key of current node
-        while node is not None:
-            parent, depth = self.hierarchy[node]
-
-            name = node_key
-            if parent is not None:
-                if "." not in name and depth > 0:
-                    # We've hit the top level from an ID-aliased node:
-                    # Resolve the alias to finish climbing the hierarchy
-                    node_key = self.aliases[name]
-                node_key, name = node_key.rsplit(".", 1)
-
-            self.nodes_to_update.setdefault((depth, node), set())
-            self.nodes_to_update[(depth, node)].add(name)
-
-            node = parent
-
-        return self.properties[key]
 
 
 def mi_load_dict(dict: dict, parallel: bool = True, optimize: bool = False) -> object:
@@ -246,6 +206,8 @@ def mi_traverse(
     This is a reimplementation of the :func:`mitsuba.traverse` function.
     """
 
+    parameters = mi.eradiate.traverse(obj, name_id_override=name_id_override)
+
     umap_template = (
         KernelSceneParameterMap(data=umap_template.data.copy())
         if umap_template is not None
@@ -258,105 +220,14 @@ def mi_traverse(
         if v.parameter_id is None and v.search is not None
     }
 
-    if name_id_override is None or name_id_override is False:
-        name_id_override = []
-
-    if name_id_override is True:
-        name_id_override = [r".*"]
-
-    if type(name_id_override) is not list:
-        name_id_override = [name_id_override]
-
-    import re
-
-    regexps = [re.compile(k).match for k in name_id_override]
-
-    class SceneTraversal(mi.TraversalCallback):
-        def __init__(
-            self,
-            node,
-            parent=None,
-            properties=None,
-            hierarchy=None,
-            prefixes=None,
-            name=None,
-            depth=0,
-            flags=+mi.ParamFlags.Differentiable,
-            aliases=None,
-        ):
-            mi.TraversalCallback.__init__(self)
-            self.properties = dict() if properties is None else properties
-            self.hierarchy = dict() if hierarchy is None else hierarchy
-            self.prefixes = set() if prefixes is None else prefixes
-            self.aliases = dict() if aliases is None else aliases
-
-            node_id = node.id()
-            if name_id_override and node_id:
-                for r in regexps:
-                    if r(node_id):
-                        if node_id != name:
-                            self.aliases[node_id] = name
-                        name = node_id
-                        break
-
-            if name is not None:
-                ctr, name_len = 1, len(name)
-                while name in self.prefixes:
-                    name = f"{name[:name_len]}_{ctr}"
-                    ctr += 1
-                self.prefixes.add(name)
-
-            self.name = name
-            self.node = node
-            self.depth = depth
-            self.hierarchy[node] = (parent, depth)
-            self.flags = flags
-
-            # Try and recover a parameter ID from this node
-            for name, uparam in list(lookups.items()):
-                lookup_result = uparam.search(self.node, self.name)
-                if lookup_result is not None:
-                    uparam.parameter_id = lookup_result
-                    del lookups[
-                        name
-                    ]  # Remove successful lookups to accelerate future searches
-
-        def put(self, name, value, flags, cpptype=None):
-            """Unified method to register both objects and values with the traversal callback."""
-            # Import Object locally to avoid circular import
-            if isinstance(value, mi.Object):
-                self.put_object(name, value, flags)
-            else:
-                self.put_value(name, value, flags, cpptype)
-
-        def put_value(self, name, ptr, flags, cpptype):
-            name = name if self.name is None else self.name + "." + name
-
-            flags = self.flags | flags
-            # Non-differentiable parameters shouldn't be flagged as discontinuous
-            if (flags & mi.ParamFlags.NonDifferentiable) != 0:
-                flags = flags & ~mi.ParamFlags.Discontinuous
-
-            self.properties[name] = (ptr, cpptype, self.node, self.flags | flags)
-
-        def put_object(self, name, obj, flags):
-            if obj is None or obj in self.hierarchy:
-                return
-            cb = SceneTraversal(
-                node=obj,
-                parent=self.node,
-                properties=self.properties,
-                hierarchy=self.hierarchy,
-                prefixes=self.prefixes,
-                name=name if self.name is None else f"{self.name}.{name}",
-                depth=self.depth + 1,
-                flags=self.flags | flags,
-                aliases=self.aliases,
-            )
-            obj.traverse(cb)
-
-    cb = SceneTraversal(obj)
-    obj.traverse(cb)
+    # build the parameter_id from the listed names
+    for name, uparam in list(lookups.items()):
+        for node, node_path in parameters.names.items():
+            result = uparam.search(node, node_path)
+            if result is not None:
+                uparam.parameter_id = result
+                del lookups[name]
+                break
 
     # Check if there are unsuccessful lookups
     if lookups:
@@ -368,7 +239,7 @@ def mi_traverse(
 
     return MitsubaObjectWrapper(
         obj=obj,
-        parameters=SceneParameters(cb.properties, cb.hierarchy, cb.aliases),
+        parameters=parameters,
         umap_template=umap_template,
     )
 

--- a/tests/01_unit/kernel/test_render.py
+++ b/tests/01_unit/kernel/test_render.py
@@ -195,6 +195,22 @@ def test_mi_traverse_name_id_override(
     assert set(mi_wrapper.parameters.keys()) == expected
 
 
+def test_mi_traverse_multi_parent_update(mode_mono):
+    # "my_bsdf" is referenced by three shapes: updating it must notify all of
+    # them, not just the first one encountered during traversal.
+    mi_scene = mi_load_dict(SCENE_DICTS["referenced_bsdf"])
+    mi_wrapper = mi_traverse(mi_scene)
+
+    out = mi_wrapper.parameters.update({"my_bsdf.reflectance.value": 0.3})
+    updated = {node.id(): keys for node, keys in out if node.id()}
+
+    for shape_id in ("_rectangle_1", "_rectangle_2", "_disk_1"):
+        assert "bsdf" in updated[shape_id]
+
+    # "_disk_2" has its own, unrelated BSDF and must not be notified
+    assert "_disk_2" not in updated
+
+
 class TestMiRender:
     def test_context_loop(self, mode_mono):
         mi_scene = mi_load_dict(


### PR DESCRIPTION
# Description

Hello,
This PR is linked to [kernel PR 37](https://github.com/eradiate/mitsuba3/pull/37). 
The aims of this PR are to:
- Move the kernel traversal logic in the kernel, enabling better separation of concern. It also ensures that it is possible to use the kernel on its own.
- Ensure that the name id pinning is properly ported over and that multiple parent node traversal properly works.

Moving the traversal logic in the kernel means that it is not possible to pass the content of `KernelSceneParameterMap` in the traverse function as it is `Eradiate` specific. This, in turn, means that populating the `uparam.parameter_id` needs to be done after the traversal, as opposed to during.  

The `mi_traverse` remains as is. The test suite was run and passed, and a test for multiple parent traversal was added to `test_render.py`.

Now that the traversal function is in the kernel, it might make sense to move parts of `test_render.py` in there too. However, I still think it valuable to have those tests run when testing Eradiate, hence why I refrained from moving them, let me know what you think about that.

This PR includes a bump of the Mitsuba submodule.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `next` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
