### PR TITLE
Pipelines: Add SRF-weighted variance to CKD results

### DIFF
--- a/docs/release_notes/v1.3.x.md
+++ b/docs/release_notes/v1.3.x.md
@@ -2,6 +2,13 @@
 
 ## v1.3.0 (upcoming release)
 
+### Added
+
+* Results now include the SRF-weighted variance `<var>_srf_var` alongside
+  `<var>_srf` whenever variance computation is enabled. This makes
+  noise-aware comparisons (*e.g.* {class}`.ZTest`) possible on band-integrated
+  quantities ({ghpr}`595`).
+
 ### Fixed
 
 * 🖥️ Fixed multiple breakages after a development environment update ({ghpr}`578`).

--- a/src/eradiate/pipelines/definitions.py
+++ b/src/eradiate/pipelines/definitions.py
@@ -234,9 +234,11 @@ def build_pipeline(config: dict) -> Pipeline:
     # ------------------------------------------------------------------
     if is_ckd and apply_srf:
 
-        def _make_srf_node(src_name):
+        def _make_srf_node(src_name, is_variance=False):
             def _srf_func(**kwargs):
-                return logic.apply_spectral_response(kwargs[src_name], kwargs["srf"])
+                return logic.apply_spectral_response(
+                    kwargs[src_name], kwargs["srf"], is_variance
+                )
 
             return _srf_func
 
@@ -247,6 +249,15 @@ def build_pipeline(config: dict) -> Pipeline:
             description=f"Apply SRF → {var_name}_srf",
             metadata=_FINAL_DATA,
         )
+
+        if calc_var:
+            pipeline.add_node(
+                f"{var_name}_srf_var",
+                func=_make_srf_node(f"{var_name}_var", is_variance=True),
+                dependencies=[f"{var_name}_var", "srf"],
+                description=f"Apply SRF → {var_name}_srf_var",
+                metadata=_FINAL_DATA,
+            )
 
         if var_name == "sector_radiosity":
             pipeline.add_node(

--- a/src/eradiate/pipelines/logic.py
+++ b/src/eradiate/pipelines/logic.py
@@ -208,26 +208,38 @@ def aggregate_ckd_quad(
     return result
 
 
-def apply_spectral_response(
+def spectral_response_weights(
     spectral_data: xr.DataArray, srf: SpectralResponseFunction
 ) -> xr.DataArray:
-    """
-    Apply SRF weighting (a.k.a. convolution) to spectral data and turn it into
-    a band aggregate.
+    r"""
+    Compute the weight each spectral bin carries in the band aggregate produced
+    by :func:`apply_spectral_response`.
 
     Parameters
     ----------
     spectral_data : DataArray
-        Spectral data to process.
+        Spectral data the weights are computed for. Only its ``w``,
+        ``bin_wmin`` and ``bin_wmax`` coordinates are used.
 
-    srf : SpectralResponseFunction
+    srf : .SpectralResponseFunction
         Spectral response function to apply.
 
     Returns
     -------
-    DataArray or None
-        A data array where the spectral dimension is removed after applying
-        SRF weighting, or ``None`` if the SRF is a :class:`.DeltaSRF`.
+    DataArray
+        Weights, indexed against the ``w`` coordinate of `spectral_data`. They
+        sum to 1 when the SRF support is entirely covered by the data.
+
+    Notes
+    -----
+    SRF weighting turns a set of per-bin values :math:`x_i` into a single band
+    value :math:`\sum_i c_i x_i`. This function computes the coefficients
+    :math:`c_i`. They are computed by feeding a unit impulse on each bin (*i.e.*
+    considering the :math:`x_i = 1`, all other values set to zero) through the
+    resampling and integration steps that are to be applied to the actual data.
+    Computed weights are consumed by :func:`apply_spectral_response`, allowing
+    different usage depending on whether the mean or variance of a variable is
+    processed.
     """
     if not {"bin_wmin", "bin_wmax"}.issubset(set(spectral_data.coords.keys())):
         raise ValueError(
@@ -246,42 +258,80 @@ def apply_spectral_response(
     else:
         raise TypeError(f"unhandled SRF type '{srf.__class__.__name__}'")
 
-    # Evaluate integral of product of variable and SRF within selected interval
     data_w = to_quantity(spectral_data.coords["w"])
 
     # Spectral grid is the finest between data and SRF grids
     w_units = data_w.units
     w_m = np.array(sorted(set(data_w.m_as(w_units)) | set(srf_w.m_as(w_units))))
 
+    # One row per spectral bin, each holding a unit impulse on that bin. Only
+    # the spectral coordinate is carried over: the others play no part here and
+    # would only be resampled for nothing.
+    basis = xr.DataArray(
+        np.eye(spectral_data.sizes["w"]),
+        dims=("bin", "w"),
+        coords={"w": spectral_data.coords["w"].values},
+    )
+
     # If data var has length 1 on spectral dimension, directly select
     # the value instead of using interpolation (it's a known scipy issue)
-    if len(spectral_data.coords["w"]) == 1:
-        # Note: The tricky thing is to recreate and extend the 'w'
-        # dimension with the same axis index as in the original data
-        spectral_values = spectral_data.isel(w=0, drop=True).expand_dims(
-            w=w_m, axis=spectral_data.get_axis_num("w")
-        )
+    if spectral_data.sizes["w"] == 1:
+        basis_values = basis.isel(w=0, drop=True).expand_dims(w=w_m, axis=1)
 
     # Otherwise, use nearest neighbour interpolation (we assume that the
     # spectral data is constant over each spectral bin)
     else:
-        spectral_values = spectral_data.interp(
+        basis_values = basis.interp(
             w=w_m, method="nearest", kwargs={"fill_value": "extrapolate"}
         )
 
-    srf_values = (
-        srf.eval(w_m * w_units)
-        .reshape([-1 if dim == "w" else 1 for dim in spectral_values.dims])
-        .magnitude
+    srf_values = xr.DataArray(srf.eval(w_m * w_units).magnitude, dims="w")
+    weights = (basis_values * srf_values).integrate("w") / srf_int.m_as(w_units)
+
+    # Rows of the identity are the bins of the input grid, in its own order
+    return xr.DataArray(
+        weights.values, dims="w", coords={"w": spectral_data.coords["w"].values}
     )
-    assert isinstance(srf_values, np.ndarray)  # Check for leftover bugs
-    var_srf_int = (spectral_values * srf_values).integrate("w")
+
+
+def apply_spectral_response(
+    spectral_data: xr.DataArray,
+    srf: SpectralResponseFunction,
+    is_variance: bool = False,
+) -> xr.DataArray:
+    """
+    Apply SRF weighting (a.k.a. convolution) to spectral data and turn it into
+    a band aggregate.
+
+    Parameters
+    ----------
+    spectral_data : DataArray
+        Spectral data to process.
+
+    srf : SpectralResponseFunction
+        Spectral response function to apply.
+
+    is_variance : bool, default: False
+        Flag that specifies whether `spectral_data` holds variance values. If
+        ``True``, the weights are squared, which propagates the variance
+        through the SRF weighting instead of averaging it. Per-bin estimates
+        are assumed to be uncorrelated, which holds for the independent Monte
+        Carlo estimates the pipeline produces.
+
+    Returns
+    -------
+    DataArray or None
+        A data array where the spectral dimension is removed after applying
+        SRF weighting, or ``None`` if the SRF is a :class:`.DeltaSRF`.
+    """
+    weights = spectral_response_weights(spectral_data, srf)
 
     # Initialize storage (we want to keep all coordinate variables)
     result = xr.full_like(spectral_data, np.nan).isel(w=0, drop=True)
 
     # Apply SRF to variable and store result
-    result.values = var_srf_int.values / srf_int.m_as(w_units)
+    band_values = (spectral_data * (weights**2 if is_variance else weights)).sum("w")
+    result.values = band_values.transpose(*result.dims).values
 
     if isinstance(srf, BandSRF):
         # Add SRF central wavelength as a scalar coordinate
@@ -301,17 +351,24 @@ def apply_spectral_response(
             }
         )
 
-    # Apply metadata
-    attrs = spectral_values.attrs.copy()
-    if "standard_name" in attrs:
-        attrs["standard_name"] += "_srf"
-    if "long_name" in attrs:
-        attrs["long_name"] += " (SRF-weighted)"
-
     try:
-        name = spectral_data.name + "_srf"
-    except TypeError as e:
+        name = (
+            spectral_data.name.removesuffix("_var") + "_srf_var"
+            if is_variance
+            else spectral_data.name + "_srf"
+        )
+    except (AttributeError, TypeError) as e:
         raise TypeError("expected a DataArray with a name") from e
+
+    # Apply metadata (as in aggregate_ckd_quad, variances carry none)
+    if is_variance:
+        attrs = {}
+    else:
+        attrs = spectral_data.attrs.copy()
+        if "standard_name" in attrs:
+            attrs["standard_name"] += "_srf"
+        if "long_name" in attrs:
+            attrs["long_name"] += " (SRF-weighted)"
 
     result.attrs = attrs
     result.name = name

--- a/tests/01_unit/pipelines/test_logic.py
+++ b/tests/01_unit/pipelines/test_logic.py
@@ -187,6 +187,14 @@ def apply_spectral_response(mode, measure, experiment, aggregate_ckd_quad):
     return logic.apply_spectral_response(spectral_data, experiment.measures[0].srf)
 
 
+@pytest.fixture
+def apply_spectral_response_var(mode, measure, experiment, aggregate_ckd_quad_var):
+    spectral_data = aggregate_ckd_quad_var
+    return logic.apply_spectral_response(
+        spectral_data, experiment.measures[0].srf, is_variance=True
+    )
+
+
 # ------------------------------------------------------------------------------
 #                                     Tests
 # ------------------------------------------------------------------------------
@@ -300,7 +308,50 @@ def test_03_aggregate_ckd_quad_var(experiment, gather_bitmaps, aggregate_ckd_qua
 
 @pytest.mark.parametrize("mode_id", ["ckd"])
 @pytest.mark.parametrize("srf", ["sentinel_2a-msi-3"])
-def test_04_apply_spectral_response_main(
+def test_04_apply_spectral_response_weights(experiment, aggregate_ckd_quad):
+    """
+    Unit test for :func:`.spectral_response_weights` and the variance
+    propagation built on it.
+
+    SRF weighting is a weighted average, so its weights are non-negative and
+    sum to 1: a spectrally constant variable comes out unchanged. A spectrally
+    constant *variance* does not — averaging uncorrelated estimates shrinks it
+    by the effective number of contributing bins, which lies between 1 and the
+    bin count.
+    """
+    srf = experiment.measures[0].srf
+    n_bins = aggregate_ckd_quad.sizes["w"]
+    assert n_bins > 1  # Otherwise variance check below is vacuous
+
+    weights = logic.spectral_response_weights(aggregate_ckd_quad, srf)
+    assert np.all(weights.values >= 0.0)
+
+    # Weights sum to 1 only up to discretization: they integrate the SRF on the
+    # union of the data and SRF grids, while the normalization term
+    # integrates it on the SRF grid alone, over the slightly wider interval
+    # spanned by the outer bin bounds
+    total = float(weights.sum())
+    np.testing.assert_allclose(total, 1.0, rtol=5e-2)
+
+    constant = xr.ones_like(aggregate_ckd_quad)
+
+    # Weighting a constant field is summing the weights, exactly
+    mean = logic.apply_spectral_response(constant, srf)
+    np.testing.assert_allclose(mean.values, total, rtol=1e-12)
+
+    # ... and propagating a constant variance is summing their squares
+    variance = logic.apply_spectral_response(constant, srf, is_variance=True)
+    np.testing.assert_allclose(variance.values, float((weights**2).sum()), rtol=1e-12)
+
+    # Averaging uncorrelated estimates shrinks the variance, down to the
+    # equal-weight bound total ** 2 / n_bins (Cauchy-Schwarz)
+    assert np.all(variance.values < mean.values)
+    assert np.all(variance.values >= total**2 / n_bins)
+
+
+@pytest.mark.parametrize("mode_id", ["ckd"])
+@pytest.mark.parametrize("srf", ["sentinel_2a-msi-3"])
+def test_05_apply_spectral_response_main(
     experiment, aggregate_ckd_quad, apply_spectral_response
 ):
     """
@@ -325,6 +376,30 @@ def test_04_apply_spectral_response_main(
 
     # The recorded central wavelength is correct
     np.testing.assert_approx_equal(result["w_srf"].values, 559.84824506)
+
+
+@pytest.mark.parametrize("mode_id", ["ckd"])
+@pytest.mark.parametrize("srf", ["sentinel_2a-msi-3"])
+def test_06_apply_spectral_response_var(
+    experiment, aggregate_ckd_quad_var, apply_spectral_response_var
+):
+    """
+    Unit test for :func:`.apply_spectral_response` when used on a variance.
+    """
+    var_name = experiment.measures[0].var[0]
+    raw = aggregate_ckd_quad_var
+    result = apply_spectral_response_var
+
+    # Dimension and coordinate checks, as for the main variable
+    assert set(result.dims) == set(raw.dims) - {"w"}
+    expected_coords = (set(raw.coords) | {"w_srf"}) - {"w", "bin_wmax", "bin_wmin"}
+    assert set(result.coords) == expected_coords
+
+    # The variance is named after the variable it qualifies, so that it pairs
+    # with '<var>_srf', and carries no metadata (as aggregate_ckd_quad does)
+    assert result.name == f"{var_name}_srf_var"
+    assert result.attrs == {}
+    assert np.all(result.values >= 0.0)
 
 
 @pytest.mark.parametrize("mode_id", ["ckd"])


### PR DESCRIPTION
# Description

Band-weighted results didn't have a variance variable, which made using them for statistical testing impossible. This PR fixes that by adding a new node to the post-processing pipeline that performs variance aggregation for the `srf`-suffixed variables.

Changes are as follows:

* SRF weighting is factored out of `apply_spectral_response()` into `spectral_response_weights()`. This makes it possible to use the weights differently to process the mean and variance of a variable.
* `apply_spectral_response()` gains an `is_variance` flag, mirroring `aggregate_ckd_quad()`, and the pipeline gains a `<var>_srf_var` node wherever `<var>_var` and `<var>_srf` are both built.


# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
