### PR TITLE
[3DATM 4/6] Spatially varying particle ensembles

### DIFF
--- a/docs/reference_api/scenes.rst
+++ b/docs/reference_api/scenes.rst
@@ -171,7 +171,7 @@ Quick access
    HomogeneousAtmosphere
    HeterogeneousAtmosphere
    MolecularAtmosphere
-   ParticleLayer
+   ParticleEnsemble
 
 **Particle distributions**
 

--- a/docs/release_notes/v1.3.x.md
+++ b/docs/release_notes/v1.3.x.md
@@ -13,6 +13,9 @@
   `r_eff`/`v_eff` support ({ghpr}`584`).
 * New `ppr_v1` data format for spatially varying particle profiles, like
   clouds ({ghpr}`585`).
+* {class}`.ParticleEnsemble`'s `bottom` and `top` altitudes can now vary per
+  horizontal grid cell. `tau_ref` can vary per cell too. Particle properties
+  are the same in every cell ({ghpr}`588`).
 
 ### Changed
 
@@ -38,6 +41,9 @@
 * 🖥️ `RayleighPhaseFunction` now builds its depolarization-factor volume with
   `generate_gridvolume()`, instead of hand-rolled `DictParameter`/
   `SceneParameter` code ({ghpr}`587`).
+* 🖥️ `ArrayParticleDistribution` now accepts 3D arrays (one per horizontal
+  cell), not just 1D. `validators.is_positive` now works on arrays too
+  ({ghpr}`588`).
 * 🖥️ Documentation now builds with Sphinx 9 and Python 3.11 ({ghpr}`580`).
 * 🖥️ Local docs build now mocks Mitsuba and Dr.Jit like the Read The Docs build
   does ({ghpr}`580`).

--- a/docs/user_guide/atmosphere/heterogeneous.rst
+++ b/docs/user_guide/atmosphere/heterogeneous.rst
@@ -9,5 +9,5 @@ consisting of both of molecules and particles.
 
 * at most one instance of :class:`.MolecularAtmosphere`, representing the
   molecular or clear-sky component of a realistic atmospheres.
-* an arbitrary number of instances of :class:`.ParticleLayer`, representing the
+* an arbitrary number of instances of :class:`.ParticleEnsemble`, representing the
   cloud/aerosol components of a realistic atmosphere.

--- a/docs/user_guide/atmosphere/index.rst
+++ b/docs/user_guide/atmosphere/index.rst
@@ -13,6 +13,6 @@ Atmosphere guide
    homogeneous
    heterogeneous
    molecular
-   particle_layer
+   particle_ensemble
    absorption
    rayleigh_scattering

--- a/docs/user_guide/atmosphere/intro.rst
+++ b/docs/user_guide/atmosphere/intro.rst
@@ -89,7 +89,7 @@ and nature of atmospheric constituents.
 Constituents  Uniform radiative properties     Non-uniform radiative properties
 ============  ===============================  =================================
 Molecules     N/A                              :class:`.MolecularAtmosphere`
-Particles     N/A                              :class:`.ParticleLayer`
+Particles     N/A                              :class:`.ParticleEnsemble`
 Both          :class:`.HomogeneousAtmosphere`  :class:`.HeterogeneousAtmosphere`
 ============  ===============================  =================================
 

--- a/docs/user_guide/atmosphere/particle_ensemble.rst
+++ b/docs/user_guide/atmosphere/particle_ensemble.rst
@@ -1,0 +1,9 @@
+.. _sec-particle_ensemble:
+
+Particle ensemble
+=================
+
+Particle ensembles are 3D non-uniform participating media consisting of particles.
+These particles possess a single phase function corresponding to a single
+distribution of particle sizes.
+Particle ensemble scene elements are created using :class:`.ParticleEnsemble`.

--- a/docs/user_guide/atmosphere/particle_layer.rst
+++ b/docs/user_guide/atmosphere/particle_layer.rst
@@ -1,7 +1,0 @@
-.. _sec-particle_layer:
-
-Particle layer
-==============
-
-Particle layers are 1D non-uniform participating media consisting of particles.
-Particle layer scene elements are created using :class:`.ParticleLayer`.

--- a/docs/user_guide/atmosphere_experiment.rst
+++ b/docs/user_guide/atmosphere_experiment.rst
@@ -130,7 +130,7 @@ Heterogeneous atmosphere [:class:`.HeterogeneousAtmosphere`, ``heterogeneous``]
     configured by specifying a molecular component
     (:class:`.MolecularAtmosphere`), describing absorption and  scattering by
     atmospheric gases, and an arbitrary number of aerosol layers
-    (:class:`.ParticleLayer`).
+    (:class:`.ParticleEnsemble`).
 
 Surface [``surface``]
 ^^^^^^^^^^^^^^^^^^^^^

--- a/src/eradiate/scenes/atmosphere/__init__.pyi
+++ b/src/eradiate/scenes/atmosphere/__init__.pyi
@@ -17,6 +17,6 @@ from ._particle_dist import UniformParticleDistribution as UniformParticleDistri
 from ._particle_dist import (
     particle_distribution_factory as particle_distribution_factory,
 )
-from ._particle_layer import ParticleLayer as ParticleLayer
+from ._particle_ensemble import ParticleEnsemble as ParticleEnsemble
 from ._util import eval_transmittance_ckd as eval_transmittance_ckd
 from ._util import eval_transmittance_mono as eval_transmittance_mono

--- a/src/eradiate/scenes/atmosphere/_core.py
+++ b/src/eradiate/scenes/atmosphere/_core.py
@@ -61,8 +61,8 @@ atmosphere_factory.register_lazy_batch(
             {},
         ),
         (
-            "_particle_layer.ParticleLayer",
-            "particle_layer",
+            "_particle_ensemble.ParticleEnsemble",
+            "particle_ensemble",
             {},
         ),
     ],
@@ -600,7 +600,7 @@ class AbstractHeterogeneousAtmosphere(Atmosphere, ABC):
         Returns
         -------
         quantity
-            Particle layer extinction coefficient.
+            Extinction coefficient.
         """
 
     @abstractmethod
@@ -618,12 +618,12 @@ class AbstractHeterogeneousAtmosphere(Atmosphere, ABC):
         grid : .GridCoords, optional
             Altitude grid on which evaluation is performed. If unset, an
             instance-specific default is used
-            (see :meth:`grid <.AbstractHeterogeneousAtmosphere.column.grid>`).
+            (see :meth:`grid <.AbstractHeterogeneousAtmosphere.geometry.grid>`).
 
         Returns
         -------
         quantity
-            Particle layer extinction coefficient.
+            Absorption coefficient.
         """
 
     @abstractmethod
@@ -646,7 +646,7 @@ class AbstractHeterogeneousAtmosphere(Atmosphere, ABC):
         Returns
         -------
         quantity
-            Particle layer scattering coefficient.
+            Scattering coefficient.
         """
 
     def eval_transmittance(
@@ -784,7 +784,7 @@ class AbstractHeterogeneousAtmosphere(Atmosphere, ABC):
             albedo_key = "albedo.volume.data"
             sigma_t_key = "sigma_t.volume.data"
         else:
-            raise ValueError(
+            raise TypeError(
                 f"unhandled scene geometry type '{type(self.geometry).__name__}'"
             )
 

--- a/src/eradiate/scenes/atmosphere/_heterogeneous.py
+++ b/src/eradiate/scenes/atmosphere/_heterogeneous.py
@@ -15,7 +15,7 @@ from axsdb import AbsorptionDatabase
 
 from ._core import AbstractHeterogeneousAtmosphere, atmosphere_factory
 from ._molecular import MolecularAtmosphere
-from ._particle_layer import ParticleLayer
+from ._particle_ensemble import ParticleEnsemble
 from ..core import traverse
 from ..phase import MultiPhaseFunction, PhaseFunction
 from ...attrs import define, documented
@@ -36,21 +36,21 @@ def _molecular_converter(value):
     return atmosphere_factory.convert(value, allowed_cls=MolecularAtmosphere)
 
 
-def _particle_layer_converter(value):
+def _particle_ensemble_converter(value):
     if not value:
         return []
 
     if not isinstance(value, (list, tuple)):
-        return _particle_layer_converter([value])
+        return _particle_ensemble_converter([value])
 
     else:
         result = []
 
         for element in value:
             if isinstance(element, cabc.MutableMapping) and ("type" not in element):
-                element["type"] = "particle_layer"
+                element["type"] = "particle_ensemble"
             result.append(
-                atmosphere_factory.convert(element, allowed_cls=ParticleLayer)
+                atmosphere_factory.convert(element, allowed_cls=ParticleEnsemble)
             )
 
         return result
@@ -89,25 +89,25 @@ class HeterogeneousAtmosphere(AbstractHeterogeneousAtmosphere):
                 "scaled individually"
             )
 
-    particle_layers: list[ParticleLayer] = documented(
+    particle_ensembles: list[ParticleEnsemble] = documented(
         attrs.field(
             factory=list,
-            converter=_particle_layer_converter,
+            converter=_particle_ensemble_converter,
             validator=attrs.validators.deep_iterable(
-                attrs.validators.instance_of(ParticleLayer)
+                attrs.validators.instance_of(ParticleEnsemble)
             ),
         ),
-        doc="List of particle layers. Elements may be specified as "
+        doc="List of particle ensembles. Elements may be specified as "
         "dictionaries interpreted by :data:`.atmosphere_factory`; in that "
         "case, the ``type`` parameter may be omitted and will automatically "
-        'be set to ``"particle_layer"``.',
-        type="list of .ParticleLayer",
-        init_type="list of .ParticleLayer, optional",
+        'be set to ``"particle_ensemble"``.',
+        type="list of .ParticleEnsemble",
+        init_type="list of .ParticleEnsemble, optional",
         default="[]",
     )
 
-    @particle_layers.validator
-    def _particle_layers_validator(self, attribute, value):
+    @particle_ensembles.validator
+    def _particle_ensembles_validator(self, attribute, value):
         if not all(component.scale is None for component in value):
             raise ValueError(
                 f"while validating {attribute.name}: components cannot be "
@@ -124,7 +124,7 @@ class HeterogeneousAtmosphere(AbstractHeterogeneousAtmosphere):
     )
 
     @property
-    def components(self) -> list[MolecularAtmosphere | ParticleLayer]:
+    def components(self) -> list[MolecularAtmosphere | ParticleEnsemble]:
         """
         Returns
         -------
@@ -132,7 +132,7 @@ class HeterogeneousAtmosphere(AbstractHeterogeneousAtmosphere):
             The list of all registered atmospheric components.
         """
         result = [self.molecular_atmosphere] if self.molecular_atmosphere else []
-        result.extend(self.particle_layers)
+        result.extend(self.particle_ensembles)
         return result
 
     def update(self):

--- a/src/eradiate/scenes/atmosphere/_molecular.py
+++ b/src/eradiate/scenes/atmosphere/_molecular.py
@@ -31,7 +31,7 @@ class MolecularAtmosphere(AbstractHeterogeneousAtmosphere):
 
     See Also
     --------
-    :class:`~eradiate.scenes.atmosphere.ParticleLayer`,
+    :class:`~eradiate.scenes.atmosphere.ParticleEnsemble`,
     :class:`~eradiate.scenes.atmosphere.HeterogeneousAtmosphere`.
 
     Notes

--- a/src/eradiate/scenes/atmosphere/_particle_dist.py
+++ b/src/eradiate/scenes/atmosphere/_particle_dist.py
@@ -2,7 +2,7 @@
 Particle distributions.
 
 Particle distributions define how the particle number fraction varies with
-altitude. The particle layer is split into a number of divisions
+altitude. The particle ensemble is split into a number of divisions
 (sub-layers) wherein the particle number fraction is evaluated.
 
 Notes
@@ -10,6 +10,8 @@ Notes
 Particle distributions are not normalized. The parent caller is responsible
 for normalizing returned values.
 """
+
+from __future__ import annotations
 
 import typing as t
 from abc import ABC, abstractmethod
@@ -38,7 +40,7 @@ particle_distribution_factory.register_lazy_batch(
 class ParticleDistribution(ABC):
     """
     Abstract base class for particle distributions used to define particle
-    layers.
+    ensembles.
 
     In practice, particle distributions are callables with the signature
     ``f(x: np.typing.ArrayLike) -> np.ndarray`` and are evaluated over the
@@ -83,10 +85,10 @@ class UniformParticleDistribution(ParticleDistribution):
         if len(value) != 2:
             raise ValueError(
                 f"while validating '{attribute.name}': passed array must have "
-                "exactly 2 elements"
+                "a length of 2"
             )
 
-        if value[1] <= value[0]:
+        if np.any(value[1] <= value[0]):
             raise ValueError(
                 f"while validating '{attribute.name}': bounds must be sorted in "
                 "ascending order "
@@ -136,7 +138,7 @@ class ExponentialParticleDistribution(ParticleDistribution):
                 f"while validating {attribute.name}: rate must be strictly positive"
             )
 
-    def __init__(self, rate: float = None, scale: float = None):
+    def __init__(self, rate: Optional[float] = None, scale: Optional[float] = None):
         if rate is None and scale is None:
             self.__attrs_init__()
         elif scale is None and rate is not None:
@@ -180,7 +182,7 @@ class GaussianParticleDistribution(ParticleDistribution):
         init_type="float, optional",
         default="0.5",
         doc="Mean of the Gaussian PDF. The default value places the mean in "
-        "the middle of the particle layer (at :math:`x = 0.5`).",
+        "the middle of the particle ensemble (at :math:`x = 0.5`).",
     )
 
     std: float = documented(
@@ -217,22 +219,27 @@ class ArrayParticleDistribution(ParticleDistribution):
 
     @values.validator
     def _values_validator(self, attribute, value):
-        if value.ndim != 1:
+        if value.ndim not in {1, 3}:
             raise ValueError(
-                f"while validating {attribute.name}: only 1D arrays are allowed"
+                f"while validating {attribute.name}: only 1D or 3D arrays are allowed"
             )
 
-        if len(value) < 2:
+        if value.shape[-1] < 2:
             raise ValueError(
                 f"while validating {attribute.name}: array must have at least 2 "
-                "elements"
+                "elements along the interpolation z-axis"
             )
 
     coords: np.ndarray = documented(
         attrs.field(
             default=attrs.Factory(
-                lambda x: (lambda edges: (edges[:-1] + edges[1:]) / 2)(
-                    np.linspace(0, 1, len(x.values) + 1)
+                lambda self: np.broadcast_to(
+                    np.convolve(
+                        np.linspace(0, 1, self.values.shape[-1] + 1),
+                        [0.5, 0.5],
+                        "valid",
+                    ),
+                    self.values.shape,
                 ),
                 takes_self=True,
             ),
@@ -255,30 +262,41 @@ class ArrayParticleDistribution(ParticleDistribution):
             )
 
     method: str = documented(
-        attrs.field(
-            default="linear",
-            converter=str,
-            validator=attrs.validators.in_(
-                {
-                    "linear",
-                    "nearest",
-                    "nearest-up",
-                    "zero",
-                    "slinear",
-                    "quadratic",
-                    "cubic",
-                    "previous",
-                    "next",
-                }
-            ),
-        ),
+        attrs.field(default="linear", converter=str),
         type="str",
         init_type='{ "linear", "nearest", "nearest-up", "zero", "slinear", '
         '"quadratic", "cubic", "previous", "next" }',
         default='"linear"',
         doc="Interpolation method. See :class:`scipy.interpolate.interp1d` "
-        "(*kind*) for more information.",
+        "(*kind*) for more information. With a 3D ``values`` array, only "
+        '``"linear"`` and ``"nearest"`` are supported.',
     )
+
+    @method.validator
+    def _method_validator(self, attribute, value):
+        allowed = {
+            "linear",
+            "nearest",
+            "nearest-up",
+            "zero",
+            "slinear",
+            "quadratic",
+            "cubic",
+            "previous",
+            "next",
+        }
+        if value not in allowed:
+            raise ValueError(
+                f"while validating '{attribute.name}': got '{value}', "
+                f"expected one of {sorted(allowed)}"
+            )
+
+        if self.values.ndim == 3 and value not in ("linear", "nearest"):
+            raise ValueError(
+                f"while validating '{attribute.name}': with a 3D 'values' "
+                f"array, only 'linear' and 'nearest' are supported (got "
+                f"'{value}')"
+            )
 
     extrapolate: str = documented(
         attrs.field(
@@ -307,11 +325,13 @@ class ArrayParticleDistribution(ParticleDistribution):
         "     - ``np.nan``\n",
     )
 
-    def __call__(self, x: np.typing.ArrayLike) -> np.ndarray:
+    def _interp1d(
+        self, coords: np.ndarray, values: np.ndarray, x: np.typing.ArrayLike
+    ) -> np.ndarray:
         if self.extrapolate == "zero":
             fill_value = 0.0
         elif self.extrapolate == "nearest":
-            fill_value = (self.values[0], self.values[-1])
+            fill_value = (values[0], values[-1])
         elif self.extrapolate == "method":
             fill_value = "extrapolate"
         else:
@@ -319,13 +339,86 @@ class ArrayParticleDistribution(ParticleDistribution):
 
         # TODO: This is unsafe, values of x outside of [0, 1] should return 0
         f = scipy.interpolate.interp1d(
-            self.coords,
-            self.values,
+            coords,
+            values,
             kind=self.method,
             bounds_error=False,
             fill_value=fill_value,
         )
         return f(x)
+
+    def _interp3d(
+        self, coords: np.ndarray, values: np.ndarray, x: np.ndarray
+    ) -> np.ndarray:
+        """
+        Evaluate one 'linear' or 'nearest' interpolant per (i_x, i_y) cell.
+        """
+        n = coords.shape[-1]
+        cell_shape = coords.shape[:-1]
+        size = int(np.prod(cell_shape, dtype=np.int64)) if cell_shape else 1
+
+        span = max(coords.max(), x.max()) - min(coords.min(), x.min())
+        cell = np.arange(size, dtype=np.int64).reshape(cell_shape + (1,))
+        offsets = (span + 1.0) * cell
+
+        coords_flat = (coords + offsets).reshape(-1)
+        x_flat = (x + offsets).reshape(-1)
+        idx = np.searchsorted(coords_flat, x_flat, side="right")
+        idx = idx.reshape(x.shape) - cell * n
+
+        if self.method == "nearest":
+            j0 = np.clip(idx - 1, 0, n - 1)
+            j1 = np.clip(idx, 0, n - 1)
+            c0 = np.take_along_axis(coords, j0, axis=-1)
+            c1 = np.take_along_axis(coords, j1, axis=-1)
+            v0 = np.take_along_axis(values, j0, axis=-1)
+            v1 = np.take_along_axis(values, j1, axis=-1)
+            # Bin edges at coord midpoints, matching interp1d.
+            result = np.where(x <= (c0 + c1) / 2.0, v0, v1)
+        else:  # "linear"
+            j0 = np.clip(idx - 1, 0, n - 2)
+            j1 = j0 + 1
+            c0 = np.take_along_axis(coords, j0, axis=-1)
+            c1 = np.take_along_axis(coords, j1, axis=-1)
+            v0 = np.take_along_axis(values, j0, axis=-1)
+            v1 = np.take_along_axis(values, j1, axis=-1)
+            t = np.where(c1 > c0, (x - c0) / (c1 - c0), 0.0)
+            result = v0 + t * (v1 - v0)
+
+        below = x < coords[..., :1]
+        above = x > coords[..., -1:]
+
+        if self.extrapolate == "zero":
+            return np.where(below | above, 0.0, result)
+        elif self.extrapolate == "nearest":
+            result = np.where(below, values[..., :1], result)
+            return np.where(above, values[..., -1:], result)
+        elif self.extrapolate == "method":
+            # 'linear' and 'nearest' extrapolate naturally, no special case.
+            return result
+        else:  # "nan"
+            return np.where(below | above, np.nan, result)
+
+    def __call__(self, x: np.typing.ArrayLike) -> np.ndarray:
+        x = np.asarray(x, dtype=float)
+
+        if self.values.ndim == 1:
+            return self._interp1d(self.coords, self.values, x)
+
+        # 3D case: one independent interpolant per (i_x, i_y) horizontal cell.
+        n_x, n_y = self.values.shape[:2]
+        if x.ndim == 1:
+            x = np.broadcast_to(x, (n_x, n_y) + x.shape)
+        elif x.shape[:2] != (n_x, n_y):
+            raise ValueError(
+                "ArrayParticleDistribution: with a 3D 'values' array, the "
+                "query array must either be 1D, or have a leading (x, y) "
+                f"shape matching it (expected {(n_x, n_y)}, got "
+                f"{x.shape[:2]})."
+            )
+
+        # 3D only allows 'linear'/'nearest' (see '_method_validator').
+        return self._interp3d(self.coords, self.values, x)
 
 
 @define

--- a/src/eradiate/scenes/atmosphere/_particle_ensemble.py
+++ b/src/eradiate/scenes/atmosphere/_particle_ensemble.py
@@ -1,5 +1,5 @@
 """
-Particle layers.
+Particle ensembles.
 """
 
 from __future__ import annotations
@@ -32,7 +32,7 @@ from ...util.misc import cache_by_id
 from ...validators import is_positive
 
 
-def _particle_layer_distribution_converter(value):
+def _particle_ensemble_distribution_converter(value):
     if isinstance(value, str):
         if value == "uniform":
             return particle_distribution_factory.convert({"type": "uniform"})
@@ -44,23 +44,22 @@ def _particle_layer_distribution_converter(value):
     return particle_distribution_factory.convert(value)
 
 
-@define(eq=False, slots=False, init=False)
-class ParticleLayer(AbstractHeterogeneousAtmosphere):
+@define(eq=False, slots=False)
+class ParticleEnsemble(AbstractHeterogeneousAtmosphere):
     """
-    Particle layer scene element [``particle_layer``].
+    Particle ensemble scene element [``particle_ensemble``].
 
-    The particle layer has a vertical extension specified by a bottom altitude
-    (set by ``bottom``) and a top altitude (set by ``top``).
-    Inside the layer, the particles number is distributed according to a
+    The particle ensemble has a vertical extension specified by a bottom
+    altitude (set by ``bottom``) and a top altitude (set by ``top``).
+    Inside the ensemble, the particles number is distributed according to a
     distribution (set by ``distribution``).
     See :mod:`~eradiate.scenes.atmosphere.particle_dist` for the available
     distribution types and corresponding parameters.
-    The particle layer is itself divided into a number of (sub-)layers
-    (``n_layers``) to allow to describe the variations of the particles number
-    with altitude.
-    The particle density in the layer is adjusted so that the particle layer's
-    optical thickness at a specified reference wavelength (``w_ref``) meets a
-    specified value (``tau_ref``).
+    The particle number fraction is evaluated on the vertical layers of the
+    render grid (see ``geometry``) to describe its variations with altitude.
+    The particle density in the ensemble is adjusted so that the particle
+    ensemble's optical thickness at a specified reference wavelength
+    (``w_ref``) meets a specified value (``tau_ref``).
     The particles radiative properties are specified by a data set
     (``dataset``).
 
@@ -76,7 +75,10 @@ class ParticleLayer(AbstractHeterogeneousAtmosphere):
             validator=[is_positive, pinttrs.validators.has_compatible_units],
             units=ucc.deferred("length"),
         ),
-        doc="Bottom altitude of the particle layer.\n"
+        doc="Bottom altitude of the particle ensemble. May be a scalar (the "
+        "same altitude everywhere) or an ``(n_x, n_y)`` array matching the "
+        "scene geometry's horizontal grid shape, for a bottom altitude that "
+        "varies spatially.\n"
         "\n"
         "Unit-enabled field (default: ucc[length])",
         type="quantity",
@@ -90,18 +92,21 @@ class ParticleLayer(AbstractHeterogeneousAtmosphere):
             default=ureg.Quantity(1.0, ureg.km),
             validator=[is_positive, pinttrs.validators.has_compatible_units],
         ),
-        doc="Top altitude of the particle layer.\n"
+        doc="Top altitude of the particle ensemble. May be a scalar (the "
+        "same altitude everywhere) or an ``(n_x, n_y)`` array matching the "
+        "scene geometry's horizontal grid shape, for a top altitude that "
+        "varies spatially.\n"
         "\n"
         "Unit-enabled field (default: ucc[length]).",
         type="quantity",
         init_type="float or quantity",
-        default="1 km.",
+        default="1 km",
     )
 
     @bottom.validator
     @top.validator
     def _bottom_top_validator(self, attribute, value):
-        if self.bottom >= self.top:
+        if np.any(self.bottom >= self.top):
             raise ValueError(
                 f"while validating '{attribute.name}': bottom altitude must be "
                 "lower than top altitude "
@@ -111,10 +116,11 @@ class ParticleLayer(AbstractHeterogeneousAtmosphere):
     distribution: ParticleDistribution = documented(
         attrs.field(
             default="uniform",
-            converter=_particle_layer_distribution_converter,
+            converter=_particle_ensemble_distribution_converter,
             validator=attrs.validators.instance_of(ParticleDistribution),
         ),
-        doc="Particle distribution. Simple defaults can be set using a string: "
+        doc="Particle distribution in the Z dimension of the coords grid. "
+        "Simple defaults can be set using a string: "
         '``"uniform"`` (resp. ``"gaussian"``, ``"exponential"``) is converted to '
         ":class:`UniformParticleDistribution() <.UniformParticleDistribution>` "
         "(resp. :class:`GaussianParticleDistribution() <.GaussianParticleDistribution>`, "
@@ -147,7 +153,7 @@ class ParticleLayer(AbstractHeterogeneousAtmosphere):
         w_units = self.particle_properties.w.u
         if not np.any(np.isclose(value.m_as(w_units), self.particle_properties.w.m)):
             warnings.warn(
-                "While initializing ParticleLayer: the provided aerosol "
+                "While initializing ParticleEnsemble: the provided aerosol "
                 "single-scattering property dataset does not contain the selected "
                 f"reference wavelength (w_ref = {value})",
                 stacklevel=2,
@@ -159,13 +165,41 @@ class ParticleLayer(AbstractHeterogeneousAtmosphere):
             factory=lambda: ureg.Quantity(0.2, ureg.dimensionless),
             validator=[is_positive, pinttrs.validators.has_compatible_units],
         ),
-        doc="Extinction optical thickness at the reference wavelength.\n"
+        doc="Extinction optical thickness at the reference wavelength. May be "
+        "a scalar (the same optical thickness everywhere) or an "
+        "``(n_x, n_y)`` array matching the scene geometry's horizontal grid "
+        "shape, for an optical thickness that varies spatially.\n"
         "\n"
         "Unit-enabled field (default: ucc[dimensionless]).",
         type="quantity",
         init_type="quantity or float",
         default="0.2",
     )
+
+    @tau_ref.validator
+    def _tau_ref_all_positive(self, attribute, value):
+        if np.any(value < 0.0):
+            raise ValueError(
+                "While initialising ParticleEnsemble: reference "
+                "extinction optical thickness must be positive"
+            )
+
+    @tau_ref.validator
+    @bottom.validator
+    @top.validator
+    def _xy_shape_validator(self, attribute, value):
+        if self.geometry is None:
+            return
+        if np.size(value) == 1:
+            return
+        if value.shape != self.geometry.grid.shape[:2]:
+            raise ValueError(
+                "While initialising ParticleEnsemble: the shape of the "
+                f"{attribute.name} attribute is inconsistent with the "
+                "scene geometry. Expected a scalar value or a "
+                f"{self.geometry.grid.shape[:2]} sized array, "
+                f"received a {value.shape} sized array."
+            )
 
     particle_properties: ParticleProperties = documented(
         attrs.field(
@@ -207,7 +241,7 @@ class ParticleLayer(AbstractHeterogeneousAtmosphere):
 
     force_polarized_phase: bool = documented(
         attrs.field(default=False, converter=bool),
-        doc="Force the use of a polarized phase function implementation, even"
+        doc="Force the use of a polarized phase function implementation, even "
         "when no polarization information is available.",
         type="bool",
         default="False",
@@ -238,21 +272,46 @@ class ParticleLayer(AbstractHeterogeneousAtmosphere):
 
     def eval_fractions(self, grid: GridCoords) -> np.ndarray:
         """
-        Compute the particle number fraction in the particle layer.
+        Compute the particle number fraction in the particle ensemble in 3D
+        according to the distribution.
 
-        Returns
+        The Z dimension (vertical extent) supports spatially varying
+        top and bottom in X and Y.
+
         -------
         ndarray
-            Particle number fractions as a (n_layers,)-shaped array.
+            Particle number fractions as a ([n_x, n_y, ]n_layers,)-shaped
+            array. The leading spatial dimensions are only present if `bottom`
+            and `top` vary spatially; otherwise the result is a flat
+            (n_layers,)-shaped array.
         """
-        x = (grid.layers - self.bottom) / (self.top - self.bottom)
-        fractions = self.distribution(x.m_as(ureg.dimensionless))
-        fractions /= np.sum(fractions)
-        return fractions
+
+        # Variable bottom and top altitude
+        bottom = np.atleast_1d(self.bottom)
+        extent = np.atleast_1d(self.top - self.bottom)
+        z = (grid.layers - bottom[..., np.newaxis]) / extent[..., np.newaxis]
+
+        if np.ndim(self.bottom) == 0:
+            z = z[0]
+
+        fractions = self.distribution(z.m_as(ureg.dimensionless))
+
+        out = np.zeros(fractions.shape)
+        fractions_sum = fractions.sum(axis=-1, keepdims=True)
+        np.divide(fractions, fractions_sum, out=out, where=fractions_sum > 0.0)
+
+        return out
 
     def eval_mfp(self, ctx: KernelContext) -> pint.Quantity:
-        min_sigma_s = self.eval_sigma_s(ctx.si).min()
-        return 1.0 / min_sigma_s if min_sigma_s != 0.0 else np.inf * ureg.m
+        min_sigma_s = self.eval_sigma_s(ctx.si).min(axis=-1)
+        out = np.full(min_sigma_s.shape, np.inf)
+        np.divide(
+            np.ones(min_sigma_s.shape[:-1]),
+            min_sigma_s,
+            where=min_sigma_s != 0,
+            out=out,
+        )
+        return out * ureg.m
 
     # --------------------------------------------------------------------------
     #                       Radiative properties
@@ -261,18 +320,18 @@ class ParticleLayer(AbstractHeterogeneousAtmosphere):
     @cache_by_id
     def _eval_albedo_impl(self, w: pint.Quantity, grid: GridCoords) -> pint.Quantity:
         # Return albedo from dataset (without accounting for bypass switches)
-        # This routine is vectorized and returns an array of shape
-        # (n_wavelengths, n_layers)
+        # This routine returns an array of shape (n_wavelengths, [x, y, ]n_layers)
         pp = self.particle_properties
-        albedo = pp.eval_ssa(w)
-        zmask = np.reshape(self.eval_fractions(grid) > 0, (1, -1))
-        return albedo * zmask
+        interpolated = pp.eval_ssa(np.atleast_1d(w))
+        fractions = self.eval_fractions(grid)
+        where_present = fractions > 0
+        albedo = interpolated[..., np.newaxis] * where_present[np.newaxis, ...]
+        return albedo
 
     @cache_by_id
     def _eval_sigma_t_impl(self, w: pint.Quantity, grid: GridCoords) -> pint.Quantity:
         # Return extinction coefficient from dataset (without accounting
-        # for bypass switches). This routine is vectorized and returns an
-        # array of shape (n_wavelengths, n_layers)
+        # for bypass switches). Returns an array of shape (n_wavelengths, [x, y, ]n_layers)
 
         # Collect input data
         w = np.atleast_1d(w)
@@ -281,34 +340,45 @@ class ParticleLayer(AbstractHeterogeneousAtmosphere):
         sigma_t_star_ref = pp.eval_ext(self.w_ref)
 
         # Compute target optical thickness value
-        tau = self.tau_ref * sigma_t_star / sigma_t_star_ref
+        sigma_t_star_expanded = sigma_t_star.reshape(
+            sigma_t_star.shape + (1,) * np.ndim(self.tau_ref)
+        )
+        tau = sigma_t_star_expanded * self.tau_ref / sigma_t_star_ref
 
         # Scatter this total OT to all layers
-        # TODO: Make sure that axis order is consistent with other vectorized
-        #  routines
         fractions = self.eval_fractions(grid)
-        tau_layers = np.broadcast_to(
-            np.reshape(tau, (-1, 1)), (len(w), grid.n_layers)
-        ) * np.reshape(fractions, (1, -1))
+        tau_layers = tau[..., np.newaxis] * fractions[np.newaxis, ...]
 
         # Compute corresponding average coefficient
         sigma_t = tau_layers / grid.layer_height
 
         return sigma_t
 
+    @staticmethod
+    def _pad_spatial_dims(value, ndim):
+        # Insert size-1 axes between the leading wavelength axis and the
+        # trailing layer axis so shapes with no spatial variation broadcast
+        # correctly against shapes that do vary spatially (via tau_ref).
+        extra = ndim - value.ndim
+        if extra <= 0:
+            return value
+        return value.reshape(value.shape[:1] + (1,) * extra + value.shape[1:])
+
     def _eval_sigma_a_impl(self, w: pint.Quantity, grid: GridCoords) -> pint.Quantity:
         # Return absorption coefficient from dataset (without accounting for
         # bypass switches). This routine is vectorized and returns an array of
         # shape (n_wavelengths, n_layers)
-        albedo = self._eval_albedo_impl(w, grid)
-        return self._eval_sigma_t_impl(w, grid) * (1.0 - albedo.m)
+        sigma_t = self._eval_sigma_t_impl(w, grid)
+        albedo = self._pad_spatial_dims(self._eval_albedo_impl(w, grid), sigma_t.ndim)
+        return sigma_t * (1.0 - albedo.m)
 
     def _eval_sigma_s_impl(self, w: pint.Quantity, grid: GridCoords) -> pint.Quantity:
         # Return scattering coefficient from dataset (without accounting for
         # bypass switches). This routine is vectorized and returns an array of
         # shape (n_wavelengths, n_layers)
-        albedo = self._eval_albedo_impl(w, grid)
-        return self._eval_sigma_t_impl(w, grid) * albedo.m
+        sigma_t = self._eval_sigma_t_impl(w, grid)
+        albedo = self._pad_spatial_dims(self._eval_albedo_impl(w, grid), sigma_t.ndim)
+        return sigma_t * albedo.m
 
     @singledispatchmethod
     def eval_albedo(
@@ -334,16 +404,13 @@ class ParticleLayer(AbstractHeterogeneousAtmosphere):
 
     def eval_albedo_mono(self, w: pint.Quantity, grid: GridCoords) -> pint.Quantity:
         if self.has_absorption and self.has_scattering:
-            albedo = self._eval_albedo_impl(w, grid).squeeze()
+            albedo = self._eval_albedo_impl(w, grid).squeeze(axis=0)
 
         elif self.has_absorption and not self.has_scattering:
             albedo = 0.0 * ureg.dimensionless
 
         elif self.has_scattering and not self.has_absorption:
             albedo = 1.0 * ureg.dimensionless
-
-        else:
-            raise RuntimeError
 
         # Albedo is constant vs spatial dimension
         return np.full_like(grid.layers, albedo)
@@ -355,7 +422,9 @@ class ParticleLayer(AbstractHeterogeneousAtmosphere):
 
     @singledispatchmethod
     def eval_sigma_t(
-        self, si: SpectralIndex, grid: GridCoords | None = None
+        self,
+        si: SpectralIndex,
+        grid: GridCoords | None = None,
     ) -> pint.Quantity:
         # Inherit docstring
         raise NotImplementedError
@@ -363,37 +432,43 @@ class ParticleLayer(AbstractHeterogeneousAtmosphere):
     @eval_sigma_t.register(MonoSpectralIndex)
     def _(self, si, grid: GridCoords | None = None) -> pint.Quantity:
         return self.eval_sigma_t_mono(
-            w=si.w, grid=self.geometry.grid if grid is None else grid
+            w=si.w,
+            grid=self.geometry.grid if grid is None else grid,
         )
 
     @eval_sigma_t.register(CKDSpectralIndex)
     def _(self, si, grid: GridCoords | None = None) -> pint.Quantity:
         return self.eval_sigma_t_ckd(
-            w=si.w, g=si.g, grid=self.geometry.grid if grid is None else grid
+            w=si.w,
+            g=si.g,
+            grid=self.geometry.grid if grid is None else grid,
         )
 
     def eval_sigma_t_mono(self, w: pint.Quantity, grid: GridCoords) -> pint.Quantity:
-        result = self._eval_sigma_t_impl(w, grid).squeeze()
+        result = self._eval_sigma_t_impl(w, grid).squeeze(axis=0)
 
         if self.has_absorption and self.has_scattering:
             return result
 
         elif not self.has_absorption and self.has_scattering:
-            return result - self._eval_sigma_a_impl(w, grid).squeeze()
+            return result - self._eval_sigma_a_impl(w, grid).squeeze(axis=0)
 
         elif self.has_absorption and not self.has_scattering:
-            return result - self._eval_sigma_s_impl(w, grid).squeeze()
-
-        raise RuntimeError
+            return result - self._eval_sigma_s_impl(w, grid).squeeze(axis=0)
 
     def eval_sigma_t_ckd(
-        self, w: pint.Quantity, g: float, grid: GridCoords
+        self,
+        w: pint.Quantity,
+        g: float,
+        grid: GridCoords,
     ) -> pint.Quantity:
         return self.eval_sigma_t_mono(w=w, grid=grid)
 
     @singledispatchmethod
     def eval_sigma_a(
-        self, si: SpectralIndex, grid: GridCoords | None = None
+        self,
+        si: SpectralIndex,
+        grid: GridCoords | None = None,
     ) -> pint.Quantity:
         # Inherit docstring
         raise NotImplementedError
@@ -401,17 +476,20 @@ class ParticleLayer(AbstractHeterogeneousAtmosphere):
     @eval_sigma_a.register(MonoSpectralIndex)
     def _(self, si, grid: GridCoords | None = None) -> pint.Quantity:
         return self.eval_sigma_a_mono(
-            w=si.w, grid=self.geometry.grid if grid is None else grid
+            w=si.w,
+            grid=self.geometry.grid if grid is None else grid,
         )
 
     @eval_sigma_a.register(CKDSpectralIndex)
     def _(self, si, grid: GridCoords | None = None) -> pint.Quantity:
         return self.eval_sigma_a_ckd(
-            w=si.w, g=si.g, grid=self.geometry.grid if grid is None else grid
+            w=si.w,
+            g=si.g,
+            grid=self.geometry.grid if grid is None else grid,
         )
 
     def eval_sigma_a_mono(self, w: pint.Quantity, grid: GridCoords) -> pint.Quantity:
-        value = self._eval_sigma_a_impl(w, grid).squeeze()
+        value = self._eval_sigma_a_impl(w, grid).squeeze(axis=0)
         return value if self.has_absorption else np.zeros_like(value) * value.units
 
     def eval_sigma_a_ckd(
@@ -429,17 +507,20 @@ class ParticleLayer(AbstractHeterogeneousAtmosphere):
     @eval_sigma_s.register(MonoSpectralIndex)
     def _(self, si, grid: GridCoords | None = None) -> pint.Quantity:
         return self.eval_sigma_s_mono(
-            w=si.w, grid=self.geometry.grid if grid is None else grid
+            w=si.w,
+            grid=self.geometry.grid if grid is None else grid,
         )
 
     @eval_sigma_s.register(CKDSpectralIndex)
     def _(self, si, grid: GridCoords | None = None) -> pint.Quantity:
         return self.eval_sigma_s_ckd(
-            w=si.w, g=si.g, grid=self.geometry.grid if grid is None else grid
+            w=si.w,
+            g=si.g,
+            grid=self.geometry.grid if grid is None else grid,
         )
 
     def eval_sigma_s_mono(self, w: pint.Quantity, grid: GridCoords) -> pint.Quantity:
-        value = self._eval_sigma_s_impl(w, grid).squeeze()
+        value = self._eval_sigma_s_impl(w, grid).squeeze(axis=0)
         return value if self.has_scattering else np.zeros_like(value) * value.units
 
     def eval_sigma_s_ckd(

--- a/src/eradiate/test_tools/test_cases/atmospheres.py
+++ b/src/eradiate/test_tools/test_cases/atmospheres.py
@@ -68,8 +68,8 @@ def create_rpv_afgl1986_continental_brfpp(absorption_database_error_handler_conf
                 "absorption_data": "monotropa",
                 "error_handler_config": absorption_database_error_handler_config,
             },
-            "particle_layers": {
-                "type": "particle_layer",
+            "particle_ensembles": {
+                "type": "particle_ensemble",
                 "bottom": 1 * ureg.km,
                 "top": 2 * ureg.km,
                 "tau_ref": 0.5,

--- a/src/eradiate/test_tools/test_cases/integrators.py
+++ b/src/eradiate/test_tools/test_cases/integrators.py
@@ -46,8 +46,8 @@ def _create_integrator_surface(
                 "absorption_data": "monotropa",
                 "error_handler_config": absorption_database_error_handler_config,
             },
-            "particle_layers": {
-                "type": "particle_layer",
+            "particle_ensembles": {
+                "type": "particle_ensemble",
                 "bottom": 1 * ureg.km,
                 "top": 2 * ureg.km,
                 "tau_ref": 0.2,
@@ -112,8 +112,8 @@ def create_integrator_canopy(absorption_database_error_handler_config, integrato
                 "absorption_data": "monotropa",
                 "error_handler_config": absorption_database_error_handler_config,
             },
-            "particle_layers": {
-                "type": "particle_layer",
+            "particle_ensembles": {
+                "type": "particle_ensemble",
                 "bottom": 0 * ureg.km,
                 "top": 2 * ureg.km,
                 "distribution": {"type": "uniform"},

--- a/src/eradiate/test_tools/test_cases/ocean.py
+++ b/src/eradiate/test_tools/test_cases/ocean.py
@@ -43,7 +43,7 @@ def create_ocean_grasp(water_body_reflectance, wind_speed, has_atmosphere=False)
         Wind speed at mast height in m/s.
 
     has_atmosphere: bool
-        Flags whether to include an atmosphere and particle layer as described
+        Flags whether to include an atmosphere and particle ensemble as described
         by 3DREAMS scenario REF_OO_UB01_I_S20_PPL.
 
     Returns
@@ -69,9 +69,9 @@ def create_ocean_grasp(water_body_reflectance, wind_speed, has_atmosphere=False)
                 ).joseki.rescale_to({"CO2": 360 * ureg.ppm}),
                 "rayleigh_depolarization": 0.0,
             },
-            "particle_layers": [
+            "particle_ensembles": [
                 {
-                    "type": "particle_layer",
+                    "type": "particle_ensemble",
                     "bottom": 0 * ureg.km,
                     "top": 40 * ureg.km,
                     "distribution": {
@@ -192,7 +192,7 @@ def create_ocean_grasp_open_atm():
     an open ocean water body reflectance spectrum.
     * Atmosphere (if `has_atmosphere=True`): afgl US standard atmosphere with
     rescaled CO2 concentration to 360 ppm and depolarization set to zero.
-    * Particle Layer (if `has_atmosphere=True): Exponentially distributed layer
+    * Particle ensemble (if `has_atmosphere=True`): Exponentially distributed layer
     with absorption and optical depth of 0.1, distribution
     * Illumination: Directional illumination with a zenith angle :math:`\theta = 20°`
     * Sensor: Multi Distant measure over the principal plane from -60 to 60 degrees

--- a/src/eradiate/test_tools/test_cases/rami4atm.py
+++ b/src/eradiate/test_tools/test_cases/rami4atm.py
@@ -211,10 +211,10 @@ def create_toa(case_id: str, spp: int, padding: int = 5) -> CanopyAtmosphereExpe
         )
 
     if aerosol_id == "0":
-        particle_layer = {}
+        particle_ensemble = {}
 
     elif aerosol_id in {"c", "d"}:
-        particle_layer = {
+        particle_ensemble = {
             "bottom": 0.0 * ureg.m,
             "top": 2000.0 * ureg.m,
             "distribution": {"type": "uniform"},
@@ -226,20 +226,20 @@ def create_toa(case_id: str, spp: int, padding: int = 5) -> CanopyAtmosphereExpe
         }
 
     else:
-        raise ValueError(f"Unhandled particle layer component id '{aerosol_id}'")
+        raise ValueError(f"Unhandled particle ensemble component id '{aerosol_id}'")
 
     if aerosol_ot_id == "0":
         pass
     elif aerosol_ot_id in {"2", "6"}:
-        if not particle_layer:
+        if not particle_ensemble:
             raise ValueError(
                 f"Optical thickness id '{aerosol_ot_id}' requires a particle "
                 f"layer, but the aerosol id is '{aerosol_id}' (none)"
             )
-        particle_layer["tau_ref"] = 0.2 if aerosol_ot_id == "2" else 0.6
+        particle_ensemble["tau_ref"] = 0.2 if aerosol_ot_id == "2" else 0.6
     else:
         raise ValueError(
-            f"Unhandled particle layer optical thickness '{aerosol_ot_id}'"
+            f"Unhandled particle ensemble optical thickness '{aerosol_ot_id}'"
         )
 
     if profile_id != "s":
@@ -248,7 +248,7 @@ def create_toa(case_id: str, spp: int, padding: int = 5) -> CanopyAtmosphereExpe
     atmosphere = {
         "type": "heterogeneous",
         "molecular_atmosphere": molecular_atmosphere,
-        "particle_layers": [particle_layer] if particle_layer else [],
+        "particle_ensembles": [particle_ensemble] if particle_ensemble else [],
     }
 
     return CanopyAtmosphereExperiment(

--- a/src/eradiate/tutorials.py
+++ b/src/eradiate/tutorials.py
@@ -62,7 +62,7 @@ def plot_polarfilm(
     """
 
     import matplotlib.pyplot as plt
-    import matplotlib.tri as tri
+    from matplotlib import tri
 
     # Filter grazing angles
     da = (
@@ -191,8 +191,19 @@ def plot_sigma_t(
 
     with plt.rc_context({"lines.linestyle": ":", "lines.marker": "."}):
         for atmosphere in atmospheres:
-            altitude = to_quantity(atmosphere.eval_radprops(si=si).z_layer).m_as("km")
-            sigma_t = to_quantity(atmosphere.eval_radprops(si=si).sigma_t).m_as("1/m")
+            radprops = atmosphere.eval_radprops(si=si)
+            altitude = to_quantity(radprops.z_layer).m_as("km")
+
+            sigma_t_da = radprops.sigma_t.squeeze()
+            if sigma_t_da.ndim != 1:
+                raise ValueError(
+                    "plot_sigma_t() only supports atmospheres without "
+                    "horizontal spatial variation; got a sigma_t array of "
+                    f"shape {radprops.sigma_t.shape} that does not reduce to "
+                    "a 1D altitude profile."
+                )
+
+            sigma_t = to_quantity(sigma_t_da).m_as("1/m")
             ax.plot(altitude, sigma_t, label=next(label_iter))
 
     formatter = ScalarFormatter(useMathText=True)
@@ -251,7 +262,7 @@ def load_ipython_extension(ipython):
     xr.set_options(display_expand_data=False)
     display(
         Markdown(
-            f"*Last updated: {datetime.datetime.now():%Y-%m-%d %H:%M} "
+            f"*Last updated: {datetime.datetime.now().astimezone():%Y-%m-%d %H:%M} "
             f"(eradiate v{__version__})*"
         )
     )

--- a/src/eradiate/validators.py
+++ b/src/eradiate/validators.py
@@ -56,14 +56,15 @@ def is_vector3(instance, attribute, value):
 
 def is_positive(_, attribute, value):
     """
-    Validate iff value is a positive number.
+    Validate iff value is a positive number. Arrays are validated
+    element-wise.
 
     Raises
     ------
     ValueError
-        If the value is not positive or zero.
+        If value is negative.
     """
-    if value < 0.0:
+    if np.any(np.atleast_1d(value) < 0.0):
         raise ValueError(f"{attribute.name} must be positive or zero, got {value}")
 
 
@@ -110,7 +111,7 @@ def path_exists(_, attribute, value):
     """
     if not value.exists():
         raise FileNotFoundError(
-            f"{attribute} points to '{str(value)}' (path does not exist)"
+            f"{attribute} points to '{value!s}' (path does not exist)"
         )
 
 
@@ -126,9 +127,7 @@ def is_file(_, attribute, value):
         file.
     """
     if not value.is_file():
-        raise FileNotFoundError(
-            f"{attribute.name} points to '{str(value)}' (not a file)"
-        )
+        raise FileNotFoundError(f"{attribute.name} points to '{value!s}' (not a file)")
 
 
 def is_dir(_, attribute, value):
@@ -144,7 +143,7 @@ def is_dir(_, attribute, value):
     """
     if not value.is_dir():
         raise FileNotFoundError(
-            f"{attribute.name} points to '{str(value)}' (not a directory)"
+            f"{attribute.name} points to '{value!s}' (not a directory)"
         )
 
 

--- a/tests/01_unit/experiments/test_atmosphere.py
+++ b/tests/01_unit/experiments/test_atmosphere.py
@@ -172,7 +172,7 @@ def test_atmosphere_experiment_run_basic(
         atmosphere={
             "type": "heterogeneous",
             "molecular_atmosphere": molecular_atmosphere,
-            "particle_layers": [{"type": "particle_layer"}],
+            "particle_ensembles": [{"type": "particle_ensemble"}],
         },
         surface={"type": "lambertian"},
         measures={

--- a/tests/01_unit/scenes/atmosphere/test_3d.py
+++ b/tests/01_unit/scenes/atmosphere/test_3d.py
@@ -1,0 +1,75 @@
+import numpy as np
+import pytest
+
+import eradiate
+from eradiate import unit_registry as ureg
+from eradiate.contexts import KernelContext
+from eradiate.grid import PlaneParallelGridCoords
+from eradiate.scenes.atmosphere import (
+    HeterogeneousAtmosphere,
+    MolecularAtmosphere,
+    ParticleEnsemble,
+)
+from eradiate.scenes.geometry import PlaneParallelGeometry
+from eradiate.spectral.index import SpectralIndex
+from eradiate.test_tools.types import check_scene_element
+
+
+def _find_nearest(array, value):
+    array = np.asarray(array)
+    idx = (np.abs(array - value)).argmin()
+    return array[idx]
+
+
+def default_spectral_index(atmosphere):
+    # This is a bit fragile (API stability is not guaranteed and units are not
+    # checked) but it works well in both mono and ckd modes
+    wavelengths = atmosphere.absorption_data._spectral_coverage.index.get_level_values(
+        1
+    ).values
+    w = _find_nearest(wavelengths, 550.0)
+    kwargs = {"w": w * ureg.nm}
+    if eradiate.mode().is_ckd:
+        kwargs["g"] = 0.5
+    return SpectralIndex.new(**kwargs)
+
+
+def test_gridded_empty(modes_all_double):
+    with pytest.raises(ValueError):
+        HeterogeneousAtmosphere()
+
+
+@pytest.mark.parametrize(
+    "geometry",
+    [
+        PlaneParallelGeometry(
+            grid=PlaneParallelGridCoords.make_default().resampled(3, 3)
+        ),
+        # SphericalShellGeometry(), TBD convenience factories
+    ],
+    ids=[
+        "grid_pparallel",
+        #     "grid_spherical"
+    ],
+)
+@pytest.mark.parametrize(
+    "atm_params",
+    [
+        lambda: {"molecular_atmosphere": MolecularAtmosphere()},
+        lambda: {
+            "molecular_atmosphere": None,
+            "particle_ensembles": ParticleEnsemble(),
+        },
+    ],
+    ids=["molecular", "particle"],
+)
+def test_gridded_single_mono(
+    mode_mono, geometry, atm_params, atmosphere_us_standard_mono
+):
+    atmosphere = HeterogeneousAtmosphere(geometry=geometry, **atm_params())
+    kernel_context = KernelContext()
+    if atmosphere.molecular_atmosphere:
+        kernel_context = KernelContext(
+            default_spectral_index(atmosphere.molecular_atmosphere)
+        )
+    check_scene_element(atmosphere, ctx=kernel_context)

--- a/tests/01_unit/scenes/atmosphere/test_heterogeneous.py
+++ b/tests/01_unit/scenes/atmosphere/test_heterogeneous.py
@@ -8,7 +8,7 @@ from eradiate import unit_registry as ureg
 from eradiate.contexts import KernelContext
 from eradiate.scenes.atmosphere import (
     HeterogeneousAtmosphere,
-    ParticleLayer,
+    ParticleEnsemble,
 )
 from eradiate.scenes.core import traverse
 from eradiate.scenes.geometry import SceneGeometry
@@ -58,9 +58,9 @@ def test_heterogeneous_single_mono(
         kernel_context = KernelContext(si=si)
 
     else:
-        component = ParticleLayer()
+        component = ParticleEnsemble()
         atmosphere = HeterogeneousAtmosphere(
-            geometry=geometry, particle_layers=[component]
+            geometry=geometry, particle_ensembles=[component]
         )
         kernel_context = KernelContext()
 
@@ -85,9 +85,9 @@ def test_heterogeneous_single_ckd(
         kernel_context = KernelContext(si=si)
 
     else:
-        component = ParticleLayer()
+        component = ParticleEnsemble()
         atmosphere = HeterogeneousAtmosphere(
-            geometry=geometry, particle_layers=[component]
+            geometry=geometry, particle_ensembles=[component]
         )
         kernel_context = KernelContext()
 
@@ -105,7 +105,7 @@ def test_heterogeneous_multi_mono(mode_mono, geometry, atmosphere_us_standard_mo
     atmosphere = HeterogeneousAtmosphere(
         geometry=geometry,
         molecular_atmosphere=atmosphere_us_standard_mono,
-        particle_layers=[ParticleLayer() for _ in range(2)],
+        particle_ensembles=[ParticleEnsemble() for _ in range(2)],
     )
 
     # The scene element produces valid kernel dictionary specifications
@@ -123,7 +123,7 @@ def test_heterogeneous_multi_ckd(mode_ckd, geometry, atmosphere_us_standard_ckd)
     atmosphere = HeterogeneousAtmosphere(
         geometry={"type": geometry, "grid": np.linspace(0, 120, 121) * ureg.km},
         molecular_atmosphere=atmosphere_us_standard_ckd,
-        particle_layers=[ParticleLayer() for _ in range(2)],
+        particle_ensembles=[ParticleEnsemble() for _ in range(2)],
     )
 
     # The scene element produces valid kernel dictionary specifications
@@ -139,16 +139,16 @@ def test_heterogeneous_mix_collision_coefficients(modes_all_double, field):
     extinction coefficients properly add up.
     """
     with ucc.override(length="km"):
-        component_1 = ParticleLayer(bottom=0.0, top=1.25)
-        component_2 = ParticleLayer(bottom=0.5, top=1.5)
-        component_3 = ParticleLayer(bottom=0.75, top=2.0)
+        component_1 = ParticleEnsemble(bottom=0.0, top=1.25)
+        component_2 = ParticleEnsemble(bottom=0.5, top=1.5)
+        component_3 = ParticleEnsemble(bottom=0.75, top=2.0)
 
     mixed = HeterogeneousAtmosphere(
         geometry={
             "type": "plane_parallel",
             "grid": np.linspace(0, 120, 1201) * ureg.km,
         },
-        particle_layers=[component_1, component_2, component_3],
+        particle_ensembles=[component_1, component_2, component_3],
     )
     ctx = KernelContext()
     grid = mixed.geometry.grid
@@ -223,7 +223,7 @@ def test_heterogeneous_mix_weights(
             if eradiate.mode().is_ckd
             else atmosphere_us_standard_mono
         ),
-        particle_layers=ParticleLayer(
+        particle_ensembles=ParticleEnsemble(
             bottom=0.0 * ureg.km,
             top=50.0 * ureg.km,
             distribution={"type": "uniform"},
@@ -246,18 +246,18 @@ def test_heterogeneous_mix_weights(
     # Second check: simple disjoint components, more than 1
     mixed = HeterogeneousAtmosphere(
         geometry=geometry,
-        particle_layers=[
-            ParticleLayer(
+        particle_ensembles=[
+            ParticleEnsemble(
                 bottom=0.0 * ureg.km,
                 top=50.0 * ureg.km,
                 distribution={"type": "uniform"},
             ),
-            ParticleLayer(
+            ParticleEnsemble(
                 bottom=50.0 * ureg.km,
                 top=80.0 * ureg.km,
                 distribution={"type": "uniform"},
             ),
-            ParticleLayer(
+            ParticleEnsemble(
                 bottom=80.0 * ureg.km,
                 top=100.0 * ureg.km,
                 distribution={"type": "uniform"},
@@ -286,14 +286,14 @@ def test_heterogeneous_mix_weights(
     # therefore they have the same extinction coefficient
     mixed = HeterogeneousAtmosphere(
         geometry=geometry,
-        particle_layers=[
-            ParticleLayer(
+        particle_ensembles=[
+            ParticleEnsemble(
                 bottom=0.0 * ureg.km,
                 top=100.0 * ureg.km,
                 tau_ref=1.0,
                 distribution={"type": "uniform"},
             ),
-            ParticleLayer(
+            ParticleEnsemble(
                 bottom=50.0 * ureg.km,
                 top=100.0 * ureg.km,
                 tau_ref=0.5,
@@ -319,7 +319,7 @@ def test_heterogeneous_scale(mode_mono, atmosphere_us_standard_mono):
     atmosphere = HeterogeneousAtmosphere(
         geometry="plane_parallel",
         molecular_atmosphere=atmosphere_us_standard_mono,
-        particle_layers=[ParticleLayer() for _ in range(2)],
+        particle_ensembles=[ParticleEnsemble() for _ in range(2)],
         scale=2.0,
     )
     template, _ = traverse(atmosphere)
@@ -335,10 +335,10 @@ def test_heterogeneous_blend_switches(
     mode_mono,
     atmosphere_us_standard_mono,
 ):
-    # Rayleigh-only atmosphere + particle layer combination works
+    # Rayleigh-only atmosphere + particle ensemble combination works
     assert HeterogeneousAtmosphere(
         molecular_atmosphere=atmosphere_us_standard_mono,
-        particle_layers=[ParticleLayer()],
+        particle_ensembles=[ParticleEnsemble()],
     )
 
 
@@ -351,20 +351,20 @@ def test_heterogeneous_absorbing_mol_atm(
 ):
     """
     Phase function weights are correct when the molecular atmosphere is
-    absorbing-only and the particle layer is either absorbing-only or
+    absorbing-only and the particle ensemble is either absorbing-only or
     scattering-only.
     """
     # Expand fixture
     _particle_radprops = request.getfixturevalue(particle_radprops)
     # Create the heterogeneous atmosphere
-    pl_bottom = 1.0 * ureg.km  # arbitrary
-    pl_top = 4.0 * ureg.km  # arbitrary
-    particle_layer = ParticleLayer(
-        bottom=pl_bottom, top=pl_top, particle_properties=_particle_radprops
+    pe_bottom = 1.0 * ureg.km  # arbitrary
+    pe_top = 4.0 * ureg.km  # arbitrary
+    particle_ensemble = ParticleEnsemble(
+        bottom=pe_bottom, top=pe_top, particle_properties=_particle_radprops
     )
     atmosphere = HeterogeneousAtmosphere(
         molecular_atmosphere=atmosphere_us_standard_ckd,
-        particle_layers=particle_layer,
+        particle_ensembles=particle_ensemble,
         geometry={
             "type": "spherical_shell",  # arbitrary
             "grid": np.linspace(0, 120, 121) * ureg.km,
@@ -376,20 +376,20 @@ def test_heterogeneous_absorbing_mol_atm(
     weights = np.squeeze(mi_wrapper.parameters["weight_1.volume.data"])
 
     # Extract phase function weights
-    inside_particle_layer = (atmosphere.geometry.grid.layers >= pl_bottom) & (
-        atmosphere.geometry.grid.layers <= pl_top
+    inside_particle_ensemble = (atmosphere.geometry.grid.layers >= pe_bottom) & (
+        atmosphere.geometry.grid.layers <= pe_top
     )
 
-    # Outside the particle layer, the phase function weight should be zero.
-    assert np.all(weights.T[~inside_particle_layer] == 0.0)
+    # Outside the particle ensemble, the phase function weight should be zero.
+    assert np.all(weights.T[~inside_particle_ensemble] == 0.0)
 
-    # Within the particle layer, the phase function weight should be:
-    #   - zero, if the particle layer is not scattering (i.e., absorbing-only)
-    #   - larger than zero, if the particle layer is scattering
+    # Within the particle ensemble, the phase function weight should be:
+    #   - zero, if the particle ensemble is not scattering (i.e., absorbing-only)
+    #   - larger than zero, if the particle ensemble is scattering
     if particle_radprops == "particle_properties_absorbing_only":
-        assert np.all(weights.T[inside_particle_layer] == 0.0)
+        assert np.all(weights.T[inside_particle_ensemble] == 0.0)
     elif particle_radprops == "particle_properties_scattering_only":
-        assert np.all(weights.T[inside_particle_layer] > 0.0)
+        assert np.all(weights.T[inside_particle_ensemble] > 0.0)
     else:
         raise ValueError(
             f"Test parametrisation inconsistent. Expected 'absorbing_only' or "

--- a/tests/01_unit/scenes/atmosphere/test_particle_dist.py
+++ b/tests/01_unit/scenes/atmosphere/test_particle_dist.py
@@ -134,3 +134,73 @@ def test_particle_dist_array_extrapolate(extrapolate, expected):
         assert np.allclose(result, expected)
     else:
         assert np.isnan(result).all()
+
+
+@pytest.mark.parametrize("method", ["linear", "nearest"])
+def test_particle_dist_array_3d(method):
+    # One profile per (i_x, i_y) horizontal cell
+    values = np.array(
+        [
+            [[0.1, 0.2, 0.3, 0.2, 0.1], [0.3, 0.2, 0.1, 0.2, 0.3]],
+            [[0.0, 0.0, 1.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0, 1.0]],
+        ]
+    )  # shape (2, 2, 5)
+
+    # Omitting 'coords' sets a default matching the 3D shape, regularly
+    # spaced along the last (z) axis
+    dist = ArrayParticleDistribution(values=values, method=method)
+    assert dist.coords.shape == values.shape
+    for ix in range(2):
+        for iy in range(2):
+            assert np.allclose(dist.coords[ix, iy], [0.1, 0.3, 0.5, 0.7, 0.9])
+
+    # Each cell is interpolated independently
+    x = np.broadcast_to(np.linspace(0, 1, 11), (2, 2, 11))
+    result = dist(x)
+    assert result.shape == (2, 2, 11)
+
+    # A cell's result matches evaluating its own profile as a standalone 1D
+    # distribution
+    for ix in range(2):
+        for iy in range(2):
+            expected = ArrayParticleDistribution(values=values[ix, iy], method=method)(
+                x[ix, iy]
+            )
+            assert np.allclose(result[ix, iy], expected)
+
+    # Distinct cells give distinct results for the same query points
+    assert not np.allclose(result[0, 0], result[0, 1])
+    assert not np.allclose(result[1, 0], result[1, 1])
+
+    # A 1D query broadcasts to every column
+    assert np.allclose(dist(np.linspace(0, 1, 11)), result)
+
+    # A mismatched leading (x, y) shape raises
+    with pytest.raises(ValueError):
+        dist(np.zeros((3, 3, 11)))
+
+
+def test_particle_dist_array_3d_method_restricted():
+    values = np.array(
+        [
+            [[0.1, 0.2, 0.3, 0.2, 0.1], [0.3, 0.2, 0.1, 0.2, 0.3]],
+            [[0.0, 0.0, 1.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0, 1.0]],
+        ]
+    )
+
+    # 'linear' and 'nearest' are supported with 3D 'values' ...
+    ArrayParticleDistribution(values=values, method="linear")
+    ArrayParticleDistribution(values=values, method="nearest")
+
+    # ... every other method is rejected at construction time
+    for method in [
+        "nearest-up",
+        "zero",
+        "slinear",
+        "quadratic",
+        "cubic",
+        "previous",
+        "next",
+    ]:
+        with pytest.raises(ValueError):
+            ArrayParticleDistribution(values=values, method=method)

--- a/tests/01_unit/scenes/atmosphere/test_particle_ensemble.py
+++ b/tests/01_unit/scenes/atmosphere/test_particle_ensemble.py
@@ -5,9 +5,13 @@ import xarray as xr
 
 from eradiate import KernelContext, fresolver
 from eradiate import unit_registry as ureg
-from eradiate.grid import GridCoords
+from eradiate.grid import GridCoords, PlaneParallelGridCoords
 from eradiate.radprops import ParticleProperties
-from eradiate.scenes.atmosphere import ParticleLayer, UniformParticleDistribution
+from eradiate.scenes.atmosphere import (
+    ArrayParticleDistribution,
+    ParticleEnsemble,
+    UniformParticleDistribution,
+)
 from eradiate.scenes.core import traverse
 from eradiate.spectral.index import SpectralIndex
 from eradiate.test_tools.types import check_scene_element
@@ -52,12 +56,20 @@ def particle_properties(particle_dataset):
 # ------------------------------------------------------------------------------
 
 
-class TestParticleLayer:
+def _make_3d_grid():
+    return PlaneParallelGridCoords(
+        edges_x=np.array([0.0, 1.0, 2.0]) * ureg.km,
+        edges_y=np.array([0.0, 1.0, 2.0]) * ureg.km,
+        levels=np.linspace(0.0, 5.0, 11) * ureg.km,
+    )
+
+
+class TestParticleEnsemble:
     @pytest.mark.parametrize("geometry", ["plane_parallel", "spherical_shell"])
     def test_basic(self, mode_mono, geometry):
         """Basic constructor pattern"""
         # Construct from path
-        layer = ParticleLayer(
+        layer = ParticleEnsemble(
             particle_properties="tests/aerosol/govaerts_2021-desert-aer_core_v2.nc",
             geometry=geometry,
         )
@@ -68,14 +80,16 @@ class TestParticleLayer:
     def test_construct_noargs(self):
         """Construction succeeds with basic parameters"""
 
-        assert ParticleLayer()  # should pick up the default dataset from shipped assets
+        assert (
+            ParticleEnsemble()
+        )  # should pick up the default dataset from shipped assets
 
     def test_construct_attrs(self, particle_properties_test):
         """Assigns parameters to expected values."""
         bottom = 1.2 * ureg.km
         top = 1.8 * ureg.km
         tau_ref = 0.3 * ureg.dimensionless
-        layer = ParticleLayer(
+        layer = ParticleEnsemble(
             geometry={
                 "type": "plane_parallel",
                 "ground_altitude": bottom,
@@ -94,7 +108,7 @@ class TestParticleLayer:
 
     def test_altitude_units(self, particle_dataset_path):
         """Accept different units for bottom and top altitudes."""
-        assert ParticleLayer(
+        assert ParticleEnsemble(
             particle_properties=particle_dataset_path,
             bottom=1.0 * ureg.km,
             top=2000.0 * ureg.m,
@@ -105,7 +119,7 @@ class TestParticleLayer:
         with pytest.raises(
             ValueError, match="bottom altitude must be lower than top altitude"
         ):
-            ParticleLayer(
+            ParticleEnsemble(
                 particle_properties=particle_dataset_path,
                 top=1.2 * ureg.km,
                 bottom=1.8 * ureg.km,
@@ -114,7 +128,7 @@ class TestParticleLayer:
     def test_invalid_tau_ref(self, particle_dataset_path):
         """Raises when 'tau_ref' is invalid."""
         with pytest.raises(ValueError, match="tau_ref must be positive or zero"):
-            ParticleLayer(
+            ParticleEnsemble(
                 particle_properties=particle_dataset_path,
                 bottom=1.2 * ureg.km,
                 top=1.8 * ureg.km,
@@ -130,7 +144,7 @@ class TestParticleLayer:
         """
         bottom = 0.0 * ureg.km
         top = 1.0 * ureg.km
-        layer = ParticleLayer(
+        layer = ParticleEnsemble(
             geometry={
                 "type": "plane_parallel",
                 "ground_altitude": bottom,
@@ -160,7 +174,7 @@ class TestParticleLayer:
         """
         bottom = 0.0 * ureg.km
         top = 1.0 * ureg.km
-        layer = ParticleLayer(
+        layer = ParticleEnsemble(
             geometry={
                 "type": "plane_parallel",
                 "ground_altitude": bottom,
@@ -190,7 +204,7 @@ class TestParticleLayer:
         """
         bottom = 0.0 * ureg.km
         top = 1.0 * ureg.km
-        layer = ParticleLayer(
+        layer = ParticleEnsemble(
             geometry={
                 "type": "plane_parallel",
                 "ground_altitude": bottom,
@@ -214,17 +228,17 @@ class TestParticleLayer:
 
     def test_kernel_scale(self, modes_all_single, particle_properties_test):
         """Scale parameter propagates to kernel dict and latter can be loaded."""
-        particle_layer = ParticleLayer(
+        particle_ensemble = ParticleEnsemble(
             id="atmosphere", particle_properties=particle_properties_test, scale=2.0
         )
-        template, _ = traverse(particle_layer)
+        template, _ = traverse(particle_ensemble)
         assert template["medium_atmosphere.scale"] == 2.0
 
     def test_eval_radprops_format(self, modes_all_single, particle_dataset_path):
         """
         Method 'eval_radprops' returns dataset with expected datavars and coords.
         """
-        layer = ParticleLayer(particle_properties=particle_dataset_path)
+        layer = ParticleEnsemble(particle_properties=particle_dataset_path)
         si = SpectralIndex.new()
         ds = layer.eval_radprops(si)
         expected_data_vars = ["sigma_t", "albedo"]
@@ -237,7 +251,7 @@ class TestParticleLayer:
         "tau_ref", list(np.array([0.6, 1.0, 2.5]) * ureg.dimensionless)
     )
     def test_eval_radprops(self, mode_mono, particle_dataset_path, tau_ref):
-        layer = ParticleLayer(
+        layer = ParticleEnsemble(
             particle_properties=particle_dataset_path,
             bottom=0.5 * ureg.km,  # arbitrary
             top=3.0 * ureg.km,  # arbitrary
@@ -275,7 +289,7 @@ class TestParticleLayer:
         Check correct handling of spectral dependency of extinction.
 
         If σ_t(λ) denotes the extinction coefficient at the wavelength λ, then the
-        optical thickness of a uniform particle layer is τ(λ) = σ_t(λ) Δz, where Δz
+        optical thickness of a uniform particle ensemble is τ(λ) = σ_t(λ) Δz, where Δz
         is the layer's thickness. From that follows:
         τ(λ) / τ(λ_ref) = σ_t(λ) / σ_t(λ_ref).
 
@@ -291,11 +305,9 @@ class TestParticleLayer:
         n_wavelengths = 3
         n_layers = 10
         wavelengths = np.linspace(500.0, 1500.0, n_wavelengths) * ureg.nm
-        grid = GridCoords.make_onedim_from_levels(
-            np.linspace(0, 5, n_layers + 1) * ureg.km
-        )
+        grid = GridCoords.convert(np.linspace(0, 5, n_layers + 1) * ureg.km)
 
-        layer = ParticleLayer(
+        layer = ParticleEnsemble(
             particle_properties=ds,
             geometry={
                 "type": "plane_parallel",
@@ -336,6 +348,144 @@ class TestParticleLayer:
         result = (tau / tau_ref).m_as(ureg.dimensionless)
         expected = (sigma_t / sigma_t_ref).m_as(ureg.dimensionless)
         np.testing.assert_allclose(result, expected)
+
+    @pytest.mark.parametrize("distribution", ["uniform", "gaussian", "exponential"])
+    @pytest.mark.parametrize(
+        "bottom, top",
+        [
+            (1.0 * ureg.km, 4.0 * ureg.km),
+            (
+                np.array([[1.0, 1.5], [2.0, 2.5]]) * ureg.km,
+                np.array([[3.0, 3.5], [4.0, 4.5]]) * ureg.km,
+            ),
+        ],
+        ids=["scalar", "varying"],
+    )
+    def test_eval_fractions_shape_and_normalization(self, distribution, bottom, top):
+        grid = _make_3d_grid()
+        layer = ParticleEnsemble(
+            geometry={
+                "type": "plane_parallel",
+                "toa_altitude": grid.levels[-1],
+                "grid": grid,
+            },
+            bottom=bottom,
+            top=top,
+            distribution=distribution,
+        )
+
+        fractions = layer.eval_fractions(grid)
+        spatial_shape = fractions.shape[:-1]
+
+        z_centers = grid.layers.m_as(ureg.km)
+        bottom_grid = np.broadcast_to(bottom.m_as(ureg.km), spatial_shape)
+        top_grid = np.broadcast_to(top.m_as(ureg.km), spatial_shape)
+
+        for idx in np.ndindex(spatial_shape):
+            in_range = (z_centers >= bottom_grid[idx]) & (z_centers <= top_grid[idx])
+            col = fractions[idx]
+            assert np.isclose(col.sum(), 1.0)
+            assert np.all(col[in_range] > 0.0)
+            assert np.allclose(col[~in_range], 0.0)
+
+    def test_eval_fractions_scalar_bottom_top_with_3d_distribution(self):
+        grid = _make_3d_grid()
+        n_z = grid.layers.size
+        values = np.zeros((2, 2, n_z))
+        peak = np.arange(4).reshape(2, 2) % n_z
+        np.put_along_axis(values, peak[..., np.newaxis], 1.0, axis=-1)
+
+        ensemble = ParticleEnsemble(
+            geometry={
+                "type": "plane_parallel",
+                "toa_altitude": grid.levels[-1],
+                "grid": grid,
+            },
+            bottom=grid.levels[0],
+            top=grid.levels[-1],
+            distribution=ArrayParticleDistribution(values=values, method="nearest"),
+        )
+
+        fractions = ensemble.eval_fractions(grid)
+        assert fractions.shape == (2, 2, n_z)
+        assert np.allclose(fractions.sum(axis=-1), 1.0)
+        assert not np.allclose(fractions[0, 0], fractions[0, 1])
+        assert not np.allclose(fractions[0, 0], fractions[1, 0])
+
+    def test_eval_fractions_uniform_is_flat(self):
+        grid = _make_3d_grid()
+        layer = ParticleEnsemble(
+            bottom=1.0 * ureg.km, top=4.0 * ureg.km, distribution="uniform"
+        )
+
+        fractions = layer.eval_fractions(grid)
+        nonzero = fractions[fractions > 0.0]
+        assert np.allclose(nonzero, nonzero[0])
+
+    @pytest.mark.parametrize(
+        "bottom, top",
+        [
+            (1.0 * ureg.km, 4.0 * ureg.km),
+            (
+                np.array([[1.0, 1.5], [2.0, 2.5]]) * ureg.km,
+                np.array([[3.0, 3.5], [4.0, 4.5]]) * ureg.km,
+            ),
+        ],
+        ids=["scalar_extent", "varying_extent"],
+    )
+    @pytest.mark.parametrize(
+        "tau_ref",
+        [
+            0.5 * ureg.dimensionless,
+            np.array([[0.2, 0.5], [1.0, 2.0]]) * ureg.dimensionless,
+        ],
+        ids=["scalar_tau_ref", "varying_tau_ref"],
+    )
+    def test_eval_sigma_t_broadcast(
+        self, mode_mono, particle_dataset_path, bottom, top, tau_ref
+    ):
+        grid = _make_3d_grid()
+        w_ref = 550 * ureg.nm
+
+        layer = ParticleEnsemble(
+            geometry={
+                "type": "plane_parallel",
+                "toa_altitude": grid.levels[-1],
+                "grid": grid,
+            },
+            particle_properties=particle_dataset_path,
+            bottom=bottom,
+            top=top,
+            tau_ref=tau_ref,
+            w_ref=w_ref,
+        )
+
+        si = SpectralIndex.new(w=w_ref)
+        sigma_t = layer.eval_sigma_t(si, grid).m_as("km^-1")
+        albedo = layer.eval_albedo(si, grid).m_as(ureg.dimensionless)
+        sigma_s = layer.eval_sigma_s(si, grid).m_as("km^-1")
+        sigma_a = layer.eval_sigma_a(si, grid).m_as("km^-1")
+        fractions = layer.eval_fractions(grid)
+
+        sigma_t, albedo, sigma_s, sigma_a, fractions = np.broadcast_arrays(
+            sigma_t, albedo, sigma_s, sigma_a, fractions
+        )
+        spatial_shape = sigma_t.shape[:-1]
+
+        tau = np.sum(sigma_t * grid.layer_height.m_as("km"), axis=-1)
+        expected_tau = np.broadcast_to(tau_ref.m_as(ureg.dimensionless), spatial_shape)
+        np.testing.assert_allclose(tau, expected_tau)
+
+        np.testing.assert_allclose(sigma_s, sigma_t * albedo, rtol=1e-6)
+        np.testing.assert_allclose(sigma_a, sigma_t * (1.0 - albedo), rtol=1e-6)
+
+        for idx in np.ndindex(spatial_shape):
+            nonzero = fractions[idx] > 0.0
+            ratios = sigma_t[idx][nonzero] / fractions[idx][nonzero]
+            np.testing.assert_allclose(ratios, ratios[0], rtol=1e-6)
+
+        if np.prod(spatial_shape, dtype=int) > 1 and np.size(tau_ref) > 1:
+            assert not np.allclose(tau, tau.flat[0])
 
     @pytest.mark.parametrize(
         "has_absorption, has_scattering, expected",
@@ -380,7 +530,7 @@ class TestParticleLayer:
         try:
             bottom = 0.0 * ureg.km
             top = 1.0 * ureg.km
-            particle_layer = ParticleLayer(
+            particle_ensemble = ParticleEnsemble(
                 particle_properties=particle_dataset_path,
                 geometry={
                     "type": "plane_parallel",
@@ -391,13 +541,13 @@ class TestParticleLayer:
                 has_absorption=has_absorption,
                 has_scattering=has_scattering,
             )
-            grid = particle_layer.geometry.grid
+            grid = particle_ensemble.geometry.grid
             w = 550.0 * ureg.nm
 
             for field in ["albedo", "sigma_t", "sigma_a", "sigma_s"]:
                 expected_value = expected[field]
                 method = f"eval_{field}_mono"
-                result = getattr(particle_layer, method)(w, grid)
+                result = getattr(particle_ensemble, method)(w, grid)
 
                 if isinstance(expected_value, pint.Quantity):
                     np.testing.assert_allclose(
@@ -418,7 +568,7 @@ class TestParticleLayer:
                     )
 
                 elif expected_value == "sigma_t":
-                    expected_value = particle_layer.eval_sigma_t_mono(w, grid)
+                    expected_value = particle_ensemble.eval_sigma_t_mono(w, grid)
                     np.testing.assert_allclose(
                         result.m_as(expected_value.units),
                         expected_value.m,
@@ -439,7 +589,7 @@ class TestParticleLayer:
         particle_properties = particle_properties_test
         w1, w2 = particle_properties.w[[1, 2]]
 
-        assert ParticleLayer(
+        assert ParticleEnsemble(
             particle_properties=particle_properties, tau_ref=1.0, w_ref=w1
         )
 
@@ -447,7 +597,7 @@ class TestParticleLayer:
             UserWarning,
             match="dataset does not contain the selected reference wavelength",
         ):
-            ParticleLayer(
+            ParticleEnsemble(
                 particle_properties=particle_properties,
                 tau_ref=1.0,
                 w_ref=0.5 * (w1 + w2),

--- a/tests/02_system/test_heterogeneous_atmosphere_expansion.py
+++ b/tests/02_system/test_heterogeneous_atmosphere_expansion.py
@@ -8,12 +8,12 @@ from eradiate import unit_registry as ureg
 @pytest.mark.slow
 @pytest.mark.parametrize("bottom", [0.0, 1.0, 10.0])
 @pytest.mark.parametrize("tau_ref", [0.1, 1.0, 10.0])
-def test_heterogeneous_atmosphere_expansion_particle_layer(
+def test_heterogeneous_atmosphere_expansion_particle_ensemble(
     mode_ckd_double, bottom, tau_ref, ert_seed_state
 ):
     """
-    Perfect single-component HeterogeneousAtmosphere expansion (particle layer)
-    ===========================================================================
+    Perfect single-component HeterogeneousAtmosphere expansion (particle ensemble)
+    ==============================================================================
 
     This test case checks if a single-component HeterogeneousAtmosphere
     container expands perfectly as its component. This is assessed by checking
@@ -25,8 +25,8 @@ def test_heterogeneous_atmosphere_expansion_particle_layer(
 
     Run an AtmosphereExperiment with two different atmosphere definitions:
 
-    1. A single particle layer.
-    2. Heterogeneous atmosphere that contains a single particle layer.
+    1. A single particle ensemble.
+    2. Heterogeneous atmosphere that contains a single particle ensemble.
 
     Expected behaviour
     ------------------
@@ -45,7 +45,7 @@ def test_heterogeneous_atmosphere_expansion_particle_layer(
         "srf": {"type": "delta", "wavelengths": 550.0 * ureg.nm},
     }
 
-    # Particle layer only
+    # Particle ensemble only
     bottom = bottom * ureg.km
     top = bottom + 1.0 * ureg.km
     geometry = {
@@ -53,27 +53,27 @@ def test_heterogeneous_atmosphere_expansion_particle_layer(
         "ground_altitude": bottom,
         "toa_altitude": top,
     }
-    layer = {
-        "type": "particle_layer",
+    ensemble = {
+        "type": "particle_ensemble",
         "bottom": bottom,
         "top": top,
         "tau_ref": tau_ref,
     }
     exp1 = eradiate.experiments.AtmosphereExperiment(
         geometry=geometry,
-        atmosphere=layer,
+        atmosphere=ensemble,
         measures=[measure],
     )
     ert_seed_state.reset()
     eradiate.run(exp1, seed_state=ert_seed_state, spp=spp)
     results1 = exp1.results["measure"]["radiance"].values
 
-    # Heterogeneous atmosphere with a particle layer
+    # Heterogeneous atmosphere with a particle ensemble
     exp2 = eradiate.experiments.AtmosphereExperiment(
         geometry=geometry,
         atmosphere={
             "type": "heterogeneous",
-            "particle_layers": [layer],
+            "particle_ensembles": [ensemble],
         },
         measures=[measure],
     )

--- a/tests/02_system/test_heterogeneous_atmosphere_flags.py
+++ b/tests/02_system/test_heterogeneous_atmosphere_flags.py
@@ -38,7 +38,7 @@ def test_heterogeneous_atm_flags(
         atmosphere={
             "type": "heterogeneous",
             "molecular_atmosphere": molecular,
-            "particle_layers": {
+            "particle_ensembles": {
                 "tau_ref": 0.2,
                 "bottom": 0.0,
                 "top": 10.0 * ureg.km,


### PR DESCRIPTION
# Description

Adapt the `ParticleLayer` class to 3D grids. The class is now named `ParticleEnsemble`, referring the the unique distribution of particles shape they represent. This class can now handle variability in its geometry and OT alongside the X and Y coordinates of the scene. 

The vertical extent of the `ParticleEnsemble` can vary
<img width="533" height="402" alt="image" src="https://github.com/user-attachments/assets/670b032d-32f0-41fb-a5ed-5cc6be734fb4" />

Optical thickness can accept a 2D array of the shape of the grid's X and Y coordinates
<img width="547" height="460" alt="image" src="https://github.com/user-attachments/assets/3f049b4d-069c-4f12-a043-367e16426b83" />

`ArrayDistribution` class is also adapted to support X and Y dimensions
<img width="534" height="377" alt="image" src="https://github.com/user-attachments/assets/e23fea6f-ca8d-41d3-b819-b19eed3c35bf" />

This class can be used for parametric configuration of 3D particles plumes geometry. Examples taken from https://github.com/eradiate/eradiate-tutorials/pull/5

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `main` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
