### PR TITLE
fix: Correct wrong indexing for spheroidal particles

### DIFF
--- a/docs/release_notes/index.md
+++ b/docs/release_notes/index.md
@@ -22,6 +22,7 @@ Emoji marks have the following meaning:
 ```{toctree}
 :maxdepth: 2
 
+v1.3.x.md
 v1.2.x.md
 v1.1.x.md
 v1.0.x.md

--- a/docs/release_notes/v1.3.x.md
+++ b/docs/release_notes/v1.3.x.md
@@ -7,6 +7,9 @@
 * 🖥️ Fixed multiple breakages after a development environment update ({ghpr}`578`).
 * {class}`.RegressionTest` no longer raises when initialized with plotting
   enabled and no reference data ({ghpr}`582`).
+* Fixed a bug where spheroidal particle datasets would raise an `IndexError`
+  upon a call to `ParticleProperties.eval_phase()` in polarized mode
+  ({ghpr}`594`).
 
 ### Internal changes
 

--- a/src/eradiate/scenes/phase/_particles.py
+++ b/src/eradiate/scenes/phase/_particles.py
@@ -233,7 +233,7 @@ class ParticlePhaseFunction(PhaseFunction):
                 result.update({"m12": 1, "m33": 2, "m34": 3})
 
                 if self.particle_properties.particle_shape == "spheroidal":
-                    result.update({"m22": 4, "m44": 6})
+                    result.update({"m22": 4, "m44": 5})
                 elif self.particle_properties.particle_shape == "spherical":
                     result.update({"m22": 0, "m44": 2})
 

--- a/tests/01_unit/scenes/phase/test_particles.py
+++ b/tests/01_unit/scenes/phase/test_particles.py
@@ -1,9 +1,11 @@
 import mitsuba as mi
 import numpy as np
 import pytest
+import xarray as xr
 
 import eradiate
 from eradiate import fresolver
+from eradiate.data.convert import make_aer_core_v2
 from eradiate.radprops import ParticleProperties
 from eradiate.scenes.phase import ParticlePhaseFunction
 from eradiate.spectral import SpectralIndex
@@ -15,6 +17,30 @@ DS_ID_TO_FNAME = {
     "polarized_data": "aeronet_sahara_spherical_RAMIA_GENERIC_extrapolated-aer_core_v2",
     "pmom_data": "soot.mie-aer_core_v2",
 }
+
+
+def make_minimal_aer_core_v2(nphamat: int) -> xr.Dataset:
+    """
+    Build a minimal Aer-Core v2 dataset with ``nphamat`` phase matrix components
+    (1: unpolarized, 4: spherical, 6: spheroidal).
+    """
+    # Phase matrix component names, in Aer-Core v2 storage order
+    phamat_names = ["11", "12", "33", "34", "22", "44"]
+
+    w = np.array([400.0, 700.0])
+    mu = np.tile(np.array([-1.0, 0.0, 1.0]), (len(w), 1))
+    phase = np.ones((nphamat, *mu.shape))
+
+    return make_aer_core_v2(
+        w=w * ureg.nm,
+        phamat=phamat_names[:nphamat],
+        mu=mu * ureg.dimensionless,
+        theta=np.degrees(np.arccos(mu)) * ureg.deg,
+        ext=np.ones_like(w) * ureg("km^-1"),
+        ssa=np.ones_like(w) * ureg.dimensionless,
+        phase=phase * ureg("1/sr"),
+        normalize=True,
+    )
 
 
 @pytest.fixture(scope="module", params=list(DS_ID_TO_FNAME.keys()))
@@ -102,6 +128,28 @@ class TestParticlePhaseFunction:
         # Repeated evaluations with the same wavelength value do not trigger a
         # recomputation
         assert pphase.eval_phase(si) is result
+
+    @pytest.mark.parametrize(
+        "nphamat, expected",
+        [
+            (4, {"m11": 0, "m12": 1, "m33": 2, "m34": 3, "m22": 0, "m44": 2}),
+            (6, {"m11": 0, "m12": 1, "m33": 2, "m34": 3, "m22": 4, "m44": 5}),
+        ],
+        ids=["spherical", "spheroidal"],
+    )
+    def test_param_to_phamat(self, mode_ckd_polarized, nphamat, expected):
+        """
+        Phase matrix components map to the storage indices documented in
+        eval_phase(), and those indices are within bounds.
+        """
+        pphase = ParticlePhaseFunction(
+            particle_properties=ParticleProperties(make_minimal_aer_core_v2(nphamat))
+        )
+        assert pphase._param_to_phamat() == expected
+
+        si = SpectralIndex.new()
+        for index in expected.values():
+            assert pphase.eval_phase(si, index).ndim == 1
 
     def test_eval_pmom(self, modes_all_double, pphase):
         si = SpectralIndex.new()


### PR DESCRIPTION
# Description

The `ParticleProperties` addition broke the spheroidal particle branch in the scene updater generation process. This bug only manifested when using a polarized mode, with spheroidal particles  (*e.g.* libRadtran's `ic.ghm.baum.cdf`), when initializing the scene (and thus calling `Experiment.init()`).

I added a minimal regression test. A test with real-world data would require checking in a large dataset, which is not practical.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
