### PR TITLE
[3DATM 5/6] Wrap Mode support

### DIFF
--- a/docs/release_notes/v1.3.x.md
+++ b/docs/release_notes/v1.3.x.md
@@ -16,6 +16,9 @@
 * {class}`.ParticleEnsemble`'s `bottom` and `top` altitudes can now vary per
   horizontal grid cell. `tau_ref` can vary per cell too. Particle properties
   are the same in every cell ({ghpr}`588`).
+* 3D atmospheres can now clamp, repeat, or mirror samples that fall outside
+  the grid extent. Set this with `SceneGeometry`'s `wrap_mode`
+  ({ghpr}`589`).
 
 ### Changed
 

--- a/src/eradiate/scenes/atmosphere/_core.py
+++ b/src/eradiate/scenes/atmosphere/_core.py
@@ -722,38 +722,52 @@ class AbstractHeterogeneousAtmosphere(Atmosphere, ABC):
         }
         sigma_t_id = f"{self.id}_sigma_t"
 
+        piecewise = (
+            isinstance(self.geometry, PlaneParallelGeometry)
+            and not self.force_majorant
+            and self.geometry.grid.onedim
+        )
+
+        aabb_conf = {}
         if isinstance(self.geometry, SphericalShellGeometry):
-            medium = "eoheterogeneous"
+            extr_conf = {
+                "type": "extremum_spherical",
+                "rmin": self.geometry.atmosphere_volume_rmin,
+            }
+        elif not piecewise:
+            extr_conf = {"type": "extremum_grid"}
+            aabb_min = self.geometry.bbox.min.m_as("m")
+            # The geometry bbox inserts a sub-surface padding. We want the data to be evaluated
+            # on the entire geometry extent in x and y directions, but we should avoid the wrap_mode
+            # to affect the z direction.
+            aabb_min[2] = self.geometry.grid.levels[0].m_as("m")
+            aabb_conf = {
+                "aabb_min": aabb_min,
+                "aabb_max": self.geometry.bbox.max.m_as("m"),
+            }
+
+        if piecewise:
+            medium = "piecewise"
+        else:
             if self.extremum_resolution != (1, 1, 1):
                 extremum = {
-                    "type": "extremum_spherical",
-                    "volume": {"type": "ref", "id": sigma_t_id},
-                    "rmin": self.geometry.atmosphere_volume_rmin,
-                    "resolution": self.extremum_resolution,
-                    "to_world": self.geometry.atmosphere_volume_to_world,
-                }
-        elif isinstance(self.geometry, PlaneParallelGeometry):
-            medium = (
-                "eoheterogeneous"
-                if self.force_majorant or not self.geometry.grid.onedim
-                else "piecewise"
-            )
-            if medium == "eoheterogeneous" and self.extremum_resolution != (1, 1, 1):
-                extremum = {
-                    "type": "extremum_grid",
+                    **extr_conf,
                     "volume": {"type": "ref", "id": sigma_t_id},
                     "resolution": self.extremum_resolution,
-                    "to_world": self.geometry.atmosphere_volume_to_world,
+                    "to_world": self.geometry.grid.to_world,
+                    "wrap_mode": str(self.geometry.wrap_mode).lower(),
                 }
-        else:
-            raise TypeError(
-                f"unhandled scene geometry type '{type(self.geometry).__name__}'"
-            )
+            medium = "eoheterogeneous"
 
         # Create medium dictionary
         result = {
             "type": medium,
-            "has_spectral_extinction": (not get_mode().check(mi_color_mode="mono")),
+            "has_spectral_extinction": (
+                # piecewise volpath currently only works with spectral extinction true
+                # hack fix by setting to True when we have a piecewise medium
+                (not get_mode().check(mi_color_mode="mono")) or (medium == "piecewise")
+            ),
+            **aabb_conf,
             **volumes,
             # Note: "phase" is deliberately unset, this is left to the
             # Atmosphere.template property

--- a/src/eradiate/scenes/shapes/_sphere.py
+++ b/src/eradiate/scenes/shapes/_sphere.py
@@ -59,7 +59,7 @@ class SphereShape(ShapeNode):
             to_world = (
                 self.to_world
                 @ mi.ScalarTransform4f().translate(self.center.m_as(length_units))
-                @ mi.ScalarTransform4f().scale(self.radius.m_as(length_units))
+                @ mi.ScalarTransform4f().scale(float(self.radius.m_as(length_units)))
             )
         else:
             to_world = mi.ScalarTransform4f().translate(
@@ -109,12 +109,12 @@ class SphereShape(ShapeNode):
             to_world = (
                 self.to_world
                 @ mi.ScalarTransform4f().translate(self.center.m_as(length_units))
-                @ mi.ScalarTransform4f().scale(self.radius.m_as(length_units))
+                @ mi.ScalarTransform4f().scale(float(self.radius.m_as(length_units)))
             )
         else:
             to_world = mi.ScalarTransform4f().translate(
                 self.center.m_as(length_units)
-            ) @ mi.ScalarTransform4f().scale(self.radius.m_as(length_units))
+            ) @ mi.ScalarTransform4f().scale(float(self.radius.m_as(length_units)))
         p = np.atleast_2d(
             ensure_units(p, default_units=ucc.get("length")).m_as(length_units)
         )

--- a/tests/01_unit/scenes/atmosphere/test_heterogeneous.py
+++ b/tests/01_unit/scenes/atmosphere/test_heterogeneous.py
@@ -6,12 +6,13 @@ import eradiate
 from eradiate import unit_context_config as ucc
 from eradiate import unit_registry as ureg
 from eradiate.contexts import KernelContext
+from eradiate.grid import PlaneParallelGridCoords
 from eradiate.scenes.atmosphere import (
     HeterogeneousAtmosphere,
     ParticleEnsemble,
 )
 from eradiate.scenes.core import traverse
-from eradiate.scenes.geometry import SceneGeometry
+from eradiate.scenes.geometry import PlaneParallelGeometry, SceneGeometry, WrapMode
 from eradiate.spectral.index import SpectralIndex
 from eradiate.test_tools.types import check_scene_element
 
@@ -450,3 +451,73 @@ def test_heterogenous_extremum_type(
     elif geometry == "spherical_shell":
         assert "extremum" in template
         assert template["extremum"]["type"] == "extremum_spherical"
+
+
+@pytest.mark.parametrize(
+    "wrap_mode", [WrapMode.CLAMP, WrapMode.REPEAT, WrapMode.MIRROR]
+)
+def test_heterogeneous_extremum_wrap_mode(
+    mode_mono, wrap_mode, atmosphere_us_standard_mono
+):
+    """
+    The extremum structure's wrap_mode always mirrors the geometry's
+    wrap_mode, for each of the three supported modes.
+    """
+    atmosphere = HeterogeneousAtmosphere(
+        geometry={"type": "plane_parallel", "wrap_mode": wrap_mode},
+        molecular_atmosphere=atmosphere_us_standard_mono,
+        force_majorant=True,
+        extremum_resolution=(1, 1, 12),
+    )
+    template = atmosphere._template_medium
+    assert template["extremum"]["wrap_mode"] == str(wrap_mode)
+
+
+def test_heterogeneous_medium_aabb(mode_mono, atmosphere_us_standard_mono):
+    """
+    The medium AABB matches the geometry bbox horizontally; its vertical
+    minimum is the grid's bottom level, not the shape bbox's own minimum.
+    """
+    atmosphere = HeterogeneousAtmosphere(
+        geometry="plane_parallel",
+        molecular_atmosphere=atmosphere_us_standard_mono,
+        force_majorant=True,
+    )
+    template = atmosphere._template_medium
+    geometry = atmosphere.geometry
+
+    assert "aabb_min" in template and "aabb_max" in template
+    bbox_min = geometry.bbox.min.m_as("m")
+    bbox_max = geometry.bbox.max.m_as("m")
+
+    np.testing.assert_allclose(template["aabb_min"][:2], bbox_min[:2])
+    np.testing.assert_allclose(template["aabb_max"], bbox_max)
+
+    grid_bottom = geometry.grid.levels[0].m_as("m")
+    assert template["aabb_min"][2] == pytest.approx(grid_bottom)
+    assert template["aabb_min"][2] != pytest.approx(bbox_min[2])
+
+
+def test_heterogeneous_medium_type_genuine_3d_grid(
+    mode_mono, atmosphere_us_standard_mono
+):
+    """
+    A non-onedim horizontal grid forces the eoheterogeneous medium type even
+    with force_majorant left at its default (False).
+    """
+    grid = PlaneParallelGridCoords(
+        edges_x=np.array([-1.0, 0.0, 1.0]) * ureg.km,
+        edges_y=np.array([-1.0, 0.0, 1.0]) * ureg.km,
+        levels=np.linspace(0.0, 10.0, 6) * ureg.km,
+    )
+    geometry = PlaneParallelGeometry(grid=grid, toa_altitude=grid.levels[-1])
+    assert not geometry.grid.onedim
+
+    atmosphere = HeterogeneousAtmosphere(
+        geometry=geometry,
+        molecular_atmosphere=atmosphere_us_standard_mono,
+    )
+    template = atmosphere._template_medium
+
+    assert template["type"] == "eoheterogeneous"
+    assert "aabb_min" in template and "aabb_max" in template

--- a/tests/03_regression/rami4atm/test_rami4atm_gridded.py
+++ b/tests/03_regression/rami4atm/test_rami4atm_gridded.py
@@ -1,0 +1,118 @@
+import attrs
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+
+import eradiate
+from eradiate import unit_registry as ureg
+from eradiate.attrs import AUTO
+from eradiate.grid import PlaneParallelGridCoords
+from eradiate.scenes.atmosphere import (
+    HeterogeneousAtmosphere,
+    MolecularAtmosphere,
+)
+from eradiate.scenes.geometry import PlaneParallelGeometry
+from eradiate.test_tools.regression import RegressionTestFailure, ZTest
+from eradiate.test_tools.report import figure_to_html, report_logger
+from eradiate.test_tools.test_cases import rami4atm
+
+# Small enough that oblique rays (these cases go out to 75 deg zenith) need to
+# sample outside the grid's own horizontal extent, so wrap_mode=CLAMP is
+# actually exercised. The atmosphere stays horizontally uniform, so a correct
+# CLAMP still reproduces the 1D (infinite homogeneous slab) reference.
+GRID_EXTENT = 2.0 * ureg.km
+
+cases = [
+    "hom00_rpv_e00s_m04_z30a000_brfpp",
+    "hom00_whi_s00s_m04_z30a000_brfpp",
+    "hom00_rpv_0d6s_m04_z30a000_brfpp",
+    "hom00_rpv_sd2s_m04_z30a000_brfpp",
+    "hom00_rpv_ac2s_m04_z30a000_brfpp",
+    "hom00_rpv_ec6s_m04_z30a000_brfpp",
+]
+
+
+@pytest.mark.regression
+@pytest.mark.slow
+@pytest.mark.parametrize("case", cases)
+def test_rami4atm_gridded(mode_ckd_double, case):
+    case_obj = rami4atm.CASES[case]
+    variables = ["radiance"]
+    threshold = 0.005
+
+    exps = case_obj.make_experiments(spp=1000)
+    exps_3d = []
+
+    resolution = (2, 3)
+    resx, resy = resolution
+
+    for exp in exps:
+        mol_atm_1d = exp.atmosphere.molecular_atmosphere
+
+        geometry = PlaneParallelGeometry(
+            grid=PlaneParallelGridCoords.from_extent_and_resolution(
+                levels=exp.geometry.grid.levels,
+                extent_x=GRID_EXTENT,
+                extent_y=GRID_EXTENT,
+                n_cells_x=resx,
+                n_cells_y=resy,
+            ),
+        )
+
+        mol_atm_3d = None
+        if mol_atm_1d:
+            mol_atm_3d = MolecularAtmosphere(
+                geometry=geometry,
+                absorption_data=mol_atm_1d.absorption_data,
+                thermoprops=mol_atm_1d.thermoprops,
+                has_absorption=mol_atm_1d.has_absorption,
+                has_scattering=mol_atm_1d.has_scattering,
+            )
+
+        atm = HeterogeneousAtmosphere(
+            geometry=geometry,
+            molecular_atmosphere=mol_atm_3d,
+            particle_ensembles=[
+                attrs.evolve(
+                    ensemble,
+                    tau_ref=ensemble.tau_ref * np.ones(resolution),
+                    geometry=geometry,
+                )
+                for ensemble in exp.atmosphere.particle_ensembles
+            ],
+        )
+
+        exps_3d.append(
+            attrs.evolve(
+                exp,
+                atmosphere=atm,
+                geometry=geometry,
+                integrator={"type": "volpath", "moment": True},
+                background_spectral_grid=AUTO,
+            )
+        )
+
+    raw_results_3d = [eradiate.run(exp) for exp in exps_3d]
+
+    result = case_obj.postprocess(raw_results_3d)
+    report_logger.html(result._repr_html_())
+
+    raw_results = [eradiate.run(exp) for exp in exps]
+    reference = case_obj.postprocess(raw_results)
+
+    report_logger.html(reference._repr_html_())
+
+    for variable in variables:
+        test = ZTest(threshold, variable=variable)
+        outcome = test.evaluate(result, reference)
+
+        figure, _ = test.plot(result, reference, outcome)
+        try:
+            report_logger.html(figure_to_html(figure))
+        finally:
+            plt.close(figure)
+
+        report_logger.info(str(outcome))
+
+        if not outcome.passed:
+            raise RegressionTestFailure(outcome)


### PR DESCRIPTION
# Description

Implement wrapmode support for 3D atmospheres. By default the `WrapMode.CLAMP` extends the atmospheric properties defined on the `GridCoords` towards the entire volume extent:
<img width="520" height="401" alt="image" src="https://github.com/user-attachments/assets/90d7c374-778e-42b8-ae3a-91af3c3b7100" />

`WrapMode.REPEAT` and `WrapMode.MIRROR` implement periodic and symetric wrap functions respectively

<img width="1086" height="443" alt="image" src="https://github.com/user-attachments/assets/69f964b9-7bc1-471a-b5f3-7914963423f5" />

The three above images leverage changes made in the 3D `ParticleEnsemble` class, configured as a checkerboard of 20 meter high particles cubes of $OT\approx5$.

Wrapmode is supported in both plane parallel and spherical geometries. Below is an example of a circular ParticleEnsemble located on ~Earth-sized sphere:

<img width="525" height="401" alt="image" src="https://github.com/user-attachments/assets/0337b81a-5282-46c4-9235-e407f8bdb1de" />

Examples taken from https://github.com/eradiate/eradiate-tutorials/pull/5.

# Checklist

- [x] The code follows the relevant coding guidelines
- [x] The code generates no new warnings
- [x] The code is appropriately documented
- [x] The code is tested to prove its function
- [x] The feature branch is rebased on the current state of the `next` branch
- [x] I updated the change log if relevant
- [x] I give permission that the Eradiate project may redistribute my contributions under the terms of its license
