### PR TITLE
[3DATM 1/6] Data formats

### DIFF
--- a/docs/data/formats/aer.rst
+++ b/docs/data/formats/aer.rst
@@ -122,6 +122,64 @@ Normalization conventions
       * ``imom``
       * ``nmommax``
 
+.. _sec-data-formats-prt_v1:
+
+Prt v1 [``prt_v1``]
+--------------------
+
+Extension of ``aer_core_v2`` for particle properties. This data format
+indexes properties defined by ``aer_core_v2`` on two extra dimensions,
+``reff`` and ``veff``, the mean and variance of the particle size
+distribution, respectively. It shares the same normalization conventions
+as ``aer_core_v2``.
+
+Format
+    ``xarray.Dataset`` (in-memory), NetCDF (storage)
+
+Dimensions
+    * ``w``: radiation wavelength
+    * ``reff``: effective radius of the particles
+    * ``veff``: variance of the particles radii
+    * ``phamat``: nonzero coefficients in the phase matrix
+    * ``iangle``: angular data points
+    * ``imom``: Legendre coefficients for the (1,1) phase matrix component
+
+Coordinates
+    *When relevant, units are required and specified in the "units" metadata field.*
+
+    * ``w(w)``: float [length]: wavelength
+    * ``reff(reff)``: float [length]: effective radius
+    * ``veff(veff)``: float [—]: variance of particles radii
+    * ``phamat(phamat)``: str [—]: row and column indices of the phase matrix coefficient
+      (*e.g.* "11", "12", etc.)
+    * ``theta(w, reff, veff, iangle)``: float [angle]: scattering angle θ; NaN-padded beyond
+      ``nangles[iw, ireff, iveff]``
+    * ``mu(w, reff, veff, iangle)``: float [—]: value of cos θ; NaN-padded beyond 
+      ``nangles[iw, ireff, iveff]``
+
+Data variables
+    *When relevant, units are required and specified in the "units" metadata field.*
+
+    * ``ext(w, reff, veff)`` float [1 / length]: extinction coefficient per unit concentration
+    * ``ssa(w, reff, veff)`` float [—]: single-scattering albedo
+    * ``phase(phamat, w, reff, veff, iangle)`` float [1 / sr]: value of the phase matrix;
+      NaN-padded beyond ``nangles[iw, ireff, iveff]``
+    * ``nangles(w, reff, veff)`` int [—]: number of valid angular samples per wavelength,
+      reff and veff; must be consistent with the NaN padding of ``theta``, ``mu``, and 
+      ``phase``
+    * ``pmom(w, reff, veff, imom)`` float [—], optional: Legendre expansion coefficients
+      of the (1,1) phase matrix element; NaN-padded beyond ``nmom[iw, ireff, iveff]``
+    * ``nmom(w, reff, veff)`` int [—], required if ``pmom`` is present: number of valid
+      Legendre coefficients per wavelength; must be consistent with the NaN
+      padding of ``pmom``
+
+.. note::
+
+    * Data are sorted in ascending order of ``w``, ``reff``, ``veff`` and ``mu``
+    * ``reff`` and ``veff`` are regularly spaced
+    * ``phamat`` conventions (valid values, and their implication for
+      polarization and particle shape) are the same as ``aer_core_v2``
+
 .. _sec-data-formats-aer_v1:
 
 Aer v1 (legacy) [``aer_v1``]

--- a/docs/data/formats/aer.rst
+++ b/docs/data/formats/aer.rst
@@ -176,7 +176,8 @@ Data variables
 .. note::
 
     * Data are sorted in ascending order of ``w``, ``reff``, ``veff`` and ``mu``
-    * ``reff`` and ``veff`` are regularly spaced
+    * ``reff`` and ``veff`` must be strictly increasing, but need not be
+      regularly spaced
     * ``phamat`` conventions (valid values, and their implication for
       polarization and particle shape) are the same as ``aer_core_v2``
 

--- a/docs/data/formats/profile.rst
+++ b/docs/data/formats/profile.rst
@@ -1,0 +1,47 @@
+Particle profile (Ppr)
+=======================
+
+.. _sec-data-formats-ppr_v1:
+
+Ppr v1 [``ppr_v1``]
+-------------------
+
+Sparse, per-voxel description of a spatially varying particle field.
+Typically used for clouds. Each entry describes one populated voxel: its
+grid cell indices, the local particle size distribution parameters, and the
+mass concentration used to scale optical properties looked up from a
+:ref:`Prt v1 <sec-data-formats-prt_v1>` dataset.
+
+The grid is described by the ``x_levels``/``y_levels``/``z_levels`` arrays of
+cell edges along each axis. The profile is defined on either a Cartesian
+coordinate system (``x_levels``/``y_levels`` in length units) or a spherical
+geocentric coordinate system (``x_levels``/``y_levels`` in angle units,
+representing azimuth/colatitude).
+
+Format
+    ``xarray.Dataset`` (in-memory), NetCDF (storage)
+
+Dimensions
+    * ``index``: flat, populated-voxel index
+
+Data variables
+    *When relevant, units are required and specified in the "units" metadata field.*
+
+    * ``x_levels`` float, 1-D [length or angle]: grid cell edges along the x
+      axis
+    * ``y_levels`` float, 1-D [length or angle]: grid cell edges along the y
+      axis
+    * ``z_levels`` float, 1-D [length]: grid cell edges along the z
+      (altitude) axis
+    * ``i_x(index)`` int [—]: index of the populated cell along the x axis,
+      0-based
+    * ``i_y(index)`` int [—]: index of the populated cell along the y axis,
+      0-based
+    * ``i_z(index)`` int [—]: index of the populated cell along the z axis,
+      0-based
+    * ``reff(index)`` float [length]: effective radius of the particle size
+      distribution
+    * ``veff(index)`` float [—]: effective variance of the particle size
+      distribution
+    * ``mass_concentration(index)`` float [mass / volume]: particle mass
+      concentration

--- a/docs/release_notes/v1.3.x.md
+++ b/docs/release_notes/v1.3.x.md
@@ -11,6 +11,8 @@
 * {class}`.ParticleProperties` can now load particle radiative property
   datasets in the new `prt_v1` format, which extends `aer_core_v2` with
   `r_eff`/`v_eff` support ({ghpr}`584`).
+* New `ppr_v1` data format for spatially varying particle profiles, like
+  clouds ({ghpr}`585`).
 
 ### Fixed
 

--- a/docs/release_notes/v1.3.x.md
+++ b/docs/release_notes/v1.3.x.md
@@ -8,6 +8,9 @@
   `<var>_srf` whenever variance computation is enabled. This makes
   noise-aware comparisons (*e.g.* {class}`.ZTest`) possible on band-integrated
   quantities ({ghpr}`595`).
+* {class}`.ParticleProperties` can now load particle radiative property
+  datasets in the new `prt_v1` format, which extends `aer_core_v2` with
+  `r_eff`/`v_eff` support ({ghpr}`584`).
 
 ### Fixed
 

--- a/pytest.toml
+++ b/pytest.toml
@@ -14,6 +14,8 @@ filterwarnings = [
   "ignore:.*utcnow.*:DeprecationWarning",
   # Ignore Skyfield ephemeris file handle warnings (expected behaviour)
   "ignore:.*de421.bsp.*:ResourceWarning",
+  # Remove when netCDF4 supports NumPy >= 2.5 (in-place reshape deprecated)
+  "ignore:Setting the shape on a NumPy array.*:DeprecationWarning",
 ]
 markers = ["unit", "system", "regression"]
 testpaths = ["tests"]

--- a/src/eradiate/data/convert.py
+++ b/src/eradiate/data/convert.py
@@ -714,8 +714,12 @@ def libradtran_to_aer_core_v2(
     # --- Build union angular grid (across all components), at every
     # (w, reff) point, and interpolate onto it ---
     ntheta_np = ds["ntheta"].values.reshape(nw, nreff, nphamat)  # (nw, nreff, nphamat)
-    theta_np = ds["theta"].values.reshape(nw, nreff, nphamat, -1)  # (nw, nreff, nphamat, nthetamax)
-    phase_np = ds["phase"].values.reshape(nw, nreff, nphamat, -1)  # (nw, nreff, nphamat, nthetamax)
+    theta_np = ds["theta"].values.reshape(
+        nw, nreff, nphamat, -1
+    )  # (nw, nreff, nphamat, nthetamax)
+    phase_np = ds["phase"].values.reshape(
+        nw, nreff, nphamat, -1
+    )  # (nw, nreff, nphamat, nthetamax)
 
     union_mus: list[np.ndarray] = []
     union_phases: list[np.ndarray] = []  # each entry: (nphamat, n_union)
@@ -744,7 +748,9 @@ def libradtran_to_aer_core_v2(
             union_phases.append(phase_pt)
 
     # Build NaN-padded arrays, uniformly shaped (nw, nreff, ...)
-    nangles_out = np.array([len(m) for m in union_mus], dtype=np.int32).reshape(nw, nreff)  # (nw, nreff)
+    nangles_out = np.array([len(m) for m in union_mus], dtype=np.int32).reshape(
+        nw, nreff
+    )  # (nw, nreff)
 
     mu_arr = _pad_ragged(union_mus).reshape(nw, nreff, -1)  # (nw, nreff, nthetamax_out)
     phase_arr = np.stack(
@@ -754,7 +760,9 @@ def libradtran_to_aer_core_v2(
         ],
         axis=0,
     )  # (nphamat, nw, nreff, nthetamax_out)
-    theta_arr = np.rad2deg(np.arccos(mu_arr))  # (nw, nreff, nthetamax_out); NaN propagates
+    theta_arr = np.rad2deg(
+        np.arccos(mu_arr)
+    )  # (nw, nreff, nthetamax_out); NaN propagates
 
     # Copy Legendre coefficients (p_11 only), uniformly shaped (nw, nreff, nmommax)
     dims_order = ("nlam", "nreff", "nmommax") if has_reff else ("nlam", "nmommax")

--- a/src/eradiate/data/convert.py
+++ b/src/eradiate/data/convert.py
@@ -64,6 +64,8 @@ def make_aer_core_v2(
     ext: pint.Quantity,
     ssa: pint.Quantity,
     phase: pint.Quantity,
+    reff: pint.Quantity | None = None,
+    veff: pint.Quantity | None = None,
     nangles: np.ndarray | None = None,
     pmom: np.ndarray | None = None,
     nmom: int | np.ndarray | None = None,
@@ -73,7 +75,8 @@ def make_aer_core_v2(
     check: Literal["none", "fast", "full"] | None = None,
 ) -> xr.Dataset:
     """
-    Create a new dataset in the Aer-Core v2 format.
+    Create a new dataset in the Aer-Core v2 format, or the Prt v1 format
+    when ``reff``/``veff`` are provided.
 
     Parameters
     ----------
@@ -84,46 +87,54 @@ def make_aer_core_v2(
         Phase matrix component list, shape (nphamat,).
 
     mu : quantity
-        Scattering angle cosine, shape (nw, nangle).
+        Scattering angle cosine, shape (nw, [nreff, nveff, ]nangle).
 
     theta : quantity
-        Scattering angle, shape (nw, nangle).
+        Scattering angle, shape (nw, [nreff, nveff, ]nangle).
 
     ext : quantity
-        Extinction coefficient, shape (nw,).
+        Extinction coefficient, shape (nw, [nreff, nveff]).
 
     ssa : quantity
-        Single-scattering albedo, shape (nw,).
+        Single-scattering albedo, shape (nw, [nreff, nveff]).
 
     phase : quantity
-        Phase matrix values, shape (nphamat, nw, nangle).
+        Phase matrix values, shape (nphamat, nw, [nreff, nveff, ]nangle).
         Integral normalized to 2 (*i.e.* ∫ p(μ) dμ = 2).
 
+    reff, veff : quantity, optional
+        Effective radius and variance grids, shape (nreff,) and (nveff,),
+        each strictly increasing (need not be regularly spaced). When set,
+        the dataset is built in the Prt v1 format: all other arrays gain
+        the corresponding ``reff``/``veff`` dimensions, between ``w`` and
+        the angular/moment dimension. Both must be set together, or
+        neither.
+
     nangles : ndarray, optional
-        Number of valid angular samples per wavelength, shape (nw,), dtype int.
-        When provided, entries at indices ``>= nangles[iw]`` in ``mu``,
-        ``theta``, and ``phase`` must be NaN-padded.  The ``nangles`` dataset
-        variable is always written; if not provided, it is inferred by counting
-        non-NaN entries in the first phase matrix component.
+        Number of valid angular samples, shape (nw, [nreff, nveff]), dtype
+        int. When provided, entries beyond ``nangles`` in ``mu``, ``theta``,
+        and ``phase`` must be NaN-padded. The ``nangles`` dataset variable is
+        always written; if not provided, it is inferred by counting non-NaN
+        entries in the first phase matrix component.
 
     pmom : ndarray, optional
         Legendre polynomials for the (1,1) phase matrix element, shape
-        (nw, nimom).  If not provided, they are computed automatically from
-        ``phase`` and ``theta`` using :func:`.compute_pmom` with
-        ``coefficients=True``.
+        (nw, [nreff, nveff, ]nimom). If not provided, they are computed
+        automatically from ``phase`` and ``theta`` using
+        :func:`.compute_pmom` with ``coefficients=True``.
 
     nmom : int or ndarray, optional
-        Controls the number of Legendre polynomials.  The ``nmom`` dataset
+        Controls the number of Legendre polynomials. The ``nmom`` dataset
         variable is always written when ``pmom`` is present.
 
         * ``None`` (default) — when ``pmom`` is not provided, compute 129
           coefficients and store their count as a uniform ``nmom`` array;
-          when ``pmom`` is provided explicitly, infer per-wavelength counts
-          by counting non-NaN entries in the first phase matrix component,
-          consistent with the NaN-padding convention.
+          when ``pmom`` is provided explicitly, infer counts by counting
+          non-NaN entries in the first phase matrix component, consistent
+          with the NaN-padding convention.
         * ``int`` — scalar moment count; used as the target for automatic
           computation and stored as a uniform ``nmom`` array.
-        * ``ndarray`` shape ``(nw,)`` — per-wavelength count stored as-is.
+        * ``ndarray`` shape ``(nw, [nreff, nveff])`` — count stored as-is.
           ``pmom`` must be provided explicitly when ``nmom`` is an ndarray.
 
     grid_res : int, default: 3
@@ -146,13 +157,13 @@ def make_aer_core_v2(
 
         * ``None`` or ``"none"`` — no check (default).
         * ``"fast"`` — sampling-based check: validates a random 10 % of
-          wavelengths (at least one). Intended as a cheap guard during bulk
+          entries (at least one). Intended as a cheap guard during bulk
           production runs.
-        * ``"full"`` — validates every wavelength.
+        * ``"full"`` — validates every entry.
 
         A ``ValueError`` is raised if any sampled row is not strictly
         monotonically increasing in μ. Only the valid (non-NaN) portion of
-        each row is checked (bounded by ``nangles[iw]``).
+        each row is checked (bounded by ``nangles``).
 
     Returns
     -------
@@ -161,49 +172,63 @@ def make_aer_core_v2(
     Raises
     ------
     ValueError
-        If a value check fails, or if ``nmom`` is an ndarray but ``pmom`` is
-        not provided.
+        If a value check fails, if ``nmom`` is an ndarray but ``pmom`` is
+        not provided, if only one of ``reff``/``veff`` is provided, or if
+        ``reff``/``veff`` are not strictly increasing.
     """
+    if (reff is None) != (veff is None):
+        raise ValueError(
+            "make_aer_core_v2(): 'reff' and 'veff' must be provided together, "
+            "or not at all"
+        )
+    if reff is not None:
+        if len(reff.m) > 1 and np.any(np.diff(reff.m) <= 0):
+            raise ValueError("make_aer_core_v2(): 'reff' must be strictly increasing")
+        if len(veff.m) > 1 and np.any(np.diff(veff.m) <= 0):
+            raise ValueError("make_aer_core_v2(): 'veff' must be strictly increasing")
+    extra_dims = [] if reff is None else ["reff", "veff"]
+
     # nangles is always stored. Infer from the first phase matrix component when
-    # not provided: count non-NaN entries per wavelength.
+    # not provided: count non-NaN entries along the angular dimension.
     if nangles is None:
         nangles = _count_valid(phase.m[0])
 
     if check is not None and check != "none":
-        mu_vals = mu.m  # (nw, nangle)
-        nw_check = mu_vals.shape[0]
+        mu_vals = mu.m  # (nw, [nreff, nveff, ]nangle)
+        indices = list(np.ndindex(mu_vals.shape[:-1]))
 
         if check == "fast":
             rng = np.random.default_rng(seed=0)
-            n_sample = max(1, nw_check // 10)
-            iw_check = rng.choice(nw_check, size=n_sample, replace=False)
-        else:  # "full"
-            iw_check = np.arange(nw_check)
+            n_sample = max(1, len(indices) // 10)
+            indices = [
+                indices[i]
+                for i in rng.choice(len(indices), size=n_sample, replace=False)
+            ]
 
-        for iw in iw_check:
-            n = int(nangles[iw])
-            row = mu_vals[iw, :n]
+        for idx in indices:
+            n = int(nangles[idx])
+            row = mu_vals[idx][:n]
             if not np.all(np.diff(row) > 0):
                 raise ValueError(
                     f"make_aer_core_v2(): mu is not strictly ascending at "
-                    f"wavelength index {iw}. Sort the angular grid in ascending "
+                    f"index {idx}. Sort the angular grid in ascending "
                     "mu order before calling this function."
                 )
 
     if normalize:
-        phase_vals = phase.m.copy()  # (nphamat, nw, nangle)
-        mu_vals = mu.m  # (nw, nangle)
-        for iw in range(phase_vals.shape[1]):
-            n = int(nangles[iw])
-            mu_w = mu_vals[iw, :n]
-            p11_w = phase_vals[0, iw, :n]
-            integral = np.trapezoid(p11_w, mu_w)
+        phase_vals = phase.m.copy()  # (nphamat, nw, [nreff, nveff, ]nangle)
+        mu_vals = mu.m  # (nw, [nreff, nveff, ]nangle)
+        for idx in np.ndindex(mu_vals.shape[:-1]):
+            n = int(nangles[idx])
+            mu_pt = mu_vals[idx][:n]
+            phase_pt = phase_vals[(slice(None), *idx)]  # (nphamat, nangle)
+            integral = np.trapezoid(phase_pt[0, :n], mu_pt)
             if integral == 0.0:
                 raise ValueError(
-                    f"make_aer_core_v2(): p11 integrates to 0 at wavelength "
-                    f"index {iw}; cannot normalize."
+                    f"make_aer_core_v2(): p11 integrates to 0 at index "
+                    f"{idx}; cannot normalize."
                 )
-            phase_vals[:, iw, :n] *= 2.0 / integral
+            phase_pt[:, :n] *= 2.0 / integral
         phase = phase_vals * phase.u
 
     if pmom is None:
@@ -221,38 +246,38 @@ def make_aer_core_v2(
         # Compute pmom for p_11 (index 0) only.
         # mu in the dataset is ascending (-1 → +1), so theta is descending
         # (180° → 0°). compute_pmom() expects theta ascending (0° → 180°),
-        # so we reverse each per-wavelength slice.
-        theta_deg = theta.to("deg").magnitude  # (nw, nangle)
-        phase_vals = phase.m  # (nphamat, nw, nangle)
-        _nw = theta_deg.shape[0]
+        # so we reverse each slice.
+        theta_deg = theta.to("deg").magnitude  # (nw, [nreff, nveff, ]nangle)
+        phase_vals = phase.m  # (nphamat, nw, [nreff, nveff, ]nangle)
+        leading_shape = theta_deg.shape[:-1]
 
-        pmom = np.zeros((_nw, _nmom_scalar))
-        for iw in range(_nw):
-            n = int(nangles[iw])
-            theta_w = theta_deg[iw, :n][::-1]  # ascending 0° → 180°
-            phase_w = phase_vals[0, iw, :n][::-1]  # p_11 component
-            pmom[iw, :] = _compute_pmom(
-                theta_w,
-                phase_w,
+        pmom = np.zeros(leading_shape + (_nmom_scalar,))
+        for idx in np.ndindex(leading_shape):
+            n = int(nangles[idx])
+            theta_pt = theta_deg[idx][:n][::-1]  # ascending 0° → 180°
+            phase_pt = phase_vals[(0, *idx)][:n][::-1]  # p_11 component
+            pmom[idx] = _compute_pmom(
+                theta_pt,
+                phase_pt,
                 nmom=_nmom_scalar,
                 grid_res=grid_res,
                 coefficients=True,
                 check_normalization=True,
             )
-        nmom = np.full(_nw, _nmom_scalar, dtype=np.int32)
+        nmom = np.full(leading_shape, _nmom_scalar, dtype=np.int32)
 
     # nmom is always stored alongside pmom.
-    # Normalize any remaining scalar or inferred form to a per-wavelength array.
+    # Normalize any remaining scalar or inferred form to a per-entry array.
     if nmom is None:
-        # pmom was provided explicitly without nmom: count non-NaN entries per
-        # wavelength, consistent with the NaN-padding convention.
+        # pmom was provided explicitly without nmom: count non-NaN entries,
+        # consistent with the NaN-padding convention.
         nmom = _count_valid(pmom)
     elif isinstance(nmom, int):
-        nmom = np.full(len(w.m), nmom, dtype=np.int32)
+        nmom = np.full(np.shape(nangles), nmom, dtype=np.int32)
 
     data_vars = {
         "ext": (
-            "w",
+            ["w", *extra_dims],
             ext.m,
             {
                 "standard_name": "extinction_coefficient",
@@ -261,7 +286,7 @@ def make_aer_core_v2(
             },
         ),
         "ssa": (
-            "w",
+            ["w", *extra_dims],
             ssa.m,
             {
                 "standard_name": "single_scattering_albedo",
@@ -270,7 +295,7 @@ def make_aer_core_v2(
             },
         ),
         "phase": (
-            ["phamat", "w", "iangle"],
+            ["phamat", "w", *extra_dims, "iangle"],
             phase.m,
             {
                 "standard_name": "phase_matrix",
@@ -282,7 +307,7 @@ def make_aer_core_v2(
     }
 
     data_vars["nangles"] = (
-        "w",
+        ["w", *extra_dims],
         nangles,
         {
             "standard_name": "n_angular_samples",
@@ -291,7 +316,7 @@ def make_aer_core_v2(
     )
 
     data_vars["nmom"] = (
-        "w",
+        ["w", *extra_dims],
         nmom,
         {
             "standard_name": "n_legendre_polys",
@@ -300,7 +325,7 @@ def make_aer_core_v2(
     )
 
     data_vars["pmom"] = (
-        ["w", "imom"],
+        ["w", *extra_dims, "imom"],
         pmom,
         {
             "standard_name": "legendre_polys",
@@ -328,7 +353,7 @@ def make_aer_core_v2(
             },
         ),
         "mu": (
-            ["w", "iangle"],
+            ["w", *extra_dims, "iangle"],
             mu.m,
             {
                 "standard_name": "cos_scattering_angle",
@@ -337,7 +362,7 @@ def make_aer_core_v2(
             },
         ),
         "theta": (
-            ["w", "iangle"],
+            ["w", *extra_dims, "iangle"],
             theta.m,
             {
                 "standard_name": "scattering_angle",
@@ -347,7 +372,116 @@ def make_aer_core_v2(
         ),
     }
 
+    if reff is not None:
+        coords["reff"] = (
+            "reff",
+            reff.m,
+            {
+                "standard_name": "effective_radius",
+                "long_name": "effective radius",
+                "units": symbol(reff.u),
+            },
+        )
+        coords["veff"] = (
+            "veff",
+            veff.m,
+            {
+                "standard_name": "effective_variance",
+                "long_name": "effective variance",
+                "units": symbol(veff.u),
+            },
+        )
+
     return xr.Dataset(data_vars=data_vars, coords=coords, attrs=attrs or {})
+
+
+def _shared_attrs(datasets: list[xr.Dataset]) -> dict:
+    """Attrs common to all *datasets*, by key and value; the rest are dropped."""
+    ref_attrs = datasets[0].attrs
+    return {
+        key: value
+        for key, value in ref_attrs.items()
+        if all(ds.attrs.get(key, ref_attrs) == value for ds in datasets[1:])
+    }
+
+
+def concat_particles_veff(datasets: list[xr.Dataset]) -> xr.Dataset:
+    """
+    Concatenate several Prt v1 datasets along the ``veff`` dimension.
+
+    Parameters
+    ----------
+    datasets : list of xr.Dataset
+        Prt v1 datasets (as produced by :func:`make_aer_core_v2` with
+        ``reff``/``veff`` set), each with a ``reff``/``veff``-dimensioned
+        layout. Every dataset may cover one or several ``veff`` values. All
+        datasets must share the same ``w``, ``reff``, and ``phamat``
+        coordinates.
+
+    Returns
+    -------
+    xr.Dataset
+        Prt v1 dataset with a ``veff`` dimension spanning the concatenation
+        of all input datasets' ``veff`` values. ``iangle``/``imom`` are
+        padded to the largest size found across inputs. Only attrs common
+        to all input datasets are retained.
+
+    Raises
+    ------
+    ValueError
+        If the datasets do not share the same ``w``, ``reff``, or ``phamat``
+        coordinates.
+    """
+    ref = datasets[0]
+
+    for ds in datasets[1:]:
+        if not np.array_equal(ds["w"].values, ref["w"].values):
+            raise ValueError("All datasets must share the same 'w' coordinate.")
+        if not np.array_equal(ds["reff"].values, ref["reff"].values):
+            raise ValueError("All datasets must share the same 'reff' coordinate.")
+        if not np.array_equal(ds["phamat"].values, ref["phamat"].values):
+            raise ValueError("All datasets must share the same 'phamat' coordinate.")
+
+    n_iangle = max(ds.sizes["iangle"] for ds in datasets)
+    n_imom = max(ds.sizes["imom"] for ds in datasets)
+
+    def pad_last(a: np.ndarray, n: int) -> np.ndarray:
+        pad_width = [(0, 0)] * (a.ndim - 1) + [(0, n - a.shape[-1])]
+        return np.pad(a, pad_width, mode="constant", constant_values=np.nan)
+
+    mu = np.concatenate(
+        [pad_last(ds["mu"].values, n_iangle) for ds in datasets], axis=2
+    )
+    theta = np.concatenate(
+        [pad_last(ds["theta"].values, n_iangle) for ds in datasets], axis=2
+    )
+    phase = np.concatenate(
+        [pad_last(ds["phase"].values, n_iangle) for ds in datasets], axis=3
+    )
+    pmom = np.concatenate(
+        [pad_last(ds["pmom"].values, n_imom) for ds in datasets], axis=2
+    )
+    ext = np.concatenate([ds["ext"].values for ds in datasets], axis=2)
+    ssa = np.concatenate([ds["ssa"].values for ds in datasets], axis=2)
+    nangles = np.concatenate([ds["nangles"].values for ds in datasets], axis=2)
+    nmom = np.concatenate([ds["nmom"].values for ds in datasets], axis=2)
+    veff = np.concatenate([ds["veff"].values for ds in datasets])
+
+    return make_aer_core_v2(
+        w=to_quantity(ref["w"]),
+        phamat=list(ref["phamat"].values),
+        mu=mu * ureg(ref["mu"].attrs["units"]),
+        theta=theta * ureg(ref["theta"].attrs["units"]),
+        ext=ext * ureg(ref["ext"].attrs["units"]),
+        ssa=ssa * ureg(ref["ssa"].attrs["units"]),
+        phase=phase * ureg(ref["phase"].attrs["units"]),
+        reff=to_quantity(ref["reff"]),
+        veff=veff * ureg(ref["veff"].attrs["units"]),
+        nangles=nangles,
+        pmom=pmom,
+        nmom=nmom,
+        attrs=_shared_attrs(datasets),
+    )
 
 
 def aer_v1_to_aer_core_v2(
@@ -491,16 +625,19 @@ def libradtran_to_aer_core_v2(
     fallback_units: dict[str, str] | None = None,
     normalize: bool = False,
     check: Literal["none", "fast", "full"] = "full",
+    veff: float | None = None,
 ) -> xr.Dataset:
     """
-    Convert a dataset in the libRadtran scattering particle property format to
-    the :ref:`Aer-Core v2 <sec-data-formats-aer_core_v2>` format.
+    Convert a libRadtran scattering particle property dataset to Aer-Core v2,
+    or to Prt v1 when ``ds`` varies over ``reff``.
 
     Parameters
     ----------
     ds : Dataset
-        A dataset in the libRadtran format. No additional dimensions such as the
-        effective radius or humidity are considered.
+        A dataset in the libRadtran format. The function checks whether
+        ``ds`` has a ``reff`` dimension to decide which target format to
+        produce. When there is no ``reff`` dimension, ``ds`` is treated as a
+        single point and the result is Aer-Core v2.
 
     attrs : dict, optional
         Additional metadata applied to the converted dataset.
@@ -517,6 +654,12 @@ def libradtran_to_aer_core_v2(
     check : {"none", "fast", "full"}, default: "full"
         Apply validation checks to the output.
 
+    veff : float, optional
+        The effective variance used to build Prt v1 output. When ``ds`` has
+        a ``reff`` dimension and ``veff`` is not given, it defaults to
+        ``1 / (param_alpha + 3)``, the standard gamma-distribution relation,
+        computed from ``ds.attrs["param_alpha"]``.
+
     Returns
     -------
     xr.Dataset
@@ -528,7 +671,8 @@ def libradtran_to_aer_core_v2(
       for a different one for each coefficient. The angular grid of the output
       dataset is constructed as the union of the libRadtran grids for all
       coefficients; all coefficients are then interpolated linearly in μ space
-      on the angular points that were missing for them.
+      on the angular points that were missing for them. The same construction
+      applies independently at each ``reff`` point for Prt v1 output.
     """
     PHAMAT_TO_IDX = [
         # Coefficients for spherical particles
@@ -541,69 +685,114 @@ def libradtran_to_aer_core_v2(
         ("44", 5),
     ]
 
+    has_reff = "nreff" in ds.sizes
+
     # Gather wavelengths
-    units = _get_units(ds, "wavelen", fallback_units)
-    w = ds["wavelen"].values * units
+    units_w = _get_units(ds, "wavelen", fallback_units)
+    w = ds["wavelen"].values * units_w
     nw = len(w)
+    nreff = ds.sizes["nreff"] if has_reff else 1  # 1 when `ds` has no reff dimension
+
+    reff = None
+    if has_reff:
+        reff = ds["reff"].values * _get_units(ds, "reff", fallback_units)  # (nreff,)
+        if veff is None:
+            veff = 1.0 / (float(ds.attrs["param_alpha"]) + 3.0)
 
     # Gather extinction coefficients
-    units = _get_units(ds, "ext", fallback_units)
-    ext = ds["ext"].values * units
+    units_ext = _get_units(ds, "ext", fallback_units)
+    ext_np = ds["ext"].values.reshape(nw, nreff)  # (nw, nreff)
 
     # Gather albedo
-    units = _get_units(ds, "ssa", fallback_units)
-    ssa = ds["ssa"].values * units
+    units_ssa = _get_units(ds, "ssa", fallback_units)
+    ssa_np = ds["ssa"].values.reshape(nw, nreff)  # (nw, nreff)
 
     # Process phase function entries
     nphamat = ds.sizes["nphamat"]
     phamat = [x for x, _ in PHAMAT_TO_IDX[:nphamat]]
 
-    # --- Build union angular grid (across all components) and interpolate onto it ---
-    ntheta_np = ds["ntheta"].values  # (nw, nphamat)
-    theta_np = ds["theta"].values  # (nw, nphamat, nthetamax)
-    phase_np = ds["phase"].values  # (nw, nphamat, nthetamax)
+    # --- Build union angular grid (across all components), at every
+    # (w, reff) point, and interpolate onto it ---
+    ntheta_np = ds["ntheta"].values.reshape(nw, nreff, nphamat)  # (nw, nreff, nphamat)
+    theta_np = ds["theta"].values.reshape(nw, nreff, nphamat, -1)  # (nw, nreff, nphamat, nthetamax)
+    phase_np = ds["phase"].values.reshape(nw, nreff, nphamat, -1)  # (nw, nreff, nphamat, nthetamax)
 
     union_mus: list[np.ndarray] = []
     union_phases: list[np.ndarray] = []  # each entry: (nphamat, n_union)
 
     for iw in range(nw):
-        # Collect per-component (mu, phase), then build the union grid in one pass.
-        comp_data: list[tuple[np.ndarray, np.ndarray]] = []
-        for i_pm in range(nphamat):
-            n = int(ntheta_np[iw, i_pm])
-            comp_mu = np.cos(np.deg2rad(theta_np[iw, i_pm, :n]))
-            comp_data.append((comp_mu, phase_np[iw, i_pm, :n]))
+        for ir in range(nreff):
+            # Collect per-component (mu, phase), then build the union grid in one pass.
+            comp_data: list[tuple[np.ndarray, np.ndarray]] = []
+            for i_pm in range(nphamat):
+                n = int(ntheta_np[iw, ir, i_pm])
+                comp_mu = np.cos(np.deg2rad(theta_np[iw, ir, i_pm, :n]))
+                comp_data.append((comp_mu, phase_np[iw, ir, i_pm, :n]))
 
-        # np.unique returns sorted, unique values (ascending); clip for
-        # floating-point safety.
-        mu_union = np.unique(np.concatenate([mu for mu, _ in comp_data]))
-        mu_union = np.clip(mu_union, -1.0, 1.0)
+            # np.unique returns sorted, unique values (ascending); clip for
+            # floating-point safety.
+            mu_union = np.unique(np.concatenate([mu for mu, _ in comp_data]))
+            mu_union = np.clip(mu_union, -1.0, 1.0)
 
-        # Interpolate each component onto the union mu grid
-        phase_iw = np.empty((nphamat, len(mu_union)))
-        for i_pm, (comp_mu, phase_) in enumerate(comp_data):
-            idx = np.argsort(comp_mu)
-            phase_iw[i_pm] = np.interp(mu_union, comp_mu[idx], phase_[idx])
+            # Interpolate each component onto the union mu grid
+            phase_pt = np.empty((nphamat, len(mu_union)))  # (nphamat, n_union)
+            for i_pm, (comp_mu, phase_) in enumerate(comp_data):
+                idx = np.argsort(comp_mu)
+                phase_pt[i_pm] = np.interp(mu_union, comp_mu[idx], phase_[idx])
 
-        union_mus.append(mu_union)
-        union_phases.append(phase_iw)
+            union_mus.append(mu_union)
+            union_phases.append(phase_pt)
 
-    # Build NaN-padded 2-D arrays
-    nangles_out = np.array([len(m) for m in union_mus], dtype=np.int32)
+    # Build NaN-padded arrays, uniformly shaped (nw, nreff, ...)
+    nangles_out = np.array([len(m) for m in union_mus], dtype=np.int32).reshape(nw, nreff)  # (nw, nreff)
 
-    mu_arr = _pad_ragged(union_mus)  # (nw, nthetamax_out)
-    phase_arr = np.full((nphamat, nw, mu_arr.shape[1]), np.nan)
-    for iw in range(nw):
-        n_ = nangles_out[iw]
-        phase_arr[:, iw, :n_] = union_phases[iw]
+    mu_arr = _pad_ragged(union_mus).reshape(nw, nreff, -1)  # (nw, nreff, nthetamax_out)
+    phase_arr = np.stack(
+        [
+            _pad_ragged([pt[i_pm] for pt in union_phases]).reshape(nw, nreff, -1)
+            for i_pm in range(nphamat)
+        ],
+        axis=0,
+    )  # (nphamat, nw, nreff, nthetamax_out)
+    theta_arr = np.rad2deg(np.arccos(mu_arr))  # (nw, nreff, nthetamax_out); NaN propagates
+
+    # Copy Legendre coefficients (p_11 only), uniformly shaped (nw, nreff, nmommax)
+    dims_order = ("nlam", "nreff", "nmommax") if has_reff else ("nlam", "nmommax")
+    pmom = ds["pmom"].isel(nphamat=0).transpose(*dims_order).values
+    if not has_reff:
+        pmom = pmom[:, np.newaxis, :]  # (nw, nreff, nmommax)
+    nmom = _count_valid(pmom)  # (nw, nreff)
+
+    if has_reff:
+        # Insert the (size-1) veff axis, between reff and the angular/moment
+        # dimension, matching make_aer_core_v2()'s (nw, nreff, nveff, ...) layout.
+        mu_arr = mu_arr[:, :, np.newaxis, :]
+        theta_arr = theta_arr[:, :, np.newaxis, :]
+        phase_arr = phase_arr[:, :, :, np.newaxis, :]
+        ext_np = ext_np[:, :, np.newaxis]
+        ssa_np = ssa_np[:, :, np.newaxis]
+        nangles_out = nangles_out[:, :, np.newaxis]
+        pmom = pmom[:, :, np.newaxis, :]
+        nmom = nmom[:, :, np.newaxis]
+        veff_arg = np.atleast_1d(veff) * ureg.dimensionless
+    else:
+        # No reff dimension in the input: squeeze the dummy reff axis back
+        # out, matching the plain (nw, ...) Aer-Core v2 shapes.
+        mu_arr = mu_arr[:, 0, :]
+        theta_arr = theta_arr[:, 0, :]
+        phase_arr = phase_arr[:, :, 0, :]
+        ext_np = ext_np[:, 0]
+        ssa_np = ssa_np[:, 0]
+        nangles_out = nangles_out[:, 0]
+        pmom = pmom[:, 0, :]
+        nmom = nmom[:, 0]
+        veff_arg = None
 
     mu = mu_arr * ureg("dimensionless")
     phase = phase_arr * ureg("1 / sr")
-    theta = np.rad2deg(np.arccos(mu_arr)) * ureg("deg")  # NaN propagates
-
-    # Copy Legendre coefficients (p_11 only)
-    pmom = ds["pmom"].isel(nphamat=0).transpose("nlam", "nmommax").values
-    nmom = _count_valid(pmom)
+    theta = theta_arr * ureg("deg")
+    ext = ext_np * units_ext
+    ssa = ssa_np * units_ssa
 
     # Add metadata
     attrs = attrs or ds.attrs
@@ -619,6 +808,8 @@ def libradtran_to_aer_core_v2(
         nmom=nmom,
         pmom=pmom,
         nangles=nangles_out,
+        reff=reff,
+        veff=veff_arg,
         attrs=attrs,
         normalize=normalize,
         check=check,

--- a/src/eradiate/radprops/_particles.py
+++ b/src/eradiate/radprops/_particles.py
@@ -13,19 +13,11 @@ from axsdb.math import interp1d
 
 from .. import converters
 from ..attrs import define, documented
+from ..data.convert import make_aer_core_v2
 from ..units import to_quantity
 from ..units import unit_context_config as ucc
 from ..units import unit_registry as ureg
 from ..util.misc import summary_repr
-
-
-def _validate_shape(value: Any) -> str:
-    valid = {"spherical", "spheroidal"}
-    if value not in valid:
-        raise ValueError(
-            f"Unrecognized particle shape {value!r} (valid values are {valid})."
-        )
-    return value
 
 
 # TODO: If _rdp1d_log becomes a performance bottleneck (e.g. with grids up to
@@ -105,7 +97,7 @@ def _rdp1d_log(mu: np.ndarray, values: np.ndarray, n_out: int) -> np.ndarray:
     heap = [(-err, 0, n - 1, best)]
 
     while count < n_out and heap:
-        neg_err, i_l, i_r, mid = heapq.heappop(heap)
+        _neg_err, i_l, i_r, mid = heapq.heappop(heap)
         if selected[mid]:
             # Stale entry: mid was already inserted via another segment; skip.
             continue
@@ -221,6 +213,12 @@ class ParticleProperties:
     _particle_shape: str | None = attrs.field(default=None, init=False, repr=True)
     # -- Fixed mu grid flag
     _has_fixed_mu_grid: bool | None = attrs.field(default=None, init=False, repr=False)
+    # -- Effective radius (size-distribution datasets only)
+    _reff: pint.Quantity | None = attrs.field(default=None, init=False, repr=False)
+    # -- Effective variance (size-distribution datasets only)
+    _veff: pint.Quantity | None = attrs.field(default=None, init=False, repr=False)
+    # -- Worst-case eval_phase_union() flat size across adjacent wavelength pairs
+    _max_union_size: int | None = attrs.field(default=None, init=False, repr=False)
 
     def __attrs_post_init__(self):
         # Resolve all cached attributes
@@ -234,6 +232,8 @@ class ParticleProperties:
             "pmom",
             "particle_shape",
             "has_fixed_mu_grid",
+            "reff",
+            "veff",
         ]:
             getattr(self, attr)
 
@@ -282,6 +282,47 @@ class ParticleProperties:
         raise TypeError(
             f"could not convert value of type {type(value).__name__} to ParticleProperties"
         )
+
+    @property
+    def has_size_distribution(self) -> bool:
+        """
+        Returns
+        -------
+        bool
+            ``True`` iff ``data`` has ``reff``/``veff`` dimensions (Prt
+            v1 format), ``False`` for a plain Aer-Core v2 dataset.
+        """
+        return "reff" in self.data.dims and "veff" in self.data.dims
+
+    @property
+    def reff(self) -> pint.Quantity | None:
+        """
+        Returns
+        -------
+        pint.Quantity or None
+            Effective radius grid, cached to minimize overhead. ``None`` if
+            :attr:`has_size_distribution` is ``False``.
+        """
+        if self._reff is None:
+            if not self.has_size_distribution:
+                return None
+            self._reff = to_quantity(self.data["reff"])
+        return self._reff
+
+    @property
+    def veff(self) -> pint.Quantity | None:
+        """
+        Returns
+        -------
+        pint.Quantity or None
+            Effective variance grid, cached to minimize overhead. ``None`` if
+            :attr:`has_size_distribution` is ``False``.
+        """
+        if self._veff is None:
+            if not self.has_size_distribution:
+                return None
+            self._veff = to_quantity(self.data["veff"])
+        return self._veff
 
     @property
     def w(self) -> pint.Quantity:
@@ -353,7 +394,7 @@ class ParticleProperties:
             layout during interpolation, cached to minimize overhead.
         """
         if self._phase is None:
-            self._phase = self.data["phase"].transpose("phamat", "iangle", "w")
+            self._phase = self.data["phase"].transpose("phamat", "iangle", "w", ...)
         return self._phase
 
     @property
@@ -368,7 +409,7 @@ class ParticleProperties:
             if "pmom" not in self.data:
                 return None
             else:
-                self._pmom = self.data["pmom"].transpose("imom", "w")
+                self._pmom = self.data["pmom"].transpose("imom", "w", ...)
 
         return self._pmom
 
@@ -413,16 +454,50 @@ class ParticleProperties:
             preserving the original grid exactly.
         """
         if self._has_fixed_mu_grid is None:
-            ds = self.data
-            nangles = ds["nangles"].values
-            n_iangle = ds.sizes["iangle"]
-            all_full = bool(np.all(nangles == n_iangle))
-            all_same = all_full and bool(
-                np.all(ds["mu"].values == ds["mu"].values[[0]])
-            )
-            self._has_fixed_mu_grid = all_same
+            self._has_fixed_mu_grid = self._has_fixed_mu_grid_at()
 
         return self._has_fixed_mu_grid
+
+    def _has_fixed_mu_grid_at(
+        self, reff_idx: int | None = None, veff_idx: int | None = None
+    ) -> bool:
+        """
+        Check whether all wavelengths share an identical angular grid (same
+        ``nangles`` and ``mu`` values), optionally restricted to a single
+        ``(reff, veff)`` grid point.
+
+        Parameters
+        ----------
+        reff_idx, veff_idx : int, optional
+            If given, restrict the check to this ``(reff, veff)`` grid point.
+
+        Returns
+        -------
+        bool
+            ``True`` iff all wavelengths share an identical mu grid.
+        """
+        ds = self.data
+        n_iangle = ds.sizes["iangle"]
+
+        if reff_idx is None:
+            nangles = ds["nangles"].values
+            mu_vals = ds["mu"].values
+        else:
+            nangles = ds["nangles"].values[:, reff_idx, veff_idx]
+            mu_vals = ds["mu"].values[:, reff_idx, veff_idx, :]
+
+        all_full = bool(np.all(nangles == n_iangle))
+        return all_full and bool(np.all(mu_vals == mu_vals[[0]]))
+
+    @staticmethod
+    def _broadcast_t(t: np.ndarray, reference: np.ndarray) -> np.ndarray:
+        """
+        Reshape a per-wavelength interpolation weight ``t`` (shape ``(nw,)``)
+        so that it broadcasts against ``reference`` (shape ``(nw, ...)``)
+        along its leading axis, instead of numpy's default trailing-axis
+        alignment.
+        """
+        return t.reshape(t.shape + (1,) * (reference.ndim - t.ndim))
 
     def eval_ext(self, w: pint.Quantity) -> pint.Quantity:
         """
@@ -437,9 +512,15 @@ class ParticleProperties:
         Returns
         -------
         quantity
-            Extinction coefficient, same shape as ``w``.
+            Extinction coefficient. Shape ``(nw,)`` if ``data`` has no
+            ``reff``/``veff`` dimensions, ``(nw, nreff, nveff)`` otherwise.
         """
-        return np.interp(w, self.w, self.ext)
+        idx_l, idx_r, t = self._locate(w)
+        ext = self.ext.m
+        ext_l, ext_r = ext[idx_l], ext[idx_r]
+        t = self._broadcast_t(t, ext_l)
+        ext_interp = (1.0 - t) * ext_l + t * ext_r
+        return ext_interp * self.ext.units
 
     def eval_ssa(self, w: pint.Quantity) -> pint.Quantity:
         """
@@ -453,7 +534,8 @@ class ParticleProperties:
         Returns
         -------
         quantity
-            Dimensionless SSA, same shape as ``w``.
+            Dimensionless SSA. Shape ``(nw,)`` if ``data`` has no
+            ``reff``/``veff`` dimensions, ``(nw, nreff, nveff)`` otherwise.
 
         Notes
         -----
@@ -472,6 +554,7 @@ class ParticleProperties:
         ssa = self.ssa.m
         ext_l, ext_r = ext[idx_l], ext[idx_r]
         ssa_l, ssa_r = ssa[idx_l], ssa[idx_r]
+        t = self._broadcast_t(t, ext_l)
         ext_interp = (1.0 - t) * ext_l + t * ext_r
         linear = (1.0 - t) * ssa_l + t * ssa_r
         weighted = ((1.0 - t) * ext_l * ssa_l + t * ext_r * ssa_r) / np.where(
@@ -480,30 +563,48 @@ class ParticleProperties:
         ssa_interp = np.where(ext_interp == 0.0, linear, weighted)
         return ssa_interp * ureg.dimensionless
 
-    def _get_mu_phase(self, w_idx: int) -> tuple[np.ndarray, np.ndarray]:
+    def _get_mu_phase(
+        self,
+        w_idx: int,
+        reff_idx: int | None = None,
+        veff_idx: int | None = None,
+    ) -> tuple[np.ndarray, np.ndarray]:
         """
-        Extract the valid mu grid and phase values for a single wavelength index.
+        Extract the valid mu grid and phase values for a single wavelength
+        index, optionally at a single ``(reff, veff)`` grid point.
 
-        Strips NaN-padding using ``nangles[w_idx]``.
+        Strips NaN-padding using ``nangles``.
 
         Parameters
         ----------
         w_idx : int
             Index along the ``w`` dimension.
 
+        reff_idx, veff_idx : int, optional
+            Index along the ``reff``/``veff`` dimensions. Both must be set
+            iff ``data`` has ``reff``/``veff`` dimensions.
+
         Returns
         -------
         mu : ndarray
-            Scattering angle cosines, shape ``(nangles[w_idx],)``.
+            Scattering angle cosines, shape ``(nangles,)``.
 
         phase : ndarray
-            Phase values, shape ``(n_phamat, nangles[w_idx])``.
+            Phase values, shape ``(n_phamat, nangles)``.
         """
         ds = self.data
-        nangles = int(ds["nangles"].values[w_idx])
-        mu = ds["mu"].values[w_idx, :nangles]
-        # phase is cached as (phamat, iangle, w)
-        phase = self.phase.values[:, :nangles, w_idx]  # (n_phamat, nangles)
+
+        if reff_idx is None:
+            nangles = int(ds["nangles"].values[w_idx])
+            mu = ds["mu"].values[w_idx, :nangles]
+            # phase is cached as (phamat, iangle, w)
+            phase = self.phase.values[:, :nangles, w_idx]  # (n_phamat, nangles)
+        else:
+            nangles = int(ds["nangles"].values[w_idx, reff_idx, veff_idx])
+            mu = ds["mu"].values[w_idx, reff_idx, veff_idx, :nangles]
+            # phase is cached as (phamat, iangle, w, reff, veff)
+            phase = self.phase.values[:, :nangles, w_idx, reff_idx, veff_idx]
+
         return mu, phase
 
     def _locate(self, w: pint.Quantity) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
@@ -540,6 +641,7 @@ class ParticleProperties:
         idx_l = idx_r - 1
         w_l, w_r = w_arr[idx_l], w_arr[idx_r]
         t = np.where(w_l == w_r, 0.0, (w_m - w_l) / (w_r - w_l))
+        t = np.clip(t, 0.0, 1.0)
         return idx_l, idx_r, t
 
     def _bracket_and_weights(
@@ -587,6 +689,7 @@ class ParticleProperties:
         scat_arr = self.scat.m
         scat_l = scat_arr[idx_l]
         scat_r = scat_arr[idx_r]
+        t = self._broadcast_t(t, scat_l)
         scat_denom = (1.0 - t) * scat_l + t * scat_r
 
         safe_denom = np.where(scat_denom == 0.0, 1.0, scat_denom)
@@ -595,17 +698,131 @@ class ParticleProperties:
 
         return idx_l, idx_r, w0, w1, scat_denom
 
-    def eval_phase(
-        self, w: pint.Quantity, n_mu: int | None = None
+    @property
+    def max_union_size(self) -> int:
+        """
+        Returns
+        -------
+        int
+            Upper bound on :meth:`eval_phase_union`'s ``total_pts`` across
+            all adjacent wavelength pairs in :attr:`w`.
+        """
+        if self._max_union_size is None:
+            w_arr = self.w
+
+            if len(w_arr) <= 1:
+                bracket_points = w_arr
+            else:
+                bracket_points = 0.5 * (w_arr[:-1] + w_arr[1:])
+
+            lens = [
+                int((~np.isnan(self.eval_phase_union(w)[0])).sum())
+                for w in bracket_points
+            ]
+            self._max_union_size = max(lens)
+
+        return self._max_union_size
+
+    def eval_phase_union(
+        self, w: pint.Quantity
     ) -> tuple[np.ndarray, np.ndarray]:
         """
-        Evaluate the phase function at wavelength ``w`` by interpolation.
+        Evaluate the phase function at a single wavelength for every native
+        ``(reff, veff)`` grid point, keeping each point's own union of its
+        two bracketing wavelengths' mu grids as-is. Every point is NaN-padded
+        to the widest point's length.
 
         Parameters
         ----------
         w : quantity
-            Query wavelength (scalar only; array input raises ``ValueError``
-            because each wavelength can have a different angular grid).
+            Query wavelength (scalar).
+
+        Returns
+        -------
+        mu : ndarray
+            Scattering angle cosines, shape ``(n_reff * n_veff, max_len)``
+            (or ``(1, max_len)`` if ``data`` has no ``reff``/``veff``
+            dimensions), row-major ``(reff, veff)`` order. NaN past a
+            point's own native length.
+
+        phase : ndarray
+            Phase function values in sr⁻¹, shape
+            ``(n_reff * n_veff, n_phamat, max_len)`` (or
+            ``(1, n_phamat, max_len)``), NaN-padded like ``mu``.
+        """
+        w_arr = np.atleast_1d(w)
+        if w_arr.size != 1:
+            raise ValueError("eval_phase_union() only accepts a scalar wavelength")
+
+        idx_l_arr, idx_r_arr, w0_arr, w1_arr, _ = self._bracket_and_weights(w_arr)
+        idx_l = int(idx_l_arr[0])
+        idx_r = int(idx_r_arr[0])
+
+        if self.has_size_distribution:
+            n_reff = self.data.sizes["reff"]
+            n_veff = self.data.sizes["veff"]
+            w0_grid = w0_arr[0]  # (n_reff, n_veff)
+            w1_grid = w1_arr[0]
+            points = [
+                (ireff, iveff)
+                for ireff in range(n_reff)
+                for iveff in range(n_veff)
+            ]
+
+            def weight_at(ireff, iveff):
+                return float(w0_grid[ireff, iveff]), float(w1_grid[ireff, iveff])
+
+        else:
+            w0_scalar = float(w0_arr[0])
+            w1_scalar = float(w1_arr[0])
+            points = [(None, None)]
+
+            def weight_at(ireff, iveff):
+                return w0_scalar, w1_scalar
+
+        mu_list: list[np.ndarray] = []
+        phase_list: list[np.ndarray] = []
+
+        for ireff, iveff in points:
+            mu1, phase1 = self._get_mu_phase(idx_l, ireff, iveff)
+            mu2, phase2 = self._get_mu_phase(idx_r, ireff, iveff)
+
+            mu_union = np.union1d(mu1, mu2)
+            phase1_union = interp1d(mu1, phase1, mu_union, bounds="clamp")
+            phase2_union = interp1d(mu2, phase2, mu_union, bounds="clamp")
+
+            w0_pt, w1_pt = weight_at(ireff, iveff)
+            phase_union = w0_pt * phase1_union + w1_pt * phase2_union
+
+            mu_list.append(mu_union)
+            phase_list.append(phase_union)
+
+        grid_len = np.array([len(m) for m in mu_list], dtype=np.uint32)
+        max_len = int(grid_len.max())
+
+        mu_pad = np.asarray([
+            np.concatenate([m, np.full(max_len - n, np.nan)])
+            for m, n in zip(mu_list, grid_len)
+        ])
+        phase_pad = np.asarray([
+            np.concatenate([ph, np.full((ph.shape[0], max_len - n), np.nan)], axis=1)
+            for ph, n in zip(phase_list, grid_len)
+        ])
+
+        return mu_pad, phase_pad
+
+    def eval_phase(
+        self, w: pint.Quantity, n_mu: int | None = None
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """
+        Evaluate the phase function at wavelength(s) ``w`` by interpolation.
+
+        Parameters
+        ----------
+        w : quantity
+            Query wavelength(s); scalar or array. Each wavelength is
+            interpolated independently, since it may have a different
+            bracketing pair and thus a different union mu grid.
 
         n_mu : int, optional
             Number of output mu points. Defaults to ``2 * n_iangle``, where
@@ -617,10 +834,12 @@ class ParticleProperties:
         Returns
         -------
         mu : ndarray
-            Scattering angle cosines of the output grid, shape ``(n_mu,)``.
+            Scattering angle cosines of the output grid: shape ``(n_mu,)``
+            for a scalar ``w``, ``(nw, n_mu)`` for an array ``w``.
 
         phase : ndarray
-            Phase function values in sr⁻¹, shape ``(n_phamat, n_mu)``.
+            Phase function values in sr⁻¹: shape ``(n_phamat, n_mu)`` for a
+            scalar ``w``, ``(n_phamat, nw, n_mu)`` for an array ``w``.
 
         Notes
         -----
@@ -635,55 +854,202 @@ class ParticleProperties:
         interpolation preserves the piecewise-linear shape that Mitsuba uses
         during tabulated phase-function look-up, so no distortion is introduced.
         """
-        if not np.isscalar(w.m):
-            raise ValueError("eval_phase() only accepts a scalar wavelength")
+        if self.has_size_distribution:
+            raise ValueError(
+                "eval_phase() cannot be called on a dataset with 'reff'/'veff' "
+                "dimensions; use eval_phase_grid() instead"
+            )
+
+        is_scalar = np.isscalar(w.m)
+        w = np.atleast_1d(w)
 
         n_iangle = self.data.sizes["iangle"]
         if n_mu is None:
             n_mu = n_iangle if self.has_fixed_mu_grid else 2 * n_iangle
 
-        # --- Step 1: bracket wavelengths and compute mixing weights ---
-        idx_l_arr, idx_r_arr, w0_arr, w1_arr, _ = self._bracket_and_weights(w)
-        idx_l = int(idx_l_arr[0])
-        idx_r = int(idx_r_arr[0])
-        w0 = float(w0_arr[0])
-        w1 = float(w1_arr[0])
+        n_phamat = self.data.sizes["phamat"]
+        mu = np.empty((len(w), n_mu))
+        phase = np.empty((n_phamat, len(w), n_mu))
 
-        mu1, phase1 = self._get_mu_phase(idx_l)
-        mu2, phase2 = self._get_mu_phase(idx_r)
+        for i in range(len(w)):
+            mu_pad, phase_pad = self.eval_phase_union(w[i])
+            n_union = int((~np.isnan(mu_pad[0])).sum())
+            mu_union = mu_pad[0, :n_union]
+            phase_union = phase_pad[0, :, :n_union]
 
-        # --- Step 2: union mu grid ---
-        mu_union = np.union1d(mu1, mu2)
+            if n_union > n_mu:
+                # Decimate: keep the most informative points in log space
+                keep = _rdp1d_log(mu_union, phase_union, n_mu)
+                mu[i] = mu_union[keep]
+                phase[:, i, :] = phase_union[:, keep]
 
-        # --- Step 3: resample both phase functions onto union grid ---
-        # interp1d expects (..., n) layout; phase is (n_phamat, nangles[w_idx])
-        phase1_union = interp1d(mu1, phase1, mu_union, bounds="clamp")
-        phase2_union = interp1d(mu2, phase2, mu_union, bounds="clamp")
+            elif n_union < n_mu:
+                # Upsample: insert midpoints into the largest gaps of the union
+                # grid. All original points are preserved, so the non-uniform
+                # density near the forward-scattering peak is maintained.
+                mu[i] = _upsample_mu(mu_union, n_mu)
+                phase[:, i, :] = interp1d(mu_union, phase_union, mu[i], bounds="clamp")
 
-        # --- Step 4: scattering-weighted spectral interpolation ---
-        phase_union = w0 * phase1_union + w1 * phase2_union
+            else:
+                mu[i] = mu_union
+                phase[:, i, :] = phase_union
 
-        # --- Step 5: bring to exactly n_mu points ---
-        n_union = len(mu_union)
+        if is_scalar:
+            return mu[0], phase[:, 0, :]
+        return mu, phase
 
-        if n_union > n_mu:
-            # Decimate: keep the most informative points in log space
-            keep = _rdp1d_log(mu_union, phase_union, n_mu)
-            mu_out = mu_union[keep]
-            phase_out = phase_union[:, keep]
+    def eval_phase_grid(
+        self, w: pint.Quantity
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        """
+        Evaluate the phase function at a single wavelength for every native
+        ``(reff, veff)`` grid point.
 
-        elif n_union < n_mu:
-            # Upsample: insert midpoints into the largest gaps of the union grid.
-            # All original points are preserved, so the non-uniform  density near
-            # the forward-scattering peak is maintained.
-            mu_out = _upsample_mu(mu_union, n_mu)
-            phase_out = interp1d(mu_union, phase_union, mu_out, bounds="clamp")
+        This is the grid-native counterpart of :meth:`eval_phase`: it calls
+        :meth:`eval_phase_union` for the raw per-point union grids, then
+        decimates or upsamples each point to its own target angle count.
 
-        else:
-            mu_out = mu_union
-            phase_out = phase_union
+        Parameters
+        ----------
+        w : quantity
+            Query wavelength (scalar).
 
-        return mu_out, phase_out
+        Returns
+        -------
+        mu : ndarray
+            Scattering angle cosines, shape ``(n_reff, n_veff, n_mu_max)``.
+            Points beyond a given grid point's own angle count are NaN-padded,
+            since different grid points may have a different native angular
+            resolution.
+
+        phase : ndarray
+            Phase function values in sr⁻¹, shape
+            ``(n_phamat, n_reff, n_veff, n_mu_max)``, NaN-padded like ``mu``.
+
+        nangles : ndarray
+            Valid angle count for each grid point, shape ``(n_reff, n_veff)``.
+        """
+        if not self.has_size_distribution:
+            raise ValueError(
+                "eval_phase_grid() requires a dataset with 'reff'/'veff' "
+                "dimensions; use eval_phase() instead"
+            )
+
+        w_arr = np.atleast_1d(w)
+        if w_arr.size != 1:
+            raise ValueError("eval_phase_grid() only accepts a scalar wavelength")
+
+        mu_pad, phase_pad = self.eval_phase_union(w_arr)
+
+        n_reff = self.data.sizes["reff"]
+        n_veff = self.data.sizes["veff"]
+        n_phamat = self.data.sizes["phamat"]
+        n_iangle = self.data.sizes["iangle"]
+
+        mu_list: list[np.ndarray] = []
+        phase_list: list[np.ndarray] = []
+
+        for idx in range(n_reff * n_veff):
+            ireff, iveff = divmod(idx, n_veff)
+
+            n = int((~np.isnan(mu_pad[idx])).sum())
+            mu_union = mu_pad[idx, :n]
+            phase_union = phase_pad[idx, :, :n]
+
+            n_mu_pt = (
+                n_iangle
+                if self._has_fixed_mu_grid_at(ireff, iveff)
+                else 2 * n_iangle
+            )
+            n_union = n
+
+            if n_union > n_mu_pt:
+                keep = _rdp1d_log(mu_union, phase_union, n_mu_pt)
+                mu_pt = mu_union[keep]
+                phase_pt = phase_union[:, keep]
+            elif n_union < n_mu_pt:
+                mu_pt = _upsample_mu(mu_union, n_mu_pt)
+                phase_pt = interp1d(mu_union, phase_union, mu_pt, bounds="clamp")
+            else:
+                mu_pt = mu_union
+                phase_pt = phase_union
+
+            mu_list.append(mu_pt)
+            phase_list.append(phase_pt)
+
+        nangles = np.array([len(m) for m in mu_list]).reshape(n_reff, n_veff)
+        n_mu_max = int(nangles.max())
+
+        mu = np.full((n_reff, n_veff, n_mu_max), np.nan)
+        phase = np.full((n_phamat, n_reff, n_veff, n_mu_max), np.nan)
+        for idx, (mu_pt, phase_pt) in enumerate(zip(mu_list, phase_list)):
+            ireff, iveff = divmod(idx, n_veff)
+            n = len(mu_pt)
+            mu[ireff, iveff, :n] = mu_pt
+            phase[:, ireff, iveff, :n] = phase_pt
+
+        return mu, phase, nangles
+
+    def phase_dataset_for_reff_veff(
+        self,
+        w: pint.Quantity,
+        i_reff: int,
+        i_veff: int,
+        ext: pint.Quantity | None = None,
+    ) -> xr.Dataset:
+        """
+        Build a single-point Aer-Core v2 phase function dataset at the given
+        wavelength, from the exact ``(i_reff, i_veff)`` grid point (no
+        interpolation across ``reff``/``veff``).
+
+        Parameters
+        ----------
+        w : quantity
+            Wavelength at which ``ext``/``ssa``/the phase function are
+            evaluated (interpolated along the wavelength axis only).
+
+        i_reff, i_veff : int
+            Index along this dataset's own ``reff``/``veff`` dimensions.
+
+        ext : quantity, optional
+            Extinction coefficient stored in the output dataset. Defaults
+            to the native grid value at ``(i_reff, i_veff)``.
+
+        Returns
+        -------
+        xr.Dataset
+            An Aer-Core v2 dataset with no ``reff``/``veff`` dimensions.
+        """
+        if not self.has_size_distribution:
+            raise ValueError(
+                "phase_dataset_for_reff_veff() requires a dataset with "
+                "'reff'/'veff' dimensions"
+            )
+
+        wavelength = np.atleast_1d(w)
+        ext_grid = self.eval_ext(wavelength)
+        ssa_grid = self.eval_ssa(wavelength)
+        ssa = ssa_grid[0, i_reff, i_veff]
+        if ext is None:
+            ext = ext_grid[0, i_reff, i_veff]
+
+        mu_grid, phase_grid, nangles_grid = self.eval_phase_grid(wavelength[0])
+        n = int(nangles_grid[i_reff, i_veff])
+        mu = mu_grid[i_reff, i_veff, :n]
+        phase_vals = phase_grid[:, i_reff, i_veff, :n]  # (nphamat, n_mu)
+        theta = np.rad2deg(np.arccos(mu))
+        assert theta[0] > theta[-1], "expected descending theta"
+
+        return make_aer_core_v2(
+            w=wavelength,
+            phamat=list(self.data["phamat"].values),
+            mu=ureg.Quantity(mu[np.newaxis, :], "dimensionless"),
+            theta=ureg.Quantity(theta[np.newaxis, :], "degree"),
+            ext=ext.reshape(1),
+            ssa=ssa.reshape(1),
+            phase=ureg.Quantity(phase_vals[:, np.newaxis, :], "1/sr"),
+            pmom=np.zeros((1, 1)),
+        )
 
     def eval_pmom(self, w: pint.Quantity, clip: bool = False) -> tuple[np.ndarray, int]:
         """

--- a/src/eradiate/radprops/_particles.py
+++ b/src/eradiate/radprops/_particles.py
@@ -723,9 +723,7 @@ class ParticleProperties:
 
         return self._max_union_size
 
-    def eval_phase_union(
-        self, w: pint.Quantity
-    ) -> tuple[np.ndarray, np.ndarray]:
+    def eval_phase_union(self, w: pint.Quantity) -> tuple[np.ndarray, np.ndarray]:
         """
         Evaluate the phase function at a single wavelength for every native
         ``(reff, veff)`` grid point, keeping each point's own union of its
@@ -764,9 +762,7 @@ class ParticleProperties:
             w0_grid = w0_arr[0]  # (n_reff, n_veff)
             w1_grid = w1_arr[0]
             points = [
-                (ireff, iveff)
-                for ireff in range(n_reff)
-                for iveff in range(n_veff)
+                (ireff, iveff) for ireff in range(n_reff) for iveff in range(n_veff)
             ]
 
             def weight_at(ireff, iveff):
@@ -800,14 +796,20 @@ class ParticleProperties:
         grid_len = np.array([len(m) for m in mu_list], dtype=np.uint32)
         max_len = int(grid_len.max())
 
-        mu_pad = np.asarray([
-            np.concatenate([m, np.full(max_len - n, np.nan)])
-            for m, n in zip(mu_list, grid_len)
-        ])
-        phase_pad = np.asarray([
-            np.concatenate([ph, np.full((ph.shape[0], max_len - n), np.nan)], axis=1)
-            for ph, n in zip(phase_list, grid_len)
-        ])
+        mu_pad = np.asarray(
+            [
+                np.concatenate([m, np.full(max_len - n, np.nan)])
+                for m, n in zip(mu_list, grid_len)
+            ]
+        )
+        phase_pad = np.asarray(
+            [
+                np.concatenate(
+                    [ph, np.full((ph.shape[0], max_len - n), np.nan)], axis=1
+                )
+                for ph, n in zip(phase_list, grid_len)
+            ]
+        )
 
         return mu_pad, phase_pad
 
@@ -957,9 +959,7 @@ class ParticleProperties:
             phase_union = phase_pad[idx, :, :n]
 
             n_mu_pt = (
-                n_iangle
-                if self._has_fixed_mu_grid_at(ireff, iveff)
-                else 2 * n_iangle
+                n_iangle if self._has_fixed_mu_grid_at(ireff, iveff) else 2 * n_iangle
             )
             n_union = n
 

--- a/tests/01_unit/data/test_convert.py
+++ b/tests/01_unit/data/test_convert.py
@@ -870,7 +870,9 @@ class TestLibradtranToAerCoreV2:
             assert ds_result.sizes["veff"] == 1
 
         def test_reff_values_preserved(self, ds_input, ds_result):
-            np.testing.assert_allclose(ds_result["reff"].values, ds_input["reff"].values)
+            np.testing.assert_allclose(
+                ds_result["reff"].values, ds_input["reff"].values
+            )
 
         def test_default_veff_from_param_alpha(self, ds_result):
             """veff defaults to 1 / (param_alpha + 3) when not given explicitly."""
@@ -883,8 +885,12 @@ class TestLibradtranToAerCoreV2:
 
         def test_ext_ssa_values_at_each_reff(self, ds_input, ds_result):
             """ext/ssa are preserved per (w, reff) point, with a size-1 veff axis appended."""
-            np.testing.assert_allclose(ds_result["ext"].values[:, :, 0], ds_input["ext"].values)
-            np.testing.assert_allclose(ds_result["ssa"].values[:, :, 0], ds_input["ssa"].values)
+            np.testing.assert_allclose(
+                ds_result["ext"].values[:, :, 0], ds_input["ext"].values
+            )
+            np.testing.assert_allclose(
+                ds_result["ssa"].values[:, :, 0], ds_input["ssa"].values
+            )
 
         def test_nangles_matches_ntheta_per_reff(self, ds_input, ds_result):
             np.testing.assert_array_equal(

--- a/tests/01_unit/data/test_convert.py
+++ b/tests/01_unit/data/test_convert.py
@@ -9,6 +9,7 @@ import xarray as xr
 from eradiate import unit_registry as ureg
 from eradiate.data.convert import (
     aer_v1_to_aer_core_v2,
+    concat_particles_veff,
     libradtran_to_aer_core_v2,
     make_aer_core_v2,
 )
@@ -44,6 +45,80 @@ def _isotropic_args(
         "ext": np.ones(nw) * ureg("1/km"),
         "ssa": 0.9 * np.ones(nw) * ureg.dimensionless,
         "phase": np.full((1, nw, nangle), scale) * ureg("1/sr"),
+    }
+
+
+def _size_distribution_args(
+    nw: int = 2,
+    nreff: int = 2,
+    nveff: int = 2,
+    nangle: int = 5,
+    scale: float = 1.0,
+) -> dict:
+    """
+    Keyword args for make_aer_core_v2 with reff/veff dimensions.
+
+    Phase is a uniform isotropic p = scale (4π-normalized when scale=1) with
+    a shared ascending mu grid across the whole (w, reff, veff) grid. ext/ssa
+    take a distinct value at every (w, reff, veff) point.
+    """
+    mu_1d = np.linspace(-1.0, 1.0, nangle)
+    mu = np.tile(mu_1d, (nw, nreff, nveff, 1))
+    theta = np.degrees(np.arccos(mu))
+    phase = np.full((1, nw, nreff, nveff, nangle), scale)
+
+    ext = np.zeros((nw, nreff, nveff))
+    ssa = np.zeros((nw, nreff, nveff))
+    for ireff in range(nreff):
+        for iveff in range(nveff):
+            ext[:, ireff, iveff] = (ireff + 1) * (iveff + 1)
+            ssa[:, ireff, iveff] = 0.5 + 0.1 * ireff + 0.01 * iveff
+
+    return {
+        "w": np.linspace(400.0, 700.0, nw) * ureg.nm,
+        "phamat": ["11"],
+        "mu": mu * ureg.dimensionless,
+        "theta": theta * ureg.deg,
+        "ext": ext * ureg("1/km"),
+        "ssa": ssa * ureg.dimensionless,
+        "phase": phase * ureg("1/sr"),
+        "reff": np.linspace(5.0, 15.0, nreff) * ureg.micron,
+        "veff": np.linspace(0.05, 0.15, nveff) * ureg.dimensionless,
+    }
+
+
+def _size_distribution_padded_args(
+    nangles_grid: np.ndarray, nangle_max: int = 10
+) -> dict:
+    """
+    Keyword args for make_aer_core_v2 with reff/veff dimensions and a
+    varying, nan padded angle count per (w, reff, veff) point.
+    """
+    nreff, nveff = nangles_grid.shape
+    nw = 1
+    mu = np.full((nw, nreff, nveff, nangle_max), np.nan)
+    theta = np.full((nw, nreff, nveff, nangle_max), np.nan)
+    phase = np.full((1, nw, nreff, nveff, nangle_max), np.nan)
+
+    for ireff in range(nreff):
+        for iveff in range(nveff):
+            n = int(nangles_grid[ireff, iveff])
+            mu_row = np.linspace(-1.0, 1.0, n)
+            mu[0, ireff, iveff, :n] = mu_row
+            theta[0, ireff, iveff, :n] = np.degrees(np.arccos(mu_row))
+            phase[0, 0, ireff, iveff, :n] = 1.0
+
+    return {
+        "w": np.linspace(400.0, 700.0, nw) * ureg.nm,
+        "phamat": ["11"],
+        "mu": mu * ureg.dimensionless,
+        "theta": theta * ureg.deg,
+        "ext": np.ones((nw, nreff, nveff)) * ureg("1/km"),
+        "ssa": 0.9 * np.ones((nw, nreff, nveff)) * ureg.dimensionless,
+        "phase": phase * ureg("1/sr"),
+        "reff": np.linspace(5.0, 15.0, nreff) * ureg.micron,
+        "veff": np.linspace(0.05, 0.15, nveff) * ureg.dimensionless,
+        "nangles": nangles_grid.reshape(nw, nreff, nveff),
     }
 
 
@@ -335,6 +410,259 @@ class TestMakeAerCoreV2:
             with pytest.raises(ValueError, match="integrates to 0"):
                 make_aer_core_v2(**args, normalize=True)
 
+    class TestSizeDistribution:
+        """Tests for the reff/veff (Prt v1) dimensions in make_aer_core_v2()."""
+
+        def test_no_reff_veff_omits_dimensions(self):
+            """Without reff/veff, the dataset has no such dimensions (Aer-Core v2)."""
+            ds = make_aer_core_v2(**_isotropic_args())
+            assert "reff" not in ds.dims
+            assert "veff" not in ds.dims
+
+        def test_only_reff_raises(self):
+            """Providing reff without veff raises ValueError."""
+            args = _size_distribution_args()
+            del args["veff"]
+            with pytest.raises(ValueError, match="must be provided together"):
+                make_aer_core_v2(**args)
+
+        def test_only_veff_raises(self):
+            """Providing veff without reff raises ValueError."""
+            args = _size_distribution_args()
+            del args["reff"]
+            with pytest.raises(ValueError, match="must be provided together"):
+                make_aer_core_v2(**args)
+
+        def test_dimensions_and_shapes(self):
+            """ext/ssa/mu/theta/phase/nangles gain reff/veff dimensions."""
+            nw, nreff, nveff, nangle = 2, 3, 2, 5
+            ds = make_aer_core_v2(
+                **_size_distribution_args(
+                    nw=nw, nreff=nreff, nveff=nveff, nangle=nangle
+                )
+            )
+            assert ds["ext"].dims == ("w", "reff", "veff")
+            assert ds["ext"].shape == (nw, nreff, nveff)
+            assert ds["mu"].dims == ("w", "reff", "veff", "iangle")
+            assert ds["mu"].shape == (nw, nreff, nveff, nangle)
+            assert ds["phase"].dims == ("phamat", "w", "reff", "veff", "iangle")
+            assert ds["nangles"].shape == (nw, nreff, nveff)
+
+        def test_ext_ssa_values_at_each_point(self):
+            """ext/ssa are stored verbatim at every (w, reff, veff) point."""
+            args = _size_distribution_args()
+            ds = make_aer_core_v2(**args)
+            np.testing.assert_allclose(ds["ext"].values, args["ext"].m)
+            np.testing.assert_allclose(ds["ssa"].values, args["ssa"].m)
+
+        def test_nangles_inferred_at_each_point(self):
+            """nangles is inferred per (w, reff, veff) point when not provided."""
+            nw, nreff, nveff, nangle = 2, 2, 2, 5
+            ds = make_aer_core_v2(
+                **_size_distribution_args(
+                    nw=nw, nreff=nreff, nveff=nveff, nangle=nangle
+                )
+            )
+            np.testing.assert_array_equal(
+                ds["nangles"].values, np.full((nw, nreff, nveff), nangle)
+            )
+
+        def test_check_full_catches_unsorted_point(self):
+            """check='full' validates every (w, reff, veff) point, not just w."""
+            args = _size_distribution_args(nw=2, nreff=2, nveff=2)
+            mu_arr = args["mu"].m.copy()
+            mu_arr[1, 1, 0, :] = mu_arr[1, 1, 0, :][::-1]
+            args["mu"] = mu_arr * ureg.dimensionless
+            with pytest.raises(ValueError, match="strictly ascending"):
+                make_aer_core_v2(**args, check="full")
+
+        def test_fast_passes_on_sorted_grid(self):
+            """check='fast' runs over the full (w, reff, veff) index space without error."""
+            args = _size_distribution_args(nw=2, nreff=5, nveff=5)
+            make_aer_core_v2(**args, check="fast")
+
+        def test_fast_catches_unsorted_point_in_reff_veff_space(self):
+            """check='fast' samples over (w, reff, veff), not just w."""
+            nw, nreff, nveff = 2, 5, 5
+            args = _size_distribution_args(nw=nw, nreff=nreff, nveff=nveff)
+
+            # check='fast' reseeds to 0 on every call, so the sampled indices
+            # are reproducible; replicate that here to target one of them.
+            indices = list(np.ndindex((nw, nreff, nveff)))
+            rng = np.random.default_rng(seed=0)
+            n_sample = max(1, len(indices) // 10)
+            sampled = [
+                indices[i]
+                for i in rng.choice(len(indices), size=n_sample, replace=False)
+            ]
+
+            mu_arr = args["mu"].m.copy()
+            mu_arr[sampled[0]] = mu_arr[sampled[0]][::-1]
+            args["mu"] = mu_arr * ureg.dimensionless
+
+            with pytest.raises(ValueError, match="strictly ascending"):
+                make_aer_core_v2(**args, check="fast")
+
+        def test_unsorted_reff_raises(self):
+            """A non-strictly-increasing reff grid raises ValueError."""
+            args = _size_distribution_args(nreff=3)
+            args["reff"] = args["reff"][::-1]
+            with pytest.raises(ValueError, match="'reff' must be strictly increasing"):
+                make_aer_core_v2(**args)
+
+        def test_unsorted_veff_raises(self):
+            """A non-strictly-increasing veff grid raises ValueError."""
+            args = _size_distribution_args(nveff=3)
+            args["veff"] = args["veff"][::-1]
+            with pytest.raises(ValueError, match="'veff' must be strictly increasing"):
+                make_aer_core_v2(**args)
+
+        def test_irregular_reff_veff_accepted(self):
+            """Strictly increasing but irregularly spaced reff/veff are accepted."""
+            args = _size_distribution_args(nreff=3, nveff=1)
+            args["reff"] = np.array([5.0, 6.0, 15.0]) * ureg.micron
+            make_aer_core_v2(**args)
+
+        def test_nangles_varies_per_reff_veff_point(self):
+            """nangles can vary independently across (w, reff, veff) points."""
+            nangles_grid = np.array([[4, 7], [10, 3]])
+            args = _size_distribution_padded_args(nangles_grid)
+            ds = make_aer_core_v2(**args)
+            np.testing.assert_array_equal(ds["nangles"].values[0], nangles_grid)
+
+        def test_check_full_ignores_nan_tails_per_point(self):
+            """check='full' validates only the valid portion of each ragged row."""
+            nangles_grid = np.array([[4, 7], [10, 3]])
+            args = _size_distribution_padded_args(nangles_grid)
+            make_aer_core_v2(**args, check="full")
+
+        def test_check_full_raises_on_unsorted_valid_portion(self):
+            """check='full' raises if the valid part of a ragged row is unsorted."""
+            nangles_grid = np.array([[4, 7], [10, 3]])
+            args = _size_distribution_padded_args(nangles_grid)
+            mu_arr = args["mu"].m.copy()
+            n = int(nangles_grid[1, 0])
+            mu_arr[0, 1, 0, :n] = mu_arr[0, 1, 0, :n][::-1]
+            args["mu"] = mu_arr * ureg.dimensionless
+            with pytest.raises(ValueError, match="strictly ascending"):
+                make_aer_core_v2(**args, check="full")
+
+        def test_normalize_at_each_point(self):
+            """normalize=True enforces the integral convention at every point."""
+            args = _size_distribution_args(scale=4.0)
+            ds = make_aer_core_v2(**args, normalize=True)
+            mu = ds["mu"].values
+            phase = ds["phase"].values
+            for idx in np.ndindex(mu.shape[:-1]):
+                integral = np.trapezoid(phase[(0, *idx)], mu[idx])
+                np.testing.assert_allclose(integral, 2.0, rtol=1e-12)
+
+        def test_auto_pmom_at_each_point(self):
+            """Automatic pmom computation runs independently at every point."""
+            nw, nreff, nveff = 2, 2, 2
+            ds = make_aer_core_v2(
+                **_size_distribution_args(nw=nw, nreff=nreff, nveff=nveff), nmom=20
+            )
+            assert ds["pmom"].shape == (nw, nreff, nveff, 20)
+            # Isotropic phase: l=0 coefficient is 1, l>0 are ~0, everywhere.
+            np.testing.assert_allclose(ds["pmom"].values[..., 0], 1.0, rtol=1e-6)
+            np.testing.assert_allclose(ds["pmom"].values[..., 1:], 0.0, atol=1e-6)
+
+        def test_scalar_nmom_broadcasts_to_grid_shape(self):
+            """An int nmom broadcasts to the full (w, reff, veff) shape."""
+            nw, nreff, nveff = 2, 3, 2
+            ds = make_aer_core_v2(
+                **_size_distribution_args(nw=nw, nreff=nreff, nveff=nveff), nmom=64
+            )
+            assert ds["nmom"].shape == (nw, nreff, nveff)
+            np.testing.assert_array_equal(
+                ds["nmom"].values, np.full((nw, nreff, nveff), 64)
+            )
+
+        def test_explicit_pmom_stored_verbatim_per_point(self):
+            """Explicit pmom is stored as-is; nmom is inferred per (w, reff, veff) point."""
+            nw, nreff, nveff = 2, 2, 2
+            args = _size_distribution_args(nw=nw, nreff=nreff, nveff=nveff)
+            sentinel = np.full((nw, nreff, nveff, 10), 42.0)
+            ds = make_aer_core_v2(**args, pmom=sentinel)
+            np.testing.assert_array_equal(ds["pmom"].values, sentinel)
+            np.testing.assert_array_equal(
+                ds["nmom"].values, np.full((nw, nreff, nveff), 10)
+            )
+
+        def test_ndarray_nmom_stored_verbatim_per_point(self):
+            """An ndarray nmom is stored as-is per (w, reff, veff) point."""
+            nw, nreff, nveff = 2, 2, 2
+            args = _size_distribution_args(nw=nw, nreff=nreff, nveff=nveff)
+            nmom_grid = np.array([[[4, 7], [10, 3]], [[5, 8], [11, 4]]], dtype=np.int32)
+            pmom = np.full((nw, nreff, nveff, int(nmom_grid.max())), np.nan)
+            for idx in np.ndindex(nmom_grid.shape):
+                pmom[idx][: nmom_grid[idx]] = 1.0
+            ds = make_aer_core_v2(**args, pmom=pmom, nmom=nmom_grid)
+            np.testing.assert_array_equal(ds["nmom"].values, nmom_grid)
+
+
+class TestConcatParticlesVeff:
+    """Tests for concat_particles_veff()."""
+
+    def test_concatenates_veff_values(self):
+        """Combined dataset spans the union of both inputs' veff values."""
+        ds1 = make_aer_core_v2(**_size_distribution_args(nveff=1))
+        ds2 = make_aer_core_v2(**_size_distribution_args(nveff=1))
+        # Give ds2 a distinct veff value so the union is non-trivial.
+        ds2 = ds2.assign_coords(veff=("veff", ds2["veff"].values + 1.0))
+
+        combined = concat_particles_veff([ds1, ds2])
+
+        assert combined.sizes["veff"] == 2
+        np.testing.assert_allclose(
+            combined["veff"].values,
+            np.concatenate([ds1["veff"].values, ds2["veff"].values]),
+        )
+        np.testing.assert_allclose(
+            combined["ext"].isel(veff=0).values, ds1["ext"].isel(veff=0).values
+        )
+        np.testing.assert_allclose(
+            combined["ext"].isel(veff=1).values, ds2["ext"].isel(veff=0).values
+        )
+
+    def test_pads_mismatched_iangle(self):
+        """Datasets with different iangle sizes are NaN-padded to the max."""
+        ds1 = make_aer_core_v2(**_size_distribution_args(nveff=1, nangle=5))
+        ds2 = make_aer_core_v2(**_size_distribution_args(nveff=1, nangle=8))
+        ds2 = ds2.assign_coords(veff=("veff", ds2["veff"].values + 1.0))
+
+        combined = concat_particles_veff([ds1, ds2])
+
+        assert combined.sizes["iangle"] == 8
+        np.testing.assert_array_equal(
+            combined["nangles"].isel(veff=0).values,
+            np.full(combined["nangles"].isel(veff=0).shape, 5),
+        )
+        phase_v0 = combined["phase"].isel(veff=0).values
+        assert np.all(np.isnan(phase_v0[..., 5:]))
+        assert not np.any(np.isnan(phase_v0[..., :5]))
+        phase_v1 = combined["phase"].isel(veff=1).values
+        assert not np.any(np.isnan(phase_v1[..., :8]))
+
+    @pytest.mark.parametrize(
+        "override, match",
+        [
+            ({"w": np.array([401.0, 700.0]) * ureg.nm}, "'w' coordinate"),
+            ({"reff": np.array([6.0, 15.0]) * ureg.micron}, "'reff' coordinate"),
+            ({"phamat": ["12"]}, "'phamat' coordinate"),
+        ],
+    )
+    def test_mismatched_grid_raises(self, override, match):
+        """Datasets with different w/reff/phamat coordinates raise ValueError."""
+        ds1 = make_aer_core_v2(**_size_distribution_args(nveff=1))
+        args2 = {**_size_distribution_args(nveff=1), **override}
+        ds2 = make_aer_core_v2(**args2)
+        ds2 = ds2.assign_coords(veff=("veff", ds2["veff"].values + 1.0))
+
+        with pytest.raises(ValueError, match=match):
+            concat_particles_veff([ds1, ds2])
+
 
 class TestAerV1ToAerCoreV2:
     class TestSorting:
@@ -499,3 +827,67 @@ class TestLibradtranToAerCoreV2:
             """nangles equals the count of distinct mu values from all components."""
             # union of [0, 90, 180]° and [45, 135]° → 5 distinct angles
             np.testing.assert_array_equal(ds_result["nangles"].values, [5, 5])
+
+    class TestReff:
+        """Tests for the multi-``reff`` input path, which produces Prt v1."""
+
+        PARAM_ALPHA = 5.0
+
+        @pytest.fixture(scope="class")
+        @classmethod
+        def ds_input(cls):
+            nw, nreff, nphamat, nthetamax = 2, 3, 1, 4
+            theta_1d = np.linspace(0.0, 180.0, nthetamax)
+            theta_arr = np.tile(theta_1d, (nw, nreff, nphamat, 1))
+            phase_arr = np.full((nw, nreff, nphamat, nthetamax), 1.0 / (4.0 * np.pi))
+            ntheta_arr = np.full((nw, nreff, nphamat), nthetamax, dtype=np.int32)
+            pmom_arr = np.full((nw, nreff, nphamat, 4), np.nan)
+            pmom_arr[:, :, 0, 0] = 1.0
+            ext_arr = np.arange(1, nw * nreff + 1, dtype=float).reshape(nw, nreff)
+            ssa_arr = 0.9 * np.ones((nw, nreff))
+            return xr.Dataset(
+                data_vars={
+                    "wavelen": ("nlam", np.linspace(400.0, 700.0, nw), {"units": "nm"}),
+                    "reff": ("nreff", np.linspace(1.0, 25.0, nreff), {"units": "um"}),
+                    "ext": (("nlam", "nreff"), ext_arr, {"units": "1/km"}),
+                    "ssa": (("nlam", "nreff"), ssa_arr, {"units": ""}),
+                    "ntheta": (("nlam", "nreff", "nphamat"), ntheta_arr),
+                    "theta": (("nlam", "nreff", "nphamat", "nthetamax"), theta_arr),
+                    "phase": (("nlam", "nreff", "nphamat", "nthetamax"), phase_arr),
+                    "pmom": (("nlam", "nreff", "nphamat", "nmommax"), pmom_arr),
+                },
+                attrs={"param_alpha": cls.PARAM_ALPHA},
+            )
+
+        @pytest.fixture(scope="class")
+        @classmethod
+        def ds_result(cls, ds_input):
+            return libradtran_to_aer_core_v2(ds_input, check="full")
+
+        def test_produces_reff_veff_dimensions(self, ds_result):
+            """Output has a 'reff' dimension and a size-1 'veff' dimension."""
+            assert "reff" in ds_result.dims
+            assert ds_result.sizes["veff"] == 1
+
+        def test_reff_values_preserved(self, ds_input, ds_result):
+            np.testing.assert_allclose(ds_result["reff"].values, ds_input["reff"].values)
+
+        def test_default_veff_from_param_alpha(self, ds_result):
+            """veff defaults to 1 / (param_alpha + 3) when not given explicitly."""
+            expected = 1.0 / (self.PARAM_ALPHA + 3.0)
+            np.testing.assert_allclose(ds_result["veff"].values, [expected])
+
+        def test_explicit_veff_overrides_default(self, ds_input):
+            ds_result = libradtran_to_aer_core_v2(ds_input, check="full", veff=0.1)
+            np.testing.assert_allclose(ds_result["veff"].values, [0.1])
+
+        def test_ext_ssa_values_at_each_reff(self, ds_input, ds_result):
+            """ext/ssa are preserved per (w, reff) point, with a size-1 veff axis appended."""
+            np.testing.assert_allclose(ds_result["ext"].values[:, :, 0], ds_input["ext"].values)
+            np.testing.assert_allclose(ds_result["ssa"].values[:, :, 0], ds_input["ssa"].values)
+
+        def test_nangles_matches_ntheta_per_reff(self, ds_input, ds_result):
+            np.testing.assert_array_equal(
+                ds_result["nangles"].values[:, :, 0],
+                ds_input["ntheta"].isel(nphamat=0).values,
+            )

--- a/tests/01_unit/radprops/test_particles.py
+++ b/tests/01_unit/radprops/test_particles.py
@@ -503,8 +503,18 @@ class TestParticleProperties:
         @pytest.mark.parametrize(
             "w_nm, exp_idx_l, exp_idx_r, expected_t",
             [
-                (300.0, 0, 1, 0.0),  # below min → boundary segment [0, 1], clamped to t=0
-                (800.0, 1, 2, 1.0),  # above max → boundary segment [1, 2], clamped to t=1
+                (
+                    300.0,
+                    0,
+                    1,
+                    0.0,
+                ),  # below min → boundary segment [0, 1], clamped to t=0
+                (
+                    800.0,
+                    1,
+                    2,
+                    1.0,
+                ),  # above max → boundary segment [1, 2], clamped to t=1
             ],
         )
         def test_out_of_range_clamps(self, pp, w_nm, exp_idx_l, exp_idx_r, expected_t):

--- a/tests/01_unit/radprops/test_particles.py
+++ b/tests/01_unit/radprops/test_particles.py
@@ -92,6 +92,136 @@ def make_single_w_dataset() -> xr.Dataset:
     )
 
 
+REFF = np.array([5.0, 15.0])  # micron
+VEFF = np.array([0.05, 0.15])  # dimensionless
+
+
+def make_size_distribution_dataset() -> xr.Dataset:
+    """
+    Build a minimal Prt v1-shaped dataset (``reff``/``veff`` dimensions
+    added to the Aer-Core v2 layout) for ``ParticleProperties``.
+
+    ``ext``/``ssa`` take a distinct value at every ``(w, reff, veff)`` grid
+    point, so index-based selection can be checked against known values. The
+    angular grid is shared across the whole grid: the ragged/union-grid
+    mechanics along ``w`` are already covered by other tests, so this dataset
+    only needs to exercise ``reff``/``veff`` selection.
+    """
+    n_w, n_reff, n_veff = len(W_NM), len(REFF), len(VEFF)
+
+    ext = np.zeros((n_w, n_reff, n_veff))
+    ssa = np.zeros((n_w, n_reff, n_veff))
+    for ireff in range(n_reff):
+        for iveff in range(n_veff):
+            ext[:, ireff, iveff] = EXT * (ireff + 1) * (iveff + 1)
+            ssa[:, ireff, iveff] = SSA * (1.0 - 0.05 * ireff - 0.01 * iveff)
+
+    mu_vals = np.tile(MU_1D, (n_w, n_reff, n_veff, 1))
+    theta_vals = np.degrees(np.arccos(mu_vals))
+    phase = np.tile(
+        _PHASE_DATA[:, :, np.newaxis, np.newaxis, :], (1, 1, n_reff, n_veff, 1)
+    )
+    nangles = np.full((n_w, n_reff, n_veff), len(MU_1D), dtype=np.int32)
+
+    return xr.Dataset(
+        {
+            "ext": (["w", "reff", "veff"], ext, {"units": "km^-1"}),
+            "ssa": (["w", "reff", "veff"], ssa, {"units": "dimensionless"}),
+            "mu": (
+                ["w", "reff", "veff", "iangle"],
+                mu_vals,
+                {"units": "dimensionless"},
+            ),
+            "theta": (
+                ["w", "reff", "veff", "iangle"],
+                theta_vals,
+                {"units": "degree"},
+            ),
+            "phase": (
+                ["phamat", "w", "reff", "veff", "iangle"],
+                phase,
+                {"units": "1/sr"},
+            ),
+            "nangles": (["w", "reff", "veff"], nangles),
+        },
+        coords={
+            "w": ("w", W_NM, {"units": "nm"}),
+            "reff": ("reff", REFF, {"units": "micron"}),
+            "veff": ("veff", VEFF, {"units": "dimensionless"}),
+            "phamat": ("phamat", ["11"]),
+        },
+    )
+
+
+def make_size_distribution_dataset_ragged() -> xr.Dataset:
+    """
+    Prt v1-shaped dataset where the native angular grid differs across the
+    ``(w, reff, veff)`` grid, to exercise ``eval_phase_grid()``'s per-point
+    raggedness/padding handling. Two wavelengths, two ``reff`` points, one
+    ``veff`` point.
+
+    * ``reff=0``: identical, fully-populated 4-point mu grid at both
+      wavelengths (fixed grid -> no padding needed for this point).
+    * ``reff=1``: only 3 valid points at w=0, 4 at w=1 (ragged -> union
+      smaller than the default ``2 * n_iangle``, triggers upsampling).
+    """
+    n_w, n_reff, n_veff, n_iangle = 2, 2, 1, 4
+
+    mu_full = np.array([-1.0, -0.3, 0.3, 1.0])
+    mu_vals = np.full((n_w, n_reff, n_veff, n_iangle), np.nan)
+    theta_vals = np.full((n_w, n_reff, n_veff, n_iangle), np.nan)
+    phase = np.full((1, n_w, n_reff, n_veff, n_iangle), np.nan)
+    nangles = np.full((n_w, n_reff, n_veff), n_iangle, dtype=np.int32)
+
+    for iw in range(n_w):
+        mu_vals[iw, 0, 0, :] = mu_full
+        theta_vals[iw, 0, 0, :] = np.degrees(np.arccos(mu_full))
+        phase[0, iw, 0, 0, :] = 1.0 + 0.1 * iw
+
+    mu_w0 = np.array([-1.0, 0.0, 1.0])
+    mu_vals[0, 1, 0, :3] = mu_w0
+    theta_vals[0, 1, 0, :3] = np.degrees(np.arccos(mu_w0))
+    phase[0, 0, 1, 0, :3] = 1.0
+    nangles[0, 1, 0] = 3
+
+    mu_vals[1, 1, 0, :] = mu_full
+    theta_vals[1, 1, 0, :] = np.degrees(np.arccos(mu_full))
+    phase[0, 1, 1, 0, :] = 1.2
+    nangles[1, 1, 0] = 4
+
+    ext = np.ones((n_w, n_reff, n_veff))
+    ssa = 0.9 * np.ones((n_w, n_reff, n_veff))
+
+    return xr.Dataset(
+        {
+            "ext": (["w", "reff", "veff"], ext, {"units": "km^-1"}),
+            "ssa": (["w", "reff", "veff"], ssa, {"units": "dimensionless"}),
+            "mu": (
+                ["w", "reff", "veff", "iangle"],
+                mu_vals,
+                {"units": "dimensionless"},
+            ),
+            "theta": (
+                ["w", "reff", "veff", "iangle"],
+                theta_vals,
+                {"units": "degree"},
+            ),
+            "phase": (
+                ["phamat", "w", "reff", "veff", "iangle"],
+                phase,
+                {"units": "1/sr"},
+            ),
+            "nangles": (["w", "reff", "veff"], nangles),
+        },
+        coords={
+            "w": ("w", [400.0, 700.0], {"units": "nm"}),
+            "reff": ("reff", [5.0, 15.0], {"units": "micron"}),
+            "veff": ("veff", [0.1], {"units": "dimensionless"}),
+            "phamat": ("phamat", ["11"]),
+        },
+    )
+
+
 @pytest.fixture
 def pp() -> ParticleProperties:
     return ParticleProperties(data=make_dataset())
@@ -201,6 +331,151 @@ class TestParticleProperties:
     def test_has_polarization(self, pp):
         assert pp.has_polarization is False
 
+    def test_has_size_distribution_false_for_aer_core_v2(self, pp):
+        assert pp.has_size_distribution is False
+
+    def test_has_size_distribution_true_for_prt_v1(self):
+        pp = ParticleProperties(data=make_size_distribution_dataset())
+        assert pp.has_size_distribution is True
+
+    class TestEvalPhaseGrid:
+        def test_eval_phase_raises_on_prt_v1(self):
+            """eval_phase() refuses a dataset with 'reff'/'veff' dimensions."""
+            pp = ParticleProperties(data=make_size_distribution_dataset())
+            with pytest.raises(ValueError, match="eval_phase_grid"):
+                pp.eval_phase(W_NM[0] * ureg.nm)
+
+        def test_raises_on_aer_core_v2(self, pp):
+            """eval_phase_grid() refuses a dataset without 'reff'/'veff' dimensions."""
+            with pytest.raises(ValueError, match="'reff'/'veff' dimensions"):
+                pp.eval_phase_grid(W_NM[0] * ureg.nm)
+
+        def test_raises_on_array_wavelength(self):
+            """eval_phase_grid() only accepts a scalar wavelength."""
+            pp = ParticleProperties(data=make_size_distribution_dataset())
+            with pytest.raises(ValueError, match="scalar wavelength"):
+                pp.eval_phase_grid(W_NM * ureg.nm)
+
+        @pytest.mark.parametrize("reff_idx", [0, 1])
+        @pytest.mark.parametrize("veff_idx", [0, 1])
+        def test_matches_manual_isel(self, reff_idx, veff_idx):
+            """Each grid point matches eval_phase() on a manually isel'd dataset."""
+            ds = make_size_distribution_dataset()
+            pp = ParticleProperties(data=ds)
+            w = 475.0 * ureg.nm  # midpoint [400, 550]
+
+            mu_grid, phase_grid, nangles_grid = pp.eval_phase_grid(w)
+
+            single = ParticleProperties(
+                data=ds.isel(reff=reff_idx, veff=veff_idx, drop=True)
+            )
+            mu_expected, phase_expected = single.eval_phase(w)
+
+            n = int(nangles_grid[reff_idx, veff_idx])
+            assert n == len(mu_expected)
+            np.testing.assert_allclose(
+                mu_grid[reff_idx, veff_idx, :n], mu_expected, rtol=1e-12
+            )
+            np.testing.assert_allclose(
+                phase_grid[:, reff_idx, veff_idx, :n], phase_expected, rtol=1e-10
+            )
+            # Beyond this point's own valid count, output is NaN-padded
+            assert np.all(np.isnan(mu_grid[reff_idx, veff_idx, n:]))
+
+        def test_ragged_grid_padding(self):
+            """
+            Points with a different native angular resolution end up with a
+            different valid count, and the shorter one is NaN-padded up to
+            the grid-wide max.
+            """
+            ds = make_size_distribution_dataset_ragged()
+            pp = ParticleProperties(data=ds)
+            w = 550.0 * ureg.nm  # midpoint [400, 700], t=0.5
+
+            mu_grid, phase_grid, nangles_grid = pp.eval_phase_grid(w)
+
+            assert mu_grid.shape[:2] == (2, 1)
+            assert phase_grid.shape[1:3] == (2, 1)
+            # reff=0: identical fixed grid at both wavelengths -> no padding
+            assert nangles_grid[0, 0] == 4
+            # reff=1: ragged native grids (3 vs 4 points) -> upsampled, more points
+            assert nangles_grid[1, 0] > nangles_grid[0, 0]
+
+            n_mu_max = mu_grid.shape[-1]
+            assert n_mu_max == nangles_grid.max()
+            n0 = int(nangles_grid[0, 0])
+            assert np.all(np.isnan(mu_grid[0, 0, n0:]))
+            assert np.all(np.isfinite(mu_grid[1, 0, :]))
+
+            # Matches a manual isel of the ragged point
+            single = ParticleProperties(data=ds.isel(reff=1, veff=0, drop=True))
+            mu_expected, phase_expected = single.eval_phase(w)
+            np.testing.assert_allclose(mu_grid[1, 0, :], mu_expected, rtol=1e-12)
+            np.testing.assert_allclose(
+                phase_grid[:, 1, 0, :], phase_expected, rtol=1e-10
+            )
+
+    class TestEvalPhaseUnion:
+        def test_raises_on_array_wavelength(self):
+            """eval_phase_union() only accepts a scalar wavelength."""
+            pp = ParticleProperties(data=make_size_distribution_dataset())
+            with pytest.raises(ValueError, match="scalar wavelength"):
+                pp.eval_phase_union(W_NM * ureg.nm)
+
+        def test_degenerate_single_point(self, pp):
+            """Without 'reff'/'veff' dims, there is a single point, so its row is the raw union grid, unpadded."""
+            w = 475.0 * ureg.nm
+            mu, phase = pp.eval_phase_union(w)
+
+            mu1, _ = pp._get_mu_phase(0)
+            mu2, _ = pp._get_mu_phase(1)
+            mu_union = np.union1d(mu1, mu2)
+
+            assert mu.shape == (1, len(mu_union))
+            np.testing.assert_allclose(mu[0], mu_union, rtol=1e-12)
+            assert phase.shape == (1, 1, len(mu_union))
+
+        def test_matches_raw_union_on_size_distribution_grid(self):
+            """Each grid point's own row is its raw union grid, NaN-padded to the widest point."""
+            ds = make_size_distribution_dataset_ragged()
+            pp = ParticleProperties(data=ds)
+            w = 550.0 * ureg.nm
+
+            mu, phase = pp.eval_phase_union(w)
+
+            single0 = ParticleProperties(data=ds.isel(reff=0, veff=0, drop=True))
+            mu1, _ = single0._get_mu_phase(0)
+            mu2, _ = single0._get_mu_phase(1)
+            mu_union0 = np.union1d(mu1, mu2)
+
+            single1 = ParticleProperties(data=ds.isel(reff=1, veff=0, drop=True))
+            mu1, _ = single1._get_mu_phase(0)
+            mu2, _ = single1._get_mu_phase(1)
+            mu_union1 = np.union1d(mu1, mu2)
+
+            max_len = max(len(mu_union0), len(mu_union1))
+            assert mu.shape == (2, max_len)
+            assert phase.shape == (2, 1, max_len)
+
+            np.testing.assert_allclose(mu[0, : len(mu_union0)], mu_union0, rtol=1e-12)
+            assert np.all(np.isnan(mu[0, len(mu_union0) :]))
+
+            np.testing.assert_allclose(mu[1, : len(mu_union1)], mu_union1, rtol=1e-12)
+            assert np.all(np.isnan(mu[1, len(mu_union1) :]))
+
+        def test_consistent_with_eval_phase_grid(self):
+            """eval_phase_grid()'s fixed-grid points match eval_phase_union()'s raw (unpadded) rows exactly."""
+            ds = make_size_distribution_dataset_ragged()
+            pp = ParticleProperties(data=ds)
+            w = 550.0 * ureg.nm
+
+            mu, _ = pp.eval_phase_union(w)
+            mu_grid, _, nangles_grid = pp.eval_phase_grid(w)
+
+            n0 = int((~np.isnan(mu[0])).sum())
+            assert n0 == nangles_grid[0, 0]
+            np.testing.assert_allclose(mu[0, :n0], mu_grid[0, 0, : nangles_grid[0, 0]])
+
     class TestLocate:
         @pytest.mark.parametrize(
             "w_nm, expected_t",
@@ -213,7 +488,7 @@ class TestParticleProperties:
         def test_at_nodes(self, pp, w_nm, expected_t):
             """t=0 at left node of a segment, t=1 at its right node."""
             w = w_nm * ureg.nm
-            idx_l, idx_r, t = pp._locate(w)
+            _idx_l, _idx_r, t = pp._locate(w)
             assert t.shape == (1,)
             np.testing.assert_allclose(t[0], expected_t, atol=1e-12)
 
@@ -226,22 +501,20 @@ class TestParticleProperties:
             assert idx_r[0] == 1
 
         @pytest.mark.parametrize(
-            "w_nm, exp_idx_l, exp_idx_r",
+            "w_nm, exp_idx_l, exp_idx_r, expected_t",
             [
-                (300.0, 0, 1),  # below min → boundary segment [0, 1], t < 0
-                (800.0, 1, 2),  # above max → boundary segment [1, 2], t > 1
+                (300.0, 0, 1, 0.0),  # below min → boundary segment [0, 1], clamped to t=0
+                (800.0, 1, 2, 1.0),  # above max → boundary segment [1, 2], clamped to t=1
             ],
         )
-        def test_out_of_range_extrapolates(self, pp, w_nm, exp_idx_l, exp_idx_r):
-            """Out-of-range w uses the boundary segment; t extrapolates beyond [0, 1]."""
+        def test_out_of_range_clamps(self, pp, w_nm, exp_idx_l, exp_idx_r, expected_t):
+            """Out-of-range w uses the boundary segment; t clamps to [0, 1], matching
+            np.interp's clamp-to-boundary behaviour (no extrapolation)."""
             w = w_nm * ureg.nm
             idx_l, idx_r, t = pp._locate(w)
             assert idx_l[0] == exp_idx_l
             assert idx_r[0] == exp_idx_r
-            if w_nm < W_NM[0]:
-                assert t[0] < 0.0
-            else:
-                assert t[0] > 1.0
+            assert t[0] == expected_t
 
         def test_array_input(self, pp):
             """Vectorized input returns arrays of correct shape."""
@@ -330,6 +603,17 @@ class TestParticleProperties:
             expected = 0.5 * (EXT[0] + EXT[1])
             np.testing.assert_allclose(result.m, expected, rtol=1e-10)
 
+        def test_preserves_reff_veff_dims(self):
+            """On a Prt v1 dataset, result keeps the 'reff'/'veff' dimensions."""
+            ds = make_size_distribution_dataset()
+            pp = ParticleProperties(data=ds)
+            w = np.array([475.0, 625.0]) * ureg.nm  # midpoints of both segments
+            result = pp.eval_ext(w)
+
+            assert result.shape == (2, len(REFF), len(VEFF))
+            expected = 0.5 * (ds["ext"].values[[0, 1]] + ds["ext"].values[[1, 2]])
+            np.testing.assert_allclose(result.m, expected, rtol=1e-10)
+
     class TestEvalSsa:
         @pytest.mark.parametrize("idx", [0, 1, 2])
         def test_at_nodes(self, pp, idx):
@@ -360,12 +644,40 @@ class TestParticleProperties:
             expected = 0.5 * SSA[0] + 0.5 * SSA[1]
             np.testing.assert_allclose(result.m, expected, rtol=1e-10)
 
+        def test_preserves_reff_veff_dims(self):
+            """On a Prt v1 dataset, result keeps the 'reff'/'veff' dimensions,
+            with the extinction-weighted formula applied independently at
+            each (reff, veff) grid point."""
+            ds = make_size_distribution_dataset()
+            pp = ParticleProperties(data=ds)
+            w = np.array([475.0, 625.0]) * ureg.nm  # midpoints of both segments
+            result = pp.eval_ssa(w)
+
+            assert result.shape == (2, len(REFF), len(VEFF))
+
+            t = 0.5
+            for iw, (il, ir) in enumerate([(0, 1), (1, 2)]):
+                ext_l = ds["ext"].values[il]
+                ext_r = ds["ext"].values[ir]
+                ssa_l = ds["ssa"].values[il]
+                ssa_r = ds["ssa"].values[ir]
+                ext_interp = (1 - t) * ext_l + t * ext_r
+                expected = ((1 - t) * ext_l * ssa_l + t * ext_r * ssa_r) / ext_interp
+                np.testing.assert_allclose(result.m[iw], expected, rtol=1e-10)
+
     class TestEvalPhase:
-        def test_array_raises(self, pp):
-            """Array w input raises ValueError."""
-            w = np.array([400.0, 550.0]) * ureg.nm
-            with pytest.raises(ValueError, match="scalar"):
-                pp.eval_phase(w)
+        def test_array_matches_scalar_calls(self, pp):
+            """Array w input matches independent per-wavelength scalar calls."""
+            w = np.array([400.0, 475.0, 550.0]) * ureg.nm
+            mu_out, phase_out = pp.eval_phase(w)
+            assert mu_out.shape == (3, phase_out.shape[-1])
+            assert phase_out.shape[0] == 1
+            assert phase_out.shape[1] == 3
+
+            for i, w_scalar in enumerate(w):
+                mu_scalar, phase_scalar = pp.eval_phase(w_scalar)
+                np.testing.assert_allclose(mu_out[i], mu_scalar)
+                np.testing.assert_allclose(phase_out[:, i, :], phase_scalar)
 
         @pytest.mark.parametrize("w_nm", [400.0, 475.0, 550.0, 700.0])
         def test_fixed_grid_shape(self, pp, w_nm):
@@ -512,7 +824,7 @@ class TestParticleProperties:
             assert pp_single.has_fixed_mu_grid
 
             # Default is n_iangle for a fixed grid; stored values reproduced exactly
-            mu_out, phase_out = pp_single.eval_phase(300.0 * ureg.nm)
+            _mu_out, phase_out = pp_single.eval_phase(300.0 * ureg.nm)
             assert phase_out.shape == (1, n_iangle)
             # phase dims in Aer-Core v2: (phamat, w, iangle)
             stored_phase = ds["phase"].values[0, 0, :]

--- a/tests/03_regression/romc/test_het01.py
+++ b/tests/03_regression/romc/test_het01.py
@@ -20,7 +20,7 @@ def test_het01_brfpp(mode_mono_double, exp, dataset_regression):
 
     Simulation results are compared to a reference obtained with a prior
     version and validated with ROMC. Comparison is done with a z-test
-    with a threshold of 0.05.
+    with a threshold of 0.01.
     """
     result = eradiate.run(exp)
 
@@ -28,6 +28,6 @@ def test_het01_brfpp(mode_mono_double, exp, dataset_regression):
 
     dataset_regression.check(
         result,
-        ZTest(0.05, variable="radiance"),
+        ZTest(0.01, variable="radiance"),
         basename="het01_brfpp_ref",
     )


### PR DESCRIPTION
# Description

This PR introduces two new data formats, prt-v1 and ppr-v1 and the supporting loading and conversion functions. It adapts the `radprops.ParticleProperties` class to the prt-v1 format. These data formats are necessary to construct particle plumes of spatially varying phase function.

## Prt v1

This format is an extension to the `aer_core_v2` data format to support `reff` and `veff` indexed particles phase functions.

It can be loaded through the same entrypoints and converters as `aer_core_v2` that will detect the presence of a `reff` and `veff` coordinates.

This new format support irregular grids of `reff` and `veff`.

## Ppr v1

This new data format describes the variation of a particle species in a 3D grid. This is a sparse data format. Particle microphysical properties `reff` and `veff` are stored alongside the concentration in `mass/volume`. This lays the groundwork for a later PR that interpolates a `prt_v1` dataset to the phase at a point in space.

## ParticlesProperties

This class of the `radprops` module has been significantly changed. It now supports `prt_v1` datasets, where phase function, extinction and albedo vary over a `(reff, veff)` size-distribution grid. The property `has_size_distribution` is used to inform which underlying format is used between `prt_v1` and `aer_core_v2`

New reff/veff accessors are provided, alongside grid-aware evaluation methods (eval_phase_union, eval_phase_grid, phase_dataset_for_reff_veff, max_union_size) to query the phase function per size-distribution point.

`max_union_size` describes the maximum size of the grid unions across the wavelength coordinate to facilitate downstream memory allocations of buffers that can not be resized during the spectral loop.

Existing methods are extended in a backward-compatible manner: eval_ext/eval_ssa gain a (nreff, nveff) shape for `prt_v1` datasets. Their behavior is unchanged for plain `aer_core_v2` datasets.

Independent safety fix, bundled here: wavelength interpolation now clamps at the dataset's edges instead of extrapolating past them. Applies to both formats.

## Minor fixes

This PR also includes two changes related to minor issues I faced:

 - Deprecation warning issued by numpy due to netCDF4 not supporting NumPy >= 2.5
 - tests/03_regression/romc/test_het01.py relax the validation threshold that was too tight

Let me know if you want to address any of these differently.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `next` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
